### PR TITLE
Fix wildcard admin permission check in UI (#70)

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -15,6 +15,11 @@ import { clearAlertAnalysisCache } from '../hooks/useAlertAnalysis';
 import { clearChartAnalysisCache } from '../hooks/useChartAnalysis';
 import { clearAnalysisCache as clearServerAnalysisCache } from '../hooks/useServerAnalysis';
 
+// Wildcard entry in admin_permissions that grants every admin permission.
+// Mirrors the server-side constant AdminPermissionWildcard in
+// server/src/internal/auth/token_scope.go.
+export const ADMIN_PERMISSION_WILDCARD = '*';
+
 export interface User {
     authenticated: boolean;
     username: string;
@@ -147,6 +152,7 @@ export const AuthProvider = ({ children }: AuthProviderProps): React.ReactElemen
     // Check if the user has a specific admin permission
     const hasPermission = useCallback((perm: string): boolean => {
         if (user?.isSuperuser) {return true;}
+        if (adminPermissions.includes(ADMIN_PERMISSION_WILDCARD)) {return true;}
         return adminPermissions.includes(perm);
     }, [user?.isSuperuser, adminPermissions]);
 

--- a/client/src/contexts/__tests__/AuthContext.test.tsx
+++ b/client/src/contexts/__tests__/AuthContext.test.tsx
@@ -11,7 +11,7 @@
 import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { AuthProvider, useAuth } from '../AuthContext';
+import { ADMIN_PERMISSION_WILDCARD, AuthProvider, useAuth } from '../AuthContext';
 
 // Mock fetch
 const mockFetch = vi.fn();
@@ -664,7 +664,7 @@ describe('AuthContext', () => {
             mockCheckAuthAuthenticated({
                 username: 'testuser',
                 is_superuser: false,
-                admin_permissions: ['*'],
+                admin_permissions: [ADMIN_PERMISSION_WILDCARD],
             });
 
             const { result } = renderHook(() => useAuth(), { wrapper });
@@ -683,7 +683,7 @@ describe('AuthContext', () => {
             mockCheckAuthAuthenticated({
                 username: 'testuser',
                 is_superuser: false,
-                admin_permissions: ['*', 'manage_users'],
+                admin_permissions: [ADMIN_PERMISSION_WILDCARD, 'manage_users'],
             });
 
             const { result } = renderHook(() => useAuth(), { wrapper });

--- a/client/src/contexts/__tests__/AuthContext.test.tsx
+++ b/client/src/contexts/__tests__/AuthContext.test.tsx
@@ -660,6 +660,82 @@ describe('AuthContext', () => {
             expect(result.current.hasPermission('any_permission')).toBe(true);
         });
 
+        it('hasPermission returns true for any admin permission when wildcard is granted', async () => {
+            mockCheckAuthAuthenticated({
+                username: 'testuser',
+                is_superuser: false,
+                admin_permissions: ['*'],
+            });
+
+            const { result } = renderHook(() => useAuth(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.hasPermission('manage_users')).toBe(true);
+            expect(result.current.hasPermission('manage_groups')).toBe(true);
+            expect(result.current.hasPermission('manage_permissions')).toBe(true);
+            expect(result.current.hasPermission('manage_token_scopes')).toBe(true);
+        });
+
+        it('hasPermission returns true for all permissions when wildcard is combined with specific perms', async () => {
+            mockCheckAuthAuthenticated({
+                username: 'testuser',
+                is_superuser: false,
+                admin_permissions: ['*', 'manage_users'],
+            });
+
+            const { result } = renderHook(() => useAuth(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.hasPermission('manage_users')).toBe(true);
+            expect(result.current.hasPermission('manage_groups')).toBe(true);
+            expect(result.current.hasPermission('manage_permissions')).toBe(true);
+            expect(result.current.hasPermission('manage_token_scopes')).toBe(true);
+        });
+
+        it('hasPermission returns false for any permission when admin_permissions is empty', async () => {
+            mockCheckAuthAuthenticated({
+                username: 'testuser',
+                is_superuser: false,
+                admin_permissions: [],
+            });
+
+            const { result } = renderHook(() => useAuth(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.hasPermission('manage_users')).toBe(false);
+            expect(result.current.hasPermission('manage_groups')).toBe(false);
+            expect(result.current.hasPermission('manage_permissions')).toBe(false);
+            expect(result.current.hasPermission('manage_token_scopes')).toBe(false);
+        });
+
+        it('hasPermission does not treat a specific permission as a wildcard (regression guard)', async () => {
+            mockCheckAuthAuthenticated({
+                username: 'testuser',
+                is_superuser: false,
+                admin_permissions: ['manage_users'],
+            });
+
+            const { result } = renderHook(() => useAuth(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.hasPermission('manage_users')).toBe(true);
+            expect(result.current.hasPermission('manage_groups')).toBe(false);
+            expect(result.current.hasPermission('manage_permissions')).toBe(false);
+            expect(result.current.hasPermission('manage_token_scopes')).toBe(false);
+        });
+
         it('hasAnyAdminAccess is true for superusers', async () => {
             mockCheckAuthAuthenticated({
                 username: 'admin',


### PR DESCRIPTION
## Summary

Fixes #70.

- The server returns `admin_permissions: ["*"]` when a group is granted **All Admin Permissions**, but `AuthContext.hasPermission()` used a plain `adminPermissions.includes(perm)` check, so the wildcard was never expanded. Non-superusers in wildcard-granted groups saw an empty Security section in the Admin Panel.
- `hasPermission()` now returns `true` when `adminPermissions` contains `"*"`, mirroring the server-side `AdminPermissionWildcard` constant (`server/src/internal/auth/token_scope.go`, `server/src/internal/auth/access.go:538`).
- Exported `ADMIN_PERMISSION_WILDCARD = '*'` near the top of `client/src/contexts/AuthContext.tsx` for shared use.

## Test plan

- [x] Added 4 unit tests in `client/src/contexts/__tests__/AuthContext.test.tsx`:
  - Wildcard grants every admin permission.
  - Wildcard combined with a specific permission still grants all.
  - Empty `admin_permissions` denies every permission.
  - Regression guard: a specific permission is not treated as a wildcard.
- [x] `vitest run src/contexts/__tests__/AuthContext.test.tsx` — 35 passed.
- [x] ESLint clean on changed files.
- [ ] Manual verification: log in as a non-superuser whose group has only the `*` admin permission; confirm Users, Groups, Permissions, and Tokens sections appear under Security.

https://claude.ai/code/session_01Q72eXXSP7Dhfgdq3aGESvi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin roles can now include a wildcard permission (`*`) that grants all admin permissions automatically.
* **Tests**
  * Expanded test coverage for admin permission checks, including wildcard behavior, mixed wildcard+specific permissions, empty permissions, and single-permission cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->