### PR TITLE
Close remaining RBAC leaks for unshared servers/clusters (#35)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,6 +83,60 @@ project adheres to
   `docs/admin-guide/api/openapi.json` now document
   the `403 Forbidden` response on the affected
   single-resource endpoints. (#35)
+- Fix server and cluster visibility leaks through the
+  cluster list, cluster group, and cluster-membership
+  REST endpoints; `GET /api/v1/clusters/list`,
+  `GET /api/v1/clusters/{id}`,
+  `GET /api/v1/clusters/{id}/servers`,
+  `GET /api/v1/cluster-groups`, and
+  `GET /api/v1/cluster-groups/{id}` now filter clusters,
+  groups, and member servers to the caller's visible
+  connections and return `404 Not Found` for clusters or
+  groups that contain no visible members. (#35)
+- Fix additional RBAC leaks surfaced by the follow-up
+  security audit; the overview REST and SSE endpoints
+  (`GET /api/v1/overview` and `GET /api/v1/overview/stream`)
+  now verify scope visibility for scoped requests and
+  filter `connection_ids` lists to the caller's visible
+  set; the blackout list and get endpoints
+  (`GET /api/v1/blackouts` and
+  `GET /api/v1/blackouts/{id}`) hide blackouts whose
+  referenced connection, cluster, or group is not
+  visible to the caller; the alert, probe, and channel
+  override list endpoints
+  (`GET /api/v1/alert-overrides/{scope}/{scopeId}`,
+  `GET /api/v1/probe-overrides/{scope}/{scopeId}`, and
+  `GET /api/v1/channel-overrides/{scope}/{scopeId}`)
+  return `404 Not Found` when the caller cannot see the
+  requested scope; and the MCP connection resolver now
+  checks RBAC before loading credentials and returns a
+  generic "connection not found or not accessible"
+  message for both missing and denied cases. (#35)
+- Fix remaining RBAC leaks flagged by the third-round
+  security audit; the `query_metrics` and `get_alert_rules`
+  MCP tools now check `CanAccessConnection` before any
+  datastore read and return a generic "connection not
+  found or not accessible" error for both missing and
+  denied connections, closing the ID/name enumeration
+  that the previous error path exposed. The overview
+  scoped-snapshot path
+  (`GET /api/v1/overview?scope_type=cluster|group`) now
+  intersects the scope's member connection IDs with the
+  caller's visible set and generates the summary from
+  the intersection through the existing connections-
+  summary path, so two callers with different visibility
+  never share a cache entry; scope denial now returns
+  `404 Not Found` to match sibling handlers. The blackout
+  schedule list and get endpoints
+  (`GET /api/v1/blackout-schedules` and
+  `GET /api/v1/blackout-schedules/{id}`) apply the same
+  visibility filter as the blackout endpoints, and the
+  alert override context endpoint
+  (`GET /api/v1/alert-overrides/context/{connectionId}/{ruleId}`)
+  now gates on `scopeVisibleToCaller` before reading
+  override hierarchy. The MCP connection resolver logs
+  RBAC denials so operators can correlate without
+  widening the caller-visible surface. (#35)
 
 ## [1.0.0-alpha3] - 2026-04-08
 

--- a/server/src/cmd/mcp-server/handlers.go
+++ b/server/src/cmd/mcp-server/handlers.go
@@ -216,7 +216,7 @@ func SetupHandlers(deps *HandlerDependencies) func(*http.ServeMux) error {
 
 		// AI Overview endpoint (for estate overview summary)
 		if deps.OverviewGen != nil {
-			overviewHandler := overview.NewHandler(deps.OverviewGen, deps.OverviewHub)
+			overviewHandler := overview.NewHandlerWithRBAC(deps.OverviewGen, deps.OverviewHub, rbacChecker, deps.Datastore)
 			overviewHandler.RegisterRoutes(mux, authWrapper)
 			deps.OverviewGen.OnRestart(func() {
 				serverInfoHandler.InvalidateCache()

--- a/server/src/internal/api/alert_override_handlers.go
+++ b/server/src/internal/api/alert_override_handlers.go
@@ -139,6 +139,10 @@ func (h *AlertOverrideHandler) handleAlertOverrides(w http.ResponseWriter, r *ht
 
 // listOverrides handles GET /api/v1/alert-overrides/{scope}/{scopeId}
 func (h *AlertOverrideHandler) listOverrides(w http.ResponseWriter, r *http.Request, scope string, scopeID int) {
+	if !scopeVisibleToCaller(r.Context(), w, h.rbacChecker, h.datastore, scope, scopeID, "Alert override scope not found") {
+		return
+	}
+
 	var overrides []database.AlertOverride
 	var err error
 
@@ -200,6 +204,13 @@ func (h *AlertOverrideHandler) deleteOverride(w http.ResponseWriter, r *http.Req
 // getOverrideContext handles GET /api/v1/alert-overrides/context/{connectionId}/{ruleId}
 func (h *AlertOverrideHandler) getOverrideContext(w http.ResponseWriter, r *http.Request, connectionID int, ruleID int64) {
 	if !h.checkPermission(w, r) {
+		return
+	}
+
+	// Gate by scope visibility so a caller cannot enumerate the
+	// override-context hierarchy for a connection they cannot see.
+	// scopeVisibleToCaller writes a 404 and logs when the caller is denied.
+	if !scopeVisibleToCaller(r.Context(), w, h.rbacChecker, h.datastore, "server", connectionID, "Connection not found") {
 		return
 	}
 

--- a/server/src/internal/api/blackout_handlers.go
+++ b/server/src/internal/api/blackout_handlers.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -248,40 +249,108 @@ func (h *BlackoutHandler) listBlackouts(w http.ResponseWriter, r *http.Request) 
 		filter.Active = &active
 	}
 
-	filter.Limit = ParseLimitWithDefaults(r, 100, 1000)
-	filter.Offset = ParseOffsetWithDefault(r, 0)
+	reqLimit := ParseLimitWithDefaults(r, 100, 1000)
+	reqOffset := ParseOffsetWithDefault(r, 0)
 
-	result, err := h.datastore.ListBlackouts(r.Context(), filter)
-	if err != nil {
-		log.Printf("[ERROR] Failed to fetch blackouts: %v", err)
-		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackouts")
-		return
-	}
-
+	// Resolve the caller's visibility up front. When the caller has
+	// unrestricted visibility (superuser or wildcard grant) we can push
+	// Limit/Offset down to the datastore unchanged, preserving the
+	// efficient path. Otherwise we must fetch the unpaginated result,
+	// apply the visibility filter, recompute TotalCount, and paginate
+	// in-memory: filtering after SQL-side LIMIT/OFFSET would silently
+	// drop hidden rows into page slots and report the wrong total.
 	visible, allConnections, err := resolveVisibleConnectionSet(r.Context(), h.rbacChecker, h.datastore)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for blackouts: %v", err)
 		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackouts")
 		return
 	}
-	if !allConnections && result != nil {
-		filtered := make([]database.Blackout, 0, len(result.Blackouts))
-		for i := range result.Blackouts {
-			ok, err := h.blackoutVisible(r.Context(), &result.Blackouts[i], visible)
-			if err != nil {
-				log.Printf("[ERROR] Failed to check blackout visibility: %v", err)
-				RespondError(w, http.StatusInternalServerError, "Failed to fetch blackouts")
-				return
-			}
-			if ok {
-				filtered = append(filtered, result.Blackouts[i])
-			}
+
+	if allConnections {
+		filter.Limit = reqLimit
+		filter.Offset = reqOffset
+		result, err := h.datastore.ListBlackouts(r.Context(), filter)
+		if err != nil {
+			log.Printf("[ERROR] Failed to fetch blackouts: %v", err)
+			RespondError(w, http.StatusInternalServerError, "Failed to fetch blackouts")
+			return
 		}
-		result.Blackouts = filtered
-		result.TotalCount = len(filtered)
+		RespondJSON(w, http.StatusOK, result)
+		return
 	}
 
+	// Fetch the full filtered set without SQL-side pagination. MaxInt32
+	// is passed as the limit because the datastore interprets Limit<=0
+	// as the legacy default of 100, which would re-introduce the bug.
+	filter.Limit = visibilityFilterFetchLimit
+	filter.Offset = 0
+	result, err := h.datastore.ListBlackouts(r.Context(), filter)
+	if err != nil {
+		log.Printf("[ERROR] Failed to fetch blackouts: %v", err)
+		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackouts")
+		return
+	}
+	if result == nil {
+		RespondJSON(w, http.StatusOK, result)
+		return
+	}
+
+	filtered := make([]database.Blackout, 0, len(result.Blackouts))
+	for i := range result.Blackouts {
+		ok, err := h.blackoutVisible(r.Context(), &result.Blackouts[i], visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check blackout visibility: %v", err)
+			RespondError(w, http.StatusInternalServerError, "Failed to fetch blackouts")
+			return
+		}
+		if ok {
+			filtered = append(filtered, result.Blackouts[i])
+		}
+	}
+	result.TotalCount = len(filtered)
+	result.Blackouts = paginateBlackouts(filtered, reqOffset, reqLimit)
+
 	RespondJSON(w, http.StatusOK, result)
+}
+
+// visibilityFilterFetchLimit is the upper bound passed to the datastore
+// when the blackout list endpoints must fetch the unpaginated result
+// set for post-query RBAC filtering. MaxInt32 leaves LIMIT effectively
+// unbounded while avoiding the Limit<=0 legacy default of 100.
+const visibilityFilterFetchLimit = math.MaxInt32
+
+// paginateBlackouts applies the request's Limit/Offset to an in-memory
+// slice. Negative offsets are treated as zero. A non-positive limit is
+// treated as "return everything past offset" to match the datastore's
+// convention when no pagination is requested.
+func paginateBlackouts(in []database.Blackout, offset, limit int) []database.Blackout {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(in) {
+		return []database.Blackout{}
+	}
+	end := len(in)
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+	return in[offset:end]
+}
+
+// paginateSchedules applies the request's Limit/Offset to an in-memory
+// slice. See paginateBlackouts for pagination semantics.
+func paginateSchedules(in []database.BlackoutSchedule, offset, limit int) []database.BlackoutSchedule {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(in) {
+		return []database.BlackoutSchedule{}
+	}
+	end := len(in)
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+	return in[offset:end]
 }
 
 // getBlackout handles GET /api/v1/blackouts/{id}
@@ -538,38 +607,60 @@ func (h *BlackoutHandler) listBlackoutSchedules(w http.ResponseWriter, r *http.R
 		filter.Active = &enabled
 	}
 
-	filter.Limit = ParseLimitWithDefaults(r, 100, 1000)
-	filter.Offset = ParseOffsetWithDefault(r, 0)
+	reqLimit := ParseLimitWithDefaults(r, 100, 1000)
+	reqOffset := ParseOffsetWithDefault(r, 0)
 
-	result, err := h.datastore.ListBlackoutSchedules(r.Context(), filter)
-	if err != nil {
-		log.Printf("[ERROR] Failed to fetch blackout schedules: %v", err)
-		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedules")
-		return
-	}
-
+	// Resolve visibility first. Superusers and wildcard-granted callers
+	// use the efficient SQL-side pagination path. Restricted callers
+	// must fetch the full set, filter, recompute TotalCount, then
+	// paginate in-memory; see listBlackouts for the rationale.
 	visible, allConnections, err := resolveVisibleConnectionSet(r.Context(), h.rbacChecker, h.datastore)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for blackout schedules: %v", err)
 		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedules")
 		return
 	}
-	if !allConnections && result != nil {
-		filtered := make([]database.BlackoutSchedule, 0, len(result.Schedules))
-		for i := range result.Schedules {
-			ok, err := h.blackoutScheduleVisible(r.Context(), &result.Schedules[i], visible)
-			if err != nil {
-				log.Printf("[ERROR] Failed to check blackout schedule visibility: %v", err)
-				RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedules")
-				return
-			}
-			if ok {
-				filtered = append(filtered, result.Schedules[i])
-			}
+
+	if allConnections {
+		filter.Limit = reqLimit
+		filter.Offset = reqOffset
+		result, err := h.datastore.ListBlackoutSchedules(r.Context(), filter)
+		if err != nil {
+			log.Printf("[ERROR] Failed to fetch blackout schedules: %v", err)
+			RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedules")
+			return
 		}
-		result.Schedules = filtered
-		result.TotalCount = len(filtered)
+		RespondJSON(w, http.StatusOK, result)
+		return
 	}
+
+	filter.Limit = visibilityFilterFetchLimit
+	filter.Offset = 0
+	result, err := h.datastore.ListBlackoutSchedules(r.Context(), filter)
+	if err != nil {
+		log.Printf("[ERROR] Failed to fetch blackout schedules: %v", err)
+		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedules")
+		return
+	}
+	if result == nil {
+		RespondJSON(w, http.StatusOK, result)
+		return
+	}
+
+	filtered := make([]database.BlackoutSchedule, 0, len(result.Schedules))
+	for i := range result.Schedules {
+		ok, err := h.blackoutScheduleVisible(r.Context(), &result.Schedules[i], visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check blackout schedule visibility: %v", err)
+			RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedules")
+			return
+		}
+		if ok {
+			filtered = append(filtered, result.Schedules[i])
+		}
+	}
+	result.TotalCount = len(filtered)
+	result.Schedules = paginateSchedules(filtered, reqOffset, reqLimit)
 
 	RespondJSON(w, http.StatusOK, result)
 }

--- a/server/src/internal/api/blackout_handlers.go
+++ b/server/src/internal/api/blackout_handlers.go
@@ -10,6 +10,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -257,6 +258,29 @@ func (h *BlackoutHandler) listBlackouts(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	visible, allConnections, err := resolveVisibleConnectionSet(r.Context(), h.rbacChecker, h.datastore)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for blackouts: %v", err)
+		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackouts")
+		return
+	}
+	if !allConnections && result != nil {
+		filtered := make([]database.Blackout, 0, len(result.Blackouts))
+		for i := range result.Blackouts {
+			ok, err := h.blackoutVisible(r.Context(), &result.Blackouts[i], visible)
+			if err != nil {
+				log.Printf("[ERROR] Failed to check blackout visibility: %v", err)
+				RespondError(w, http.StatusInternalServerError, "Failed to fetch blackouts")
+				return
+			}
+			if ok {
+				filtered = append(filtered, result.Blackouts[i])
+			}
+		}
+		result.Blackouts = filtered
+		result.TotalCount = len(filtered)
+	}
+
 	RespondJSON(w, http.StatusOK, result)
 }
 
@@ -273,7 +297,50 @@ func (h *BlackoutHandler) getBlackout(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 
+	visible, allConnections, err := resolveVisibleConnectionSet(r.Context(), h.rbacChecker, h.datastore)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for blackout %d: %v", id, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout")
+		return
+	}
+	if !allConnections {
+		ok, err := h.blackoutVisible(r.Context(), blackout, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check blackout visibility (id=%d): %v", id, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Blackout not found")
+			return
+		}
+	}
+
 	RespondJSON(w, http.StatusOK, blackout)
+}
+
+// blackoutVisible reports whether the caller may see the given blackout
+// given the precomputed visible connection set. A blackout with no
+// resource reference (estate/global scope) is visible to everyone; a
+// blackout tied to a connection, cluster, or group is visible only when
+// the referenced resource contains at least one visible connection.
+func (h *BlackoutHandler) blackoutVisible(ctx context.Context, b *database.Blackout, visible map[int]bool) (bool, error) {
+	if b == nil {
+		return false, nil
+	}
+	if b.ConnectionID == nil && b.ClusterID == nil && b.GroupID == nil {
+		return true, nil
+	}
+	if b.ConnectionID != nil {
+		return visible[*b.ConnectionID], nil
+	}
+	if b.ClusterID != nil {
+		return clusterHasVisibleConnectionFn(ctx, h.datastore, *b.ClusterID, visible)
+	}
+	if b.GroupID != nil {
+		return groupHasVisibleConnectionFn(ctx, h.datastore, *b.GroupID, visible)
+	}
+	return false, nil
 }
 
 // createBlackout handles POST /api/v1/blackouts
@@ -481,6 +548,29 @@ func (h *BlackoutHandler) listBlackoutSchedules(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	visible, allConnections, err := resolveVisibleConnectionSet(r.Context(), h.rbacChecker, h.datastore)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for blackout schedules: %v", err)
+		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedules")
+		return
+	}
+	if !allConnections && result != nil {
+		filtered := make([]database.BlackoutSchedule, 0, len(result.Schedules))
+		for i := range result.Schedules {
+			ok, err := h.blackoutScheduleVisible(r.Context(), &result.Schedules[i], visible)
+			if err != nil {
+				log.Printf("[ERROR] Failed to check blackout schedule visibility: %v", err)
+				RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedules")
+				return
+			}
+			if ok {
+				filtered = append(filtered, result.Schedules[i])
+			}
+		}
+		result.Schedules = filtered
+		result.TotalCount = len(filtered)
+	}
+
 	RespondJSON(w, http.StatusOK, result)
 }
 
@@ -497,7 +587,51 @@ func (h *BlackoutHandler) getBlackoutSchedule(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	visible, allConnections, err := resolveVisibleConnectionSet(r.Context(), h.rbacChecker, h.datastore)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for blackout schedule %d: %v", id, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedule")
+		return
+	}
+	if !allConnections {
+		ok, err := h.blackoutScheduleVisible(r.Context(), schedule, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check blackout schedule visibility (id=%d): %v", id, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to fetch blackout schedule")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Blackout schedule not found")
+			return
+		}
+	}
+
 	RespondJSON(w, http.StatusOK, schedule)
+}
+
+// blackoutScheduleVisible reports whether the caller may see the given
+// blackout schedule given the precomputed visible connection set. A
+// schedule with no resource reference (estate/global scope) is visible
+// to everyone; one tied to a connection, cluster, or group is visible
+// only when the referenced resource contains at least one visible
+// connection.
+func (h *BlackoutHandler) blackoutScheduleVisible(ctx context.Context, s *database.BlackoutSchedule, visible map[int]bool) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	if s.ConnectionID == nil && s.ClusterID == nil && s.GroupID == nil {
+		return true, nil
+	}
+	if s.ConnectionID != nil {
+		return visible[*s.ConnectionID], nil
+	}
+	if s.ClusterID != nil {
+		return clusterHasVisibleConnectionFn(ctx, h.datastore, *s.ClusterID, visible)
+	}
+	if s.GroupID != nil {
+		return groupHasVisibleConnectionFn(ctx, h.datastore, *s.GroupID, visible)
+	}
+	return false, nil
 }
 
 // createBlackoutSchedule handles POST /api/v1/blackout-schedules

--- a/server/src/internal/api/channel_override_handlers.go
+++ b/server/src/internal/api/channel_override_handlers.go
@@ -113,6 +113,10 @@ func (h *ChannelOverrideHandler) handleChannelOverrides(w http.ResponseWriter, r
 
 // listOverrides handles GET /api/v1/channel-overrides/{scope}/{scopeId}
 func (h *ChannelOverrideHandler) listOverrides(w http.ResponseWriter, r *http.Request, scope string, scopeID int) {
+	if !scopeVisibleToCaller(r.Context(), w, h.rbacChecker, h.datastore, scope, scopeID, "Channel override scope not found") {
+		return
+	}
+
 	var overrides []database.ChannelOverride
 	var err error
 

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -609,6 +609,20 @@ func (h *ClusterHandler) listClustersInGroup(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if !allConnections {
+		// Gate on parent-group visibility before per-cluster filtering so
+		// the response mirrors getClusterGroup: callers who cannot see
+		// the group at all must receive 404 rather than an empty list
+		// that leaks the group's existence.
+		groupVisible, err := h.groupHasVisibleConnection(ctx, groupID, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster group visibility (id=%d): %v", groupID, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to filter clusters")
+			return
+		}
+		if !groupVisible {
+			RespondError(w, http.StatusNotFound, "Cluster group not found")
+			return
+		}
 		ids := make([]int, 0, len(clusters))
 		for i := range clusters {
 			ids = append(ids, clusters[i].ID)

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -556,6 +556,25 @@ func (h *ClusterHandler) deleteClusterGroup(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster group %d: %v", id, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to delete cluster group")
+		return
+	}
+	if !allConnections {
+		ok, err := h.groupHasVisibleConnection(ctx, id, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster group visibility (id=%d): %v", id, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to delete cluster group")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Cluster group not found")
+			return
+		}
+	}
+
 	// Protect the default group from deletion
 	defaultGroupID, err := h.datastore.GetDefaultGroupID(ctx)
 	if err == nil && defaultGroupID == id {
@@ -717,6 +736,25 @@ func (h *ClusterHandler) updateCluster(w http.ResponseWriter, r *http.Request, i
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster %d: %v", id, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to update cluster")
+		return
+	}
+	if !allConnections {
+		ok, err := h.clusterHasVisibleConnection(ctx, id, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster visibility (id=%d): %v", id, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to update cluster")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Cluster not found")
+			return
+		}
+	}
+
 	cluster, err := h.datastore.UpdateClusterPartial(ctx, id, req.GroupID, req.Name, req.Description, req.ReplicationType)
 	if err != nil {
 		log.Printf("[ERROR] Failed to update cluster (id=%d): %v", id, err)
@@ -731,7 +769,26 @@ func (h *ClusterHandler) deleteCluster(w http.ResponseWriter, r *http.Request, i
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	err := h.datastore.DeleteCluster(ctx, id)
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster %d: %v", id, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to delete cluster")
+		return
+	}
+	if !allConnections {
+		ok, err := h.clusterHasVisibleConnection(ctx, id, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster visibility (id=%d): %v", id, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to delete cluster")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Cluster not found")
+			return
+		}
+	}
+
+	err = h.datastore.DeleteCluster(ctx, id)
 	if err != nil {
 		log.Printf("[ERROR] Failed to delete cluster (id=%d): %v", id, err)
 		if errors.Is(err, database.ErrClusterNotFound) {
@@ -929,7 +986,30 @@ func (h *ClusterHandler) addServerToCluster(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	err := h.datastore.AddServerToCluster(ctx, clusterID, req.ConnectionID, req.Role)
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster %d: %v", clusterID, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to add server to cluster")
+		return
+	}
+	if !allConnections {
+		ok, err := h.clusterHasVisibleConnection(ctx, clusterID, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster visibility (id=%d): %v", clusterID, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to add server to cluster")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Cluster not found")
+			return
+		}
+		if !visible[req.ConnectionID] {
+			RespondError(w, http.StatusNotFound, "Connection not found")
+			return
+		}
+	}
+
+	err = h.datastore.AddServerToCluster(ctx, clusterID, req.ConnectionID, req.Role)
 	if err != nil {
 		if errors.Is(err, database.ErrClusterNotFound) {
 			RespondError(w, http.StatusNotFound, "Cluster not found")
@@ -962,7 +1042,26 @@ func (h *ClusterHandler) handleRemoveServerFromCluster(w http.ResponseWriter, r 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	err := h.datastore.RemoveServerFromCluster(ctx, clusterID, connectionID)
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster %d: %v", clusterID, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to remove server from cluster")
+		return
+	}
+	if !allConnections {
+		ok, err := h.clusterHasVisibleConnection(ctx, clusterID, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster visibility (id=%d): %v", clusterID, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to remove server from cluster")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Cluster not found")
+			return
+		}
+	}
+
+	err = h.datastore.RemoveServerFromCluster(ctx, clusterID, connectionID)
 	if err != nil {
 		if errors.Is(err, database.ErrConnectionNotFound) {
 			RespondError(w, http.StatusNotFound, "Connection not found in this cluster")

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -192,6 +192,43 @@ func filterTopologyServers(servers []database.TopologyServerInfo, visible map[in
 	return out
 }
 
+// resolveVisibleConnections delegates to the package-level helper.
+func (h *ClusterHandler) resolveVisibleConnections(ctx context.Context) (map[int]bool, bool, error) {
+	return resolveVisibleConnectionSet(ctx, h.rbacChecker, h.datastore)
+}
+
+// clusterHasVisibleConnection delegates to the package-level helper.
+func (h *ClusterHandler) clusterHasVisibleConnection(ctx context.Context, clusterID int, visible map[int]bool) (bool, error) {
+	return clusterHasVisibleConnectionFn(ctx, h.datastore, clusterID, visible)
+}
+
+// groupHasVisibleConnection delegates to the package-level helper.
+func (h *ClusterHandler) groupHasVisibleConnection(ctx context.Context, groupID int, visible map[int]bool) (bool, error) {
+	return groupHasVisibleConnectionFn(ctx, h.datastore, groupID, visible)
+}
+
+// clusterConnectionMembership delegates to the package-level helper.
+func (h *ClusterHandler) clusterConnectionMembership(ctx context.Context, clusterIDs []int) (map[int][]int, error) {
+	return clusterConnectionMembershipFn(ctx, h.datastore, clusterIDs)
+}
+
+// clusterMembersVisible returns true when at least one connection ID in
+// members appears in the visible set. A cluster with no member
+// connections is treated as not visible to any non-privileged caller.
+func clusterMembersVisible(members []int, visible map[int]bool) bool {
+	for _, id := range members {
+		if visible[id] {
+			return true
+		}
+	}
+	return false
+}
+
+// filterGroupsByVisibility delegates to the package-level helper.
+func (h *ClusterHandler) filterGroupsByVisibility(ctx context.Context, groups []database.ClusterGroup, visible map[int]bool) ([]database.ClusterGroup, error) {
+	return filterGroupsByVisibilityFn(ctx, h.datastore, groups, visible)
+}
+
 // handleClusterSubpath handles /api/v1/clusters/{id}
 func (h *ClusterHandler) handleClusterSubpath(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/clusters/")
@@ -390,6 +427,22 @@ func (h *ClusterHandler) listClusterGroups(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster groups: %v", err)
+		RespondError(w, http.StatusInternalServerError, "Failed to filter cluster groups")
+		return
+	}
+	if !allConnections {
+		filtered, err := h.filterGroupsByVisibility(ctx, groups, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to filter cluster groups by visibility: %v", err)
+			RespondError(w, http.StatusInternalServerError, "Failed to filter cluster groups")
+			return
+		}
+		groups = filtered
+	}
+
 	RespondJSON(w, http.StatusOK, groups)
 }
 
@@ -402,6 +455,25 @@ func (h *ClusterHandler) getClusterGroup(w http.ResponseWriter, r *http.Request,
 		log.Printf("[ERROR] Cluster group not found (id=%d): %v", id, err)
 		RespondError(w, http.StatusNotFound, "Cluster group not found")
 		return
+	}
+
+	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster group %d: %v", id, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to load cluster group")
+		return
+	}
+	if !allConnections {
+		ok, err := h.groupHasVisibleConnection(ctx, id, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster group visibility (id=%d): %v", id, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to load cluster group")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Cluster group not found")
+			return
+		}
 	}
 
 	RespondJSON(w, http.StatusOK, group)
@@ -530,6 +602,32 @@ func (h *ClusterHandler) listClustersInGroup(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for group %d: %v", groupID, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to filter clusters")
+		return
+	}
+	if !allConnections {
+		ids := make([]int, 0, len(clusters))
+		for i := range clusters {
+			ids = append(ids, clusters[i].ID)
+		}
+		membership, err := h.clusterConnectionMembership(ctx, ids)
+		if err != nil {
+			log.Printf("[ERROR] Failed to resolve cluster membership for group %d: %v", groupID, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to filter clusters")
+			return
+		}
+		filtered := make([]database.Cluster, 0, len(clusters))
+		for i := range clusters {
+			if clusterMembersVisible(membership[clusters[i].ID], visible) {
+				filtered = append(filtered, clusters[i])
+			}
+		}
+		clusters = filtered
+	}
+
 	RespondJSON(w, http.StatusOK, clusters)
 }
 
@@ -566,6 +664,25 @@ func (h *ClusterHandler) getCluster(w http.ResponseWriter, r *http.Request, id i
 		log.Printf("[ERROR] Cluster not found (id=%d): %v", id, err)
 		RespondError(w, http.StatusNotFound, "Cluster not found")
 		return
+	}
+
+	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster %d: %v", id, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to load cluster")
+		return
+	}
+	if !allConnections {
+		ok, err := h.clusterHasVisibleConnection(ctx, id, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster visibility (id=%d): %v", id, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to load cluster")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Cluster not found")
+			return
+		}
 	}
 
 	RespondJSON(w, http.StatusOK, cluster)
@@ -754,6 +871,32 @@ func (h *ClusterHandler) listServersInCluster(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster %d servers: %v", clusterID, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to list servers")
+		return
+	}
+	if !allConnections {
+		ok, err := h.clusterHasVisibleConnection(ctx, clusterID, visible)
+		if err != nil {
+			log.Printf("[ERROR] Failed to check cluster visibility (id=%d): %v", clusterID, err)
+			RespondError(w, http.StatusInternalServerError, "Failed to list servers")
+			return
+		}
+		if !ok {
+			RespondError(w, http.StatusNotFound, "Cluster not found")
+			return
+		}
+		filtered := make([]database.ServerInfo, 0, len(servers))
+		for i := range servers {
+			if visible[servers[i].ID] {
+				filtered = append(filtered, servers[i])
+			}
+		}
+		servers = filtered
+	}
+
 	RespondJSON(w, http.StatusOK, servers)
 }
 
@@ -844,6 +987,32 @@ func (h *ClusterHandler) handleListClusters(w http.ResponseWriter, r *http.Reque
 		log.Printf("[ERROR] Failed to list clusters: %v", err)
 		RespondError(w, http.StatusInternalServerError, "Failed to list clusters")
 		return
+	}
+
+	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for cluster autocomplete: %v", err)
+		RespondError(w, http.StatusInternalServerError, "Failed to list clusters")
+		return
+	}
+	if !allConnections {
+		ids := make([]int, 0, len(clusters))
+		for i := range clusters {
+			ids = append(ids, clusters[i].ID)
+		}
+		membership, err := h.clusterConnectionMembership(ctx, ids)
+		if err != nil {
+			log.Printf("[ERROR] Failed to resolve cluster membership for autocomplete: %v", err)
+			RespondError(w, http.StatusInternalServerError, "Failed to list clusters")
+			return
+		}
+		filtered := make([]database.ClusterSummary, 0, len(clusters))
+		for i := range clusters {
+			if clusterMembersVisible(membership[clusters[i].ID], visible) {
+				filtered = append(filtered, clusters[i])
+			}
+		}
+		clusters = filtered
 	}
 
 	RespondJSON(w, http.StatusOK, clusters)

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -427,7 +427,7 @@ func (h *ClusterHandler) listClusterGroups(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for cluster groups: %v", err)
 		RespondError(w, http.StatusInternalServerError, "Failed to filter cluster groups")
@@ -457,7 +457,7 @@ func (h *ClusterHandler) getClusterGroup(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for cluster group %d: %v", id, err)
 		RespondError(w, http.StatusInternalServerError, "Failed to load cluster group")
@@ -602,7 +602,7 @@ func (h *ClusterHandler) listClustersInGroup(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for group %d: %v", groupID, err)
 		RespondError(w, http.StatusInternalServerError, "Failed to filter clusters")
@@ -666,7 +666,7 @@ func (h *ClusterHandler) getCluster(w http.ResponseWriter, r *http.Request, id i
 		return
 	}
 
-	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for cluster %d: %v", id, err)
 		RespondError(w, http.StatusInternalServerError, "Failed to load cluster")
@@ -871,7 +871,7 @@ func (h *ClusterHandler) listServersInCluster(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for cluster %d servers: %v", clusterID, err)
 		RespondError(w, http.StatusInternalServerError, "Failed to list servers")
@@ -989,7 +989,7 @@ func (h *ClusterHandler) handleListClusters(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	visible, allConnections, err := h.resolveVisibleConnections(r.Context())
+	visible, allConnections, err := h.resolveVisibleConnections(ctx)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for cluster autocomplete: %v", err)
 		RespondError(w, http.StatusInternalServerError, "Failed to list clusters")

--- a/server/src/internal/api/probe_override_handlers.go
+++ b/server/src/internal/api/probe_override_handlers.go
@@ -113,6 +113,10 @@ func (h *ProbeOverrideHandler) handleProbeOverrides(w http.ResponseWriter, r *ht
 
 // listOverrides handles GET /api/v1/probe-overrides/{scope}/{scopeId}
 func (h *ProbeOverrideHandler) listOverrides(w http.ResponseWriter, r *http.Request, scope string, scopeID int) {
+	if !scopeVisibleToCaller(r.Context(), w, h.rbacChecker, h.datastore, scope, scopeID, "Probe override scope not found") {
+		return
+	}
+
 	var overrides []database.ProbeOverride
 	var err error
 

--- a/server/src/internal/api/rbac_issue35_clusters_test.go
+++ b/server/src/internal/api/rbac_issue35_clusters_test.go
@@ -1,0 +1,276 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+)
+
+// =============================================================================
+// Regression Test Coverage for GitHub Issue #35 - Cluster Endpoints
+//
+// Issue #35 was an access-control leak in which non-owner users could see
+// unshared connections (and the clusters/groups that contained them)
+// through cluster-list, cluster-detail, cluster-servers, cluster-group-
+// list, cluster-group-detail, and clusters-in-group REST endpoints.
+//
+// The production fix added the following to ClusterHandler:
+//
+//   - resolveVisibleConnections builds the caller's visible connection-ID
+//     set via rbacChecker.VisibleConnectionIDs. Superuser/wildcard
+//     callers get allConnections=true so the handler skips filtering.
+//   - clusterMembersVisible is the pure decision function used by every
+//     gated endpoint: a cluster is visible iff at least one of its
+//     member connections is in the caller's visible set. Empty clusters
+//     are invisible (no ownership claim to satisfy).
+//   - filterGroupsByVisibility, groupHasVisibleConnection, and
+//     clusterHasVisibleConnection wrap clusterMembersVisible with the
+//     datastore lookups.
+//
+// The tests in this file exercise clusterMembersVisible directly
+// (pure function, no datastore) and the VisibleConnectionIDs pairing
+// the handler uses to build the visible set. Full handler-level end-
+// to-end tests against a real PostgreSQL are covered by the integration
+// suite gated on TEST_AI_WORKBENCH_SERVER (see cluster_handlers_test.go
+// for the pattern); the decision surface is what regresses under
+// refactoring, and clusterMembersVisible is where any regression would
+// land.
+//
+// This mirrors the approach TestFilterTopologyByVisibility_Issue35_*
+// already takes for the cluster-topology endpoint: test the pure
+// filter that drives the gate, and rely on the handler glue
+// (resolveVisibleConnections + filterGroupsByVisibility) being thin.
+// =============================================================================
+
+// TestClusterMembersVisible_Issue35_NonOwnerZeroGrant verifies the
+// regression case the fix targets: a non-owner zero-grant user's visible
+// set is empty, so a cluster whose only members are unshared non-owned
+// connections is not visible. This is the exact code path that makes
+// GET /api/v1/clusters/list hide an unshared cluster owned by another
+// user.
+func TestClusterMembersVisible_Issue35_NonOwnerZeroGrant(t *testing.T) {
+	// Non-owner zero-grant callers produce an empty visible set.
+	visible := map[int]bool{}
+
+	// A cluster holds two unshared non-owned connections (IDs 42, 43).
+	members := []int{42, 43}
+
+	if clusterMembersVisible(members, visible) {
+		t.Fatal("Expected cluster with only unshared non-owned members " +
+			"to be invisible to non-owner zero-grant caller")
+	}
+}
+
+// TestClusterMembersVisible_Issue35_OwnerSeesOwnUnshared verifies the
+// owner of an unshared connection can still see the cluster that
+// contains it. This guards against an over-eager filter that would
+// block the owner from their own cluster.
+func TestClusterMembersVisible_Issue35_OwnerSeesOwnUnshared(t *testing.T) {
+	// The owner's visible set contains the connection ID they own.
+	visible := map[int]bool{42: true}
+
+	members := []int{42, 43}
+
+	if !clusterMembersVisible(members, visible) {
+		t.Fatal("Expected cluster with an owner-visible member to be " +
+			"visible; owner must see their own unshared cluster")
+	}
+}
+
+// TestClusterMembersVisible_Issue35_OnlySharedVisible verifies a cluster
+// that mixes a shared member (visible to the caller) and unshared non-
+// owned members is still visible to the caller. The caller sees the
+// cluster because their shared-member stake is enough; the server
+// filter on listServersInCluster is what drops the unshared servers
+// from the membership view.
+func TestClusterMembersVisible_Issue35_OnlySharedVisible(t *testing.T) {
+	// Caller can see connection 100 (shared) but not 42, 43.
+	visible := map[int]bool{100: true}
+
+	members := []int{42, 43, 100}
+
+	if !clusterMembersVisible(members, visible) {
+		t.Fatal("Expected cluster with at least one shared-member to be " +
+			"visible to the caller")
+	}
+}
+
+// TestClusterMembersVisible_Issue35_EmptyClusterInvisible verifies that
+// a cluster containing zero connections is invisible. An empty cluster
+// has no ownership or sharing claim to satisfy, so non-superuser
+// callers must not see it. This closes the naive "cluster exists ->
+// caller can see it" leak.
+func TestClusterMembersVisible_Issue35_EmptyClusterInvisible(t *testing.T) {
+	visible := map[int]bool{100: true}
+
+	if clusterMembersVisible(nil, visible) {
+		t.Fatal("Expected nil-members cluster to be invisible")
+	}
+	if clusterMembersVisible([]int{}, visible) {
+		t.Fatal("Expected empty-members cluster to be invisible")
+	}
+}
+
+// TestClusterMembersVisible_Issue35_MultipleSharedVisible verifies that
+// when several connections are visible to the caller, any overlap with
+// the cluster's members makes the cluster visible. This protects
+// against the short-circuit ever depending on ordering.
+func TestClusterMembersVisible_Issue35_MultipleSharedVisible(t *testing.T) {
+	visible := map[int]bool{10: true, 20: true, 30: true}
+
+	// Cluster members interleave visible and hidden IDs; any overlap
+	// is enough for visibility.
+	members := []int{42, 20, 43}
+
+	if !clusterMembersVisible(members, visible) {
+		t.Fatal("Expected cluster to be visible when its members overlap " +
+			"the visible set at any position")
+	}
+}
+
+// =============================================================================
+// VisibleConnectionIDs integration for cluster endpoints (issue #35)
+//
+// The cluster-list, cluster-detail, and cluster-group endpoints all
+// call resolveVisibleConnections, which in turn calls
+// rbacChecker.VisibleConnectionIDs against a datastore-backed lister.
+// These tests pair the checker with a stubVisibilityLister (from
+// rbac_issue35_test.go) so we can assert the visible-set contract the
+// cluster handlers depend on end-to-end, without requiring a running
+// PostgreSQL.
+// =============================================================================
+
+// TestVisibleConnectionIDs_Issue35_Clusters_NonOwnerZeroGrant_HidesUnshared
+// locks in the contract that drives listClusterGroups / handleListClusters
+// for a non-owner zero-grant user: the visible set is empty, so both
+// endpoints will filter every cluster whose only members are unshared
+// non-owned connections.
+func TestVisibleConnectionIDs_Issue35_Clusters_NonOwnerZeroGrant_HidesUnshared(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	bobID := newTestUser(t, store, "bob")
+
+	checker := auth.NewRBACChecker(store)
+
+	// A single unshared connection owned by alice: bob has no grant
+	// and is not a superuser, so the visible set must be empty.
+	lister := &stubVisibilityLister{
+		connections: []auth.ConnectionVisibilityInfo{
+			{ID: rbacUnsharedConnID, IsShared: false, OwnerUsername: "alice"},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, bobID)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "bob")
+
+	ids, all, err := checker.VisibleConnectionIDs(ctx, lister)
+	if err != nil {
+		t.Fatalf("VisibleConnectionIDs: %v", err)
+	}
+	if all {
+		t.Fatal("Non-superuser zero-grant caller must not get allConnections")
+	}
+	if len(ids) != 0 {
+		t.Errorf("Expected empty visible set for non-owner zero-grant, got %v", ids)
+	}
+
+	// Feeding that visible set into clusterMembersVisible with a
+	// cluster composed entirely of the unshared connection ID must
+	// return false: the cluster is invisible to bob. This is the
+	// end-to-end decision the getCluster handler makes via
+	// clusterHasVisibleConnection.
+	visibleMap := make(map[int]bool, len(ids))
+	for _, id := range ids {
+		visibleMap[id] = true
+	}
+	if clusterMembersVisible([]int{rbacUnsharedConnID}, visibleMap) {
+		t.Error("Expected cluster with only unshared member to be " +
+			"invisible to non-owner zero-grant caller")
+	}
+}
+
+// TestVisibleConnectionIDs_Issue35_Clusters_OwnerSeesOwnUnshared locks
+// in the positive case: the owner of an unshared connection still sees
+// any cluster that contains it through getCluster / listClustersInGroup.
+func TestVisibleConnectionIDs_Issue35_Clusters_OwnerSeesOwnUnshared(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	aliceID := newTestUser(t, store, "alice")
+
+	checker := auth.NewRBACChecker(store)
+
+	lister := &stubVisibilityLister{
+		connections: []auth.ConnectionVisibilityInfo{
+			{ID: rbacUnsharedConnID, IsShared: false, OwnerUsername: "alice"},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, aliceID)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "alice")
+
+	ids, all, err := checker.VisibleConnectionIDs(ctx, lister)
+	if err != nil {
+		t.Fatalf("VisibleConnectionIDs: %v", err)
+	}
+	if all {
+		t.Fatal("Owner should not be flagged as having allConnections")
+	}
+	if len(ids) != 1 || ids[0] != rbacUnsharedConnID {
+		t.Fatalf("Expected owner to see [%d], got %v",
+			rbacUnsharedConnID, ids)
+	}
+
+	// The pure filter confirms the cluster containing the owner's
+	// connection is visible through the same code path the handler
+	// uses after resolveVisibleConnections.
+	visibleMap := map[int]bool{ids[0]: true}
+	if !clusterMembersVisible([]int{rbacUnsharedConnID}, visibleMap) {
+		t.Error("Owner must see the cluster containing their own unshared " +
+			"connection")
+	}
+}
+
+// TestVisibleConnectionIDs_Issue35_Clusters_Superuser_SkipsFilter locks
+// in the superuser escape-hatch. Superusers get allConnections=true, so
+// the cluster handlers must not filter and must return every cluster
+// including those composed entirely of unshared non-owned connections.
+func TestVisibleConnectionIDs_Issue35_Clusters_Superuser_SkipsFilter(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	checker := auth.NewRBACChecker(store)
+
+	// Superuser identity has IsSuperuserContextKey=true; user ID/name
+	// are irrelevant for VisibleConnectionIDs in the superuser path.
+	ctx := context.WithValue(context.Background(), auth.IsSuperuserContextKey, true)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "admin")
+
+	lister := &stubVisibilityLister{
+		connections: []auth.ConnectionVisibilityInfo{
+			{ID: rbacUnsharedConnID, IsShared: false, OwnerUsername: "alice"},
+		},
+	}
+
+	_, all, err := checker.VisibleConnectionIDs(ctx, lister)
+	if err != nil {
+		t.Fatalf("VisibleConnectionIDs: %v", err)
+	}
+	if !all {
+		t.Fatal("Superuser must receive allConnections=true so the cluster " +
+			"handlers skip filtering entirely")
+	}
+}

--- a/server/src/internal/api/rbac_issue35_overview_blackout_test.go
+++ b/server/src/internal/api/rbac_issue35_overview_blackout_test.go
@@ -108,8 +108,10 @@ func TestOverrideListHandlers_ServerScope_NonOwnerUnshared_404(t *testing.T) {
 
 // TestOverrideListHandlers_ServerScope_Superuser_NotDenied verifies a
 // superuser bypasses the gate. With a nil datastore the handler panics
-// after the gate; the test recovers and asserts the response never
-// became 404 or 403.
+// after the gate is cleared; noRespPanic recovers the panic before any
+// response is written, leaving rec.Code at the httptest default (200).
+// Asserting on the default status confirms the gate passed AND that no
+// error response (403/404/500) was written before the datastore call.
 func TestOverrideListHandlers_ServerScope_Superuser_NotDenied(t *testing.T) {
 	for _, tc := range overrideListInvokers {
 		tc := tc
@@ -128,8 +130,14 @@ func TestOverrideListHandlers_ServerScope_Superuser_NotDenied(t *testing.T) {
 				tc.invoke(store, checker, rec, req, "server", rbacUnsharedConnID)
 			})
 
-			if rec.Code == http.StatusNotFound || rec.Code == http.StatusForbidden {
-				t.Errorf("%s/superuser: gate wrote %d; expected gate to pass. Body: %s",
+			// The gate must not write any error status. The datastore
+			// call that follows panics on nil and noRespPanic recovers
+			// before any status is written, so rec.Code remains the
+			// httptest default of 200. Anything else (403, 404, or a
+			// 500 from a premature error response) indicates the gate
+			// path is broken.
+			if rec.Code != http.StatusOK {
+				t.Errorf("%s/superuser: gate wrote %d; expected gate to pass (rec.Code should remain default 200). Body: %s",
 					tc.name, rec.Code, rec.Body.String())
 			}
 		})
@@ -139,7 +147,9 @@ func TestOverrideListHandlers_ServerScope_Superuser_NotDenied(t *testing.T) {
 // TestOverrideListHandlers_ServerScope_GroupGranted_NotDenied verifies
 // that a user with an explicit group grant clears the gate. The explicit
 // grant lets the handler's resolver see the connection via the auth
-// store without needing a datastore-backed lister.
+// store without needing a datastore-backed lister. noRespPanic recovers
+// the nil-datastore panic that follows the gate, leaving rec.Code at
+// the httptest default (200) when the gate passes cleanly.
 func TestOverrideListHandlers_ServerScope_GroupGranted_NotDenied(t *testing.T) {
 	for _, tc := range overrideListInvokers {
 		tc := tc
@@ -161,8 +171,11 @@ func TestOverrideListHandlers_ServerScope_GroupGranted_NotDenied(t *testing.T) {
 				tc.invoke(store, checker, rec, req, "server", rbacUnsharedConnID)
 			})
 
-			if rec.Code == http.StatusNotFound || rec.Code == http.StatusForbidden {
-				t.Errorf("%s/group-granted: gate wrote %d; expected gate to pass. Body: %s",
+			// See TestOverrideListHandlers_ServerScope_Superuser_NotDenied
+			// for why the expected status is the default 200. Anything
+			// else (403, 404, 500) indicates the gate wrote an error.
+			if rec.Code != http.StatusOK {
+				t.Errorf("%s/group-granted: gate wrote %d; expected gate to pass (rec.Code should remain default 200). Body: %s",
 					tc.name, rec.Code, rec.Body.String())
 			}
 		})

--- a/server/src/internal/api/rbac_issue35_overview_blackout_test.go
+++ b/server/src/internal/api/rbac_issue35_overview_blackout_test.go
@@ -1,0 +1,326 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+)
+
+// =============================================================================
+// Regression tests for the second pass of GitHub issue #35 (RBAC leaks).
+//
+// These tests cover two narrow slices of the fix:
+//
+//   - The override list handlers (alert/probe/channel) at scope=server
+//     return 404 when a non-owner zero-grant caller asks about an
+//     unshared server. The gate runs before any datastore call, so the
+//     nil-datastore harness from rbac_issue35_test.go suffices.
+//
+//   - The blackoutVisible helper implements the blackout getter's RBAC
+//     decision. A pure unit test pins down the decision matrix for the
+//     no-datastore branches (global and server-scoped blackouts). The
+//     cluster/group branches call the datastore and are covered by the
+//     integration tests accompanying issue #35.
+// =============================================================================
+
+// newBlackoutForTest constructs a Blackout populated only with the
+// resource pointer fields. The rest are zero values because
+// blackoutVisible only inspects the resource pointers.
+func newBlackoutForTest(connID, clusterID, groupID *int) *database.Blackout {
+	return &database.Blackout{
+		ConnectionID: connID,
+		ClusterID:    clusterID,
+		GroupID:      groupID,
+	}
+}
+
+// overrideListInvoker describes one override list handler under test.
+type overrideListInvoker struct {
+	name   string
+	invoke func(store *auth.AuthStore, checker *auth.RBACChecker,
+		w http.ResponseWriter, r *http.Request, scope string, scopeID int)
+}
+
+var overrideListInvokers = []overrideListInvoker{
+	{
+		name: "alert_override",
+		invoke: func(store *auth.AuthStore, checker *auth.RBACChecker,
+			w http.ResponseWriter, r *http.Request, scope string, scopeID int) {
+			NewAlertOverrideHandler(nil, store, checker).listOverrides(w, r, scope, scopeID)
+		},
+	},
+	{
+		name: "probe_override",
+		invoke: func(store *auth.AuthStore, checker *auth.RBACChecker,
+			w http.ResponseWriter, r *http.Request, scope string, scopeID int) {
+			NewProbeOverrideHandler(nil, store, checker).listOverrides(w, r, scope, scopeID)
+		},
+	},
+	{
+		name: "channel_override",
+		invoke: func(store *auth.AuthStore, checker *auth.RBACChecker,
+			w http.ResponseWriter, r *http.Request, scope string, scopeID int) {
+			NewChannelOverrideHandler(nil, store, checker).listOverrides(w, r, scope, scopeID)
+		},
+	},
+}
+
+// TestOverrideListHandlers_ServerScope_NonOwnerUnshared_404 verifies that
+// every override list handler returns 404 when a non-owner user with no
+// grants asks for overrides attached to an unshared server owned by
+// someone else. The gate runs before any datastore call so the nil
+// datastore is never reached.
+func TestOverrideListHandlers_ServerScope_NonOwnerUnshared_404(t *testing.T) {
+	for _, tc := range overrideListInvokers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			bobID := newTestUser(t, store, "bob")
+			checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+
+			req := httptest.NewRequest(http.MethodGet,
+				fmtURL("/api/v1/alert-overrides/server/%d", rbacUnsharedConnID), nil)
+			req = withUser(req, bobID)
+			req = withUsername(req, "bob")
+			rec := httptest.NewRecorder()
+
+			tc.invoke(store, checker, rec, req, "server", rbacUnsharedConnID)
+
+			requireStatus(t, rec, http.StatusNotFound)
+		})
+	}
+}
+
+// TestOverrideListHandlers_ServerScope_Superuser_NotDenied verifies a
+// superuser bypasses the gate. With a nil datastore the handler panics
+// after the gate; the test recovers and asserts the response never
+// became 404 or 403.
+func TestOverrideListHandlers_ServerScope_Superuser_NotDenied(t *testing.T) {
+	for _, tc := range overrideListInvokers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+
+			req := httptest.NewRequest(http.MethodGet,
+				fmtURL("/api/v1/alert-overrides/server/%d", rbacUnsharedConnID), nil)
+			req = withSuperuser(req)
+			rec := httptest.NewRecorder()
+
+			noRespPanic(func() {
+				tc.invoke(store, checker, rec, req, "server", rbacUnsharedConnID)
+			})
+
+			if rec.Code == http.StatusNotFound || rec.Code == http.StatusForbidden {
+				t.Errorf("%s/superuser: gate wrote %d; expected gate to pass. Body: %s",
+					tc.name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestOverrideListHandlers_ServerScope_GroupGranted_NotDenied verifies
+// that a user with an explicit group grant clears the gate. The explicit
+// grant lets the handler's resolver see the connection via the auth
+// store without needing a datastore-backed lister.
+func TestOverrideListHandlers_ServerScope_GroupGranted_NotDenied(t *testing.T) {
+	for _, tc := range overrideListInvokers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			bobID := newGroupGrantedUser(t, store, "bob",
+				rbacUnsharedConnID, auth.AccessLevelReadWrite)
+			checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+
+			req := httptest.NewRequest(http.MethodGet,
+				fmtURL("/api/v1/alert-overrides/server/%d", rbacUnsharedConnID), nil)
+			req = withUser(req, bobID)
+			req = withUsername(req, "bob")
+			rec := httptest.NewRecorder()
+
+			noRespPanic(func() {
+				tc.invoke(store, checker, rec, req, "server", rbacUnsharedConnID)
+			})
+
+			if rec.Code == http.StatusNotFound || rec.Code == http.StatusForbidden {
+				t.Errorf("%s/group-granted: gate wrote %d; expected gate to pass. Body: %s",
+					tc.name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestBlackoutVisible_DecisionMatrix exercises the pure visibility
+// decision for blackouts with server-scoped or global references. The
+// cluster/group branches call the datastore and are tested via the
+// integration harness.
+func TestBlackoutVisible_DecisionMatrix(t *testing.T) {
+	const connID = rbacUnsharedConnID
+
+	visibleYes := map[int]bool{connID: true}
+	visibleNo := map[int]bool{}
+
+	connPtr := func(id int) *int { return &id }
+
+	type row struct {
+		name    string
+		connID  *int
+		visible map[int]bool
+		want    bool
+	}
+	rows := []row{
+		{name: "global_visible_to_all", connID: nil, visible: visibleNo, want: true},
+		{name: "server_visible", connID: connPtr(connID), visible: visibleYes, want: true},
+		{name: "server_not_visible", connID: connPtr(connID), visible: visibleNo, want: false},
+	}
+
+	h := &BlackoutHandler{}
+	for _, r := range rows {
+		r := r
+		t.Run(r.name, func(t *testing.T) {
+			b := newBlackoutForTest(r.connID, nil, nil)
+			got, err := h.blackoutVisible(context.Background(), b, r.visible)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != r.want {
+				t.Errorf("blackoutVisible = %v, want %v", got, r.want)
+			}
+		})
+	}
+}
+
+// TestBlackoutScheduleVisible_DecisionMatrix exercises the pure
+// visibility decision for blackout schedules with server-scoped or
+// global references, matching the guard added to listBlackoutSchedules
+// and getBlackoutSchedule in the #35 follow-up. This locks in that a
+// non-owner caller cannot see a schedule attached to an unshared
+// server that was not filtered by the legacy code path.
+func TestBlackoutScheduleVisible_DecisionMatrix(t *testing.T) {
+	const connID = rbacUnsharedConnID
+
+	visibleYes := map[int]bool{connID: true}
+	visibleNo := map[int]bool{}
+
+	connPtr := func(id int) *int { return &id }
+
+	type row struct {
+		name    string
+		connID  *int
+		visible map[int]bool
+		want    bool
+	}
+	rows := []row{
+		{name: "global_visible_to_all", connID: nil, visible: visibleNo, want: true},
+		{name: "server_visible", connID: connPtr(connID), visible: visibleYes, want: true},
+		{name: "server_not_visible", connID: connPtr(connID), visible: visibleNo, want: false},
+	}
+
+	h := &BlackoutHandler{}
+	for _, r := range rows {
+		r := r
+		t.Run(r.name, func(t *testing.T) {
+			s := &database.BlackoutSchedule{ConnectionID: r.connID}
+			got, err := h.blackoutScheduleVisible(context.Background(), s, r.visible)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != r.want {
+				t.Errorf("blackoutScheduleVisible = %v, want %v", got, r.want)
+			}
+		})
+	}
+}
+
+// TestAlertOverrideGetContext_NonOwnerUnshared_404 verifies that a
+// user with the manage_alert_rules admin permission (so the permission
+// gate passes) but no visibility into an unshared server receives 404
+// from the getOverrideContext endpoint. The scope gate runs before any
+// datastore call so the nil datastore is never reached.
+func TestAlertOverrideGetContext_NonOwnerUnshared_404(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	bobID := newTestUser(t, store, "bob")
+	// Grant bob the admin permission so checkPermission passes and the
+	// scope-visibility gate becomes the test target.
+	groupID, err := store.CreateGroup("bob_group", "")
+	if err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	if err := store.AddUserToGroup(groupID, bobID); err != nil {
+		t.Fatalf("AddUserToGroup: %v", err)
+	}
+	if err := store.GrantAdminPermission(groupID, auth.PermManageAlertRules); err != nil {
+		t.Fatalf("GrantAdminPermission: %v", err)
+	}
+
+	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+
+	h := NewAlertOverrideHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmtURL("/api/v1/alert-overrides/context/%d/1", rbacUnsharedConnID), nil)
+	req = withUser(req, bobID)
+	req = withUsername(req, "bob")
+	rec := httptest.NewRecorder()
+
+	h.getOverrideContext(rec, req, rbacUnsharedConnID, 1)
+
+	requireStatus(t, rec, http.StatusNotFound)
+}
+
+// TestVisibleConnectionIDs_Issue35_Overview_NonOwnerZeroGrant pins down
+// the visible-set contract the overview handler depends on for scoped
+// queries. A non-owner zero-grant caller must see the unshared
+// connection as invisible, so a scope=server request for it will be
+// denied with 403 and a connection_ids list containing only it will be
+// filtered to empty.
+func TestVisibleConnectionIDs_Issue35_Overview_NonOwnerZeroGrant(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	bobID := newTestUser(t, store, "bob")
+
+	checker := auth.NewRBACChecker(store)
+
+	lister := &stubVisibilityLister{
+		connections: []auth.ConnectionVisibilityInfo{
+			{ID: rbacUnsharedConnID, IsShared: false, OwnerUsername: "alice"},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, bobID)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "bob")
+
+	ids, all, err := checker.VisibleConnectionIDs(ctx, lister)
+	if err != nil {
+		t.Fatalf("VisibleConnectionIDs: %v", err)
+	}
+	if all {
+		t.Fatal("Non-superuser zero-grant caller must not receive allConnections=true")
+	}
+	if len(ids) != 0 {
+		t.Errorf("Expected empty visible set for non-owner zero-grant, got %v", ids)
+	}
+}

--- a/server/src/internal/api/rbac_visibility.go
+++ b/server/src/internal/api/rbac_visibility.go
@@ -102,6 +102,18 @@ func clusterConnectionMembershipFn(ctx context.Context, ds rbacVisibilityDatasto
 // return immediately when this function returns false. The scope
 // argument must be one of "server", "cluster", or "group".
 func scopeVisibleToCaller(ctx context.Context, w http.ResponseWriter, rbac *auth.RBACChecker, ds *database.Datastore, scope string, scopeID int, notFoundMsg string) bool {
+	// Validate the scope string before any visibility shortcut so that
+	// unrestricted callers (superuser or wildcard grant) cannot bypass
+	// the documented "server" | "cluster" | "group" contract by passing
+	// garbage. Restricted callers hit the same check, keeping the 400
+	// response consistent across caller types.
+	switch scope {
+	case "server", "cluster", "group":
+	default:
+		RespondError(w, http.StatusBadRequest, "Invalid scope")
+		return false
+	}
+
 	visible, allConnections, err := resolveVisibleConnectionSet(ctx, rbac, ds)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for %s scope %d: %v", scope, scopeID, err)
@@ -120,9 +132,6 @@ func scopeVisibleToCaller(ctx context.Context, w http.ResponseWriter, rbac *auth
 		ok, err = clusterHasVisibleConnectionFn(ctx, ds, scopeID, visible)
 	case "group":
 		ok, err = groupHasVisibleConnectionFn(ctx, ds, scopeID, visible)
-	default:
-		RespondError(w, http.StatusBadRequest, "Invalid scope")
-		return false
 	}
 	if err != nil {
 		log.Printf("[ERROR] Failed to check %s scope %d visibility: %v", scope, scopeID, err)

--- a/server/src/internal/api/rbac_visibility.go
+++ b/server/src/internal/api/rbac_visibility.go
@@ -32,6 +32,13 @@ type rbacVisibilityDatastore interface {
 // filtering entirely. The visible map is nil when allConnections is
 // true.
 func resolveVisibleConnectionSet(ctx context.Context, rbac *auth.RBACChecker, ds *database.Datastore) (map[int]bool, bool, error) {
+	// Defence-in-depth: NewBlackoutHandler and NewClusterHandler both
+	// accept a nil rbacChecker (and are exercised with nil in tests),
+	// so treat a nil checker as unrestricted visibility rather than
+	// panicking on the method call below.
+	if rbac == nil {
+		return nil, true, nil
+	}
 	lister := newConnectionVisibilityLister(ds)
 	ids, all, err := rbac.VisibleConnectionIDs(ctx, lister)
 	if err != nil {

--- a/server/src/internal/api/rbac_visibility.go
+++ b/server/src/internal/api/rbac_visibility.go
@@ -74,6 +74,10 @@ func groupHasVisibleConnectionFn(ctx context.Context, ds rbacVisibilityDatastore
 // values are the connection IDs assigned to each cluster. Clusters
 // absent from the map have no connections. The implementation issues
 // one datastore call per cluster.
+//
+// TODO(#35 follow-up): the per-cluster lookup is intentional at
+// autocomplete scale (tens of clusters per caller); batch via the
+// datastore if cluster count grows large enough to become a hot path.
 func clusterConnectionMembershipFn(ctx context.Context, ds rbacVisibilityDatastore, clusterIDs []int) (map[int][]int, error) {
 	out := make(map[int][]int, len(clusterIDs))
 	for _, id := range clusterIDs {
@@ -128,6 +132,10 @@ func scopeVisibleToCaller(ctx context.Context, w http.ResponseWriter, rbac *auth
 // filterGroupsByVisibilityFn drops cluster groups whose clusters contain
 // no visible member connections. It issues one datastore lookup per
 // group via GetConnectionIDsForGroup.
+//
+// TODO(#35 follow-up): the per-group lookup is intentional at
+// autocomplete scale (tens of groups per caller); batch via the
+// datastore if group count grows large enough to become a hot path.
 func filterGroupsByVisibilityFn(ctx context.Context, ds rbacVisibilityDatastore, groups []database.ClusterGroup, visible map[int]bool) ([]database.ClusterGroup, error) {
 	out := make([]database.ClusterGroup, 0, len(groups))
 	for i := range groups {

--- a/server/src/internal/api/rbac_visibility.go
+++ b/server/src/internal/api/rbac_visibility.go
@@ -32,7 +32,7 @@ type rbacVisibilityDatastore interface {
 // filtering entirely. The visible map is nil when allConnections is
 // true.
 func resolveVisibleConnectionSet(ctx context.Context, rbac *auth.RBACChecker, ds *database.Datastore) (map[int]bool, bool, error) {
-	// Defence-in-depth: NewBlackoutHandler and NewClusterHandler both
+	// Defense-in-depth: NewBlackoutHandler and NewClusterHandler both
 	// accept a nil rbacChecker (and are exercised with nil in tests),
 	// so treat a nil checker as unrestricted visibility rather than
 	// panicking on the method call below.

--- a/server/src/internal/api/rbac_visibility.go
+++ b/server/src/internal/api/rbac_visibility.go
@@ -1,0 +1,143 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+)
+
+// rbacVisibilityDatastore is the narrow datastore contract required by
+// the shared visibility helpers. The full *database.Datastore satisfies
+// this interface; tests may substitute a lightweight fake.
+type rbacVisibilityDatastore interface {
+	GetConnectionIDsForCluster(ctx context.Context, clusterID int) ([]int, error)
+	GetConnectionIDsForGroup(ctx context.Context, groupID int) ([]int, error)
+}
+
+// resolveVisibleConnectionSet returns the caller's visible connection-ID
+// set. The second return value is true when the caller has unrestricted
+// visibility (superuser or wildcard grant); callers should then skip
+// filtering entirely. The visible map is nil when allConnections is
+// true.
+func resolveVisibleConnectionSet(ctx context.Context, rbac *auth.RBACChecker, ds *database.Datastore) (map[int]bool, bool, error) {
+	lister := newConnectionVisibilityLister(ds)
+	ids, all, err := rbac.VisibleConnectionIDs(ctx, lister)
+	if err != nil {
+		return nil, false, err
+	}
+	if all {
+		return nil, true, nil
+	}
+	visible := make(map[int]bool, len(ids))
+	for _, id := range ids {
+		visible[id] = true
+	}
+	return visible, false, nil
+}
+
+// clusterHasVisibleConnectionFn reports whether the given cluster has any
+// member connection in the visible set. Empty clusters are treated as
+// invisible: without a member connection there is no ownership or
+// sharing claim the caller could satisfy.
+func clusterHasVisibleConnectionFn(ctx context.Context, ds rbacVisibilityDatastore, clusterID int, visible map[int]bool) (bool, error) {
+	ids, err := ds.GetConnectionIDsForCluster(ctx, clusterID)
+	if err != nil {
+		return false, err
+	}
+	return clusterMembersVisible(ids, visible), nil
+}
+
+// groupHasVisibleConnectionFn reports whether the given group contains
+// at least one cluster whose member connections include a visible ID.
+// See clusterHasVisibleConnectionFn for the empty-group contract.
+func groupHasVisibleConnectionFn(ctx context.Context, ds rbacVisibilityDatastore, groupID int, visible map[int]bool) (bool, error) {
+	ids, err := ds.GetConnectionIDsForGroup(ctx, groupID)
+	if err != nil {
+		return false, err
+	}
+	return clusterMembersVisible(ids, visible), nil
+}
+
+// clusterConnectionMembershipFn returns a map keyed by cluster ID whose
+// values are the connection IDs assigned to each cluster. Clusters
+// absent from the map have no connections. The implementation issues
+// one datastore call per cluster.
+func clusterConnectionMembershipFn(ctx context.Context, ds rbacVisibilityDatastore, clusterIDs []int) (map[int][]int, error) {
+	out := make(map[int][]int, len(clusterIDs))
+	for _, id := range clusterIDs {
+		ids, err := ds.GetConnectionIDsForCluster(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		out[id] = ids
+	}
+	return out, nil
+}
+
+// scopeVisibleToCaller reports whether the caller may see the given
+// scope and writes a 404 response when they cannot. The caller should
+// return immediately when this function returns false. The scope
+// argument must be one of "server", "cluster", or "group".
+func scopeVisibleToCaller(ctx context.Context, w http.ResponseWriter, rbac *auth.RBACChecker, ds *database.Datastore, scope string, scopeID int, notFoundMsg string) bool {
+	visible, allConnections, err := resolveVisibleConnectionSet(ctx, rbac, ds)
+	if err != nil {
+		log.Printf("[ERROR] Failed to resolve visible connections for %s scope %d: %v", scope, scopeID, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to check scope visibility")
+		return false
+	}
+	if allConnections {
+		return true
+	}
+
+	var ok bool
+	switch scope {
+	case "server":
+		ok = visible[scopeID]
+	case "cluster":
+		ok, err = clusterHasVisibleConnectionFn(ctx, ds, scopeID, visible)
+	case "group":
+		ok, err = groupHasVisibleConnectionFn(ctx, ds, scopeID, visible)
+	default:
+		RespondError(w, http.StatusBadRequest, "Invalid scope")
+		return false
+	}
+	if err != nil {
+		log.Printf("[ERROR] Failed to check %s scope %d visibility: %v", scope, scopeID, err)
+		RespondError(w, http.StatusInternalServerError, "Failed to check scope visibility")
+		return false
+	}
+	if !ok {
+		RespondError(w, http.StatusNotFound, notFoundMsg)
+		return false
+	}
+	return true
+}
+
+// filterGroupsByVisibilityFn drops cluster groups whose clusters contain
+// no visible member connections. It issues one datastore lookup per
+// group via GetConnectionIDsForGroup.
+func filterGroupsByVisibilityFn(ctx context.Context, ds rbacVisibilityDatastore, groups []database.ClusterGroup, visible map[int]bool) ([]database.ClusterGroup, error) {
+	out := make([]database.ClusterGroup, 0, len(groups))
+	for i := range groups {
+		ok, err := groupHasVisibleConnectionFn(ctx, ds, groups[i].ID, visible)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out = append(out, groups[i])
+		}
+	}
+	return out, nil
+}

--- a/server/src/internal/api/rbac_visibility_test.go
+++ b/server/src/internal/api/rbac_visibility_test.go
@@ -11,6 +11,8 @@ package api
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -32,5 +34,22 @@ func TestResolveVisibleConnectionSet_NilRBAC_ReturnsAllConnections(t *testing.T)
 	}
 	if visible != nil {
 		t.Errorf("Expected nil visible map when allConnections=true, got %v", visible)
+	}
+}
+
+// TestScopeVisibleToCaller_InvalidScope_RejectsUnrestrictedCaller verifies
+// that scope validation runs before the allConnections shortcut. An
+// unrestricted caller (nil rbac, thanks to the guard added for #35) that
+// passes a garbage scope must receive 400, matching the behavior
+// restricted callers already saw via the switch default. This closes the
+// inconsistency CodeRabbit flagged on the recurring #35 follow-up.
+func TestScopeVisibleToCaller_InvalidScope_RejectsUnrestrictedCaller(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ok := scopeVisibleToCaller(context.Background(), rec, nil, nil, "garbage", 1, "not found")
+	if ok {
+		t.Fatal("Expected scopeVisibleToCaller to return false for invalid scope")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for invalid scope, got %d", rec.Code)
 	}
 }

--- a/server/src/internal/api/rbac_visibility_test.go
+++ b/server/src/internal/api/rbac_visibility_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestResolveVisibleConnectionSet_NilRBAC_ReturnsAllConnections verifies
-// the defence-in-depth nil guard added after CodeRabbit's follow-up
+// the defense-in-depth nil guard added after CodeRabbit's follow-up
 // review on issue #35. NewBlackoutHandler and NewClusterHandler both
 // accept a nil rbacChecker (the blackout and cluster handler tests
 // construct handlers that way), so resolveVisibleConnectionSet must

--- a/server/src/internal/api/rbac_visibility_test.go
+++ b/server/src/internal/api/rbac_visibility_test.go
@@ -1,0 +1,36 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+// TestResolveVisibleConnectionSet_NilRBAC_ReturnsAllConnections verifies
+// the defence-in-depth nil guard added after CodeRabbit's follow-up
+// review on issue #35. NewBlackoutHandler and NewClusterHandler both
+// accept a nil rbacChecker (the blackout and cluster handler tests
+// construct handlers that way), so resolveVisibleConnectionSet must
+// treat a nil checker as unrestricted visibility rather than panicking
+// on the method call. The ds argument is also nil here to prove the
+// guard returns before touching the datastore.
+func TestResolveVisibleConnectionSet_NilRBAC_ReturnsAllConnections(t *testing.T) {
+	visible, all, err := resolveVisibleConnectionSet(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("resolveVisibleConnectionSet with nil rbac: %v", err)
+	}
+	if !all {
+		t.Error("Expected allConnections=true when rbacChecker is nil")
+	}
+	if visible != nil {
+		t.Errorf("Expected nil visible map when allConnections=true, got %v", visible)
+	}
+}

--- a/server/src/internal/database/datastore.go
+++ b/server/src/internal/database/datastore.go
@@ -4705,6 +4705,22 @@ func (d *Datastore) getConnectionIDsForGroup(ctx context.Context, groupID int) (
 	return ids, rows.Err()
 }
 
+// GetConnectionIDsForCluster returns all connection IDs that belong to
+// the given cluster. It is an exported wrapper around the internal
+// helper so other packages (notably the API handlers that apply RBAC
+// visibility filtering) can enumerate a cluster's members without
+// duplicating the SQL.
+func (d *Datastore) GetConnectionIDsForCluster(ctx context.Context, clusterID int) ([]int, error) {
+	return d.getConnectionIDsForCluster(ctx, clusterID)
+}
+
+// GetConnectionIDsForGroup returns all connection IDs that belong to
+// any cluster in the given group. Exported companion to
+// GetConnectionIDsForCluster for group-scoped RBAC checks.
+func (d *Datastore) GetConnectionIDsForGroup(ctx context.Context, groupID int) ([]int, error) {
+	return d.getConnectionIDsForGroup(ctx, groupID)
+}
+
 // gatherScopedServerData populates server status counts for a specific
 // set of connection IDs by walking the full topology and filtering.
 func (d *Datastore) gatherScopedServerData(ctx context.Context, snapshot *EstateSnapshot, connectionIDs []int) {

--- a/server/src/internal/overview/handler.go
+++ b/server/src/internal/overview/handler.go
@@ -134,8 +134,41 @@ func (h *Handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// When no scope parameters are provided, return the estate-wide
-	// overview using the existing behavior.
+	// overview. Restricted callers receive a scoped summary covering
+	// only their visible connections instead of the full estate
+	// snapshot.
 	if scopeType == "" && scopeIDStr == "" {
+		if h.rbacChecker != nil && h.datastore != nil {
+			visible, allConns, err := h.resolveVisible(r.Context())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: overview: failed to resolve visible connections: %v\n", err)
+				http.Error(w, "Failed to resolve connection visibility", http.StatusInternalServerError)
+				return
+			}
+			if !allConns {
+				ids := make([]int, 0, len(visible))
+				for id := range visible {
+					ids = append(ids, id)
+				}
+				ids = dedupeAndSort(ids)
+				if len(ids) == 0 {
+					if err := json.NewEncoder(w).Encode(generatingResponse{Status: "empty", Summary: nil}); err != nil {
+						fmt.Fprintf(os.Stderr, "ERROR: overview: failed to encode empty response: %v\n", err)
+					}
+					return
+				}
+				overview, err := h.generator.GetConnectionsSummary(ids, "", refresh)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "ERROR: overview: connections summary failed: %v\n", err)
+					http.Error(w, "Failed to generate connections summary", http.StatusInternalServerError)
+					return
+				}
+				if err := json.NewEncoder(w).Encode(overview); err != nil {
+					fmt.Fprintf(os.Stderr, "ERROR: overview: failed to encode connections response: %v\n", err)
+				}
+				return
+			}
+		}
 		if refresh {
 			h.generator.ForceRefresh()
 		}
@@ -290,6 +323,33 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 			scopeKey = "connections:" + strings.Join(parts, ",")
 			// When the intersection is empty we still accept the
 			// subscription but will not kick off generation below.
+		}
+	}
+
+	// When no scope params are given, check RBAC. Restricted callers
+	// receive a scoped SSE feed covering only their visible connections
+	// instead of the full estate-wide stream.
+	if scopeKey == "" && h.rbacChecker != nil && h.datastore != nil {
+		visible, allConns, err := h.resolveVisible(r.Context())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: overview/sse: failed to resolve visible connections: %v\n", err)
+			http.Error(w, "Failed to resolve connection visibility", http.StatusInternalServerError)
+			return
+		}
+		if !allConns {
+			ids := make([]int, 0, len(visible))
+			for id := range visible {
+				ids = append(ids, id)
+			}
+			ids = dedupeAndSort(ids)
+			filteredConnectionIDs = ids
+			parts := make([]string, len(ids))
+			for i, id := range ids {
+				parts[i] = fmt.Sprintf("%d", id)
+			}
+			if len(ids) > 0 {
+				scopeKey = "connections:" + strings.Join(parts, ",")
+			}
 		}
 	}
 

--- a/server/src/internal/overview/handler.go
+++ b/server/src/internal/overview/handler.go
@@ -249,12 +249,11 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
+		// filterConnectionIDs returns a deduplicated, sorted slice so the
+		// cache/SSE scope key is stable across equivalent inputs.
 		filteredConnectionIDs = filtered
-		sorted := make([]int, len(filtered))
-		copy(sorted, filtered)
-		sortInts(sorted)
-		parts := make([]string, len(sorted))
-		for i, id := range sorted {
+		parts := make([]string, len(filtered))
+		for i, id := range filtered {
 			parts[i] = fmt.Sprintf("%d", id)
 		}
 		scopeKey = "connections:" + strings.Join(parts, ",")
@@ -280,14 +279,12 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 			scopeKey = fmt.Sprintf("%s:%d", scopeType, scopeID)
 		} else {
 			// Restricted visibility routes through the connections-summary
-			// path. Reuse the sorted-ID cache key scheme so two users with
-			// different visibility never share a cache entry.
+			// path. intersectVisible returns a deduplicated, sorted slice
+			// so two users with different visibility never share a cache
+			// entry.
 			filteredConnectionIDs = intersect
-			sorted := make([]int, len(intersect))
-			copy(sorted, intersect)
-			sortInts(sorted)
-			parts := make([]string, len(sorted))
-			for i, id := range sorted {
+			parts := make([]string, len(intersect))
+			for i, id := range intersect {
 				parts[i] = fmt.Sprintf("%d", id)
 			}
 			scopeKey = "connections:" + strings.Join(parts, ",")
@@ -371,12 +368,18 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 // filterConnectionIDs restricts the supplied connection ID list to those
 // visible to the caller. When RBAC is not configured (nil checker or
-// nil datastore) the list is returned unchanged. The second return
-// value is false when the function wrote an error response and the
-// caller must return immediately.
+// nil datastore) the list is deduplicated and sorted but not filtered.
+// The second return value is false when the function wrote an error
+// response and the caller must return immediately.
+//
+// The output is deduplicated and sorted so that equivalent input lists
+// (same members, different order or duplicates) produce the same
+// "connections:" cache key and SSE scope key, preventing duplicate cache
+// entries and duplicate connection IDs from reaching the summary
+// generator.
 func (h *Handler) filterConnectionIDs(ctx context.Context, w http.ResponseWriter, ids []int) ([]int, bool) {
 	if h.rbacChecker == nil || h.datastore == nil {
-		return ids, true
+		return dedupeAndSort(ids), true
 	}
 	visible, allConnections, err := h.resolveVisible(ctx)
 	if err != nil {
@@ -385,15 +388,41 @@ func (h *Handler) filterConnectionIDs(ctx context.Context, w http.ResponseWriter
 		return nil, false
 	}
 	if allConnections {
-		return ids, true
+		return dedupeAndSort(ids), true
 	}
+	seen := make(map[int]struct{}, len(ids))
 	out := make([]int, 0, len(ids))
 	for _, id := range ids {
-		if visible[id] {
-			out = append(out, id)
+		if !visible[id] {
+			continue
 		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
+	sortInts(out)
 	return out, true
+}
+
+// dedupeAndSort returns a new slice containing the unique elements of
+// ids in ascending order. The input is not modified.
+func dedupeAndSort(ids []int) []int {
+	if len(ids) == 0 {
+		return []int{}
+	}
+	seen := make(map[int]struct{}, len(ids))
+	out := make([]int, 0, len(ids))
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	sortInts(out)
+	return out
 }
 
 // scopeVisible reports whether the caller may see the requested scope
@@ -456,14 +485,26 @@ func (h *Handler) scopeVisible(ctx context.Context, w http.ResponseWriter, scope
 }
 
 // intersectVisible returns the subset of members that are also in the
-// visible set, preserving the original order.
+// visible set. The result is deduplicated and sorted in ascending order
+// so that equivalent inputs (same members in different order or with
+// duplicates) produce the same cache/SSE scope key downstream.
 func intersectVisible(members []int, visible map[int]bool) []int {
+	if len(members) == 0 {
+		return []int{}
+	}
+	seen := make(map[int]struct{}, len(members))
 	out := make([]int, 0, len(members))
 	for _, id := range members {
-		if visible[id] {
-			out = append(out, id)
+		if !visible[id] {
+			continue
 		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
+	sortInts(out)
 	return out
 }
 

--- a/server/src/internal/overview/handler.go
+++ b/server/src/internal/overview/handler.go
@@ -56,7 +56,7 @@ func NewHandler(generator *Generator, hub *Hub) *Handler {
 
 // NewHandlerWithRBAC creates a new overview handler that enforces scope
 // visibility against the caller's RBAC view. A nil rbacChecker or
-// datastore disables the gate (preserves pre-RBAC behaviour for tests).
+// datastore disables the gate (preserves pre-RBAC behavior for tests).
 func NewHandlerWithRBAC(generator *Generator, hub *Hub, rbacChecker *auth.RBACChecker, datastore *database.Datastore) *Handler {
 	return &Handler{
 		generator:   generator,
@@ -404,7 +404,7 @@ func (h *Handler) filterConnectionIDs(ctx context.Context, w http.ResponseWriter
 // true) is returned so the caller can use the full-scope snapshot path.
 // On denial the function writes a 404 response and returns ok=false.
 // The caller must return immediately when ok is false. Matching the
-// behaviour of sibling handlers, 404 is used for scope-denial to avoid
+// behavior of sibling handlers, 404 is used for scope-denial to avoid
 // leaking the existence of scopes the caller cannot see.
 func (h *Handler) scopeVisible(ctx context.Context, w http.ResponseWriter, scopeType string, scopeID int) (intersect []int, unrestricted bool, ok bool) {
 	if h.rbacChecker == nil || h.datastore == nil {

--- a/server/src/internal/overview/handler.go
+++ b/server/src/internal/overview/handler.go
@@ -10,6 +10,7 @@
 package overview
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -17,6 +18,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/database"
 )
 
 // openAPISpecPath is the path to the OpenAPI specification for RFC 8631
@@ -34,15 +38,31 @@ var validScopeTypes = map[string]bool{
 // endpoint. It satisfies the routeRegistrar interface used by the
 // server's handler setup.
 type Handler struct {
-	generator *Generator
-	hub       *Hub
+	generator   *Generator
+	hub         *Hub
+	rbacChecker *auth.RBACChecker
+	datastore   *database.Datastore
 }
 
 // NewHandler creates a new overview handler backed by the given generator.
+// RBAC filtering is disabled when called without an rbacChecker; use
+// NewHandlerWithRBAC to enable scope visibility enforcement.
 func NewHandler(generator *Generator, hub *Hub) *Handler {
 	return &Handler{
 		generator: generator,
 		hub:       hub,
+	}
+}
+
+// NewHandlerWithRBAC creates a new overview handler that enforces scope
+// visibility against the caller's RBAC view. A nil rbacChecker or
+// datastore disables the gate (preserves pre-RBAC behaviour for tests).
+func NewHandlerWithRBAC(generator *Generator, hub *Hub, rbacChecker *auth.RBACChecker, datastore *database.Datastore) *Handler {
+	return &Handler{
+		generator:   generator,
+		hub:         hub,
+		rbacChecker: rbacChecker,
+		datastore:   datastore,
 	}
 }
 
@@ -89,7 +109,18 @@ func (h *Handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		overview, err := h.generator.GetConnectionsSummary(connectionIDs, scopeName, refresh)
+		filtered, ok := h.filterConnectionIDs(r.Context(), w, connectionIDs)
+		if !ok {
+			return
+		}
+		if len(filtered) == 0 {
+			if err := json.NewEncoder(w).Encode(generatingResponse{Status: "empty", Summary: nil}); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: overview: failed to encode empty response: %v\n", err)
+			}
+			return
+		}
+
+		overview, err := h.generator.GetConnectionsSummary(filtered, scopeName, refresh)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: overview: connections summary failed: %v\n", err)
 			http.Error(w, "Failed to generate connections summary", http.StatusInternalServerError)
@@ -129,7 +160,21 @@ func (h *Handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	overview, err := h.generator.GetScopedSummary(scopeType, scopeID, refresh)
+	intersect, unrestricted, ok := h.scopeVisible(r.Context(), w, scopeType, scopeID)
+	if !ok {
+		return
+	}
+
+	var overview *Overview
+	if unrestricted {
+		overview, err = h.generator.GetScopedSummary(scopeType, scopeID, refresh)
+	} else {
+		// Restricted visibility: generate a summary over only the scope
+		// members the caller may see. The scope name is still useful for
+		// the LLM prompt; fetch it so the summary reads correctly.
+		scopeName := h.resolveScopeName(r.Context(), scopeType, scopeID)
+		overview, err = h.generator.GetConnectionsSummary(intersect, scopeName, refresh)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: overview: scoped summary failed: %v\n", err)
 		http.Error(w, "Failed to generate scoped summary", http.StatusInternalServerError)
@@ -193,14 +238,20 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// Build the scope key for subscribing.
 	// Estate-wide subscribers use an empty key.
 	var scopeKey string
+	var filteredConnectionIDs []int
 	if connectionIDsStr != "" {
 		connectionIDs, err := parseConnectionIDs(connectionIDsStr)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		sorted := make([]int, len(connectionIDs))
-		copy(sorted, connectionIDs)
+		filtered, ok := h.filterConnectionIDs(r.Context(), w, connectionIDs)
+		if !ok {
+			return
+		}
+		filteredConnectionIDs = filtered
+		sorted := make([]int, len(filtered))
+		copy(sorted, filtered)
 		sortInts(sorted)
 		parts := make([]string, len(sorted))
 		for i, id := range sorted {
@@ -221,7 +272,28 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "scope_id must be a positive integer", http.StatusBadRequest)
 			return
 		}
-		scopeKey = fmt.Sprintf("%s:%d", scopeType, scopeID)
+		intersect, unrestricted, ok := h.scopeVisible(r.Context(), w, scopeType, scopeID)
+		if !ok {
+			return
+		}
+		if unrestricted {
+			scopeKey = fmt.Sprintf("%s:%d", scopeType, scopeID)
+		} else {
+			// Restricted visibility routes through the connections-summary
+			// path. Reuse the sorted-ID cache key scheme so two users with
+			// different visibility never share a cache entry.
+			filteredConnectionIDs = intersect
+			sorted := make([]int, len(intersect))
+			copy(sorted, intersect)
+			sortInts(sorted)
+			parts := make([]string, len(sorted))
+			for i, id := range sorted {
+				parts[i] = fmt.Sprintf("%d", id)
+			}
+			scopeKey = "connections:" + strings.Join(parts, ",")
+			// When the intersection is empty we still accept the
+			// subscription but will not kick off generation below.
+		}
 	}
 
 	// Set SSE headers and flush immediately so the client receives the
@@ -243,18 +315,27 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 			h.writeSSEEvent(w, current)
 			flusher.Flush()
 		}
-	} else if connectionIDsStr != "" {
-		// For connections scope, trigger generation in a goroutine.
-		// The generator will broadcast when complete.
-		connectionIDs, err := parseConnectionIDs(connectionIDsStr)
-		if err != nil {
-			return // Already validated above.
-		}
-		go func() {
-			if _, err := h.generator.GetConnectionsSummary(connectionIDs, scopeName, false); err != nil {
-				fmt.Fprintf(os.Stderr, "overview: scoped generation failed: %v\n", err)
+	} else if connectionIDsStr != "" || len(filteredConnectionIDs) > 0 {
+		// For connections scope (either explicit connection_ids or a
+		// scope request that was restricted to a visibility subset),
+		// trigger generation in a goroutine. The generator will
+		// broadcast when complete. If the caller has no visible
+		// connections in the set we skip generation but keep the SSE
+		// connection open for keepalives.
+		if len(filteredConnectionIDs) > 0 {
+			ids := filteredConnectionIDs
+			effectiveName := scopeName
+			if effectiveName == "" && scopeType != "" && scopeIDStr != "" {
+				if id, convErr := strconv.Atoi(scopeIDStr); convErr == nil {
+					effectiveName = h.resolveScopeName(r.Context(), scopeType, id)
+				}
 			}
-		}()
+			go func() {
+				if _, err := h.generator.GetConnectionsSummary(ids, effectiveName, false); err != nil {
+					fmt.Fprintf(os.Stderr, "overview: scoped generation failed: %v\n", err)
+				}
+			}()
+		}
 	} else if scopeType != "" {
 		scopeID, err := strconv.Atoi(scopeIDStr)
 		if err != nil {
@@ -286,6 +367,184 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 	}
+}
+
+// filterConnectionIDs restricts the supplied connection ID list to those
+// visible to the caller. When RBAC is not configured (nil checker or
+// nil datastore) the list is returned unchanged. The second return
+// value is false when the function wrote an error response and the
+// caller must return immediately.
+func (h *Handler) filterConnectionIDs(ctx context.Context, w http.ResponseWriter, ids []int) ([]int, bool) {
+	if h.rbacChecker == nil || h.datastore == nil {
+		return ids, true
+	}
+	visible, allConnections, err := h.resolveVisible(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: overview: failed to resolve visible connections: %v\n", err)
+		http.Error(w, "Failed to resolve connection visibility", http.StatusInternalServerError)
+		return nil, false
+	}
+	if allConnections {
+		return ids, true
+	}
+	out := make([]int, 0, len(ids))
+	for _, id := range ids {
+		if visible[id] {
+			out = append(out, id)
+		}
+	}
+	return out, true
+}
+
+// scopeVisible reports whether the caller may see the requested scope
+// and, when they can, returns the intersection of the scope's member
+// connection IDs with the caller's visible set. When RBAC is not
+// configured the check is skipped and (nil, true, true) is returned.
+// When the caller is a superuser or has a wildcard grant, (nil, true,
+// true) is returned so the caller can use the full-scope snapshot path.
+// On denial the function writes a 404 response and returns ok=false.
+// The caller must return immediately when ok is false. Matching the
+// behaviour of sibling handlers, 404 is used for scope-denial to avoid
+// leaking the existence of scopes the caller cannot see.
+func (h *Handler) scopeVisible(ctx context.Context, w http.ResponseWriter, scopeType string, scopeID int) (intersect []int, unrestricted bool, ok bool) {
+	if h.rbacChecker == nil || h.datastore == nil {
+		return nil, true, true
+	}
+	visible, allConnections, err := h.resolveVisible(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: overview: failed to resolve visible connections: %v\n", err)
+		http.Error(w, "Failed to resolve connection visibility", http.StatusInternalServerError)
+		return nil, false, false
+	}
+	if allConnections {
+		return nil, true, true
+	}
+
+	switch scopeType {
+	case "server":
+		if !visible[scopeID] {
+			http.Error(w, "Scope not found", http.StatusNotFound)
+			return nil, false, false
+		}
+		return []int{scopeID}, false, true
+	case "cluster":
+		ids, lookupErr := h.datastore.GetConnectionIDsForCluster(ctx, scopeID)
+		if lookupErr != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: overview: failed to check cluster %d visibility: %v\n", scopeID, lookupErr)
+			http.Error(w, "Failed to check scope visibility", http.StatusInternalServerError)
+			return nil, false, false
+		}
+		intersect = intersectVisible(ids, visible)
+	case "group":
+		ids, lookupErr := h.datastore.GetConnectionIDsForGroup(ctx, scopeID)
+		if lookupErr != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: overview: failed to check group %d visibility: %v\n", scopeID, lookupErr)
+			http.Error(w, "Failed to check scope visibility", http.StatusInternalServerError)
+			return nil, false, false
+		}
+		intersect = intersectVisible(ids, visible)
+	default:
+		http.Error(w, "Invalid scope_type", http.StatusBadRequest)
+		return nil, false, false
+	}
+
+	if len(intersect) == 0 {
+		http.Error(w, "Scope not found", http.StatusNotFound)
+		return nil, false, false
+	}
+	return intersect, false, true
+}
+
+// intersectVisible returns the subset of members that are also in the
+// visible set, preserving the original order.
+func intersectVisible(members []int, visible map[int]bool) []int {
+	out := make([]int, 0, len(members))
+	for _, id := range members {
+		if visible[id] {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// resolveScopeName fetches the human-readable name for a scope so that
+// the generator prompt can include it in the summary. Returns an empty
+// string when the lookup fails; the generator tolerates an empty name.
+func (h *Handler) resolveScopeName(ctx context.Context, scopeType string, scopeID int) string {
+	if h.datastore == nil {
+		return ""
+	}
+	switch scopeType {
+	case "server":
+		conn, err := h.datastore.GetConnection(ctx, scopeID)
+		if err != nil || conn == nil {
+			return ""
+		}
+		return conn.Name
+	case "cluster":
+		cluster, err := h.datastore.GetCluster(ctx, scopeID)
+		if err != nil || cluster == nil {
+			return ""
+		}
+		return cluster.Name
+	case "group":
+		group, err := h.datastore.GetClusterGroup(ctx, scopeID)
+		if err != nil || group == nil {
+			return ""
+		}
+		return group.Name
+	}
+	return ""
+}
+
+// resolveVisible returns the caller's visible connection-ID set via the
+// overview handler's RBAC checker. The allConnections flag is true when
+// the caller has unrestricted visibility (superuser or wildcard grant).
+func (h *Handler) resolveVisible(ctx context.Context) (map[int]bool, bool, error) {
+	lister := newOverviewVisibilityLister(h.datastore)
+	ids, all, err := h.rbacChecker.VisibleConnectionIDs(ctx, lister)
+	if err != nil {
+		return nil, false, err
+	}
+	if all {
+		return nil, true, nil
+	}
+	visible := make(map[int]bool, len(ids))
+	for _, id := range ids {
+		visible[id] = true
+	}
+	return visible, false, nil
+}
+
+// overviewVisibilityLister adapts *database.Datastore.GetAllConnections
+// to the auth.ConnectionVisibilityLister interface. This duplicates the
+// api-package adapter so the overview package does not depend on the
+// api package.
+type overviewVisibilityLister struct {
+	ds *database.Datastore
+}
+
+func newOverviewVisibilityLister(ds *database.Datastore) auth.ConnectionVisibilityLister {
+	if ds == nil {
+		return nil
+	}
+	return &overviewVisibilityLister{ds: ds}
+}
+
+func (l *overviewVisibilityLister) GetAllConnections(ctx context.Context) ([]auth.ConnectionVisibilityInfo, error) {
+	conns, err := l.ds.GetAllConnections(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]auth.ConnectionVisibilityInfo, 0, len(conns))
+	for i := range conns {
+		result = append(result, auth.ConnectionVisibilityInfo{
+			ID:            conns[i].ID,
+			IsShared:      conns[i].IsShared,
+			OwnerUsername: conns[i].OwnerUsername,
+		})
+	}
+	return result, nil
 }
 
 // writeSSEEvent marshals an Overview to JSON and writes it as an SSE event.

--- a/server/src/internal/overview/handler_test.go
+++ b/server/src/internal/overview/handler_test.go
@@ -16,10 +16,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/database"
 )
 
@@ -728,5 +730,110 @@ func TestHandleSSE_SubscriberCleanupOnDisconnect(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	if hub.Count() != 0 {
 		t.Errorf("expected 0 subscribers after disconnect, got %d", hub.Count())
+	}
+}
+
+// --- RBAC estate-wide filtering tests --------------------------------------
+
+// newRBACTestStore creates a throwaway SQLite auth store for RBAC tests.
+// The caller must invoke the returned cleanup function when finished.
+func newRBACTestStore(t *testing.T) (*auth.AuthStore, func()) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "overview-rbac-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	store, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	return store, func() {
+		store.Close()
+		os.RemoveAll(tmpDir)
+	}
+}
+
+// doRequestWithContext sends an HTTP request with context to the handler.
+func doRequestWithContext(t *testing.T, h *Handler, ctx context.Context, method, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	h.handleOverview(rr, req)
+	return rr
+}
+
+func TestHandleOverview_EstateWideRBAC_SuperuserBypass(t *testing.T) {
+	// When RBAC is configured but the caller is a superuser, the handler
+	// must serve the estate-wide overview without RBAC filtering.
+	store, cleanup := newRBACTestStore(t)
+	defer cleanup()
+
+	g := &Generator{
+		scopedCache: make(map[string]*scopedEntry),
+	}
+	g.current = newTestOverview("Full estate overview.")
+
+	rbac := auth.NewRBACChecker(store)
+	// A zero-value Datastore is non-nil, which is enough to enter the
+	// RBAC path. The superuser context causes VisibleConnectionIDs to
+	// return (nil, true, nil) before the lister is called, so the nil
+	// pool inside the Datastore is never touched.
+	ds := &database.Datastore{}
+	h := NewHandlerWithRBAC(g, NewHub(), rbac, ds)
+
+	ctx := context.WithValue(context.Background(), auth.IsSuperuserContextKey, true)
+
+	rr := doRequestWithContext(t, h, ctx, http.MethodGet, "/api/v1/overview")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp Overview
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Summary != "Full estate overview." {
+		t.Errorf("expected full estate summary, got %q", resp.Summary)
+	}
+}
+
+func TestHandleOverview_EstateWideRBAC_RestrictedCaller(t *testing.T) {
+	// When RBAC is configured and the caller is a restricted non-superuser,
+	// the handler must NOT serve the estate-wide overview. Instead it must
+	// attempt to resolve the caller's visible connections (which involves
+	// calling the datastore via the visibility lister). With a zero-value
+	// Datastore the lister panics on the nil pool, proving that the RBAC
+	// filtering path was entered.
+	store, cleanup := newRBACTestStore(t)
+	defer cleanup()
+
+	if err := store.CreateUser("restricted", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := store.GetUserID("restricted")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	g := &Generator{
+		scopedCache: make(map[string]*scopedEntry),
+	}
+	g.current = newTestOverview("Full estate overview - should NOT be served.")
+
+	rbac := auth.NewRBACChecker(store)
+	ds := &database.Datastore{}
+	h := NewHandlerWithRBAC(g, NewHub(), rbac, ds)
+
+	ctx := context.WithValue(context.Background(), auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "restricted")
+
+	panicked := invokePanics(func() {
+		doRequestWithContext(t, h, ctx, http.MethodGet, "/api/v1/overview")
+	})
+	if !panicked {
+		t.Error("expected resolveVisible to panic on nil datastore pool, " +
+			"proving the handler entered the RBAC filtering path for restricted callers")
 	}
 }

--- a/server/src/internal/overview/handler_test.go
+++ b/server/src/internal/overview/handler_test.go
@@ -251,6 +251,85 @@ func TestHandleOverview_WhitespaceOnlyConnectionIDs(t *testing.T) {
 	}
 }
 
+// --- intersectVisible tests -------------------------------------------------
+
+// TestIntersectVisible is the unit-level guard for the #35 follow-up
+// audit on scoped overview snapshots. scopeVisible computes the
+// intersection of a cluster/group's member connection IDs with the
+// caller's visible set and routes the summary generator through the
+// intersected list so two users with different visibility never share
+// a cache entry. The ordering must be preserved so the cache key is
+// stable across retries.
+func TestIntersectVisible(t *testing.T) {
+	tests := []struct {
+		name    string
+		members []int
+		visible map[int]bool
+		want    []int
+	}{
+		{
+			name:    "full overlap preserves order",
+			members: []int{3, 1, 2},
+			visible: map[int]bool{1: true, 2: true, 3: true},
+			want:    []int{3, 1, 2},
+		},
+		{
+			name:    "one of three visible",
+			members: []int{10, 20, 30},
+			visible: map[int]bool{20: true},
+			want:    []int{20},
+		},
+		{
+			name:    "no members visible",
+			members: []int{10, 20, 30},
+			visible: map[int]bool{99: true},
+			want:    []int{},
+		},
+		{
+			name:    "empty member list",
+			members: []int{},
+			visible: map[int]bool{1: true},
+			want:    []int{},
+		},
+		{
+			name:    "nil visible map yields empty",
+			members: []int{1, 2, 3},
+			visible: nil,
+			want:    []int{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := intersectVisible(tc.members, tc.visible)
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %d ids, got %d (%v)", len(tc.want), len(got), got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("id[%d]: expected %d, got %d", i, tc.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+// TestHandleOverview_RestrictedCallerNotFound verifies the scope-denial
+// path now returns 404 rather than 403 to match sibling handlers and
+// avoid exposing scope existence as an oracle. The nil datastore on
+// this handler short-circuits scopeVisible into the "skipped" branch,
+// so we only exercise the 404 path through the invalid-scope_type
+// guard that sits alongside the rewritten denial path; this locks in
+// that the handler does not accidentally reintroduce a 403 on other
+// denial branches.
+func TestHandleOverview_InvalidScopeTypeStillBadRequest(t *testing.T) {
+	h := newTestHandler()
+	rr := doRequest(t, h, http.MethodGet, "/api/v1/overview?scope_type=invalid&scope_id=1")
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected %d for invalid scope_type, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
 // --- parseConnectionIDs tests -----------------------------------------------
 
 func TestParseConnectionIDs(t *testing.T) {

--- a/server/src/internal/overview/handler_test.go
+++ b/server/src/internal/overview/handler_test.go
@@ -258,8 +258,9 @@ func TestHandleOverview_WhitespaceOnlyConnectionIDs(t *testing.T) {
 // intersection of a cluster/group's member connection IDs with the
 // caller's visible set and routes the summary generator through the
 // intersected list so two users with different visibility never share
-// a cache entry. The ordering must be preserved so the cache key is
-// stable across retries.
+// a cache entry. The result is deduplicated and sorted in ascending
+// order so that equivalent inputs (different order or with duplicates)
+// yield the same cache key.
 func TestIntersectVisible(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -268,10 +269,10 @@ func TestIntersectVisible(t *testing.T) {
 		want    []int
 	}{
 		{
-			name:    "full overlap preserves order",
+			name:    "full overlap sorted ascending",
 			members: []int{3, 1, 2},
 			visible: map[int]bool{1: true, 2: true, 3: true},
-			want:    []int{3, 1, 2},
+			want:    []int{1, 2, 3},
 		},
 		{
 			name:    "one of three visible",
@@ -297,6 +298,18 @@ func TestIntersectVisible(t *testing.T) {
 			visible: nil,
 			want:    []int{},
 		},
+		{
+			name:    "duplicates are removed",
+			members: []int{3, 1, 2, 1, 3},
+			visible: map[int]bool{1: true, 2: true, 3: true},
+			want:    []int{1, 2, 3},
+		},
+		{
+			name:    "duplicates removed with partial visibility",
+			members: []int{5, 3, 5, 1, 3},
+			visible: map[int]bool{1: true, 3: true},
+			want:    []int{1, 3},
+		},
 	}
 
 	for _, tc := range tests {
@@ -311,22 +324,6 @@ func TestIntersectVisible(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// TestHandleOverview_RestrictedCallerNotFound verifies the scope-denial
-// path now returns 404 rather than 403 to match sibling handlers and
-// avoid exposing scope existence as an oracle. The nil datastore on
-// this handler short-circuits scopeVisible into the "skipped" branch,
-// so we only exercise the 404 path through the invalid-scope_type
-// guard that sits alongside the rewritten denial path; this locks in
-// that the handler does not accidentally reintroduce a 403 on other
-// denial branches.
-func TestHandleOverview_InvalidScopeTypeStillBadRequest(t *testing.T) {
-	h := newTestHandler()
-	rr := doRequest(t, h, http.MethodGet, "/api/v1/overview?scope_type=invalid&scope_id=1")
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("expected %d for invalid scope_type, got %d", http.StatusBadRequest, rr.Code)
 	}
 }
 

--- a/server/src/internal/tools/connection_resolver.go
+++ b/server/src/internal/tools/connection_resolver.go
@@ -12,6 +12,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/server/internal/auth"
@@ -123,26 +124,34 @@ func (r *ConnectionResolver) resolveExplicit(
 	ctx context.Context,
 	ca connectionArgs,
 ) (*ResolvedConnection, *mcp.ToolResponse) {
-	// Look up connection credentials.
-	conn, password, err := r.datastore.GetConnectionWithPassword(ctx, ca.ConnectionID)
-	if err != nil {
+	// RBAC: verify access before touching credentials. Using a generic
+	// "not found or not accessible" message for both missing and denied
+	// cases prevents the caller from using the resolver as a probe to
+	// enumerate connection IDs they cannot see. CanAccessConnection
+	// folds lookup errors into a denied decision; log the deny with the
+	// connection ID so operators can correlate without widening the
+	// surface the caller sees. Fail-closed: we keep the deny even if
+	// the underlying cause was a transient lookup error.
+	canAccess, _ := r.rbacChecker.CanAccessConnection(ctx, ca.ConnectionID)
+	if !canAccess {
+		fmt.Fprintf(os.Stderr, "WARNING: connection_resolver: RBAC denied access to connection %d\n", ca.ConnectionID)
 		resp := mcp.ToolResponse{
 			Content: []mcp.ContentItem{{
 				Type: "text",
-				Text: fmt.Sprintf("Failed to look up connection ID %d: %v", ca.ConnectionID, err),
+				Text: "connection not found or not accessible",
 			}},
 			IsError: true,
 		}
 		return nil, &resp
 	}
 
-	// RBAC: verify the caller may access this connection.
-	canAccess, _ := r.rbacChecker.CanAccessConnection(ctx, ca.ConnectionID)
-	if !canAccess {
+	// Look up connection credentials.
+	conn, password, err := r.datastore.GetConnectionWithPassword(ctx, ca.ConnectionID)
+	if err != nil {
 		resp := mcp.ToolResponse{
 			Content: []mcp.ContentItem{{
 				Type: "text",
-				Text: fmt.Sprintf("Access denied: you do not have permission to access connection ID %d", ca.ConnectionID),
+				Text: "connection not found or not accessible",
 			}},
 			IsError: true,
 		}

--- a/server/src/internal/tools/connection_resolver.go
+++ b/server/src/internal/tools/connection_resolver.go
@@ -181,10 +181,11 @@ func (r *ConnectionResolver) resolveExplicit(
 
 	client, err := r.clientManager.GetClientForSession(sessionInfo, connStr)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: connection_resolver: failed to connect to connection %d: %v\n", ca.ConnectionID, err)
 		resp := mcp.ToolResponse{
 			Content: []mcp.ContentItem{{
 				Type: "text",
-				Text: fmt.Sprintf("Failed to connect to connection ID %d: %v", ca.ConnectionID, err),
+				Text: "Failed to establish database connection",
 			}},
 			IsError: true,
 		}
@@ -198,10 +199,11 @@ func (r *ConnectionResolver) resolveExplicit(
 
 	pool := client.GetPoolFor(connStr)
 	if pool == nil {
+		fmt.Fprintf(os.Stderr, "ERROR: connection_resolver: pool not available for connection %d\n", ca.ConnectionID)
 		resp := mcp.ToolResponse{
 			Content: []mcp.ContentItem{{
 				Type: "text",
-				Text: fmt.Sprintf("Connection pool not available for connection ID %d", ca.ConnectionID),
+				Text: "Failed to establish database connection",
 			}},
 			IsError: true,
 		}

--- a/server/src/internal/tools/context_aware_provider.go
+++ b/server/src/internal/tools/context_aware_provider.go
@@ -90,7 +90,7 @@ func (p *ContextAwareProvider) registerDatastoreTools(registry *Registry) {
 			registry.Register("query_metrics", QueryMetricsTool(datastorePool, p.rbacChecker))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("list_connections") {
-			registry.Register("list_connections", ListConnectionsTool(datastorePool))
+			registry.Register("list_connections", ListConnectionsTool(datastorePool, p.rbacChecker, visibilityLister))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("get_alert_history") {
 			registry.Register("get_alert_history", GetAlertHistoryTool(datastorePool, p.rbacChecker, visibilityLister))
@@ -130,7 +130,7 @@ func (p *ContextAwareProvider) registerDatastoreTools(registry *Registry) {
 			registry.Register("query_metrics", QueryMetricsTool(nil, p.rbacChecker))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("list_connections") {
-			registry.Register("list_connections", ListConnectionsTool(nil))
+			registry.Register("list_connections", ListConnectionsTool(nil, p.rbacChecker, nil))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("get_alert_history") {
 			registry.Register("get_alert_history", GetAlertHistoryTool(nil, p.rbacChecker, nil))

--- a/server/src/internal/tools/context_aware_provider.go
+++ b/server/src/internal/tools/context_aware_provider.go
@@ -87,7 +87,7 @@ func (p *ContextAwareProvider) registerDatastoreTools(registry *Registry) {
 			registry.Register("describe_probe", DescribeProbeTool(datastorePool))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("query_metrics") {
-			registry.Register("query_metrics", QueryMetricsTool(datastorePool))
+			registry.Register("query_metrics", QueryMetricsTool(datastorePool, p.rbacChecker))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("list_connections") {
 			registry.Register("list_connections", ListConnectionsTool(datastorePool))
@@ -96,7 +96,7 @@ func (p *ContextAwareProvider) registerDatastoreTools(registry *Registry) {
 			registry.Register("get_alert_history", GetAlertHistoryTool(datastorePool, p.rbacChecker, visibilityLister))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("get_alert_rules") {
-			registry.Register("get_alert_rules", GetAlertRulesTool(datastorePool))
+			registry.Register("get_alert_rules", GetAlertRulesTool(datastorePool, p.rbacChecker))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("get_metric_baselines") {
 			registry.Register("get_metric_baselines", GetMetricBaselinesTool(datastorePool, p.rbacChecker, visibilityLister))
@@ -127,7 +127,7 @@ func (p *ContextAwareProvider) registerDatastoreTools(registry *Registry) {
 			registry.Register("describe_probe", DescribeProbeTool(nil))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("query_metrics") {
-			registry.Register("query_metrics", QueryMetricsTool(nil))
+			registry.Register("query_metrics", QueryMetricsTool(nil, p.rbacChecker))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("list_connections") {
 			registry.Register("list_connections", ListConnectionsTool(nil))
@@ -136,7 +136,7 @@ func (p *ContextAwareProvider) registerDatastoreTools(registry *Registry) {
 			registry.Register("get_alert_history", GetAlertHistoryTool(nil, p.rbacChecker, nil))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("get_alert_rules") {
-			registry.Register("get_alert_rules", GetAlertRulesTool(nil))
+			registry.Register("get_alert_rules", GetAlertRulesTool(nil, p.rbacChecker))
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("get_metric_baselines") {
 			registry.Register("get_metric_baselines", GetMetricBaselinesTool(nil, p.rbacChecker, nil))

--- a/server/src/internal/tools/get_alert_rules.go
+++ b/server/src/internal/tools/get_alert_rules.go
@@ -15,12 +15,16 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/mcp"
 	"github.com/pgedge/ai-workbench/server/internal/tsv"
 )
 
-// GetAlertRulesTool creates the get_alert_rules tool for querying alert rules and thresholds
-func GetAlertRulesTool(pool *pgxpool.Pool) Tool {
+// GetAlertRulesTool creates the get_alert_rules tool for querying alert rules and thresholds.
+// When the caller supplies a connection_id, rbacChecker is consulted before
+// the datastore is read so that a caller cannot use the effective-threshold
+// lookup to probe connections they are not permitted to see.
+func GetAlertRulesTool(pool *pgxpool.Pool, rbacChecker *auth.RBACChecker) Tool {
 	return Tool{
 		Definition: mcp.Tool{
 			Name: "get_alert_rules",
@@ -92,12 +96,28 @@ Returns TSV data with:
 				return mcp.NewToolError("Datastore not configured. The get_alert_rules tool requires a datastore connection.")
 			}
 
+			// Extract context from args (injected by registry.Execute).
+			// Done here so the RBAC check below can use it.
+			ctx, ok := args["__context"].(context.Context)
+			if !ok {
+				ctx = context.Background()
+			}
+
 			// Parse optional connection_id
 			var connectionID *int
 			if _, ok := args["connection_id"]; ok {
 				cid, err := parseIntArg(args, "connection_id")
 				if err != nil {
 					return mcp.NewToolError("Invalid 'connection_id' parameter: must be an integer")
+				}
+				// RBAC: verify the caller may access this connection before
+				// reading its effective thresholds. Missing and denied cases
+				// share a message to avoid an existence oracle.
+				if rbacChecker != nil {
+					canAccess, _ := rbacChecker.CanAccessConnection(ctx, cid)
+					if !canAccess {
+						return mcp.NewToolError("connection not found or not accessible")
+					}
 				}
 				connectionID = &cid
 			}
@@ -127,12 +147,6 @@ Returns TSV data with:
 			enabledOnly := true
 			if eo, ok := args["enabled_only"].(bool); ok {
 				enabledOnly = eo
-			}
-
-			// Extract context from args (injected by registry.Execute)
-			ctx, ok := args["__context"].(context.Context)
-			if !ok {
-				ctx = context.Background()
 			}
 
 			// Build the query

--- a/server/src/internal/tools/list_connections.go
+++ b/server/src/internal/tools/list_connections.go
@@ -12,9 +12,11 @@ package tools
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/mcp"
 )
 
@@ -30,8 +32,11 @@ type MonitoredConnectionInfo struct {
 	ConnectionError string `json:"connection_error,omitempty"`
 }
 
-// ListConnectionsTool creates the list_connections tool for listing monitored connections
-func ListConnectionsTool(pool *pgxpool.Pool) Tool {
+// ListConnectionsTool creates the list_connections tool for listing monitored connections.
+// When rbacChecker and visibilityLister are non-nil, the returned list is
+// filtered to connections the caller can see. Pass nil for both in tests
+// or when RBAC is not configured.
+func ListConnectionsTool(pool *pgxpool.Pool, rbacChecker *auth.RBACChecker, visibilityLister auth.ConnectionVisibilityLister) Tool {
 	return Tool{
 		Definition: mcp.Tool{
 			Name: "list_connections",
@@ -154,6 +159,26 @@ CRITICAL: Never silently analyze multiple connections. Always get explicit user 
 
 			if err := rows.Err(); err != nil {
 				return mcp.NewToolError(fmt.Sprintf("Error iterating connections: %v", err))
+			}
+
+			// RBAC: filter connections to the caller's visible set.
+			if rbacChecker != nil {
+				visible, allConns, visErr := rbacChecker.VisibleConnectionIDs(ctx, visibilityLister)
+				if visErr != nil {
+					fmt.Fprintf(os.Stderr, "ERROR: list_connections: failed to resolve visible connections: %v\n", visErr)
+				} else if !allConns {
+					visibleSet := make(map[int]bool, len(visible))
+					for _, id := range visible {
+						visibleSet[id] = true
+					}
+					filtered := make([]MonitoredConnectionInfo, 0, len(connections))
+					for _, conn := range connections {
+						if visibleSet[conn.ID] {
+							filtered = append(filtered, conn)
+						}
+					}
+					connections = filtered
+				}
 			}
 
 			if len(connections) == 0 {

--- a/server/src/internal/tools/list_connections_test.go
+++ b/server/src/internal/tools/list_connections_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestListConnectionsTool_Definition(t *testing.T) {
-	tool := ListConnectionsTool(nil)
+	tool := ListConnectionsTool(nil, nil, nil)
 
 	if tool.Definition.Name != "list_connections" {
 		t.Errorf("Expected tool name 'list_connections', got '%s'", tool.Definition.Name)
@@ -36,7 +36,7 @@ func TestListConnectionsTool_Definition(t *testing.T) {
 }
 
 func TestListConnectionsTool_NoDatastore(t *testing.T) {
-	tool := ListConnectionsTool(nil)
+	tool := ListConnectionsTool(nil, nil, nil)
 
 	// Execute with no datastore - should return error
 	response, err := tool.Handler(map[string]any{})

--- a/server/src/internal/tools/query_metrics.go
+++ b/server/src/internal/tools/query_metrics.go
@@ -16,13 +16,18 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/mcp"
 	"github.com/pgedge/ai-workbench/server/internal/metrics"
 	"github.com/pgedge/ai-workbench/server/internal/tsv"
 )
 
-// QueryMetricsTool creates the query_metrics tool for querying collected metrics
-func QueryMetricsTool(pool *pgxpool.Pool) Tool {
+// QueryMetricsTool creates the query_metrics tool for querying collected metrics.
+// The rbacChecker is consulted before any datastore read so that callers cannot
+// query metrics for connections they are not permitted to see. It may be nil
+// in unit tests or when auth is not configured; a nil checker opens access
+// (matching the behaviour of other tools in this package).
+func QueryMetricsTool(pool *pgxpool.Pool, rbacChecker *auth.RBACChecker) Tool {
 	return Tool{
 		Definition: mcp.Tool{
 			Name: "query_metrics",
@@ -171,30 +176,24 @@ To manage response sizes:
 				return mcp.NewToolError("Missing or invalid 'connection_id' parameter. If you haven't selected a database connection, use list_connections to find available connection IDs, then specify connection_id explicitly.")
 			}
 
-			// Verify the connection_id exists in the connections table
+			// RBAC: verify the caller may access this connection before any
+			// datastore read. Combined with the unified error below, this
+			// prevents the tool from being used to enumerate connection IDs
+			// or names the caller cannot see.
+			if rbacChecker != nil {
+				canAccess, _ := rbacChecker.CanAccessConnection(ctx, connectionID)
+				if !canAccess {
+					return mcp.NewToolError("connection not found or not accessible")
+				}
+			}
+
+			// Verify the connection_id exists in the connections table.
+			// On missing or error return a generic message; never echo the
+			// list of valid IDs/names, which would leak visibility.
 			var connName string
 			err = pool.QueryRow(ctx, "SELECT name FROM connections WHERE id = $1", connectionID).Scan(&connName)
 			if err != nil {
-				// Connection doesn't exist - provide helpful error with valid IDs
-				rows, qerr := pool.Query(ctx, "SELECT id, name FROM connections ORDER BY id LIMIT 20")
-				if qerr == nil {
-					defer rows.Close()
-					var validIDs []string
-					for rows.Next() {
-						var id int
-						var name string
-						if rows.Scan(&id, &name) == nil {
-							validIDs = append(validIDs, fmt.Sprintf("%d (%s)", id, name))
-						}
-					}
-					if len(validIDs) > 0 {
-						return mcp.NewToolError(fmt.Sprintf(
-							"Connection ID %d does not exist. Valid connection IDs are: %s. "+
-								"Use list_connections to see all available connections.",
-							connectionID, strings.Join(validIDs, ", ")))
-					}
-				}
-				return mcp.NewToolError(fmt.Sprintf("Connection ID %d does not exist. Use list_connections to see available connections.", connectionID))
+				return mcp.NewToolError("connection not found or not accessible")
 			}
 
 			// Parse time range

--- a/server/src/internal/tools/query_metrics.go
+++ b/server/src/internal/tools/query_metrics.go
@@ -26,7 +26,7 @@ import (
 // The rbacChecker is consulted before any datastore read so that callers cannot
 // query metrics for connections they are not permitted to see. It may be nil
 // in unit tests or when auth is not configured; a nil checker opens access
-// (matching the behaviour of other tools in this package).
+// (matching the behavior of other tools in this package).
 func QueryMetricsTool(pool *pgxpool.Pool, rbacChecker *auth.RBACChecker) Tool {
 	return Tool{
 		Definition: mcp.Tool{

--- a/server/src/internal/tools/query_metrics_test.go
+++ b/server/src/internal/tools/query_metrics_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestQueryMetrics_NilPool(t *testing.T) {
-	tool := QueryMetricsTool(nil)
+	tool := QueryMetricsTool(nil, nil)
 
 	if tool.Definition.Name != "query_metrics" {
 		t.Errorf("Expected tool name 'query_metrics', got '%s'", tool.Definition.Name)
@@ -39,7 +39,7 @@ func TestQueryMetrics_NilPool(t *testing.T) {
 }
 
 func TestQueryMetrics_MissingParameters(t *testing.T) {
-	tool := QueryMetricsTool(nil)
+	tool := QueryMetricsTool(nil, nil)
 
 	tests := []struct {
 		name string

--- a/server/src/internal/tools/rbac_regression_test.go
+++ b/server/src/internal/tools/rbac_regression_test.go
@@ -187,6 +187,115 @@ func TestGetMetricBaselinesTool_RBAC_NoAccessDeniesEmptyResult(t *testing.T) {
 	}
 }
 
+// TestQueryMetricsTool_RBAC_DeniesUnsharedConnection is the regression
+// guard for the query_metrics leak flagged in the #35 follow-up audit.
+//
+// A non-owner non-superuser calling query_metrics with an explicit
+// connection_id for an unshared connection must receive a generic
+// "connection not found or not accessible" error. Previously the tool
+// executed the existence probe and, on miss, echoed up to 20 valid
+// connection IDs/names in the error body. Both behaviours leaked
+// visibility information.
+func TestQueryMetricsTool_RBAC_DeniesUnsharedConnection(t *testing.T) {
+	store, cleanup := newRBACRegressionTestStore(t)
+	defer cleanup()
+
+	if err := store.CreateUser("bob", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := store.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	pool := dummyPool(t)
+	defer pool.Close()
+
+	// Sharing lookup returns a connection owned by alice that is not
+	// shared; bob must therefore be denied.
+	rbac := auth.NewRBACChecker(store)
+	rbac.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 42 {
+			return false, "alice", nil
+		}
+		return false, "", nil
+	})
+	tool := QueryMetricsTool(pool, rbac)
+
+	ctx := nonSuperuserContext(userID, "bob")
+	resp, err := tool.Handler(map[string]any{
+		"__context":     ctx,
+		"probe_name":    "pg_stat_database",
+		"connection_id": float64(42),
+	})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatalf("Expected error response, got success: %+v", resp.Content)
+	}
+	if len(resp.Content) == 0 {
+		t.Fatal("Expected content in response")
+	}
+	body := resp.Content[0].Text
+	if !strings.Contains(body, "connection not found or not accessible") {
+		t.Errorf("Expected generic RBAC denial message, got: %q", body)
+	}
+	// Must not leak connection IDs/names or any other enumeration hint.
+	if strings.Contains(body, "alice") || strings.Contains(body, "Valid connection IDs") {
+		t.Errorf("Response leaked enumeration data: %q", body)
+	}
+}
+
+// TestGetAlertRulesTool_RBAC_DeniesUnsharedConnection is the regression
+// guard for the get_alert_rules leak flagged in the #35 follow-up audit.
+// A non-owner non-superuser supplying connection_id for an unshared
+// connection must receive the generic denial message without any
+// threshold data being returned.
+func TestGetAlertRulesTool_RBAC_DeniesUnsharedConnection(t *testing.T) {
+	store, cleanup := newRBACRegressionTestStore(t)
+	defer cleanup()
+
+	if err := store.CreateUser("bob", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := store.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	pool := dummyPool(t)
+	defer pool.Close()
+
+	rbac := auth.NewRBACChecker(store)
+	rbac.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 42 {
+			return false, "alice", nil
+		}
+		return false, "", nil
+	})
+	tool := GetAlertRulesTool(pool, rbac)
+
+	ctx := nonSuperuserContext(userID, "bob")
+	resp, err := tool.Handler(map[string]any{
+		"__context":     ctx,
+		"connection_id": float64(42),
+	})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatalf("Expected error response, got success: %+v", resp.Content)
+	}
+	if len(resp.Content) == 0 {
+		t.Fatal("Expected content in response")
+	}
+	body := resp.Content[0].Text
+	if !strings.Contains(body, "connection not found or not accessible") {
+		t.Errorf("Expected generic RBAC denial message, got: %q", body)
+	}
+}
+
 // TestGetBlackoutsTool_RBAC_NoAccessDeniesEmptyResult mirrors the above
 // tests for get_blackouts. The tool is not currently registered in
 // cmd/mcp-server/privileges.go, but the code path must still honor RBAC

--- a/server/src/internal/tools/rbac_regression_test.go
+++ b/server/src/internal/tools/rbac_regression_test.go
@@ -294,6 +294,19 @@ func TestGetAlertRulesTool_RBAC_DeniesUnsharedConnection(t *testing.T) {
 	if !strings.Contains(body, "connection not found or not accessible") {
 		t.Errorf("Expected generic RBAC denial message, got: %q", body)
 	}
+	// Must not leak enumeration hints: the unshared connection's owner
+	// name, its ID, any adjacent connection identifiers the tool
+	// previously echoed back, or the "Valid connection IDs" list header.
+	leakers := []string{
+		"alice",                // unshared connection's owner
+		"42",                   // unshared connection's ID
+		"Valid connection IDs", // legacy enumeration header
+	}
+	for _, s := range leakers {
+		if strings.Contains(body, s) {
+			t.Errorf("Response leaked enumeration data %q: %q", s, body)
+		}
+	}
 }
 
 // TestGetBlackoutsTool_RBAC_NoAccessDeniesEmptyResult mirrors the above

--- a/server/src/internal/tools/rbac_regression_test.go
+++ b/server/src/internal/tools/rbac_regression_test.go
@@ -194,7 +194,7 @@ func TestGetMetricBaselinesTool_RBAC_NoAccessDeniesEmptyResult(t *testing.T) {
 // connection_id for an unshared connection must receive a generic
 // "connection not found or not accessible" error. Previously the tool
 // executed the existence probe and, on miss, echoed up to 20 valid
-// connection IDs/names in the error body. Both behaviours leaked
+// connection IDs/names in the error body. Both behaviors leaked
 // visibility information.
 func TestQueryMetricsTool_RBAC_DeniesUnsharedConnection(t *testing.T) {
 	store, cleanup := newRBACRegressionTestStore(t)


### PR DESCRIPTION
Fixes #35 (third recurrence). Closes every known path by which a non-owner, non-superuser can see a server or cluster marked unshared.

## Summary

Prior fixes gated `/api/v1/connections/{id}`, the cluster topology view, and most MCP tools, but left cluster list/detail/membership, cluster-group, blackout, override, overview, and two MCP tools unguarded. QA's Apr 20 reproduction (unshared server visible in the sidebar, and `/api/v1/connections/4` retrievable by a non-owner token) plus a subsequent security sweep surfaced 11 additional endpoints leaking data for unshared resources.

Security-auditor sign-off across three review rounds; final verdict: "Safe to commit, push, and claim this resolves issue #35."

## REST API handlers now filter by caller visibility

- `GET /api/v1/clusters/list`, `/api/v1/clusters/{id}`, `/api/v1/clusters/{id}/servers`
- `GET /api/v1/cluster-groups`, `/api/v1/cluster-groups/{id}`, `/api/v1/cluster-groups/{id}/clusters`
- `GET /api/v1/blackouts`, `/api/v1/blackouts/{id}`, `/api/v1/blackout-schedules`, `/api/v1/blackout-schedules/{id}`
- `GET /api/v1/alert-overrides`, `/api/v1/probe-overrides`, `/api/v1/channel-overrides` (each `listOverrides`); `GET /api/v1/alert-overrides/context`
- `GET /api/v1/overview` and its SSE stream: scope is admitted only when the caller can see at least one member; the response then covers only the intersection of scope members and the caller's visible set. The generator cache key is derived from that intersection, so two users with different visibility cannot share a cached summary.

## MCP tools

- `query_metrics` and `get_alert_rules` now take an `rbacChecker` and gate `CanAccessConnection` before any datastore read; the missing-connection error no longer enumerates other connection IDs or names (the prior behaviour was an estate-enumeration oracle).
- `connection_resolver` checks RBAC before loading credentials and returns a generic "connection not found or not accessible" for both missing and denied; RBAC errors are logged instead of silently dropped.

## Shared infrastructure

- New package-level helpers in `server/src/internal/api/rbac_visibility.go` (`resolveVisibleConnectionSet`, `scopeVisibleToCaller`, cluster/group visibility) so the overview, blackout, override, and cluster handlers all use the same code path.
- `server/src/internal/database/datastore.go` exposes `GetConnectionIDsForCluster` and `GetConnectionIDsForGroup`.

## Test plan

- [ ] `cd server/src && go test ./... -count=1` — all 22 packages green locally (verified).
- [ ] `gofmt -l server/src` clean (verified).
- [ ] `go vet ./...` clean (verified).
- [ ] QA reproduction from issue #35: non-owner user no longer sees unshared cluster in left sidebar; `GET /api/v1/connections/4` with non-owner Bearer token returns 403; `GET /api/v1/clusters/list` filtered correctly.
- [ ] CI green on this branch.

## Known follow-up (out of scope for this PR)

The `list_connections` MCP tool (`server/src/internal/tools/list_connections.go`) returns all datastore connections without RBAC filtering. The security auditor confirmed this is pre-existing (not touched or introduced by this branch) and is not blocking for the QA reproduction, but it should be tracked as a separate ticket.

https://claude.ai/code/session_01TkvQb4wqnNJf8HhAacLLws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced RBAC/visibility across cluster, group, server, blackout, schedule, and override endpoints so only caller-visible items are returned; invisible scopes now return 404.
  * Overview REST/SSE and subscription caching now isolate summaries by the caller’s visible connections to prevent cross-user cache sharing.
  * Connection-related tools and resolver now check access before reads and return a generic "connection not found or not accessible"; RBAC denials are logged.

* **Tests**
  * Added regression tests for cluster/overview/blackout visibility and tool RBAC behavior.

* **Documentation**
  * Updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->