### PR TITLE
Exclude manually-assigned servers from auto-detected clusters (#74)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,13 @@ project adheres to
   lookups. (#36)
 - Fix partitions not being dropped at the appropriate
   time by the collector. (#62)
+- Fix servers assigned to a manually created cluster
+  continuing to appear under a re-created
+  auto-detected cluster after the next topology
+  refresh; auto-detected Spock, binary-replication,
+  and logical-replication grouping now skip
+  connections with `membership_source = 'manual'`.
+  (#74)
 
 ### Security
 

--- a/server/src/internal/database/datastore.go
+++ b/server/src/internal/database/datastore.go
@@ -2339,7 +2339,8 @@ func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, 
 			continue
 		}
 		if !conn.HasSpock && (conn.PrimaryRole == "binary_primary" && len(childrenMap[conn.ID]) > 0) {
-			server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections)
+			// Auto binary cluster: exclude manually pinned children.
+			server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections, false)
 			autoKey := fmt.Sprintf("binary:%d", conn.ID)
 			clusterName := conn.Name
 			clusterDescription := ""
@@ -2373,8 +2374,9 @@ func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, 
 		if assignedConnections[conn.ID] {
 			continue
 		}
-		// Build server info
-		server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections)
+		// Build server info. Standalone is an auto-detected entry, so
+		// manually pinned children must not be pulled into it.
+		server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections, false)
 		autoKey := fmt.Sprintf("standalone:%d", conn.ID)
 		clusterName := conn.Name
 		clusterDescription := ""
@@ -3529,8 +3531,9 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 				continue
 			}
 
-			// Build server with children
-			server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections)
+			// Build server with children. This is an auto binary
+			// cluster, so manually pinned standbys must be excluded.
+			server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections, false)
 
 			clusterName := conn.Name
 			clusterDescription := ""
@@ -3584,8 +3587,10 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 			continue
 		}
 
-		// Build server (with any children if applicable)
-		server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections)
+		// Build server (with any children if applicable). Standalone is
+		// an auto-detected entry, so manually pinned children must not
+		// leak into its tree.
+		server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections, false)
 		standaloneDescription := ""
 		if override, ok := clusterOverrides[autoKey]; ok {
 			standaloneDescription = override.Description
@@ -3668,8 +3673,10 @@ func (d *Datastore) groupSpockNodesByClusters(
 		}
 
 		for _, node := range nodes {
-			// Use buildServerWithChildren to include hot standbys as children
-			server := d.buildServerWithChildren(node, childrenMap, connByID, assignedConnections)
+			// Use buildServerWithChildren to include hot standbys as
+			// children. This is an auto Spock (or Spock HA) cluster, so
+			// manually pinned hot standbys must be excluded.
+			server := d.buildServerWithChildren(node, childrenMap, connByID, assignedConnections, false)
 			cluster.Servers = append(cluster.Servers, server)
 		}
 
@@ -3876,12 +3883,20 @@ func (d *Datastore) extractClusterPrefix(name string) string {
 	return name
 }
 
-// buildServerWithChildren recursively builds server tree with standbys as children
+// buildServerWithChildren recursively builds server tree with standbys as children.
+//
+// The allowManual parameter controls whether children whose
+// MembershipSource is "manual" are included in the returned tree. Auto
+// cluster builders (binary, spock, standalone) must pass false so that a
+// child pinned to a manual cluster does not leak into the auto-detected
+// tree; manual cluster builders (which legitimately include every server
+// they own) must pass true. See issue #74.
 func (d *Datastore) buildServerWithChildren(
 	conn *connectionWithRole,
 	childrenMap map[int][]int,
 	connByID map[int]*connectionWithRole,
 	assignedConnections map[int]bool,
+	allowManual bool,
 ) TopologyServerInfo {
 	assignedConnections[conn.ID] = true
 
@@ -3941,12 +3956,20 @@ func (d *Datastore) buildServerWithChildren(
 		server.ConnectionError = conn.ConnectionError.String
 	}
 
-	// Recursively add children
+	// Recursively add children. When allowManual is false, skip any
+	// child whose MembershipSource is "manual": that connection has been
+	// pinned to a manually created cluster and must not leak into the
+	// auto-detected tree (issue #74).
 	for _, childID := range childrenMap[conn.ID] {
-		if child, exists := connByID[childID]; exists && !assignedConnections[childID] {
-			childServer := d.buildServerWithChildren(child, childrenMap, connByID, assignedConnections)
-			server.Children = append(server.Children, childServer)
+		child, exists := connByID[childID]
+		if !exists || assignedConnections[childID] {
+			continue
 		}
+		if !allowManual && child.MembershipSource == "manual" {
+			continue
+		}
+		childServer := d.buildServerWithChildren(child, childrenMap, connByID, assignedConnections, allowManual)
+		server.Children = append(server.Children, childServer)
 	}
 
 	return server

--- a/server/src/internal/database/datastore.go
+++ b/server/src/internal/database/datastore.go
@@ -2309,10 +2309,13 @@ func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, 
 	}
 
 	// Process Spock clusters
+	// Exclude connections with membership_source = 'manual'; those are
+	// pinned to a manually created cluster and must not be re-grouped
+	// into an auto-detected cluster on the next topology refresh.
 	spockNodes := make([]*connectionWithRole, 0)
 	for i := range connections {
 		conn := &connections[i]
-		if conn.HasSpock && conn.PrimaryRole != "binary_standby" {
+		if conn.HasSpock && conn.PrimaryRole != "binary_standby" && conn.MembershipSource != "manual" {
 			spockNodes = append(spockNodes, conn)
 		}
 	}
@@ -2325,9 +2328,14 @@ func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, 
 	}
 
 	// Process binary replication clusters
+	// Skip connections pinned to a manual cluster (membership_source =
+	// 'manual'); they must not feed auto-detected cluster creation.
 	for i := range connections {
 		conn := &connections[i]
 		if assignedConnections[conn.ID] {
+			continue
+		}
+		if conn.MembershipSource == "manual" {
 			continue
 		}
 		if !conn.HasSpock && (conn.PrimaryRole == "binary_primary" && len(childrenMap[conn.ID]) > 0) {
@@ -3470,13 +3478,16 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 	}
 
 	// Identify Spock nodes (has_spock=true AND not a standby)
-	// These are the actual Spock multi-master nodes
+	// These are the actual Spock multi-master nodes.
+	// Connections with membership_source = 'manual' are pinned to a
+	// manually created cluster and must be excluded from auto-detected
+	// Spock grouping; otherwise they would appear in both clusters.
 	spockNodes := make([]*connectionWithRole, 0)
 	for i := range connections {
 		conn := &connections[i]
 		// A Spock node has Spock installed and is not a binary standby
 		// (binary standbys with Spock are hot standbys of Spock nodes)
-		if conn.HasSpock && conn.PrimaryRole != "binary_standby" {
+		if conn.HasSpock && conn.PrimaryRole != "binary_standby" && conn.MembershipSource != "manual" {
 			spockNodes = append(spockNodes, conn)
 		}
 	}
@@ -3497,10 +3508,15 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 	}
 
 	// 2. Create entries for non-Spock primaries with standbys (binary replication)
-	// These now get a cluster wrapper with type "binary" so UI shows cluster header
+	// These now get a cluster wrapper with type "binary" so UI shows cluster header.
+	// Skip connections pinned to a manual cluster (membership_source =
+	// 'manual'); they must not feed auto-detected cluster creation.
 	for i := range connections {
 		conn := &connections[i]
 		if assignedConnections[conn.ID] {
+			continue
+		}
+		if conn.MembershipSource == "manual" {
 			continue
 		}
 		// Check if this is a primary with standbys (and not a Spock node)
@@ -3673,12 +3689,18 @@ func (d *Datastore) groupLogicalReplicationByPublisher(
 	assignedConnections map[int]bool,
 	overrides map[string]clusterOverride,
 ) []TopologyCluster {
-	// Build publisher->subscribers map by matching publisher_host:port to connections
+	// Build publisher->subscribers map by matching publisher_host:port to connections.
+	// Subscribers or publishers with membership_source = 'manual' are
+	// pinned to a manually created cluster and must not be used to build
+	// an auto-detected logical-replication cluster.
 	subscribersByPublisher := make(map[int][]*connectionWithRole) // publisher connection ID -> subscribers
 
 	for i := range connections {
 		conn := &connections[i]
 		if assignedConnections[conn.ID] {
+			continue
+		}
+		if conn.MembershipSource == "manual" {
 			continue
 		}
 
@@ -3702,7 +3724,7 @@ func (d *Datastore) groupLogicalReplicationByPublisher(
 			publisher = pub
 		}
 
-		if publisher != nil && !assignedConnections[publisher.ID] {
+		if publisher != nil && !assignedConnections[publisher.ID] && publisher.MembershipSource != "manual" {
 			subscribersByPublisher[publisher.ID] = append(subscribersByPublisher[publisher.ID], conn)
 		}
 	}

--- a/server/src/internal/database/topology_manual_membership_test.go
+++ b/server/src/internal/database/topology_manual_membership_test.go
@@ -1,0 +1,290 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestTopologyExcludesManualMembersFromAutoClusters is the regression test
+// for issue #74. When a user deletes an auto-detected (Spock) cluster and
+// its servers, re-adds those servers, and assigns them to a manually
+// created cluster (which sets connections.membership_source = 'manual'),
+// the next topology refresh must NOT regroup those servers under a
+// re-created auto-detected Spock cluster.
+//
+// The two topology builders exercised here are pure functions that
+// operate on in-memory []connectionWithRole slices, so the test runs
+// without a database.
+func TestTopologyExcludesManualMembersFromAutoClusters(t *testing.T) {
+	ds := &Datastore{}
+
+	// Three Spock nodes that share a naming prefix ("pg17-") would
+	// normally form an auto-detected Spock cluster. Here all three are
+	// pinned to a manually created cluster (membership_source='manual'),
+	// so they must not appear under any auto-detected cluster.
+	manualSpockConns := []connectionWithRole{
+		{
+			ID:               101,
+			Name:             "pg17-node1",
+			Host:             "10.0.0.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "spock_node",
+			HasSpock:         true,
+			MembershipSource: "manual",
+			Status:           "online",
+			ClusterID:        sql.NullInt64{Int64: 42, Valid: true},
+		},
+		{
+			ID:               102,
+			Name:             "pg17-node2",
+			Host:             "10.0.0.2",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "spock_node",
+			HasSpock:         true,
+			MembershipSource: "manual",
+			Status:           "online",
+			ClusterID:        sql.NullInt64{Int64: 42, Valid: true},
+		},
+		{
+			ID:               103,
+			Name:             "pg17-node3",
+			Host:             "10.0.0.3",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "spock_node",
+			HasSpock:         true,
+			MembershipSource: "manual",
+			Status:           "online",
+			ClusterID:        sql.NullInt64{Int64: 42, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	// buildAutoDetectedClusters must not produce a Spock cluster for the
+	// "pg17-" prefix when every candidate is pinned to a manual cluster.
+	autoClusters := ds.buildAutoDetectedClusters(manualSpockConns, overrides)
+	if cluster, ok := autoClusters["spock:pg17"]; ok {
+		t.Fatalf("manual Spock members were regrouped into auto cluster %q with %d servers (issue #74)",
+			cluster.AutoClusterKey, len(cluster.Servers))
+	}
+	for key, cluster := range autoClusters {
+		if cluster.ClusterType == "spock" || cluster.ClusterType == "spock_ha" {
+			t.Fatalf("unexpected auto Spock cluster %q (%s) containing %d manual servers",
+				key, cluster.ClusterType, len(cluster.Servers))
+		}
+	}
+
+	// buildTopologyHierarchy must not expose the same connections as an
+	// auto-detected Spock cluster inside the default group either. Any
+	// clusters produced here should be "server" (standalone) entries
+	// carrying the manual servers individually at most; however, because
+	// each connection has cluster_id set, they are also skipped from the
+	// standalone branch. Either way, no cluster with type "spock" or
+	// "spock_ha" should be returned.
+	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
+	claimed := map[string]bool{}
+	groups := ds.buildTopologyHierarchy(manualSpockConns, overrides, claimed, defaultGroup)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 topology group, got %d", len(groups))
+	}
+	for _, cluster := range groups[0].Clusters {
+		if cluster.ClusterType == "spock" || cluster.ClusterType == "spock_ha" {
+			t.Fatalf("buildTopologyHierarchy produced auto Spock cluster %q for manual members (issue #74)",
+				cluster.AutoClusterKey)
+		}
+		// The manual servers also must not leak out as auto-detected
+		// binary or logical clusters.
+		if cluster.ClusterType == "binary" || cluster.ClusterType == "logical" {
+			for _, s := range cluster.Servers {
+				if s.MembershipSource == "manual" {
+					t.Fatalf("manual server %d (%s) surfaced in auto %s cluster %q (issue #74)",
+						s.ID, s.Name, cluster.ClusterType, cluster.AutoClusterKey)
+				}
+			}
+		}
+	}
+}
+
+// TestTopologyExcludesManualBinaryPrimaryFromAutoClusters verifies that
+// a manually pinned binary primary (with a streaming standby child) is
+// not regrouped under an auto-detected binary cluster.
+func TestTopologyExcludesManualBinaryPrimaryFromAutoClusters(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               201,
+			Name:             "prod-primary",
+			Host:             "10.0.1.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "binary_primary",
+			MembershipSource: "manual",
+			Status:           "online",
+			ClusterID:        sql.NullInt64{Int64: 99, Valid: true},
+		},
+		{
+			ID:                 202,
+			Name:               "prod-standby",
+			Host:               "10.0.1.2",
+			Port:               5432,
+			DatabaseName:       "app",
+			Username:           "postgres",
+			PrimaryRole:        "binary_standby",
+			MembershipSource:   "manual",
+			Status:             "online",
+			IsStreamingStandby: true,
+			UpstreamHost:       sql.NullString{String: "10.0.1.1", Valid: true},
+			UpstreamPort:       sql.NullInt32{Int32: 5432, Valid: true},
+			ClusterID:          sql.NullInt64{Int64: 99, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	if cluster, ok := autoClusters["binary:201"]; ok {
+		t.Fatalf("manual binary primary regrouped into auto cluster %q with %d servers (issue #74)",
+			cluster.AutoClusterKey, len(cluster.Servers))
+	}
+
+	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 topology group, got %d", len(groups))
+	}
+	for _, cluster := range groups[0].Clusters {
+		if cluster.ClusterType == "binary" {
+			t.Fatalf("buildTopologyHierarchy produced auto binary cluster %q for manual members (issue #74)",
+				cluster.AutoClusterKey)
+		}
+	}
+}
+
+// TestTopologyExcludesManualLogicalPublisherFromAutoClusters verifies
+// that a manually pinned logical publisher/subscriber pair does not
+// regroup into an auto-detected logical-replication cluster.
+func TestTopologyExcludesManualLogicalPublisherFromAutoClusters(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               301,
+			Name:             "pub",
+			Host:             "10.0.2.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_publisher",
+			MembershipSource: "manual",
+			Status:           "online",
+			ClusterID:        sql.NullInt64{Int64: 7, Valid: true},
+		},
+		{
+			ID:               302,
+			Name:             "sub",
+			Host:             "10.0.2.2",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_subscriber",
+			MembershipSource: "manual",
+			Status:           "online",
+			PublisherHost:    sql.NullString{String: "10.0.2.1", Valid: true},
+			PublisherPort:    sql.NullInt32{Int32: 5432, Valid: true},
+			ClusterID:        sql.NullInt64{Int64: 7, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	if cluster, ok := autoClusters["logical:301"]; ok {
+		t.Fatalf("manual logical publisher regrouped into auto cluster %q with %d servers (issue #74)",
+			cluster.AutoClusterKey, len(cluster.Servers))
+	}
+
+	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 topology group, got %d", len(groups))
+	}
+	for _, cluster := range groups[0].Clusters {
+		if cluster.ClusterType == "logical" {
+			t.Fatalf("buildTopologyHierarchy produced auto logical cluster %q for manual members (issue #74)",
+				cluster.AutoClusterKey)
+		}
+	}
+}
+
+// TestTopologyIncludesAutoMembersInAutoClusters is a sanity check that
+// the manual-membership filter does not accidentally suppress genuine
+// auto-detected clusters. Three Spock nodes with membership_source =
+// 'auto' must still form a spock cluster.
+func TestTopologyIncludesAutoMembersInAutoClusters(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               401,
+			Name:             "pg17-node1",
+			Host:             "10.0.3.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "spock_node",
+			HasSpock:         true,
+			MembershipSource: "auto",
+			Status:           "online",
+		},
+		{
+			ID:               402,
+			Name:             "pg17-node2",
+			Host:             "10.0.3.2",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "spock_node",
+			HasSpock:         true,
+			MembershipSource: "auto",
+			Status:           "online",
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	cluster, ok := autoClusters["spock:pg17"]
+	if !ok {
+		t.Fatalf("expected auto Spock cluster %q for two auto Spock nodes; got keys %v",
+			"spock:pg17", keysOf(autoClusters))
+	}
+	if len(cluster.Servers) != 2 {
+		t.Fatalf("expected 2 servers in auto Spock cluster, got %d", len(cluster.Servers))
+	}
+}
+
+// keysOf returns the keys of a map[string]TopologyCluster for readable
+// test failure messages.
+func keysOf(m map[string]TopologyCluster) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/server/src/internal/database/topology_manual_membership_test.go
+++ b/server/src/internal/database/topology_manual_membership_test.go
@@ -265,17 +265,242 @@ func TestTopologyIncludesAutoMembersInAutoClusters(t *testing.T) {
 			MembershipSource: "auto",
 			Status:           "online",
 		},
+		{
+			ID:               403,
+			Name:             "pg17-node3",
+			Host:             "10.0.3.3",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "spock_node",
+			HasSpock:         true,
+			MembershipSource: "auto",
+			Status:           "online",
+		},
 	}
 
 	overrides := map[string]clusterOverride{}
 	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
 	cluster, ok := autoClusters["spock:pg17"]
 	if !ok {
-		t.Fatalf("expected auto Spock cluster %q for two auto Spock nodes; got keys %v",
+		t.Fatalf("expected auto Spock cluster %q for three auto Spock nodes; got keys %v",
 			"spock:pg17", keysOf(autoClusters))
 	}
-	if len(cluster.Servers) != 2 {
-		t.Fatalf("expected 2 servers in auto Spock cluster, got %d", len(cluster.Servers))
+	if len(cluster.Servers) != 3 {
+		t.Fatalf("expected 3 servers in auto Spock cluster, got %d", len(cluster.Servers))
+	}
+}
+
+// TestTopologyExcludesManualChildrenFromAutoBinaryCluster is a
+// regression test for the follow-up to issue #74: a child connection
+// pinned to a manual cluster must not be pulled into the auto-detected
+// tree rooted at a still-auto primary. Prior to the fix,
+// buildServerWithChildren recursed over childrenMap without inspecting
+// MembershipSource, so an auto binary primary with a manually-pinned
+// streaming standby child produced an auto cluster that contained the
+// manual standby in its Children tree.
+func TestTopologyExcludesManualChildrenFromAutoBinaryCluster(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               401,
+			Name:             "auto-primary",
+			Host:             "10.0.4.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "binary_primary",
+			MembershipSource: "auto",
+			Status:           "online",
+		},
+		{
+			ID:                 402,
+			Name:               "manual-standby",
+			Host:               "10.0.4.2",
+			Port:               5432,
+			DatabaseName:       "app",
+			Username:           "postgres",
+			PrimaryRole:        "binary_standby",
+			MembershipSource:   "manual",
+			Status:             "online",
+			IsStreamingStandby: true,
+			UpstreamHost:       sql.NullString{String: "10.0.4.1", Valid: true},
+			UpstreamPort:       sql.NullInt32{Int32: 5432, Valid: true},
+			ClusterID:          sql.NullInt64{Int64: 55, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	// buildAutoDetectedClusters must produce the auto binary cluster for
+	// the primary (it still has the standby linked via childrenMap), but
+	// the Children list of that primary must not contain the manually
+	// pinned standby.
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	cluster, ok := autoClusters["binary:401"]
+	if !ok {
+		t.Fatalf("expected auto binary cluster %q for auto primary; got keys %v",
+			"binary:401", keysOf(autoClusters))
+	}
+	if len(cluster.Servers) != 1 {
+		t.Fatalf("expected 1 top-level server in auto binary cluster, got %d",
+			len(cluster.Servers))
+	}
+	primary := cluster.Servers[0]
+	if primary.ID != 401 {
+		t.Fatalf("expected primary ID 401 at the top of the auto cluster, got %d", primary.ID)
+	}
+	for _, child := range primary.Children {
+		if child.MembershipSource == "manual" {
+			t.Fatalf("manual child %d (%s) leaked into auto binary cluster %q (issue #74 follow-up)",
+				child.ID, child.Name, cluster.AutoClusterKey)
+		}
+		if child.ID == 402 {
+			t.Fatalf("manual standby 402 leaked into auto binary cluster %q (issue #74 follow-up)",
+				cluster.AutoClusterKey)
+		}
+	}
+
+	// buildTopologyHierarchy must likewise keep the manual standby out of
+	// the auto binary cluster tree in the default group.
+	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 topology group, got %d", len(groups))
+	}
+	foundAutoBinary := false
+	for _, c := range groups[0].Clusters {
+		if c.AutoClusterKey != "binary:401" {
+			continue
+		}
+		foundAutoBinary = true
+		if len(c.Servers) != 1 {
+			t.Fatalf("expected 1 top-level server in auto binary cluster, got %d",
+				len(c.Servers))
+		}
+		for _, child := range c.Servers[0].Children {
+			if child.MembershipSource == "manual" {
+				t.Fatalf("manual child %d (%s) leaked into auto binary cluster %q via buildTopologyHierarchy (issue #74 follow-up)",
+					child.ID, child.Name, c.AutoClusterKey)
+			}
+			if child.ID == 402 {
+				t.Fatalf("manual standby 402 leaked into auto binary cluster %q via buildTopologyHierarchy (issue #74 follow-up)",
+					c.AutoClusterKey)
+			}
+		}
+	}
+	if !foundAutoBinary {
+		t.Fatalf("expected buildTopologyHierarchy to return auto binary cluster %q; clusters: %+v",
+			"binary:401", groups[0].Clusters)
+	}
+}
+
+// TestTopologyExcludesManualSubscriberFromAutoLogicalCluster verifies
+// that an auto-detected logical publisher does not pick up a manually
+// pinned logical subscriber. The auto cluster is only created when the
+// publisher has at least one non-manual subscriber; a manual subscriber
+// must never appear in an auto logical cluster.
+func TestTopologyExcludesManualSubscriberFromAutoLogicalCluster(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               501,
+			Name:             "auto-pub",
+			Host:             "10.0.5.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_publisher",
+			MembershipSource: "auto",
+			Status:           "online",
+		},
+		{
+			ID:               502,
+			Name:             "auto-sub",
+			Host:             "10.0.5.2",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_subscriber",
+			MembershipSource: "auto",
+			Status:           "online",
+			PublisherHost:    sql.NullString{String: "10.0.5.1", Valid: true},
+			PublisherPort:    sql.NullInt32{Int32: 5432, Valid: true},
+		},
+		{
+			ID:               503,
+			Name:             "manual-sub",
+			Host:             "10.0.5.3",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_subscriber",
+			MembershipSource: "manual",
+			Status:           "online",
+			PublisherHost:    sql.NullString{String: "10.0.5.1", Valid: true},
+			PublisherPort:    sql.NullInt32{Int32: 5432, Valid: true},
+			ClusterID:        sql.NullInt64{Int64: 77, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	cluster, ok := autoClusters["logical:501"]
+	if !ok {
+		t.Fatalf("expected auto logical cluster %q for auto publisher; got keys %v",
+			"logical:501", keysOf(autoClusters))
+	}
+	if len(cluster.Servers) != 1 {
+		t.Fatalf("expected 1 top-level server in auto logical cluster, got %d",
+			len(cluster.Servers))
+	}
+	publisher := cluster.Servers[0]
+	if publisher.ID != 501 {
+		t.Fatalf("expected publisher ID 501 at the top of the auto cluster, got %d", publisher.ID)
+	}
+	for _, child := range publisher.Children {
+		if child.MembershipSource == "manual" {
+			t.Fatalf("manual subscriber %d (%s) leaked into auto logical cluster %q (issue #74 follow-up)",
+				child.ID, child.Name, cluster.AutoClusterKey)
+		}
+		if child.ID == 503 {
+			t.Fatalf("manual subscriber 503 leaked into auto logical cluster %q (issue #74 follow-up)",
+				cluster.AutoClusterKey)
+		}
+	}
+
+	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 topology group, got %d", len(groups))
+	}
+	foundAutoLogical := false
+	for _, c := range groups[0].Clusters {
+		if c.AutoClusterKey != "logical:501" {
+			continue
+		}
+		foundAutoLogical = true
+		if len(c.Servers) != 1 {
+			t.Fatalf("expected 1 top-level server in auto logical cluster, got %d",
+				len(c.Servers))
+		}
+		for _, child := range c.Servers[0].Children {
+			if child.MembershipSource == "manual" {
+				t.Fatalf("manual subscriber %d (%s) leaked into auto logical cluster %q via buildTopologyHierarchy (issue #74 follow-up)",
+					child.ID, child.Name, c.AutoClusterKey)
+			}
+			if child.ID == 503 {
+				t.Fatalf("manual subscriber 503 leaked into auto logical cluster %q via buildTopologyHierarchy (issue #74 follow-up)",
+					c.AutoClusterKey)
+			}
+		}
+	}
+	if !foundAutoLogical {
+		t.Fatalf("expected buildTopologyHierarchy to return auto logical cluster %q; clusters: %+v",
+			"logical:501", groups[0].Clusters)
 	}
 }
 

--- a/server/src/internal/database/topology_manual_membership_test.go
+++ b/server/src/internal/database/topology_manual_membership_test.go
@@ -504,6 +504,294 @@ func TestTopologyExcludesManualSubscriberFromAutoLogicalCluster(t *testing.T) {
 	}
 }
 
+// TestTopologyAutoPrimaryWithManualStandby verifies that when an auto
+// primary has both an auto standby and a manual standby, only the auto
+// standby appears as a child in the auto-detected binary cluster. The
+// manual standby must NOT be pulled in via buildServerWithChildren.
+func TestTopologyAutoPrimaryWithManualStandby(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               501,
+			Name:             "auto-primary",
+			Host:             "10.0.5.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "binary_primary",
+			MembershipSource: "auto",
+			Status:           "online",
+		},
+		{
+			ID:                 502,
+			Name:               "auto-standby",
+			Host:               "10.0.5.2",
+			Port:               5432,
+			DatabaseName:       "app",
+			Username:           "postgres",
+			PrimaryRole:        "binary_standby",
+			MembershipSource:   "auto",
+			Status:             "online",
+			IsStreamingStandby: true,
+			UpstreamHost:       sql.NullString{String: "10.0.5.1", Valid: true},
+			UpstreamPort:       sql.NullInt32{Int32: 5432, Valid: true},
+		},
+		{
+			ID:                 503,
+			Name:               "manual-standby",
+			Host:               "10.0.5.3",
+			Port:               5432,
+			DatabaseName:       "app",
+			Username:           "postgres",
+			PrimaryRole:        "binary_standby",
+			MembershipSource:   "manual",
+			Status:             "online",
+			IsStreamingStandby: true,
+			UpstreamHost:       sql.NullString{String: "10.0.5.1", Valid: true},
+			UpstreamPort:       sql.NullInt32{Int32: 5432, Valid: true},
+			ClusterID:          sql.NullInt64{Int64: 55, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	// buildAutoDetectedClusters should form a binary cluster with the
+	// auto primary and auto standby, but NOT include the manual standby.
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	cluster, ok := autoClusters["binary:501"]
+	if !ok {
+		t.Fatalf("expected auto binary cluster binary:501; got keys %v",
+			keysOf(autoClusters))
+	}
+	if len(cluster.Servers) != 1 {
+		t.Fatalf("expected 1 top-level server in binary cluster, got %d",
+			len(cluster.Servers))
+	}
+	primary := cluster.Servers[0]
+	if primary.ID != 501 {
+		t.Fatalf("expected primary server ID 501, got %d", primary.ID)
+	}
+	if len(primary.Children) != 1 {
+		t.Fatalf("expected 1 child (auto standby) under primary, got %d",
+			len(primary.Children))
+	}
+	if primary.Children[0].ID != 502 {
+		t.Fatalf("expected child ID 502 (auto standby), got %d",
+			primary.Children[0].ID)
+	}
+
+	// Verify the manual standby does not appear anywhere in the cluster.
+	for _, s := range primary.Children {
+		if s.ID == 503 {
+			t.Fatalf("manual standby 503 was pulled into auto binary cluster")
+		}
+	}
+
+	// buildTopologyHierarchy should produce the same result.
+	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 topology group, got %d", len(groups))
+	}
+	for _, cl := range groups[0].Clusters {
+		if cl.ClusterType == "binary" {
+			if len(cl.Servers) != 1 {
+				t.Fatalf("expected 1 top-level server in hierarchy binary cluster, got %d",
+					len(cl.Servers))
+			}
+			hier := cl.Servers[0]
+			for _, child := range hier.Children {
+				if child.MembershipSource == "manual" {
+					t.Fatalf("manual standby %d leaked into hierarchy binary cluster",
+						child.ID)
+				}
+			}
+		}
+	}
+}
+
+// TestTopologyManualPrimaryWithAutoStandby verifies that a manual
+// primary is filtered out at the binary-cluster level, so no binary
+// cluster forms. In buildAutoDetectedClusters the manual primary still
+// appears as a standalone wrapper (no ClusterID filter there); the auto
+// standby becomes its child. In buildTopologyHierarchy, however, the
+// manual primary is skipped from standalone processing (ClusterID is
+// set), so the auto standby ends up standalone on its own.
+func TestTopologyManualPrimaryWithAutoStandby(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               601,
+			Name:             "manual-primary",
+			Host:             "10.0.6.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "binary_primary",
+			MembershipSource: "manual",
+			Status:           "online",
+			ClusterID:        sql.NullInt64{Int64: 77, Valid: true},
+		},
+		{
+			ID:                 602,
+			Name:               "auto-standby",
+			Host:               "10.0.6.2",
+			Port:               5432,
+			DatabaseName:       "app",
+			Username:           "postgres",
+			PrimaryRole:        "binary_standby",
+			MembershipSource:   "auto",
+			Status:             "online",
+			IsStreamingStandby: true,
+			UpstreamHost:       sql.NullString{String: "10.0.6.1", Valid: true},
+			UpstreamPort:       sql.NullInt32{Int32: 5432, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	// buildAutoDetectedClusters: no binary cluster should form because
+	// the primary is manual.
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	if cluster, ok := autoClusters["binary:601"]; ok {
+		t.Fatalf("manual primary regrouped into auto binary cluster %q with %d servers",
+			cluster.AutoClusterKey, len(cluster.Servers))
+	}
+
+	// buildTopologyHierarchy: the manual primary (ClusterID set) is
+	// skipped from both binary-cluster and standalone processing. The
+	// auto standby should appear as a standalone server.
+	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 topology group, got %d", len(groups))
+	}
+	for _, cl := range groups[0].Clusters {
+		if cl.ClusterType == "binary" {
+			t.Fatalf("buildTopologyHierarchy produced binary cluster %q for manual primary",
+				cl.AutoClusterKey)
+		}
+	}
+	// Verify auto standby appears as standalone (type "server").
+	found := false
+	for _, cl := range groups[0].Clusters {
+		if cl.ClusterType == "server" {
+			for _, s := range cl.Servers {
+				if s.ID == 602 {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("auto standby 602 not found as standalone server in hierarchy")
+	}
+}
+
+// TestTopologyAutoPublisherWithManualSubscriber verifies that a logical
+// cluster does not form when the subscriber is manual, even though the
+// publisher is auto. The subscriber filter in
+// groupLogicalReplicationByPublisher should skip it.
+func TestTopologyAutoPublisherWithManualSubscriber(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               701,
+			Name:             "auto-publisher",
+			Host:             "10.0.7.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_publisher",
+			MembershipSource: "auto",
+			Status:           "online",
+		},
+		{
+			ID:               702,
+			Name:             "manual-subscriber",
+			Host:             "10.0.7.2",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_subscriber",
+			MembershipSource: "manual",
+			Status:           "online",
+			PublisherHost:    sql.NullString{String: "10.0.7.1", Valid: true},
+			PublisherPort:    sql.NullInt32{Int32: 5432, Valid: true},
+			ClusterID:        sql.NullInt64{Int64: 88, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	// No logical cluster should form because the subscriber is manual.
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	if cluster, ok := autoClusters["logical:701"]; ok {
+		t.Fatalf("auto publisher + manual subscriber formed logical cluster %q with %d servers",
+			cluster.AutoClusterKey, len(cluster.Servers))
+	}
+	for key, cluster := range autoClusters {
+		if cluster.ClusterType == "logical" {
+			t.Fatalf("unexpected logical cluster %q formed with manual subscriber",
+				key)
+		}
+	}
+}
+
+// TestTopologyManualPublisherWithAutoSubscriber verifies that a logical
+// cluster does not form when the publisher is manual, even though the
+// subscriber is auto. The publisher filter in
+// groupLogicalReplicationByPublisher should reject it.
+func TestTopologyManualPublisherWithAutoSubscriber(t *testing.T) {
+	ds := &Datastore{}
+
+	conns := []connectionWithRole{
+		{
+			ID:               801,
+			Name:             "manual-publisher",
+			Host:             "10.0.8.1",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_publisher",
+			MembershipSource: "manual",
+			Status:           "online",
+			ClusterID:        sql.NullInt64{Int64: 99, Valid: true},
+		},
+		{
+			ID:               802,
+			Name:             "auto-subscriber",
+			Host:             "10.0.8.2",
+			Port:             5432,
+			DatabaseName:     "app",
+			Username:         "postgres",
+			PrimaryRole:      "logical_subscriber",
+			MembershipSource: "auto",
+			Status:           "online",
+			PublisherHost:    sql.NullString{String: "10.0.8.1", Valid: true},
+			PublisherPort:    sql.NullInt32{Int32: 5432, Valid: true},
+		},
+	}
+
+	overrides := map[string]clusterOverride{}
+
+	// No logical cluster should form because the publisher is manual.
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	if cluster, ok := autoClusters["logical:801"]; ok {
+		t.Fatalf("manual publisher + auto subscriber formed logical cluster %q with %d servers",
+			cluster.AutoClusterKey, len(cluster.Servers))
+	}
+	for key, cluster := range autoClusters {
+		if cluster.ClusterType == "logical" {
+			t.Fatalf("unexpected logical cluster %q formed with manual publisher",
+				key)
+		}
+	}
+}
+
 // keysOf returns the keys of a map[string]TopologyCluster for readable
 // test failure messages.
 func keysOf(m map[string]TopologyCluster) []string {


### PR DESCRIPTION
## Summary

Fixes #74. When a user deleted an auto-detected (Spock) cluster, re-added the servers, and assigned them to a manually created cluster, the same servers re-appeared under a recreated auto-detected cluster after the next 30-second topology refresh.

Root cause: `AddServerToCluster` sets `connections.membership_source = 'manual'`, but the auto-detection paths in `server/src/internal/database/datastore.go` did not check this field when aggregating Spock / binary-primary / logical-publisher nodes into auto-detected clusters.

- Filter out `membership_source = 'manual'` connections at every auto-cluster aggregation site: `buildAutoDetectedClusters` (Spock, binary-primary), `buildTopologyHierarchy` (Spock, binary-primary), and `groupLogicalReplicationByPublisher` (subscriber and publisher filters).
- Add `server/src/internal/database/topology_manual_membership_test.go` with four pure unit tests covering Spock, binary-primary, logical-publisher regression cases plus a sanity check that `membership_source = 'auto'` still forms auto clusters.
- Add a Fixed entry to `docs/changelog.md`.

## Test plan

- [x] `gofmt -l` — clean
- [x] `go build ./...` (server/src) — clean
- [x] `go vet ./...` (server/src) — clean
- [x] `go test ./... -timeout 10m` — all 23 server packages pass, including the four new regression tests
- [ ] CI green on all matrix jobs (PG 14/15/16/17/18)
- [ ] Manual verification in UI: delete auto-detected cluster, re-add servers to a manual cluster, wait 30s, confirm no duplicate cluster appears

Opened as draft until CI reports green; will mark ready afterwards.

https://claude.ai/code/session_01HoM1adHv7qw3neC86a9t2h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manual cluster assignments now persist across topology refreshes: auto-detection skips manually pinned servers so they are not regrouped into re-created auto-detected clusters (including Spock, binary replication, and logical replication scenarios).

* **Tests**
  * Added regression tests to validate manual-membership filtering and prevent regressions in auto-detected cluster formation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->