### PR TITLE
Fix empty token scope dropdowns for wildcard owners (#73)

### DIFF
--- a/client/src/components/AdminPanel/AdminTokenScopes.tsx
+++ b/client/src/components/AdminPanel/AdminTokenScopes.tsx
@@ -299,18 +299,26 @@ const AdminTokenScopes: React.FC = () => {
                 }
                 // Filter MCP privileges to those the user has
                 const allowedMcp = data.mcp_privileges || [];
-                setOwnerMcpPrivileges(
-                    mcpPrivileges.filter((p: McpPrivilege) =>
-                        allowedMcp.includes(p.identifier)
-                    )
-                );
+                if (allowedMcp.includes('*')) {
+                    setOwnerMcpPrivileges(mcpPrivileges);
+                } else {
+                    setOwnerMcpPrivileges(
+                        mcpPrivileges.filter((p: McpPrivilege) =>
+                            allowedMcp.includes(p.identifier)
+                        )
+                    );
+                }
                 // Filter admin permissions to those the user has
                 const allowedAdmin = data.admin_permissions || [];
-                setOwnerAdminPermissions(
-                    ADMIN_PERMISSIONS.filter(p =>
-                        allowedAdmin.includes(p.id)
-                    )
-                );
+                if (allowedAdmin.includes('*')) {
+                    setOwnerAdminPermissions(ADMIN_PERMISSIONS);
+                } else {
+                    setOwnerAdminPermissions(
+                        ADMIN_PERMISSIONS.filter(p =>
+                            allowedAdmin.includes(p.id)
+                        )
+                    );
+                }
             }
         } catch {
             // If privilege fetch fails, show all options as fallback
@@ -424,17 +432,25 @@ const AdminTokenScopes: React.FC = () => {
                         );
                     }
                     const allowedMcp = data.mcp_privileges || [];
-                    setEditAvailableMcpPrivileges(
-                        mcpPrivileges.filter((p: McpPrivilege) =>
-                            allowedMcp.includes(p.identifier)
-                        )
-                    );
+                    if (allowedMcp.includes('*')) {
+                        setEditAvailableMcpPrivileges(mcpPrivileges);
+                    } else {
+                        setEditAvailableMcpPrivileges(
+                            mcpPrivileges.filter((p: McpPrivilege) =>
+                                allowedMcp.includes(p.identifier)
+                            )
+                        );
+                    }
                     const allowedAdmin = data.admin_permissions || [];
-                    setEditAvailableAdminPermissions(
-                        ADMIN_PERMISSIONS.filter(p =>
-                            allowedAdmin.includes(p.id)
-                        )
-                    );
+                    if (allowedAdmin.includes('*')) {
+                        setEditAvailableAdminPermissions(ADMIN_PERMISSIONS);
+                    } else {
+                        setEditAvailableAdminPermissions(
+                            ADMIN_PERMISSIONS.filter(p =>
+                                allowedAdmin.includes(p.id)
+                            )
+                        );
+                    }
                 }
             } catch {
                 setEditOwnerIsSuperuser(false);

--- a/client/src/components/AdminPanel/AdminTokenScopes.tsx
+++ b/client/src/components/AdminPanel/AdminTokenScopes.tsx
@@ -153,6 +153,25 @@ interface UserPrivilegesResponse {
     admin_permissions?: string[];
 }
 
+const filterMcpPrivileges = (
+    allPrivileges: McpPrivilege[],
+    allowedIdentifiers: string[],
+): McpPrivilege[] => {
+    if (allowedIdentifiers.includes('*')) {
+        return allPrivileges;
+    }
+    return allPrivileges.filter((p) => allowedIdentifiers.includes(p.identifier));
+};
+
+const filterAdminPermissions = (
+    allowedPermissionIds: string[],
+): AdminPermissionEntry[] => {
+    if (allowedPermissionIds.includes('*')) {
+        return ADMIN_PERMISSIONS;
+    }
+    return ADMIN_PERMISSIONS.filter((p) => allowedPermissionIds.includes(p.id));
+};
+
 const AdminTokenScopes: React.FC = () => {
     const theme = useTheme();
     const [tokens, setTokens] = useState<Token[]>([]);
@@ -298,27 +317,9 @@ const AdminTokenScopes: React.FC = () => {
                     );
                 }
                 // Filter MCP privileges to those the user has
-                const allowedMcp = data.mcp_privileges || [];
-                if (allowedMcp.includes('*')) {
-                    setOwnerMcpPrivileges(mcpPrivileges);
-                } else {
-                    setOwnerMcpPrivileges(
-                        mcpPrivileges.filter((p: McpPrivilege) =>
-                            allowedMcp.includes(p.identifier)
-                        )
-                    );
-                }
+                setOwnerMcpPrivileges(filterMcpPrivileges(mcpPrivileges, data.mcp_privileges || []));
                 // Filter admin permissions to those the user has
-                const allowedAdmin = data.admin_permissions || [];
-                if (allowedAdmin.includes('*')) {
-                    setOwnerAdminPermissions(ADMIN_PERMISSIONS);
-                } else {
-                    setOwnerAdminPermissions(
-                        ADMIN_PERMISSIONS.filter(p =>
-                            allowedAdmin.includes(p.id)
-                        )
-                    );
-                }
+                setOwnerAdminPermissions(filterAdminPermissions(data.admin_permissions || []));
             }
         } catch {
             // If privilege fetch fails, show all options as fallback
@@ -431,26 +432,8 @@ const AdminTokenScopes: React.FC = () => {
                             )
                         );
                     }
-                    const allowedMcp = data.mcp_privileges || [];
-                    if (allowedMcp.includes('*')) {
-                        setEditAvailableMcpPrivileges(mcpPrivileges);
-                    } else {
-                        setEditAvailableMcpPrivileges(
-                            mcpPrivileges.filter((p: McpPrivilege) =>
-                                allowedMcp.includes(p.identifier)
-                            )
-                        );
-                    }
-                    const allowedAdmin = data.admin_permissions || [];
-                    if (allowedAdmin.includes('*')) {
-                        setEditAvailableAdminPermissions(ADMIN_PERMISSIONS);
-                    } else {
-                        setEditAvailableAdminPermissions(
-                            ADMIN_PERMISSIONS.filter(p =>
-                                allowedAdmin.includes(p.id)
-                            )
-                        );
-                    }
+                    setEditAvailableMcpPrivileges(filterMcpPrivileges(mcpPrivileges, data.mcp_privileges || []));
+                    setEditAvailableAdminPermissions(filterAdminPermissions(data.admin_permissions || []));
                 }
             } catch {
                 setEditOwnerIsSuperuser(false);

--- a/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
@@ -67,6 +67,18 @@ const setupApiGetMock = () => {
     });
 };
 
+const expectedAdminLabels = [
+    'Manage Connections',
+    'Manage Groups',
+    'Manage Permissions',
+    'Manage Users',
+    'Manage Token Scopes',
+    'Manage Blackouts',
+    'Manage Probes',
+    'Manage Alert Rules',
+    'Manage Notification Channels',
+];
+
 describe('AdminTokenScopes', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -122,17 +134,88 @@ describe('AdminTokenScopes', () => {
         expect(
             within(adminListbox).getByRole('option', { name: 'All Admin Permissions' }),
         ).toBeInTheDocument();
-        const expectedAdminLabels = [
-            'Manage Connections',
-            'Manage Groups',
-            'Manage Permissions',
-            'Manage Users',
-            'Manage Token Scopes',
-            'Manage Blackouts',
-            'Manage Probes',
-            'Manage Alert Rules',
-            'Manage Notification Channels',
-        ];
+        for (const label of expectedAdminLabels) {
+            expect(
+                within(adminListbox).getByRole('option', { name: label }),
+            ).toBeInTheDocument();
+        }
+    });
+
+    it('exposes all MCP and admin options in edit dialog when owner has wildcard privileges', async () => {
+        const TOKEN = {
+            id: 7,
+            name: 'alice-token',
+            token_prefix: 'abc',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: false,
+                    connection_privileges: {},
+                    mcp_privileges: ['*'],
+                    admin_permissions: ['*'],
+                });
+            }
+            return Promise.reject(new Error(`Unexpected URL: ${url}`));
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        const editButton = await screen.findByRole('button', { name: /edit token/i });
+        await user.click(editButton);
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledWith(
+                `/api/v1/rbac/users/${USERS[0].id}/privileges`,
+            );
+        });
+
+        const mcpCombo = await screen.findByRole('combobox', {
+            name: /allowed mcp privileges/i,
+        });
+        await user.click(mcpCombo);
+
+        const mcpListbox = await screen.findByRole('listbox');
+        expect(
+            within(mcpListbox).getByRole('option', { name: 'All MCP Privileges' }),
+        ).toBeInTheDocument();
+        for (const priv of MCP_PRIVILEGES) {
+            expect(
+                within(mcpListbox).getByRole('option', { name: priv.identifier }),
+            ).toBeInTheDocument();
+        }
+
+        await user.keyboard('{Escape}');
+
+        const adminCombo = screen.getByRole('combobox', {
+            name: /allowed admin permissions/i,
+        });
+        await user.click(adminCombo);
+
+        const adminListbox = await screen.findByRole('listbox');
+        expect(
+            within(adminListbox).getByRole('option', { name: 'All Admin Permissions' }),
+        ).toBeInTheDocument();
         for (const label of expectedAdminLabels) {
             expect(
                 within(adminListbox).getByRole('option', { name: label }),

--- a/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
@@ -1,0 +1,142 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+const mockApiPut = vi.fn();
+const mockApiDelete = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+}));
+
+import AdminTokenScopes from '../AdminTokenScopes';
+
+const MCP_PRIVILEGES = [
+    { id: 1, identifier: 'query_read' },
+    { id: 2, identifier: 'query_write' },
+    { id: 3, identifier: 'schema_read' },
+];
+
+const USERS = [
+    { id: 42, username: 'alice' },
+];
+
+const CONNECTIONS = [
+    { id: 100, name: 'primary-db' },
+];
+
+const setupApiGetMock = () => {
+    mockApiGet.mockImplementation((url: string) => {
+        if (url === '/api/v1/rbac/tokens') {
+            return Promise.resolve({ tokens: [] });
+        }
+        if (url === '/api/v1/connections') {
+            return Promise.resolve({ connections: CONNECTIONS });
+        }
+        if (url === '/api/v1/rbac/privileges/mcp') {
+            return Promise.resolve(MCP_PRIVILEGES);
+        }
+        if (url === '/api/v1/rbac/users') {
+            return Promise.resolve({ users: USERS });
+        }
+        if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+            return Promise.resolve({
+                is_superuser: false,
+                connection_privileges: {},
+                mcp_privileges: ['*'],
+                admin_permissions: ['*'],
+            });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+};
+
+describe('AdminTokenScopes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('exposes all MCP and admin options when owner has wildcard privileges', async () => {
+        setupApiGetMock();
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /create token/i }))
+                .toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        const ownerCombo = await screen.findByRole('combobox', { name: /owner/i });
+        await user.click(ownerCombo);
+        const ownerOption = await screen.findByRole('option', { name: 'alice' });
+        await user.click(ownerOption);
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledWith(
+                `/api/v1/rbac/users/${USERS[0].id}/privileges`,
+            );
+        });
+
+        const mcpCombo = screen.getByRole('combobox', {
+            name: /allowed mcp privileges/i,
+        });
+        await user.click(mcpCombo);
+
+        const mcpListbox = await screen.findByRole('listbox');
+        expect(
+            within(mcpListbox).getByRole('option', { name: 'All MCP Privileges' }),
+        ).toBeInTheDocument();
+        for (const priv of MCP_PRIVILEGES) {
+            expect(
+                within(mcpListbox).getByRole('option', { name: priv.identifier }),
+            ).toBeInTheDocument();
+        }
+
+        await user.keyboard('{Escape}');
+
+        const adminCombo = screen.getByRole('combobox', {
+            name: /allowed admin permissions/i,
+        });
+        await user.click(adminCombo);
+
+        const adminListbox = await screen.findByRole('listbox');
+        expect(
+            within(adminListbox).getByRole('option', { name: 'All Admin Permissions' }),
+        ).toBeInTheDocument();
+        const expectedAdminLabels = [
+            'Manage Connections',
+            'Manage Groups',
+            'Manage Permissions',
+            'Manage Users',
+            'Manage Token Scopes',
+            'Manage Blackouts',
+            'Manage Probes',
+            'Manage Alert Rules',
+            'Manage Notification Channels',
+        ];
+        for (const label of expectedAdminLabels) {
+            expect(
+                within(adminListbox).getByRole('option', { name: label }),
+            ).toBeInTheDocument();
+        }
+    });
+});


### PR DESCRIPTION
Fixes #73.

## Summary
- When a token owner inherits `*` MCP or admin privileges through a group, the Create/Edit Token dialogs rendered empty Allowed MCP Privileges and Allowed Admin Permissions dropdowns. The client filter used strict `Array.includes` against option identifiers, so the wildcard never matched any real option and the intersection was empty.
- `AuthContext.hasPermission` had the same bug: non-superusers with wildcard admin grants silently lost access to admin UI.
- Short-circuits the filters in `handleOwnerChange` and `handleOpenEdit` (`AdminTokenScopes.tsx`) and `hasPermission` (`AuthContext.tsx`) when the privilege list contains `'*'`, assigning the full option set. This mirrors the existing connection-privilege wildcard pattern (`id === 0`) in the same file.

## Changes
- `client/src/components/AdminPanel/AdminTokenScopes.tsx` — wildcard short-circuit in `handleOwnerChange` and `handleOpenEdit` for both MCP and admin filters.
- `client/src/contexts/AuthContext.tsx` — wildcard short-circuit in `hasPermission` alongside the existing `isSuperuser` check.
- `client/src/contexts/__tests__/AuthContext.test.tsx` — new test: non-superuser with `admin_permissions: ['*']` returns `true` from `hasPermission`.
- `client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx` — new test file: both dropdowns expose the full option list when owner privileges are `['*']`.

## Test plan
- [x] `cd client && npm test -- --run` — 38 files / 583 tests pass locally.
- [x] New `AuthContext` wildcard test passes.
- [x] New `AdminTokenScopes` wildcard test passes.
- [ ] Manual smoke test: create a user in a group with `*` MCP and `*` admin grants, open Create Token, select that user as owner, confirm both dropdowns populate.

https://claude.ai/code/session_01FdNPR1rxZLyv57JzoE8UtZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for admin token scope creation and editing flows with MCP privileges and admin permissions validation.

* **Bug Fixes**
  * Improved wildcard privilege handling in admin token scope management to display full available options when wildcard permissions are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->