### PR TITLE
Fix crypto compatibility and timezone handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ password.txt
 *.tmp
 tmp/
 temp/
+
+# Runtime data directories
+server/data/
 coverage.html
 alerter/ai-dba-alerter-linux
 CLAUDE.local.md

--- a/collector/src/database/crypto.go
+++ b/collector/src/database/crypto.go
@@ -74,43 +74,85 @@ func EncryptPassword(password string, serverSecret string, username string) (str
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
-// DecryptPassword decrypts a password using AES-256-GCM
-// The key is derived from the server secret and username
+// DecryptPassword decrypts a password using AES-256-GCM.
+// Supports two formats:
+// 1. New format (server): [salt (16 bytes)][nonce][ciphertext] - random salt
+// 2. Legacy format (collector): [nonce][ciphertext] - username as salt
 func DecryptPassword(encryptedPassword string, serverSecret string, username string) (string, error) {
 	if serverSecret == "" {
 		return "", fmt.Errorf("server secret is required for decryption")
 	}
 
-	// Derive key from server secret and username
-	key := deriveKey(serverSecret, username)
-
 	// Decode from base64
-	ciphertext, err := base64.StdEncoding.DecodeString(encryptedPassword)
+	data, err := base64.StdEncoding.DecodeString(encryptedPassword)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode base64: %w", err)
 	}
 
-	// Create cipher block
+	// Try new format first (server uses 16-byte random salt prepended)
+	const saltSize = 16
+	if len(data) > saltSize+12 { // salt + minimum nonce size
+		if plaintext, err := decryptWithRandomSalt(data, serverSecret, saltSize); err == nil {
+			return plaintext, nil
+		}
+	}
+
+	// Fall back to legacy format (username as salt)
+	return decryptWithUsernameSalt(data, serverSecret, username)
+}
+
+// decryptWithRandomSalt decrypts data in the server's format: [salt][nonce][ciphertext]
+func decryptWithRandomSalt(data []byte, serverSecret string, saltSize int) (string, error) {
+	salt := data[:saltSize]
+	ciphertext := data[saltSize:]
+
+	// Derive key using the extracted salt (as bytes, not string)
+	key := pbkdf2.Key([]byte(serverSecret), salt, 100000, 32, sha256.New)
+
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return "", fmt.Errorf("failed to create cipher: %w", err)
+		return "", err
 	}
 
-	// Create GCM mode
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return "", fmt.Errorf("failed to create GCM: %w", err)
+		return "", err
 	}
 
-	// Extract nonce
 	nonceSize := gcm.NonceSize()
 	if len(ciphertext) < nonceSize {
 		return "", fmt.Errorf("ciphertext too short")
 	}
 
-	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	nonce, ciphertextBytes := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertextBytes, nil)
+	if err != nil {
+		return "", err
+	}
 
-	// Decrypt
+	return string(plaintext), nil
+}
+
+// decryptWithUsernameSalt decrypts data in the legacy format: [nonce][ciphertext]
+func decryptWithUsernameSalt(data []byte, serverSecret string, username string) (string, error) {
+	key := deriveKey(serverSecret, username)
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt: %w", err)

--- a/collector/src/probes/base.go
+++ b/collector/src/probes/base.go
@@ -143,7 +143,7 @@ func EnsurePartition(ctx context.Context, conn *pgxpool.Conn, tableName string, 
 // DropExpiredPartitions drops partitions that contain only expired data
 func DropExpiredPartitions(ctx context.Context, conn *pgxpool.Conn, tableName string, retentionDays int) error {
 	// Calculate the cutoff timestamp
-	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
 
 	// For change-tracked probes (pg_settings, pg_hba_file_rules, pg_ident_file_mappings, pg_server_info),
 	// find the most recent partition with data for each connection

--- a/collector/src/scheduler/scheduler.go
+++ b/collector/src/scheduler/scheduler.go
@@ -334,7 +334,7 @@ func (ps *ProbeScheduler) executeProbeForConnection(ctx context.Context, probe p
 	// Collect all metrics before storing
 	var allMetrics []map[string]interface{}
 	var databases []string
-	timestamp := time.Now()
+	timestamp := time.Now().UTC()
 
 	if probe.IsDatabaseScoped() {
 		// Execute probe for each database and collect metrics

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -571,6 +571,17 @@ func mergeConfig(dest, src *Config) {
 		dest.TraceFile = src.TraceFile
 	}
 
+	// Connection security - merge if any fields are set
+	if src.ConnectionSecurity.AllowInternalNetworks {
+		dest.ConnectionSecurity.AllowInternalNetworks = src.ConnectionSecurity.AllowInternalNetworks
+	}
+	if len(src.ConnectionSecurity.AllowedHosts) > 0 {
+		dest.ConnectionSecurity.AllowedHosts = src.ConnectionSecurity.AllowedHosts
+	}
+	if len(src.ConnectionSecurity.BlockedHosts) > 0 {
+		dest.ConnectionSecurity.BlockedHosts = src.ConnectionSecurity.BlockedHosts
+	}
+
 	// Builtins - merge individual settings (pointer fields preserve explicit false values)
 	// Tools
 	if src.Builtins.Tools.QueryDatabase != nil {

--- a/server/src/internal/database/datastore.go
+++ b/server/src/internal/database/datastore.go
@@ -1218,7 +1218,7 @@ func (d *Datastore) GetServersInCluster(ctx context.Context, clusterID int) ([]S
 	}
 	defer rows.Close()
 
-	now := time.Now()
+	now := time.Now().UTC()
 	var servers []ServerInfo
 	for rows.Next() {
 		var s ServerInfo
@@ -1471,7 +1471,7 @@ func (d *Datastore) getServersInClusterInternal(ctx context.Context, clusterID i
 	}
 	defer rows.Close()
 
-	now := time.Now()
+	now := time.Now().UTC()
 	var servers []ServerInfo
 	for rows.Next() {
 		var s ServerInfo


### PR DESCRIPTION
## Summary

- **Crypto compatibility**: Collector can decrypt passwords using both the server's random-salt format and the legacy username-salt format
- **Timezone fix**: The collector was storing timestamps in local time while the server compared against UTC. This caused two issues:
  - Servers showed as "Initializing" instead of "Online" (status calculation compared current UTC time against local-time timestamps, making recent data appear stale)
  - All time-based client views were offset by the user's timezone difference from UTC (e.g., a user in EST would see data appear 5 hours older than it actually was, affecting metrics, timeline events, and any time-range queries)
- **Gitignore**: Added `server/data/` to prevent committing runtime auth databases

## Test plan

- [ ] Verify servers show correct status (Online/Warning/Offline) regardless of user timezone
- [ ] Verify timeline events and metrics display with correct timestamps
- [ ] Verify collector can connect to databases with passwords encrypted by the server

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password decryption to support both legacy and current encryption formats with automatic fallback.
  * Fixed timestamp calculations to use UTC consistently across metrics and server status tracking.
  * Enhanced configuration management to properly merge connection security settings.

* **Chores**
  * Updated ignore patterns for runtime data directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->