### PR TITLE
Fix flaky ServerDialog CI test and eliminate act warnings (#79)

### DIFF
--- a/client/src/components/__tests__/ServerDialog.test.tsx
+++ b/client/src/components/__tests__/ServerDialog.test.tsx
@@ -9,10 +9,11 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import ServerDialog from '../ServerDialog';
+import { renderWithTheme } from '../../test/renderWithTheme';
 
 // Mock AlertOverridesPanel to avoid fetch calls during ServerDialog tests
 vi.mock('../AlertOverridesPanel', () => ({
@@ -54,18 +55,18 @@ describe('ServerDialog', () => {
 
     describe('rendering', () => {
         it('renders dialog with Add Server title in create mode', () => {
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
             expect(screen.getByText('Add Server')).toBeInTheDocument();
         });
 
         it('renders dialog with Server Settings title in edit mode', () => {
             const server = { id: 1, name: 'Test Server', host: 'localhost', port: 5432, database: 'postgres', username: 'user', password: '', sslmode: 'prefer' };
-            render(<ServerDialog {...defaultProps} mode="edit" server={server} />);
+            renderWithTheme(<ServerDialog {...defaultProps} mode="edit" server={server} />);
             expect(screen.getByText('Server Settings: Test Server')).toBeInTheDocument();
         });
 
         it('renders all required form fields', () => {
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             expect(getNameField()).toBeInTheDocument();
             expect(getHostField()).toBeInTheDocument();
@@ -76,34 +77,34 @@ describe('ServerDialog', () => {
         });
 
         it('renders monitor checkbox checked by default', () => {
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
             const monitorCheckbox = screen.getByLabelText(/monitor this server/i);
             expect(monitorCheckbox).toBeChecked();
         });
 
         it('does not render shared checkbox for non-superusers', () => {
-            render(<ServerDialog {...defaultProps} isSuperuser={false} />);
+            renderWithTheme(<ServerDialog {...defaultProps} isSuperuser={false} />);
             expect(screen.queryByLabelText(/share with all users/i)).not.toBeInTheDocument();
         });
 
         it('renders shared checkbox for superusers', () => {
-            render(<ServerDialog {...defaultProps} isSuperuser={true} />);
+            renderWithTheme(<ServerDialog {...defaultProps} isSuperuser={true} />);
             expect(screen.getByLabelText(/share with all users/i)).toBeInTheDocument();
         });
 
         it('renders SSL Settings accordion', () => {
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
             expect(screen.getByText(/ssl settings/i)).toBeInTheDocument();
         });
 
         it('renders Cancel and Save buttons', () => {
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
             expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
             expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
         });
 
         it('does not render when open is false', () => {
-            render(<ServerDialog {...defaultProps} open={false} />);
+            renderWithTheme(<ServerDialog {...defaultProps} open={false} />);
             expect(screen.queryByText('Add Server')).not.toBeInTheDocument();
         });
     });
@@ -124,7 +125,7 @@ describe('ServerDialog', () => {
         };
 
         it('pre-populates fields with existing server data', () => {
-            render(
+            renderWithTheme(
                 <ServerDialog
                     {...defaultProps}
                     mode="edit"
@@ -140,7 +141,7 @@ describe('ServerDialog', () => {
         });
 
         it('does not pre-populate password field', () => {
-            render(
+            renderWithTheme(
                 <ServerDialog
                     {...defaultProps}
                     mode="edit"
@@ -152,7 +153,7 @@ describe('ServerDialog', () => {
         });
 
         it('shows helper text for password in edit mode', () => {
-            render(
+            renderWithTheme(
                 <ServerDialog
                     {...defaultProps}
                     mode="edit"
@@ -167,7 +168,7 @@ describe('ServerDialog', () => {
     describe('validation', () => {
         it('shows error when name is empty', async () => {
             const user = userEvent.setup({ delay: null });
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             await user.click(screen.getByRole('button', { name: /save/i }));
 
@@ -178,7 +179,7 @@ describe('ServerDialog', () => {
 
         it('shows error when host is empty', async () => {
             const user = userEvent.setup({ delay: null });
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.click(screen.getByRole('button', { name: /save/i }));
@@ -188,7 +189,7 @@ describe('ServerDialog', () => {
 
         it('shows error for invalid port', async () => {
             const user = userEvent.setup({ delay: null });
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.type(getHostField(), 'localhost');
@@ -201,7 +202,7 @@ describe('ServerDialog', () => {
 
         it('shows error when maintenance database is empty', async () => {
             const user = userEvent.setup({ delay: null });
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.type(getHostField(), 'localhost');
@@ -214,7 +215,7 @@ describe('ServerDialog', () => {
 
         it('shows error when username is empty', async () => {
             const user = userEvent.setup({ delay: null });
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.type(getHostField(), 'localhost');
@@ -228,7 +229,7 @@ describe('ServerDialog', () => {
 
         it('shows error when password is empty in create mode', async () => {
             const user = userEvent.setup({ delay: null });
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.type(getHostField(), 'localhost');
@@ -250,7 +251,7 @@ describe('ServerDialog', () => {
                 username: 'admin',
             };
 
-            render(
+            renderWithTheme(
                 <ServerDialog
                     {...defaultProps}
                     mode="edit"
@@ -268,7 +269,7 @@ describe('ServerDialog', () => {
 
         it('clears field error when user types', async () => {
             const user = userEvent.setup({ delay: null });
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             // Trigger validation error
             await user.click(screen.getByRole('button', { name: /save/i }));
@@ -287,7 +288,7 @@ describe('ServerDialog', () => {
         it('calls onSave with trimmed form data', async () => {
             const user = userEvent.setup({ delay: null });
             const onSave = vi.fn().mockResolvedValue();
-            render(<ServerDialog {...defaultProps} onSave={onSave} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} />);
 
             await user.type(getNameField(), '  Test Server  ');
             await user.type(getHostField(), '  localhost  ');
@@ -317,7 +318,7 @@ describe('ServerDialog', () => {
         it('shows success message after successful save', async () => {
             const user = userEvent.setup({ delay: null });
             const onSave = vi.fn().mockResolvedValue();
-            render(<ServerDialog {...defaultProps} onSave={onSave} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.type(getHostField(), 'localhost');
@@ -335,7 +336,7 @@ describe('ServerDialog', () => {
         it('shows error alert when save fails', async () => {
             const user = userEvent.setup({ delay: null });
             const onSave = vi.fn().mockRejectedValue(new Error('Connection refused'));
-            render(<ServerDialog {...defaultProps} onSave={onSave} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.type(getHostField(), 'localhost');
@@ -354,7 +355,7 @@ describe('ServerDialog', () => {
             const user = userEvent.setup({ delay: null });
             const onSave = vi.fn().mockRejectedValue(new Error('Failed'));
             const onClose = vi.fn();
-            render(<ServerDialog {...defaultProps} onSave={onSave} onClose={onClose} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} onClose={onClose} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.type(getHostField(), 'localhost');
@@ -373,13 +374,14 @@ describe('ServerDialog', () => {
 
         it('disables form during save', async () => {
             const user = userEvent.setup({ delay: null });
-            // Create a promise that we control
-            let resolvePromise: (value: unknown) => void;
+            // Create a promise we control so the save stays pending while
+            // we assert on the disabled fields.
+            let resolvePromise: (value: unknown) => void = () => undefined;
             const savePromise = new Promise((resolve) => {
                 resolvePromise = resolve;
             });
             const onSave = vi.fn().mockReturnValue(savePromise);
-            render(<ServerDialog {...defaultProps} onSave={onSave} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} />);
 
             await user.type(getNameField(), 'Test Server');
             await user.type(getHostField(), 'localhost');
@@ -395,8 +397,18 @@ describe('ServerDialog', () => {
             });
             expect(getHostField()).toBeDisabled();
 
-            // Resolve the promise to clean up
-            resolvePromise();
+            // Resolve the promise inside `act` and wait for the dialog's
+            // `finally { setIsSaving(false) }` branch to flush before the
+            // test returns. Without this, the trailing `setIsSaving`
+            // commits after the test function resolves and emits a
+            // `not wrapped in act(...)` warning.
+            await act(async () => {
+                resolvePromise(undefined);
+                await savePromise;
+            });
+            await waitFor(() => {
+                expect(getNameField()).not.toBeDisabled();
+            });
         });
     });
 
@@ -404,7 +416,7 @@ describe('ServerDialog', () => {
         it('calls onClose when Cancel button is clicked', async () => {
             const user = userEvent.setup({ delay: null });
             const onClose = vi.fn();
-            render(<ServerDialog {...defaultProps} onClose={onClose} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onClose={onClose} />);
 
             await user.click(screen.getByRole('button', { name: /cancel/i }));
 
@@ -413,7 +425,7 @@ describe('ServerDialog', () => {
 
         it('resets form when reopened', async () => {
             const user = userEvent.setup({ delay: null });
-            const { rerender } = render(<ServerDialog {...defaultProps} />);
+            const { rerender } = renderWithTheme(<ServerDialog {...defaultProps} />);
 
             await user.type(getNameField(), 'Test Server');
 
@@ -428,7 +440,7 @@ describe('ServerDialog', () => {
     describe('SSL settings', () => {
         it('expands SSL section when clicked', async () => {
             const user = userEvent.setup({ delay: null });
-            render(<ServerDialog {...defaultProps} />);
+            renderWithTheme(<ServerDialog {...defaultProps} />);
 
             // Click the accordion
             await user.click(screen.getByText(/ssl settings/i));
@@ -444,7 +456,7 @@ describe('ServerDialog', () => {
         it('includes SSL settings in save data', async () => {
             const user = userEvent.setup({ delay: null });
             const onSave = vi.fn().mockResolvedValue();
-            render(<ServerDialog {...defaultProps} onSave={onSave} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} />);
 
             // Fill required fields
             await user.type(getNameField(), 'Test Server');
@@ -476,7 +488,7 @@ describe('ServerDialog', () => {
         it('includes is_monitored in save data', async () => {
             const user = userEvent.setup({ delay: null });
             const onSave = vi.fn().mockResolvedValue();
-            render(<ServerDialog {...defaultProps} onSave={onSave} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} />);
 
             // Fill required fields
             await user.type(getNameField(), 'Test Server');
@@ -502,7 +514,7 @@ describe('ServerDialog', () => {
         it('includes is_shared in save data when superuser', async () => {
             const user = userEvent.setup({ delay: null });
             const onSave = vi.fn().mockResolvedValue();
-            render(<ServerDialog {...defaultProps} onSave={onSave} isSuperuser={true} />);
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} isSuperuser={true} />);
 
             // Fill required fields
             await user.type(getNameField(), 'Test Server');
@@ -537,14 +549,14 @@ describe('ServerDialog', () => {
         };
 
         it('does not render tabs in create mode', () => {
-            render(<ServerDialog {...defaultProps} mode="create" />);
+            renderWithTheme(<ServerDialog {...defaultProps} mode="create" />);
 
             expect(screen.queryByRole('tab', { name: /details/i })).not.toBeInTheDocument();
             expect(screen.queryByRole('tab', { name: /alert overrides/i })).not.toBeInTheDocument();
         });
 
         it('renders Details and Alert Overrides tabs in edit mode', () => {
-            render(
+            renderWithTheme(
                 <ServerDialog
                     {...defaultProps}
                     mode="edit"
@@ -558,7 +570,7 @@ describe('ServerDialog', () => {
 
         it('renders AlertOverridesPanel when Alert Overrides tab is clicked', async () => {
             const user = userEvent.setup({ delay: null });
-            render(
+            renderWithTheme(
                 <ServerDialog
                     {...defaultProps}
                     mode="edit"
@@ -576,7 +588,7 @@ describe('ServerDialog', () => {
 
         it('shows Save button on Details tab and Close button on Alert Overrides tab', async () => {
             const user = userEvent.setup({ delay: null });
-            render(
+            renderWithTheme(
                 <ServerDialog
                     {...defaultProps}
                     mode="edit"

--- a/client/src/test/ImmediateTransition.tsx
+++ b/client/src/test/ImmediateTransition.tsx
@@ -1,0 +1,65 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Synchronous stand-in for `react-transition-group`'s `Transition`.
+ *
+ * Invokes the enter/exit lifecycle callbacks immediately on mount so
+ * MUI components that chain off them (Dialog, Popover, Modal) complete
+ * their state machine inside the same React commit; no `setTimeout` is
+ * scheduled and no state update escapes `act()`.
+ *
+ * Shared between `renderWithTheme` (which wires it as a default
+ * `TransitionComponent` on `MuiDialog`/`MuiPopover`) and test setup
+ * (which uses it to mock the project-local `SlideTransition` module so
+ * explicit `TransitionComponent={SlideTransition}` props on dialogs do
+ * not bypass the synchronous behaviour).
+ */
+
+import React from 'react';
+import { TransitionProps } from '@mui/material/transitions';
+
+const ImmediateTransition = React.forwardRef<
+    HTMLElement,
+    TransitionProps & { children: React.ReactElement }
+>(function ImmediateTransition(props, ref) {
+    const {
+        children,
+        in: inProp,
+        onEnter,
+        onEntering,
+        onEntered,
+        onExit,
+        onExiting,
+        onExited,
+    } = props;
+
+    // useLayoutEffect runs synchronously inside the same commit that
+    // userEvent's act() wraps, so the setState calls that Modal/Dialog
+    // fire from these lifecycle callbacks stay inside the act boundary.
+    React.useLayoutEffect(() => {
+        if (inProp) {
+            onEnter?.(null as unknown as HTMLElement, false);
+            onEntering?.(null as unknown as HTMLElement, false);
+            onEntered?.(null as unknown as HTMLElement, false);
+        } else {
+            onExit?.(null as unknown as HTMLElement);
+            onExiting?.(null as unknown as HTMLElement);
+            onExited?.(null as unknown as HTMLElement);
+        }
+    }, [inProp, onEnter, onEntering, onEntered, onExit, onExiting, onExited]);
+
+    if (!inProp) {
+        return null;
+    }
+    return React.cloneElement(children, { ref });
+});
+
+export default ImmediateTransition;

--- a/client/src/test/renderWithTheme.tsx
+++ b/client/src/test/renderWithTheme.tsx
@@ -1,0 +1,126 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Shared test render helper that wraps components in an MUI ThemeProvider
+ * with all transitions disabled.
+ *
+ * MUI components (Dialog, Accordion, Tabs, Fade, Slide, etc.) default to
+ * ~225ms CSS transitions driven by `react-transition-group`. Even with
+ * `timeout: 0`, the underlying `Transition` primitive still schedules a
+ * `setTimeout` callback that fires outside React's `act()` boundary,
+ * producing `Warning: An update to ... was not wrapped in act(...)` in
+ * test output. Under real timers on slow CI runners these same deferred
+ * callbacks also accumulate enough wall-clock time to exceed Vitest's
+ * default 5000ms per-test timeout.
+ *
+ * This helper builds a theme that:
+ *
+ * - Replaces `theme.transitions.create()` with a no-op so any inline
+ *   MUI style call produces no CSS transition.
+ *
+ * - Zeros every entry in `theme.transitions.duration`.
+ *
+ * - Swaps `Dialog`'s and `Popover`'s `TransitionComponent` for a
+ *   synchronous passthrough component (`ImmediateTransition`) that
+ *   fires the enter/exit lifecycle callbacks inline instead of via
+ *   `setTimeout`. This eliminates the deferred state updates that
+ *   generate `act(...)` warnings.
+ *
+ * - Sets `timeout: 0` on `Collapse` (used by `Accordion`) as a
+ *   belt-and-suspenders default for components that render it directly.
+ *
+ * - Disables ripples on `ButtonBase` so clicks do not spawn their own
+ *   deferred animations.
+ *
+ * Note: when a component passes its own `TransitionComponent` prop on a
+ * Dialog element (for example, the project-shared `SlideTransition`),
+ * that prop overrides the theme's default. The global `vi.mock` in
+ * `src/test/setup.ts` replaces the `SlideTransition` module with the
+ * same synchronous component so those dialogs also stay inside
+ * `act()`.
+ *
+ * Use this helper in place of `@testing-library/react`'s `render` for any
+ * test that mounts a Dialog, Accordion, Drawer, Menu, Popover, Snackbar,
+ * or similar transition-wrapped component.
+ */
+
+import React from 'react';
+import { render, RenderOptions, RenderResult } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import ImmediateTransition from './ImmediateTransition';
+
+const noTransitionsTheme = createTheme({
+    transitions: {
+        create: () => 'none',
+        duration: {
+            shortest: 0,
+            shorter: 0,
+            short: 0,
+            standard: 0,
+            complex: 0,
+            enteringScreen: 0,
+            leavingScreen: 0,
+        },
+    },
+    components: {
+        MuiDialog: {
+            defaultProps: {
+                transitionDuration: 0,
+                TransitionComponent: ImmediateTransition as never,
+            },
+        },
+        MuiPopover: {
+            defaultProps: {
+                transitionDuration: 0,
+                TransitionComponent: ImmediateTransition as never,
+            },
+        },
+        MuiModal: {
+            defaultProps: {
+                closeAfterTransition: false,
+            },
+        },
+        MuiAccordion: {
+            defaultProps: {
+                TransitionProps: { timeout: 0 },
+                TransitionComponent: ImmediateTransition as never,
+            },
+        },
+        MuiCollapse: {
+            defaultProps: {
+                timeout: 0,
+            },
+        },
+        MuiButtonBase: {
+            defaultProps: {
+                disableRipple: true,
+            },
+        },
+    },
+});
+
+/**
+ * Render a React element wrapped in a ThemeProvider whose theme disables
+ * all MUI transitions and ripples. Returns the standard
+ * `@testing-library/react` RenderResult so callers can destructure
+ * `rerender`, `unmount`, `container`, etc.
+ */
+export const renderWithTheme = (
+    ui: React.ReactElement,
+    options?: Omit<RenderOptions, 'wrapper'>,
+): RenderResult => {
+    const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+        <ThemeProvider theme={noTransitionsTheme}>{children}</ThemeProvider>
+    );
+    return render(ui, { wrapper: Wrapper, ...options });
+};
+
+export default renderWithTheme;

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -13,6 +13,16 @@ import { configure as configureDom } from '@testing-library/dom';
 import { act } from '@testing-library/react';
 
 /*
+ * Capture a reference to the native `setTimeout` at module init so the
+ * asyncWrapper below keeps working when a test calls
+ * `vi.useFakeTimers()`. Without this, RTL async helpers (`findBy*`,
+ * `waitFor`) invoked under fake timers would deadlock because the
+ * replaced global `setTimeout` never fires until the fake clock is
+ * advanced.
+ */
+const nativeSetTimeout = globalThis.setTimeout;
+
+/*
  * React Testing Library (RTL) ships with its own nested copy of
  * `@testing-library/dom` (v9) and, on import, patches THAT copy's
  * `asyncWrapper` / `eventWrapper` / `unstable_advanceTimersWrapper`
@@ -54,7 +64,7 @@ configureDom({
         try {
             const result = await cb();
             await new Promise<void>((resolve) => {
-                setTimeout(() => resolve(), 0);
+                nativeSetTimeout(() => resolve(), 0);
             });
             return result;
         } finally {

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -9,6 +9,66 @@
  */
 
 import '@testing-library/jest-dom';
+import { configure as configureDom } from '@testing-library/dom';
+import { act } from '@testing-library/react';
+
+/*
+ * React Testing Library (RTL) ships with its own nested copy of
+ * `@testing-library/dom` (v9) and, on import, patches THAT copy's
+ * `asyncWrapper` / `eventWrapper` / `unstable_advanceTimersWrapper`
+ * so every `userEvent` call is wrapped in `act()`. The project's
+ * direct dependency on `@testing-library/user-event` pulls in
+ * `@testing-library/dom` v10 at the top of `node_modules`, so the
+ * user-event code resolves the OUTER dom package and reads an
+ * unpatched `getConfig()`. The result is that none of the
+ * `userEvent` APIs are wrapped in `act()`, and every MUI internal
+ * state update (`InputBase.checkDirty`, `FormControl.onFilled`,
+ * `ButtonBase` mount flag, the `open` reset effect in `ServerDialog`,
+ * etc.) surfaces a `Warning: An update to ... was not wrapped in
+ * act(...)` message in stderr. See
+ * https://github.com/testing-library/react-testing-library/issues/1338
+ * for the upstream report.
+ *
+ * Re-apply the same wrappers on the outer `@testing-library/dom`
+ * instance so `userEvent` sees them and every event dispatch runs
+ * inside `act()`. Copied from RTL's own configure block in
+ * `node_modules/@testing-library/react/dist/pure.js`.
+ */
+function getIsReactActEnvironment(): boolean {
+    return (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+        .IS_REACT_ACT_ENVIRONMENT ?? false;
+}
+
+function setIsReactActEnvironment(value: boolean): void {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+        .IS_REACT_ACT_ENVIRONMENT = value;
+}
+
+configureDom({
+    unstable_advanceTimersWrapper: (cb: () => unknown) => {
+        return act(cb as () => void | Promise<void>);
+    },
+    asyncWrapper: async (cb: () => unknown) => {
+        const previous = getIsReactActEnvironment();
+        setIsReactActEnvironment(false);
+        try {
+            const result = await cb();
+            await new Promise<void>((resolve) => {
+                setTimeout(() => resolve(), 0);
+            });
+            return result;
+        } finally {
+            setIsReactActEnvironment(previous);
+        }
+    },
+    eventWrapper: (cb: () => unknown) => {
+        let result: unknown;
+        act(() => {
+            result = cb();
+        });
+        return result;
+    },
+});
 
 // Mock localStorage
 const localStorageMock = {
@@ -27,3 +87,27 @@ const sessionStorageMock = {
     clear: vi.fn(),
 };
 Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock });
+
+/*
+ * Replace the project-shared `SlideTransition` with a synchronous
+ * passthrough in every test. Several dialogs (ServerDialog,
+ * ServerInfoDialog, GroupDialog, ClusterConfigDialog, AdminPanel, and
+ * the analysis dialogs) pass `TransitionComponent={SlideTransition}`
+ * explicitly on their `<Dialog>` element; that prop overrides the
+ * default `TransitionComponent` that `renderWithTheme` installs on the
+ * theme, so MUI's `Slide` still mounts a real `react-transition-group`
+ * `Transition` and schedules `setTimeout` callbacks that fire outside
+ * React's `act()` boundary, emitting `not wrapped in act(...)` warnings.
+ *
+ * Mocking `SlideTransition` at the module level bypasses the Slide
+ * entirely and keeps the enter/exit lifecycle inside the current commit,
+ * so every dialog test inherits the same act-safe behaviour without
+ * needing per-file `vi.mock` calls. Any test that genuinely needs the
+ * real slide behaviour can opt back in with
+ * `vi.unmock('./components/shared/SlideTransition')`.
+ */
+vi.mock('../components/shared/SlideTransition', async () => {
+    const mod = await import('./ImmediateTransition');
+    return { default: mod.default };
+});
+


### PR DESCRIPTION
## Summary

Fixes #79. The `ServerDialog > form submission > calls onSave with trimmed form data` test intermittently timed out at 5000ms on Ubuntu CI while passing locally (~16s on macOS). Root causes were two-fold:

- **MUI transitions under real timers.** `Dialog`, the custom `SlideTransition`, and `Accordion`'s `Collapse` each schedule real `setTimeout` callbacks. Under ~52 keystrokes from `userEvent.type`, those accumulated enough wall-clock time on slower CI runners to exceed the 5000ms per-test budget.
- **RTL v14 / dom dual-install.** React Testing Library 14 patches its bundled `@testing-library/dom@9` with `asyncWrapper`/`eventWrapper`/`unstable_advanceTimersWrapper`, but the project's direct dep on `@testing-library/user-event` hoists `@testing-library/dom@10` to the root of `node_modules`. `userEvent` resolves the outer (unpatched) instance, so every interaction bypassed `act()` and every MUI internal `setState` (InputBase `checkDirty`, FormControl `onFilled`, ButtonBase mount flag, the `open` reset effect) surfaced as a `Warning: An update to ... was not wrapped in act(...)`. Upstream issue: testing-library/react-testing-library#1338.

## Changes

- `client/src/test/renderWithTheme.tsx` (new) — render helper wrapping components in a `ThemeProvider` whose theme zeroes all transition durations and swaps `Dialog`/`Popover`'s `TransitionComponent` for a synchronous stand-in.
- `client/src/test/ImmediateTransition.tsx` (new) — synchronous transition component that fires `onEnter`/`onEntered`/etc. inline via `useLayoutEffect`, keeping all state updates inside the current `act()` boundary.
- `client/src/test/setup.ts` — re-applies RTL's `configure({ asyncWrapper, eventWrapper, unstable_advanceTimersWrapper })` on the outer `@testing-library/dom` instance so `userEvent` calls are wrapped in `act()`. Also globally mocks `components/shared/SlideTransition` to a synchronous passthrough, covering all nine dialogs that use it (`ServerDialog`, `GroupDialog`, `ClusterConfigDialog`, `ServerInfoDialog`, `QueryAnalysisDialog`, `ChartAnalysisDialog`, `AdminPanel`, `AlertAnalysisDialog`, `ServerAnalysisDialog`).
- `client/src/components/__tests__/ServerDialog.test.tsx` — swapped `render` for `renderWithTheme` in all 35 tests; tightened the `disables form during save` test to resolve the pending save inside `act()` and wait for the saving-state reset.

## Verification

- `ServerDialog.test.tsx`: 35/35 pass, **0** `act` warnings (down from dozens), duration ~31s (vs ~37s pre-fix).
- Full client suite: **581/581** tests pass across 37 files. Total `not wrapped in act` warnings dropped from 12,101 to 30. The 30 residuals come from 4 pre-existing tests unrelated to #79 (`TopQueriesSection`, `ServerInfoDialog` AI-loading skeleton, `AuthContext` loading state) and are out of scope.
- `npm run lint`: 0 errors (27 pre-existing warnings in unrelated files).
- `npx tsc --noEmit`: only pre-existing baseline errors; no new ones introduced.

## Test plan

- [x] Target test passes with 0 act warnings
- [x] Full client test suite passes
- [x] Lint clean on changed files
- [x] Nine other dialogs using `SlideTransition` automatically benefit from the global mock
- [ ] Confirm on CI runner (Ubuntu, Node.js 20) that timing is stable — CI run on this PR will validate

https://claude.ai/code/session_013RtSJjsfdRJFaW13VLp6zA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a shared test renderer that disables transitions and ripples for deterministic UI tests.
  * Introduced a synchronous transition helper to complete transition lifecycles immediately in tests.
  * Updated dialog-related tests to use the new test renderer and act wrapping for more stable assertions.
  * Configured the test environment to wrap async timing helpers in act and preserve timer behavior under fake timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->