### PR TITLE
Add vitest coverage for client/src/contexts/ (#113)

### DIFF
--- a/client/src/contexts/__tests__/AICapabilitiesContext.test.tsx
+++ b/client/src/contexts/__tests__/AICapabilitiesContext.test.tsx
@@ -1,0 +1,132 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - AICapabilitiesContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    AICapabilitiesProvider,
+    useAICapabilities,
+} from '../AICapabilitiesContext';
+
+// Mock apiClient.apiGet
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: vi.fn(),
+}));
+
+import { apiGet } from '../../utils/apiClient';
+const mockApiGet = apiGet as unknown as ReturnType<typeof vi.fn>;
+
+describe('AICapabilitiesContext', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <AICapabilitiesProvider>{children}</AICapabilitiesProvider>
+    );
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('initial state and fetch', () => {
+        it('starts in a loading state with default values', () => {
+            // Never-resolving promise to keep in loading state
+            mockApiGet.mockReturnValue(new Promise(() => {}));
+
+            const { result } = renderHook(() => useAICapabilities(), { wrapper });
+
+            expect(result.current.loading).toBe(true);
+            expect(result.current.aiEnabled).toBe(false);
+            expect(result.current.maxIterations).toBe(50);
+        });
+
+        it('sets aiEnabled and maxIterations from API response', async () => {
+            mockApiGet.mockResolvedValueOnce({
+                ai_enabled: true,
+                max_iterations: 25,
+            });
+
+            const { result } = renderHook(() => useAICapabilities(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.aiEnabled).toBe(true);
+            expect(result.current.maxIterations).toBe(25);
+        });
+
+        it('defaults maxIterations to 50 when not provided', async () => {
+            mockApiGet.mockResolvedValueOnce({
+                ai_enabled: true,
+            });
+
+            const { result } = renderHook(() => useAICapabilities(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.maxIterations).toBe(50);
+        });
+
+        it('sets aiEnabled to false when not strictly true', async () => {
+            mockApiGet.mockResolvedValueOnce({
+                ai_enabled: 'yes',
+            });
+
+            const { result } = renderHook(() => useAICapabilities(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.aiEnabled).toBe(false);
+        });
+
+        it('sets aiEnabled to false when fetch fails', async () => {
+            mockApiGet.mockRejectedValueOnce(new Error('Network error'));
+
+            const { result } = renderHook(() => useAICapabilities(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.aiEnabled).toBe(false);
+        });
+
+        it('calls /api/v1/capabilities', async () => {
+            mockApiGet.mockResolvedValueOnce({ ai_enabled: false });
+
+            renderHook(() => useAICapabilities(), { wrapper });
+
+            await waitFor(() => {
+                expect(mockApiGet).toHaveBeenCalledWith('/api/v1/capabilities');
+            });
+        });
+    });
+
+    describe('useAICapabilities hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useAICapabilities());
+                }).toThrow('useAICapabilities must be used within an AICapabilitiesProvider');
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});

--- a/client/src/contexts/__tests__/AlertsContext.test.tsx
+++ b/client/src/contexts/__tests__/AlertsContext.test.tsx
@@ -1,0 +1,260 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - AlertsContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AlertsProvider, useAlerts } from '../AlertsContext';
+
+// Mock apiGet
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: vi.fn(),
+}));
+
+// Mock AuthContext — provide a stable user object
+let mockUser: { username: string } | null = { username: 'testuser' };
+vi.mock('../AuthContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+
+import { apiGet } from '../../utils/apiClient';
+const mockApiGet = apiGet as unknown as ReturnType<typeof vi.fn>;
+
+describe('AlertsContext', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <AlertsProvider>{children}</AlertsProvider>
+    );
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUser = { username: 'testuser' };
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe('default state', () => {
+        it('starts with zero alerts and no lastFetch', () => {
+            mockApiGet.mockReturnValueOnce(new Promise(() => {}));
+
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            expect(result.current.alertCounts).toEqual({
+                total: 0,
+                byServer: {},
+                byCluster: {},
+            });
+            expect(result.current.lastFetch).toBeNull();
+        });
+
+        it('provides all expected context properties', async () => {
+            mockApiGet.mockResolvedValueOnce({
+                total: 0,
+                by_server: {},
+                by_cluster: {},
+            });
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current).toHaveProperty('alertCounts');
+            expect(result.current).toHaveProperty('loading');
+            expect(result.current).toHaveProperty('lastFetch');
+            expect(result.current).toHaveProperty('fetchAlertCounts');
+            expect(result.current).toHaveProperty('getServerAlertCount');
+            expect(result.current).toHaveProperty('getClusterAlertCount');
+            expect(result.current).toHaveProperty('getTotalAlertCount');
+        });
+    });
+
+    describe('fetchAlertCounts', () => {
+        it('populates counts from the API response', async () => {
+            mockApiGet.mockResolvedValueOnce({
+                total: 5,
+                by_server: { 1: 2, 2: 3 },
+                by_cluster: { 'cluster-1': 5 },
+            });
+
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.alertCounts.total).toBe(5);
+            });
+
+            expect(result.current.alertCounts.byServer).toEqual({ 1: 2, 2: 3 });
+            expect(result.current.alertCounts.byCluster).toEqual({ 'cluster-1': 5 });
+            expect(result.current.lastFetch).toBeInstanceOf(Date);
+            expect(result.current.loading).toBe(false);
+        });
+
+        it('defaults missing fields to 0 / empty objects', async () => {
+            mockApiGet.mockResolvedValueOnce({});
+
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.lastFetch).not.toBeNull();
+            });
+
+            expect(result.current.alertCounts).toEqual({
+                total: 0,
+                byServer: {},
+                byCluster: {},
+            });
+        });
+
+        it('logs error and keeps state when fetch fails', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            mockApiGet.mockRejectedValueOnce(new Error('boom'));
+
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(consoleSpy).toHaveBeenCalled();
+            expect(result.current.alertCounts.total).toBe(0);
+            expect(result.current.lastFetch).toBeNull();
+        });
+
+        it('fetchAlertCounts is a no-op when user is null', async () => {
+            mockUser = null;
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await act(async () => {
+                await result.current.fetchAlertCounts();
+            });
+
+            expect(mockApiGet).not.toHaveBeenCalled();
+        });
+
+        it('calls the correct endpoint', async () => {
+            mockApiGet.mockResolvedValueOnce({ total: 0 });
+            renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(mockApiGet).toHaveBeenCalledWith('/api/v1/alerts/counts');
+            });
+        });
+    });
+
+    describe('helper selectors', () => {
+        it('getServerAlertCount returns count for the server', async () => {
+            mockApiGet.mockResolvedValueOnce({
+                total: 10,
+                by_server: { 42: 7 },
+            });
+
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.alertCounts.total).toBe(10);
+            });
+
+            expect(result.current.getServerAlertCount(42)).toBe(7);
+            expect(result.current.getServerAlertCount(99)).toBe(0);
+        });
+
+        it('getClusterAlertCount sums counts for all provided server IDs', async () => {
+            mockApiGet.mockResolvedValueOnce({
+                total: 10,
+                by_server: { 1: 3, 2: 4, 3: 1 },
+            });
+
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.alertCounts.total).toBe(10);
+            });
+
+            expect(result.current.getClusterAlertCount([1, 2, 3])).toBe(8);
+            expect(result.current.getClusterAlertCount([1, 99])).toBe(3);
+        });
+
+        it('getClusterAlertCount returns 0 for empty or missing arrays', async () => {
+            mockApiGet.mockResolvedValueOnce({ total: 0 });
+
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.getClusterAlertCount([])).toBe(0);
+            expect(
+                result.current.getClusterAlertCount(
+                    null as unknown as number[],
+                ),
+            ).toBe(0);
+        });
+
+        it('getTotalAlertCount returns the running total', async () => {
+            mockApiGet.mockResolvedValueOnce({ total: 42 });
+
+            const { result } = renderHook(() => useAlerts(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.alertCounts.total).toBe(42);
+            });
+
+            expect(result.current.getTotalAlertCount()).toBe(42);
+        });
+    });
+
+    describe('auto-refresh', () => {
+        it('refetches every 30 seconds', async () => {
+            vi.useFakeTimers();
+            mockApiGet.mockResolvedValue({ total: 0 });
+
+            renderHook(() => useAlerts(), { wrapper });
+
+            // Allow initial fetch to resolve.
+            await vi.runOnlyPendingTimersAsync();
+            const initialCallCount = mockApiGet.mock.calls.length;
+            expect(initialCallCount).toBeGreaterThanOrEqual(1);
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(30000);
+            });
+
+            expect(mockApiGet.mock.calls.length).toBeGreaterThan(initialCallCount);
+        });
+    });
+
+    describe('user-gating', () => {
+        it('does not fetch when user is null', async () => {
+            mockUser = null;
+            renderHook(() => useAlerts(), { wrapper });
+
+            // Allow any pending microtasks.
+            await new Promise((r) => setTimeout(r, 10));
+            expect(mockApiGet).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('useAlerts hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useAlerts());
+                }).toThrow('useAlerts must be used within an AlertsProvider');
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});

--- a/client/src/contexts/__tests__/BlackoutContext.test.tsx
+++ b/client/src/contexts/__tests__/BlackoutContext.test.tsx
@@ -1,0 +1,488 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - BlackoutContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    BlackoutProvider,
+    useBlackouts,
+    Blackout,
+    BlackoutSchedule,
+    BlackoutSelection,
+} from '../BlackoutContext';
+
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
+    apiPut: vi.fn(),
+    apiDelete: vi.fn(),
+}));
+
+let mockUser: { username: string } | null = { username: 'testuser' };
+vi.mock('../AuthContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+
+import {
+    apiGet,
+    apiPost,
+    apiPut,
+    apiDelete,
+} from '../../utils/apiClient';
+
+const mockApiGet = apiGet as unknown as ReturnType<typeof vi.fn>;
+const mockApiPost = apiPost as unknown as ReturnType<typeof vi.fn>;
+const mockApiPut = apiPut as unknown as ReturnType<typeof vi.fn>;
+const mockApiDelete = apiDelete as unknown as ReturnType<typeof vi.fn>;
+
+const activeEstateBlackout: Blackout = {
+    id: 1,
+    scope: 'estate',
+    reason: 'estate wide',
+    start_time: '2026-01-01T00:00:00Z',
+    end_time: '2026-12-31T00:00:00Z',
+    created_by: 'admin',
+    created_at: '2026-01-01T00:00:00Z',
+    is_active: true,
+};
+
+const activeClusterBlackout: Blackout = {
+    id: 2,
+    scope: 'cluster',
+    cluster_id: 10,
+    reason: 'cluster',
+    start_time: '2026-01-01T00:00:00Z',
+    end_time: '2026-12-31T00:00:00Z',
+    created_by: 'admin',
+    created_at: '2026-01-01T00:00:00Z',
+    is_active: true,
+};
+
+const activeServerBlackout: Blackout = {
+    id: 3,
+    scope: 'server',
+    connection_id: 100,
+    reason: 'server',
+    start_time: '2026-01-01T00:00:00Z',
+    end_time: '2026-12-31T00:00:00Z',
+    created_by: 'admin',
+    created_at: '2026-01-01T00:00:00Z',
+    is_active: true,
+};
+
+const inactiveBlackout: Blackout = {
+    id: 4,
+    scope: 'estate',
+    reason: 'past',
+    start_time: '2025-01-01T00:00:00Z',
+    end_time: '2025-06-01T00:00:00Z',
+    created_by: 'admin',
+    created_at: '2025-01-01T00:00:00Z',
+    is_active: false,
+};
+
+const schedule: BlackoutSchedule = {
+    id: 5,
+    scope: 'estate',
+    name: 'nightly',
+    cron_expression: '0 2 * * *',
+    duration_minutes: 60,
+    timezone: 'UTC',
+    reason: 'maintenance',
+    enabled: true,
+    created_by: 'admin',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+};
+
+const mockBlackoutsResponse = {
+    blackouts: [
+        activeEstateBlackout,
+        activeClusterBlackout,
+        activeServerBlackout,
+        inactiveBlackout,
+    ],
+};
+
+const mockSchedulesResponse = { schedules: [schedule] };
+
+describe('BlackoutContext', () => {
+    const buildWrapper = (selection: BlackoutSelection | null = null) => {
+        return ({ children }: { children: React.ReactNode }) => (
+            <BlackoutProvider selection={selection}>{children}</BlackoutProvider>
+        );
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUser = { username: 'testuser' };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/blackouts') {
+                return Promise.resolve(mockBlackoutsResponse);
+            }
+            if (url === '/api/v1/blackout-schedules') {
+                return Promise.resolve(mockSchedulesResponse);
+            }
+            return Promise.reject(new Error('unknown url ' + url));
+        });
+        mockApiPost.mockResolvedValue({});
+        mockApiPut.mockResolvedValue({});
+        mockApiDelete.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe('initial load', () => {
+        it('fetches both blackouts and schedules on mount', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            expect(result.current.schedules.length).toBe(1);
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/blackouts');
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/blackout-schedules');
+        });
+
+        it('defaults to empty arrays when responses lack fields', async () => {
+            mockApiGet.mockReset();
+            mockApiGet.mockResolvedValue({});
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.blackouts).toEqual([]);
+            expect(result.current.schedules).toEqual([]);
+        });
+
+        it('sets error when fetch fails', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            mockApiGet.mockReset();
+            mockApiGet.mockRejectedValue(new Error('fetch failed'));
+
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.error).toBe('fetch failed');
+            });
+
+            expect(consoleSpy).toHaveBeenCalled();
+        });
+
+        it('does not fetch when user is null', async () => {
+            mockUser = null;
+
+            renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            // Flush microtasks.
+            await new Promise((r) => setTimeout(r, 10));
+            expect(mockApiGet).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('CRUD operations', () => {
+        it('createBlackout POSTs and refetches', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            mockApiGet.mockClear();
+
+            await act(async () => {
+                await result.current.createBlackout({
+                    scope: 'estate',
+                    reason: 'new',
+                    start_time: '2026-05-01T00:00:00Z',
+                    end_time: '2026-05-02T00:00:00Z',
+                });
+            });
+
+            expect(mockApiPost).toHaveBeenCalledWith(
+                '/api/v1/blackouts',
+                expect.objectContaining({ scope: 'estate', reason: 'new' }),
+            );
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        it('stopBlackout calls the stop endpoint and refetches', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            await act(async () => {
+                await result.current.stopBlackout(1);
+            });
+
+            expect(mockApiPost).toHaveBeenCalledWith('/api/v1/blackouts/1/stop');
+        });
+
+        it('deleteBlackout DELETEs and refetches', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            await act(async () => {
+                await result.current.deleteBlackout(1);
+            });
+
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/blackouts/1');
+        });
+
+        it('createSchedule POSTs and refetches', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            await act(async () => {
+                await result.current.createSchedule({
+                    scope: 'estate',
+                    name: 'maint',
+                    cron_expression: '0 0 * * *',
+                    duration_minutes: 10,
+                    timezone: 'UTC',
+                    reason: 'r',
+                });
+            });
+
+            expect(mockApiPost).toHaveBeenCalledWith(
+                '/api/v1/blackout-schedules',
+                expect.objectContaining({ name: 'maint' }),
+            );
+        });
+
+        it('updateSchedule PUTs and refetches', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            await act(async () => {
+                await result.current.updateSchedule(5, { enabled: false });
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/blackout-schedules/5',
+                { enabled: false },
+            );
+        });
+
+        it('deleteSchedule DELETEs and refetches', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            await act(async () => {
+                await result.current.deleteSchedule(5);
+            });
+
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/blackout-schedules/5');
+        });
+    });
+
+    describe('activeBlackoutsForSelection', () => {
+        it('returns only active blackouts when selection is null', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(null),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            expect(result.current.activeBlackoutsForSelection).toHaveLength(3);
+            expect(
+                result.current.activeBlackoutsForSelection.every(b => b.is_active),
+            ).toBe(true);
+        });
+
+        it('estate selection shows all active blackouts', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper({ type: 'estate' }),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            expect(result.current.activeBlackoutsForSelection).toHaveLength(3);
+        });
+
+        it('cluster selection shows estate, matching cluster, and server-in-cluster blackouts', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper({
+                    type: 'cluster',
+                    id: 10,
+                    serverIds: [100],
+                }),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            const ids = result.current.activeBlackoutsForSelection.map(b => b.id);
+            expect(ids).toContain(1); // estate
+            expect(ids).toContain(2); // matching cluster
+            expect(ids).toContain(3); // server in cluster
+        });
+
+        it('cluster selection filters out non-matching cluster blackouts', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper({
+                    type: 'cluster',
+                    id: 999,
+                    serverIds: [999],
+                }),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            const ids = result.current.activeBlackoutsForSelection.map(b => b.id);
+            expect(ids).toContain(1); // estate still applies
+            expect(ids).not.toContain(2);
+            expect(ids).not.toContain(3);
+        });
+
+        it('server selection shows estate and matching server blackouts but excludes cluster', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper({ type: 'server', id: 100 }),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            const ids = result.current.activeBlackoutsForSelection.map(b => b.id);
+            expect(ids).toContain(1); // estate
+            expect(ids).toContain(3); // server
+            expect(ids).not.toContain(2); // cluster excluded for server view
+        });
+
+        it('server selection without match only shows estate blackouts', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper({ type: 'server', id: 9999 }),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            const ids = result.current.activeBlackoutsForSelection.map(b => b.id);
+            expect(ids).toEqual([1]);
+        });
+
+        it('unknown selection type only keeps estate blackouts', async () => {
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper({ type: 'unknown-type' }),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            const ids = result.current.activeBlackoutsForSelection.map(b => b.id);
+            expect(ids).toEqual([1]);
+        });
+    });
+
+    describe('auto-refresh', () => {
+        it('refetches every 30 seconds', async () => {
+            vi.useFakeTimers();
+            const { result } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await vi.runOnlyPendingTimersAsync();
+            const callsBefore = mockApiGet.mock.calls.length;
+            expect(result.current).toBeDefined();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(30000);
+            });
+
+            expect(mockApiGet.mock.calls.length).toBeGreaterThan(callsBefore);
+        });
+    });
+
+    describe('user logout clears state', () => {
+        it('resets blackouts and schedules when user becomes null', async () => {
+            const { result, rerender } = renderHook(() => useBlackouts(), {
+                wrapper: buildWrapper(),
+            });
+
+            await waitFor(() => {
+                expect(result.current.blackouts.length).toBe(4);
+            });
+
+            mockUser = null;
+            rerender();
+
+            await waitFor(() => {
+                expect(result.current.blackouts).toEqual([]);
+            });
+
+            expect(result.current.schedules).toEqual([]);
+        });
+    });
+
+    describe('useBlackouts hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useBlackouts());
+                }).toThrow('useBlackouts must be used within a BlackoutProvider');
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});

--- a/client/src/contexts/__tests__/ChatContext.test.tsx
+++ b/client/src/contexts/__tests__/ChatContext.test.tsx
@@ -1,0 +1,383 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - ChatContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ChatProvider, useChatContext } from '../ChatContext';
+
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: vi.fn(),
+    apiDelete: vi.fn(),
+    apiPatch: vi.fn(),
+}));
+
+let mockUser: { username: string } | null = { username: 'testuser' };
+vi.mock('../AuthContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+
+// Mock useChat hook — return a controllable "instance" per render.
+const chatHookState = {
+    messages: [] as unknown[],
+    isLoading: false,
+    error: null as string | null,
+    conversationId: null as string | null,
+    conversationTitle: '',
+    activeTools: [] as unknown[],
+    inputHistory: [] as string[],
+    sendMessage: vi.fn(async (_text: string) => {}),
+    clearChat: vi.fn(),
+    loadConversation: vi.fn(async (_id: string) => {}),
+};
+
+vi.mock('../../hooks/useChat', () => ({
+    default: () => chatHookState,
+}));
+
+import { apiGet, apiDelete, apiPatch } from '../../utils/apiClient';
+const mockApiGet = apiGet as unknown as ReturnType<typeof vi.fn>;
+const mockApiDelete = apiDelete as unknown as ReturnType<typeof vi.fn>;
+const mockApiPatch = apiPatch as unknown as ReturnType<typeof vi.fn>;
+
+const sampleConversations = [
+    {
+        id: 'c1',
+        title: 'Convo 1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        preview: 'hi',
+    },
+    {
+        id: 'c2',
+        title: 'Convo 2',
+        created_at: '2026-01-02T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+        preview: 'hello',
+    },
+];
+
+describe('ChatContext', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <ChatProvider>{children}</ChatProvider>
+    );
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUser = { username: 'testuser' };
+        chatHookState.messages = [];
+        chatHookState.isLoading = false;
+        chatHookState.error = null;
+        chatHookState.conversationId = null;
+        chatHookState.conversationTitle = '';
+        chatHookState.activeTools = [];
+        chatHookState.inputHistory = [];
+        chatHookState.sendMessage = vi.fn(async () => {});
+        chatHookState.clearChat = vi.fn();
+        chatHookState.loadConversation = vi.fn(async () => {});
+        mockApiGet.mockResolvedValue({ conversations: sampleConversations });
+        mockApiDelete.mockResolvedValue({});
+        mockApiPatch.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('default state', () => {
+        it('starts with panel closed and provides expected properties', async () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            expect(result.current.isOpen).toBe(false);
+            expect(result.current).toHaveProperty('openChat');
+            expect(result.current).toHaveProperty('closeChat');
+            expect(result.current).toHaveProperty('toggleChat');
+            expect(result.current).toHaveProperty('sendMessage');
+            expect(result.current).toHaveProperty('clearChat');
+            expect(result.current).toHaveProperty('loadConversation');
+            expect(result.current).toHaveProperty('deleteConversation');
+            expect(result.current).toHaveProperty('renameConversation');
+            expect(result.current).toHaveProperty('refreshConversations');
+        });
+    });
+
+    describe('panel controls', () => {
+        it('openChat sets isOpen to true', () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            act(() => {
+                result.current.openChat();
+            });
+
+            expect(result.current.isOpen).toBe(true);
+        });
+
+        it('closeChat sets isOpen to false', () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            act(() => {
+                result.current.openChat();
+            });
+            act(() => {
+                result.current.closeChat();
+            });
+
+            expect(result.current.isOpen).toBe(false);
+        });
+
+        it('toggleChat flips isOpen', () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            act(() => {
+                result.current.toggleChat();
+            });
+            expect(result.current.isOpen).toBe(true);
+
+            act(() => {
+                result.current.toggleChat();
+            });
+            expect(result.current.isOpen).toBe(false);
+        });
+    });
+
+    describe('refreshConversations', () => {
+        it('fetches the conversation list on mount when user is set', async () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.conversations).toHaveLength(2);
+            });
+
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/conversations');
+        });
+
+        it('handles array-shaped responses', async () => {
+            mockApiGet.mockResolvedValueOnce(sampleConversations);
+
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.conversations).toHaveLength(2);
+            });
+        });
+
+        it('handles responses without a conversations field', async () => {
+            mockApiGet.mockResolvedValueOnce({});
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                // When response is {} (truthy but no conversations), list stays empty.
+                expect(result.current.conversations).toEqual([]);
+            });
+        });
+
+        it('logs and swallows fetch errors', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            mockApiGet.mockRejectedValue(new Error('boom'));
+
+            renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(consoleSpy).toHaveBeenCalled();
+            });
+        });
+
+        it('does not fetch when user is null', async () => {
+            mockUser = null;
+
+            renderHook(() => useChatContext(), { wrapper });
+
+            await new Promise((r) => setTimeout(r, 10));
+            expect(mockApiGet).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('loadConversation', () => {
+        it('delegates to the hook and refreshes list', async () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.conversations).toHaveLength(2);
+            });
+
+            mockApiGet.mockClear();
+
+            await act(async () => {
+                await result.current.loadConversation('c1');
+            });
+
+            expect(chatHookState.loadConversation).toHaveBeenCalledWith('c1');
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+    });
+
+    describe('deleteConversation', () => {
+        it('removes the deleted conversation from the list', async () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.conversations).toHaveLength(2);
+            });
+
+            await act(async () => {
+                await result.current.deleteConversation('c1');
+            });
+
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/conversations/c1');
+            expect(
+                result.current.conversations.map((c) => c.id),
+            ).toEqual(['c2']);
+        });
+
+        it('clears the chat when deleting the active conversation', async () => {
+            chatHookState.conversationId = 'c1';
+
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.conversations).toHaveLength(2);
+            });
+
+            await act(async () => {
+                await result.current.deleteConversation('c1');
+            });
+
+            expect(chatHookState.clearChat).toHaveBeenCalled();
+        });
+
+        it('rethrows errors from delete requests', async () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            mockApiDelete.mockRejectedValueOnce(new Error('forbidden'));
+
+            try {
+                const { result } = renderHook(() => useChatContext(), { wrapper });
+
+                await waitFor(() => {
+                    expect(result.current.conversations).toHaveLength(2);
+                });
+
+                await expect(
+                    act(async () => {
+                        await result.current.deleteConversation('c1');
+                    }),
+                ).rejects.toThrow('forbidden');
+
+                // List should be unchanged since delete failed.
+                expect(result.current.conversations).toHaveLength(2);
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+
+    describe('renameConversation', () => {
+        it('PATCHes and updates the title in the list', async () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.conversations).toHaveLength(2);
+            });
+
+            await act(async () => {
+                await result.current.renameConversation('c1', 'Renamed');
+            });
+
+            expect(mockApiPatch).toHaveBeenCalledWith(
+                '/api/v1/conversations/c1',
+                { title: 'Renamed' },
+            );
+
+            const updated = result.current.conversations.find(
+                (c) => c.id === 'c1',
+            );
+            expect(updated?.title).toBe('Renamed');
+        });
+
+        it('rethrows errors from rename requests', async () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            mockApiPatch.mockRejectedValueOnce(new Error('bad request'));
+
+            try {
+                const { result } = renderHook(() => useChatContext(), { wrapper });
+
+                await waitFor(() => {
+                    expect(result.current.conversations).toHaveLength(2);
+                });
+
+                const originalTitle = result.current.conversations.find(
+                    (c) => c.id === 'c1',
+                )?.title;
+
+                await expect(
+                    act(async () => {
+                        await result.current.renameConversation('c1', 'X');
+                    }),
+                ).rejects.toThrow('bad request');
+
+                // Title should remain the original since the rename failed.
+                expect(
+                    result.current.conversations.find((c) => c.id === 'c1')?.title,
+                ).toBe(originalTitle);
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+
+    describe('clearChat wrapper', () => {
+        it('delegates to hook and refreshes list', async () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.conversations).toHaveLength(2);
+            });
+
+            mockApiGet.mockClear();
+
+            act(() => {
+                result.current.clearChat();
+            });
+
+            expect(chatHookState.clearChat).toHaveBeenCalled();
+        });
+    });
+
+    describe('sendMessage wrapper', () => {
+        it('delegates to hook and refreshes list', async () => {
+            const { result } = renderHook(() => useChatContext(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.conversations).toHaveLength(2);
+            });
+
+            await act(async () => {
+                await result.current.sendMessage('hello');
+            });
+
+            expect(chatHookState.sendMessage).toHaveBeenCalledWith('hello');
+        });
+    });
+
+    describe('hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useChatContext());
+                }).toThrow('useChatContext must be used within a ChatProvider');
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});

--- a/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
@@ -1,0 +1,429 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - ClusterActionsContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    ClusterActionsProvider,
+    useClusterActions,
+} from '../ClusterActionsContext';
+
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
+    apiPut: vi.fn(),
+    apiDelete: vi.fn(),
+}));
+
+let mockUser: { username: string } | null = { username: 'testuser' };
+const mockFetchClusterData = vi.fn(async () => {});
+const mockClearSelection = vi.fn(async () => {});
+let mockSelectedServer: { id: number } | null = null;
+
+vi.mock('../AuthContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+vi.mock('../ClusterDataContext', () => ({
+    useClusterData: () => ({ fetchClusterData: mockFetchClusterData }),
+}));
+vi.mock('../ClusterSelectionContext', () => ({
+    useClusterSelection: () => ({
+        selectedServer: mockSelectedServer,
+        clearSelection: mockClearSelection,
+    }),
+}));
+
+import {
+    apiGet,
+    apiPost,
+    apiPut,
+    apiDelete,
+} from '../../utils/apiClient';
+
+const mockApiGet = apiGet as unknown as ReturnType<typeof vi.fn>;
+const mockApiPost = apiPost as unknown as ReturnType<typeof vi.fn>;
+const mockApiPut = apiPut as unknown as ReturnType<typeof vi.fn>;
+const mockApiDelete = apiDelete as unknown as ReturnType<typeof vi.fn>;
+
+describe('ClusterActionsContext', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <ClusterActionsProvider>{children}</ClusterActionsProvider>
+    );
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUser = { username: 'testuser' };
+        mockSelectedServer = null;
+        mockApiGet.mockResolvedValue({});
+        mockApiPost.mockResolvedValue({});
+        mockApiPut.mockResolvedValue({});
+        mockApiDelete.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('auth gating', () => {
+        it.each([
+            ['updateGroupName', ['group-1', 'new']],
+            ['updateClusterName', ['cluster-1', 'x', 'group-1']],
+            ['updateServerName', [1, 'x']],
+            ['getServer', [1]],
+            ['createServer', [{ name: 'x' }]],
+            ['updateServer', [1, { name: 'x' }]],
+            ['deleteServer', [1]],
+            ['deleteCluster', ['cluster-1']],
+            ['createGroup', [{ name: 'x' }]],
+            ['deleteGroup', ['group-1']],
+            ['moveClusterToGroup', ['cluster-1', 'group-2']],
+        ] as const)('%s throws when user is null', async (fn, args) => {
+            mockUser = null;
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await expect(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (result.current as any)[fn](...args),
+            ).rejects.toThrow('Not authenticated');
+        });
+    });
+
+    describe('updateGroupName', () => {
+        it('uses group id as-is for auto-detected groups', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateGroupName('group-auto', 'My Auto');
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/cluster-groups/group-auto',
+                { name: 'My Auto' },
+            );
+            expect(mockFetchClusterData).toHaveBeenCalled();
+        });
+
+        it('uses numeric id for database-backed groups', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateGroupName('group-42', 'Prod');
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/cluster-groups/42',
+                { name: 'Prod' },
+            );
+        });
+
+        it('uses the full id for named (non-numeric) database groups', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateGroupName('group-named', 'X');
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/cluster-groups/group-named',
+                { name: 'X' },
+            );
+        });
+    });
+
+    describe('updateClusterName', () => {
+        it('sends auto_cluster_key for auto-detected clusters', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateClusterName(
+                    'server-5',
+                    'my cluster',
+                    'group-1',
+                    'auto-key',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/clusters/server-5',
+                { name: 'my cluster', auto_cluster_key: 'auto-key' },
+            );
+        });
+
+        it('omits auto_cluster_key when not provided for auto clusters', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateClusterName(
+                    'cluster-spock-abc',
+                    'pg-cluster',
+                    'group-1',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/clusters/cluster-spock-abc',
+                { name: 'pg-cluster' },
+            );
+        });
+
+        it('updates database-backed clusters with numeric ids', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateClusterName(
+                    'cluster-7',
+                    'db cluster',
+                    'group-3',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/clusters/7',
+                { name: 'db cluster', group_id: 3 },
+            );
+        });
+
+        it('throws when cluster id is not numeric and not auto-detected', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await expect(
+                result.current.updateClusterName(
+                    'cluster-not-a-number',
+                    'x',
+                    'group-1',
+                ),
+            ).rejects.toThrow('Invalid cluster ID');
+        });
+
+        it('throws when group id is not numeric', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await expect(
+                result.current.updateClusterName(
+                    'cluster-1',
+                    'x',
+                    'group-named',
+                ),
+            ).rejects.toThrow('Invalid group ID');
+        });
+    });
+
+    describe('updateServerName', () => {
+        it('PUTs /connections and refetches', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateServerName(1, 'New');
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/connections/1',
+                { name: 'New' },
+            );
+            expect(mockFetchClusterData).toHaveBeenCalled();
+        });
+    });
+
+    describe('getServer / createServer / updateServer / deleteServer', () => {
+        it('getServer GETs the connection and returns the payload', async () => {
+            mockApiGet.mockResolvedValueOnce({ id: 1, name: 'x' });
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            let payload: unknown;
+            await act(async () => {
+                payload = await result.current.getServer(1);
+            });
+
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/1');
+            expect(payload).toEqual({ id: 1, name: 'x' });
+        });
+
+        it('createServer POSTs and refetches', async () => {
+            mockApiPost.mockResolvedValueOnce({ id: 99 });
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            let created: unknown;
+            await act(async () => {
+                created = await result.current.createServer({ name: 'new' });
+            });
+
+            expect(mockApiPost).toHaveBeenCalledWith('/api/v1/connections', {
+                name: 'new',
+            });
+            expect(mockFetchClusterData).toHaveBeenCalled();
+            expect(created).toEqual({ id: 99 });
+        });
+
+        it('updateServer PUTs and refetches', async () => {
+            mockApiPut.mockResolvedValueOnce({ id: 1 });
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateServer(1, { name: 'edited' });
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith('/api/v1/connections/1', {
+                name: 'edited',
+            });
+            expect(mockFetchClusterData).toHaveBeenCalled();
+        });
+
+        it('deleteServer calls clearSelection when selected server is deleted', async () => {
+            mockSelectedServer = { id: 5 };
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.deleteServer(5);
+            });
+
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/connections/5');
+            expect(mockClearSelection).toHaveBeenCalled();
+        });
+
+        it('deleteServer leaves selection alone when deleting a different server', async () => {
+            mockSelectedServer = { id: 5 };
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.deleteServer(6);
+            });
+
+            expect(mockClearSelection).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('deleteCluster', () => {
+        it('DELETEs the cluster and refetches', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.deleteCluster('cluster-1');
+            });
+
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/clusters/cluster-1');
+            expect(mockFetchClusterData).toHaveBeenCalled();
+        });
+    });
+
+    describe('createGroup and deleteGroup', () => {
+        it('createGroup POSTs and refetches', async () => {
+            mockApiPost.mockResolvedValueOnce({ id: 10 });
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            let created: unknown;
+            await act(async () => {
+                created = await result.current.createGroup({ name: 'new-group' });
+            });
+
+            expect(mockApiPost).toHaveBeenCalledWith('/api/v1/cluster-groups', {
+                name: 'new-group',
+            });
+            expect(created).toEqual({ id: 10 });
+        });
+
+        it('deleteGroup extracts numeric id from group- prefix', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.deleteGroup('group-42');
+            });
+
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/cluster-groups/42');
+        });
+
+        it('deleteGroup accepts raw numeric IDs', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.deleteGroup(7);
+            });
+
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/cluster-groups/7');
+        });
+    });
+
+    describe('moveClusterToGroup', () => {
+        it('sends numeric group_id extracted from group-NN format', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.moveClusterToGroup('cluster-1', 'group-42');
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith('/api/v1/clusters/cluster-1', {
+                group_id: 42,
+            });
+        });
+
+        it('sends group_id = null when targetGroupId is null', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.moveClusterToGroup('cluster-1', null);
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith('/api/v1/clusters/cluster-1', {
+                group_id: null,
+            });
+        });
+
+        it('includes auto_cluster_key and name when provided', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.moveClusterToGroup(
+                    'server-3',
+                    'group-1',
+                    'auto-key-abc',
+                    'My Cluster',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith('/api/v1/clusters/server-3', {
+                group_id: 1,
+                auto_cluster_key: 'auto-key-abc',
+                name: 'My Cluster',
+            });
+        });
+
+        it('leaves group_id null when target format is unrecognized', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.moveClusterToGroup(
+                    'cluster-1',
+                    'not-a-group-ref',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/clusters/cluster-1',
+                { group_id: null },
+            );
+        });
+    });
+
+    describe('hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useClusterActions());
+                }).toThrow(
+                    'useClusterActions must be used within a ClusterActionsProvider',
+                );
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});

--- a/client/src/contexts/__tests__/ClusterDataContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterDataContext.test.tsx
@@ -1,0 +1,367 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - ClusterDataContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    ClusterDataProvider,
+    useClusterData,
+    ClusterGroup,
+    generateDataFingerprint,
+    collectServerFingerprints,
+    transformConnectionsToHierarchy,
+} from '../ClusterDataContext';
+
+// Mock apiClient — keep ApiError real for instanceof checks.
+vi.mock('../../utils/apiClient', async () => {
+    const actual = await vi.importActual<
+        typeof import('../../utils/apiClient')
+    >('../../utils/apiClient');
+    return {
+        ...actual,
+        apiGet: vi.fn(),
+    };
+});
+
+let mockUser: { username: string } | null = { username: 'testuser' };
+vi.mock('../AuthContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+
+import { apiGet, ApiError } from '../../utils/apiClient';
+const mockApiGet = apiGet as unknown as ReturnType<typeof vi.fn>;
+
+const defaultData: ClusterGroup[] = [
+    {
+        id: 'group-1',
+        name: 'Production',
+        clusters: [
+            {
+                id: 'cluster-1',
+                name: 'us-east',
+                servers: [
+                    { id: 1, name: 'pg-1', status: 'online' },
+                    { id: 2, name: 'pg-2', status: 'online' },
+                ],
+            },
+        ],
+    },
+];
+
+describe('ClusterDataContext', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <ClusterDataProvider>{children}</ClusterDataProvider>
+    );
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUser = { username: 'testuser' };
+        mockApiGet.mockResolvedValue(defaultData);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe('fingerprint helpers', () => {
+        it('generateDataFingerprint returns empty for empty data', () => {
+            expect(generateDataFingerprint([])).toBe('');
+        });
+
+        it('generateDataFingerprint encodes structure and values', () => {
+            const fp = generateDataFingerprint(defaultData);
+            expect(fp).toContain('group-1');
+            expect(fp).toContain('Production');
+            expect(fp).toContain('cluster-1');
+            expect(fp).toContain('pg-1');
+        });
+
+        it('collectServerFingerprints handles empty lists', () => {
+            expect(collectServerFingerprints([])).toBe('');
+        });
+
+        it('collectServerFingerprints recurses into children', () => {
+            const fp = collectServerFingerprints([
+                {
+                    id: 1,
+                    name: 'parent',
+                    status: 'online',
+                    children: [
+                        { id: 2, name: 'child', status: 'online' },
+                    ],
+                },
+            ]);
+            expect(fp).toContain('parent');
+            expect(fp).toContain('child');
+        });
+    });
+
+    describe('transformConnectionsToHierarchy', () => {
+        it('groups connections by cluster_group and cluster_name', () => {
+            const conns = [
+                {
+                    id: 1,
+                    name: 'srv1',
+                    host: 'h1',
+                    port: 5432,
+                    cluster_group: 'prod',
+                    cluster_name: 'cluster-a',
+                },
+                {
+                    id: 2,
+                    name: 'srv2',
+                    host: 'h2',
+                    port: 5432,
+                    cluster_group: 'prod',
+                    cluster_name: 'cluster-a',
+                },
+            ];
+
+            const result = transformConnectionsToHierarchy(conns);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('prod');
+            expect(result[0].clusters).toHaveLength(1);
+            expect(result[0].clusters[0].servers).toHaveLength(2);
+        });
+
+        it('creates standalone clusters for connections without cluster_name', () => {
+            const conns = [
+                { id: 1, name: 'lone', host: 'h', port: 5432 },
+            ];
+
+            const result = transformConnectionsToHierarchy(conns);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Ungrouped');
+            expect(result[0].clusters[0].isStandalone).toBe(true);
+            expect(result[0].clusters[0].servers[0].id).toBe(1);
+        });
+
+        it('uses Ungrouped when cluster_group is missing', () => {
+            const conns = [
+                {
+                    id: 1,
+                    name: 'srv',
+                    host: 'h',
+                    port: 5432,
+                    cluster_name: 'c',
+                },
+            ];
+            const result = transformConnectionsToHierarchy(conns);
+            expect(result[0].name).toBe('Ungrouped');
+        });
+    });
+
+    describe('initial fetch and state', () => {
+        it('fetches cluster data on mount', async () => {
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.clusterData.length).toBeGreaterThan(0);
+            });
+
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/clusters');
+            expect(result.current.loading).toBe(false);
+        });
+
+        it('updates lastRefresh after fetch', async () => {
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.lastRefresh).not.toBeNull();
+            });
+
+            expect(result.current.lastRefresh).toBeInstanceOf(Date);
+        });
+
+        it('provides all expected properties', async () => {
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.clusterData.length).toBeGreaterThan(0);
+            });
+
+            expect(result.current).toHaveProperty('clusterData');
+            expect(result.current).toHaveProperty('loading');
+            expect(result.current).toHaveProperty('error');
+            expect(result.current).toHaveProperty('lastRefresh');
+            expect(result.current).toHaveProperty('autoRefreshEnabled');
+            expect(result.current).toHaveProperty('setAutoRefreshEnabled');
+            expect(result.current).toHaveProperty('fetchClusterData');
+        });
+
+        it('does not fetch when user is null', async () => {
+            mockUser = null;
+            renderHook(() => useClusterData(), { wrapper });
+            await new Promise((r) => setTimeout(r, 10));
+            expect(mockApiGet).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('fingerprint-based change detection', () => {
+        it('keeps the same reference when fingerprint is unchanged', async () => {
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.clusterData.length).toBeGreaterThan(0);
+            });
+
+            const initial = result.current.clusterData;
+
+            await act(async () => {
+                await result.current.fetchClusterData();
+            });
+
+            expect(result.current.clusterData).toBe(initial);
+        });
+
+        it('updates reference when fingerprint changes', async () => {
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.clusterData.length).toBeGreaterThan(0);
+            });
+
+            const initial = result.current.clusterData;
+
+            const changed = JSON.parse(JSON.stringify(defaultData));
+            changed[0].clusters[0].servers[0].status = 'offline';
+            mockApiGet.mockResolvedValue(changed);
+
+            await act(async () => {
+                await result.current.fetchClusterData();
+            });
+
+            expect(result.current.clusterData).not.toBe(initial);
+        });
+    });
+
+    describe('fallback to /connections on 404', () => {
+        it('falls back when /clusters returns ApiError 404', async () => {
+            const connectionRecords = [
+                {
+                    id: 1,
+                    name: 'c1',
+                    host: 'h',
+                    port: 5432,
+                    cluster_group: 'g',
+                    cluster_name: 'c',
+                },
+            ];
+
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/clusters') {
+                    return Promise.reject(new ApiError('not found', 404));
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve(connectionRecords);
+                }
+                return Promise.reject(new Error('unexpected ' + url));
+            });
+
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.clusterData.length).toBeGreaterThan(0);
+            });
+
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections');
+            expect(result.current.clusterData[0].name).toBe('g');
+        });
+
+        it('sets error for non-404 API failures', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            mockApiGet.mockReset();
+            mockApiGet.mockRejectedValue(new Error('boom'));
+
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.error).toBe('boom');
+            });
+
+            expect(consoleSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('auto-refresh', () => {
+        it('refetches on the 30-second interval when enabled', async () => {
+            vi.useFakeTimers();
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await vi.runOnlyPendingTimersAsync();
+            const initialCount = mockApiGet.mock.calls.length;
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(30000);
+            });
+
+            expect(mockApiGet.mock.calls.length).toBeGreaterThan(initialCount);
+            expect(result.current.autoRefreshEnabled).toBe(true);
+        });
+
+        it('stops refetching when auto refresh is disabled', async () => {
+            vi.useFakeTimers();
+            const { result } = renderHook(() => useClusterData(), { wrapper });
+
+            await vi.runOnlyPendingTimersAsync();
+
+            act(() => {
+                result.current.setAutoRefreshEnabled(false);
+            });
+
+            const before = mockApiGet.mock.calls.length;
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(120000);
+            });
+
+            expect(mockApiGet.mock.calls.length).toBe(before);
+        });
+    });
+
+    describe('user logout clears state', () => {
+        it('resets clusterData when user becomes null', async () => {
+            const { result, rerender } = renderHook(() => useClusterData(), {
+                wrapper,
+            });
+
+            await waitFor(() => {
+                expect(result.current.clusterData.length).toBeGreaterThan(0);
+            });
+
+            mockUser = null;
+            rerender();
+
+            await waitFor(() => {
+                expect(result.current.clusterData).toEqual([]);
+            });
+        });
+    });
+
+    describe('useClusterData hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useClusterData());
+                }).toThrow(
+                    'useClusterData must be used within a ClusterDataProvider',
+                );
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});

--- a/client/src/contexts/__tests__/ClusterSelectionContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterSelectionContext.test.tsx
@@ -1,0 +1,389 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - ClusterSelectionContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    ClusterSelectionProvider,
+    useClusterSelection,
+} from '../ClusterSelectionContext';
+import type { ClusterGroup, ClusterServer, ClusterEntry } from '../ClusterDataContext';
+
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
+    apiDelete: vi.fn(),
+}));
+
+// Control user + clusterData from the test.
+let mockUser: { username: string } | null = { username: 'testuser' };
+let mockClusterData: ClusterGroup[] = [];
+vi.mock('../AuthContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+vi.mock('../ClusterDataContext', () => ({
+    useClusterData: () => ({ clusterData: mockClusterData }),
+}));
+
+import { apiGet, apiPost, apiDelete } from '../../utils/apiClient';
+const mockApiGet = apiGet as unknown as ReturnType<typeof vi.fn>;
+const mockApiPost = apiPost as unknown as ReturnType<typeof vi.fn>;
+const mockApiDelete = apiDelete as unknown as ReturnType<typeof vi.fn>;
+
+const server1: ClusterServer = { id: 1, name: 'pg-1', status: 'online' };
+const server2: ClusterServer = { id: 2, name: 'pg-2', status: 'online' };
+const cluster1: ClusterEntry = {
+    id: 'cluster-1',
+    name: 'us-east',
+    servers: [server1, server2],
+};
+const baseData: ClusterGroup[] = [
+    { id: 'group-1', name: 'prod', clusters: [cluster1] },
+];
+
+describe('ClusterSelectionContext', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <ClusterSelectionProvider>{children}</ClusterSelectionProvider>
+    );
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUser = { username: 'testuser' };
+        mockClusterData = [];
+        mockApiGet.mockRejectedValue(new Error('no current connection'));
+        mockApiPost.mockResolvedValue({ connection_id: 0 });
+        mockApiDelete.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('default state', () => {
+        it('starts with no selection', () => {
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            expect(result.current.selectedServer).toBeNull();
+            expect(result.current.selectedCluster).toBeNull();
+            expect(result.current.selectionType).toBeNull();
+            expect(result.current.currentConnection).toBeNull();
+        });
+
+        it('provides all expected properties', () => {
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            expect(result.current).toHaveProperty('selectedServer');
+            expect(result.current).toHaveProperty('selectedCluster');
+            expect(result.current).toHaveProperty('selectionType');
+            expect(result.current).toHaveProperty('currentConnection');
+            expect(result.current).toHaveProperty('selectServer');
+            expect(result.current).toHaveProperty('selectCluster');
+            expect(result.current).toHaveProperty('selectEstate');
+            expect(result.current).toHaveProperty('clearSelection');
+        });
+    });
+
+    describe('selectServer', () => {
+        it('sets selectedServer and posts to /connections/current', async () => {
+            mockApiPost.mockResolvedValueOnce({ connection_id: 1 });
+
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            await act(async () => {
+                await result.current.selectServer(server1);
+            });
+
+            expect(result.current.selectedServer).toEqual(server1);
+            expect(result.current.selectedCluster).toBeNull();
+            expect(result.current.selectionType).toBe('server');
+            expect(mockApiPost).toHaveBeenCalledWith(
+                '/api/v1/connections/current',
+                { connection_id: 1 },
+            );
+            expect(result.current.currentConnection).toEqual({ connection_id: 1 });
+        });
+
+        it('logs but does not throw when POST fails', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            mockApiPost.mockRejectedValueOnce(new Error('boom'));
+
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            await act(async () => {
+                await result.current.selectServer(server1);
+            });
+
+            expect(consoleSpy).toHaveBeenCalled();
+            expect(result.current.selectedServer).toEqual(server1);
+        });
+
+        it('is a no-op when user is null', async () => {
+            mockUser = null;
+
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            await act(async () => {
+                await result.current.selectServer(server1);
+            });
+
+            expect(mockApiPost).not.toHaveBeenCalled();
+            expect(result.current.selectedServer).toBeNull();
+        });
+    });
+
+    describe('selectCluster', () => {
+        it('sets selectedCluster and clears others', () => {
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            act(() => {
+                result.current.selectCluster(cluster1);
+            });
+
+            expect(result.current.selectedCluster).toEqual(cluster1);
+            expect(result.current.selectedServer).toBeNull();
+            expect(result.current.currentConnection).toBeNull();
+            expect(result.current.selectionType).toBe('cluster');
+        });
+    });
+
+    describe('selectEstate', () => {
+        it('clears selection and sets type to estate', () => {
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            act(() => {
+                result.current.selectEstate();
+            });
+
+            expect(result.current.selectedCluster).toBeNull();
+            expect(result.current.selectedServer).toBeNull();
+            expect(result.current.selectionType).toBe('estate');
+        });
+    });
+
+    describe('clearSelection', () => {
+        it('clears state and calls DELETE', async () => {
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            act(() => {
+                result.current.selectCluster(cluster1);
+            });
+
+            await act(async () => {
+                await result.current.clearSelection();
+            });
+
+            expect(result.current.selectedCluster).toBeNull();
+            expect(result.current.selectedServer).toBeNull();
+            expect(result.current.selectionType).toBeNull();
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/connections/current');
+        });
+
+        it('logs on DELETE failure but still clears local state', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            mockApiDelete.mockRejectedValueOnce(new Error('boom'));
+
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            await act(async () => {
+                await result.current.clearSelection();
+            });
+
+            expect(consoleSpy).toHaveBeenCalled();
+            expect(result.current.selectionType).toBeNull();
+        });
+
+        it('is a no-op when user is null', async () => {
+            mockUser = null;
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            await act(async () => {
+                await result.current.clearSelection();
+            });
+
+            expect(mockApiDelete).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('fetchCurrentConnection (cluster data effect)', () => {
+        it('syncs selectedServer based on current connection', async () => {
+            mockApiGet.mockResolvedValueOnce({ connection_id: 1 });
+            mockClusterData = baseData;
+
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.selectedServer?.id).toBe(1);
+            });
+
+            expect(result.current.selectionType).toBe('server');
+            expect(result.current.currentConnection).toEqual({ connection_id: 1 });
+        });
+
+        it('silently ignores errors from /connections/current', async () => {
+            mockApiGet.mockRejectedValueOnce(new Error('no current'));
+            mockClusterData = baseData;
+
+            const { result } = renderHook(() => useClusterSelection(), { wrapper });
+
+            // Give the effect a chance to run.
+            await new Promise((r) => setTimeout(r, 20));
+            expect(result.current.selectedServer).toBeNull();
+        });
+    });
+
+    describe('user logout resets selection', () => {
+        it('clears selection when user becomes null', async () => {
+            const { result, rerender } = renderHook(() => useClusterSelection(), {
+                wrapper,
+            });
+
+            act(() => {
+                result.current.selectCluster(cluster1);
+            });
+
+            mockUser = null;
+            rerender();
+
+            await waitFor(() => {
+                expect(result.current.selectedCluster).toBeNull();
+            });
+
+            expect(result.current.selectionType).toBeNull();
+        });
+    });
+
+    describe('re-syncing on cluster data updates', () => {
+        it('updates selectedCluster reference when cluster data refreshes', async () => {
+            mockClusterData = baseData;
+
+            const { result, rerender } = renderHook(() => useClusterSelection(), {
+                wrapper,
+            });
+
+            act(() => {
+                result.current.selectCluster(cluster1);
+            });
+
+            // Simulate a fresh reference for the same cluster id.
+            const refreshedCluster: ClusterEntry = {
+                ...cluster1,
+                name: 'us-east-refreshed',
+            };
+            mockClusterData = [
+                {
+                    id: 'group-1',
+                    name: 'prod',
+                    clusters: [refreshedCluster],
+                },
+            ];
+            rerender();
+
+            await waitFor(() => {
+                expect(result.current.selectedCluster).toBe(refreshedCluster);
+            });
+        });
+
+        it('updates selectedServer reference when cluster data refreshes', async () => {
+            mockClusterData = baseData;
+            mockApiPost.mockResolvedValue({ connection_id: 1 });
+
+            const { result, rerender } = renderHook(() => useClusterSelection(), {
+                wrapper,
+            });
+
+            await act(async () => {
+                await result.current.selectServer(server1);
+            });
+
+            const refreshedServer: ClusterServer = { ...server1, status: 'warning' };
+            const refreshedCluster: ClusterEntry = {
+                ...cluster1,
+                servers: [refreshedServer, server2],
+            };
+            mockClusterData = [
+                { id: 'group-1', name: 'prod', clusters: [refreshedCluster] },
+            ];
+            rerender();
+
+            await waitFor(() => {
+                expect(result.current.selectedServer).toBe(refreshedServer);
+            });
+        });
+
+        it('finds servers nested inside children', async () => {
+            const childServer: ClusterServer = {
+                id: 50,
+                name: 'replica',
+                status: 'online',
+            };
+            const parentServer: ClusterServer = {
+                id: 49,
+                name: 'primary',
+                status: 'online',
+                children: [childServer],
+            };
+            const nestedCluster: ClusterEntry = {
+                id: 'cluster-nested',
+                name: 'nested',
+                servers: [parentServer],
+            };
+            mockClusterData = [
+                { id: 'group-n', name: 'nested-group', clusters: [nestedCluster] },
+            ];
+            mockApiPost.mockResolvedValue({ connection_id: 50 });
+
+            const { result, rerender } = renderHook(() => useClusterSelection(), {
+                wrapper,
+            });
+
+            await act(async () => {
+                await result.current.selectServer(childServer);
+            });
+
+            const refreshedChild: ClusterServer = {
+                ...childServer,
+                status: 'warning',
+            };
+            const refreshedParent: ClusterServer = {
+                ...parentServer,
+                children: [refreshedChild],
+            };
+            mockClusterData = [
+                {
+                    id: 'group-n',
+                    name: 'nested-group',
+                    clusters: [{ ...nestedCluster, servers: [refreshedParent] }],
+                },
+            ];
+            rerender();
+
+            await waitFor(() => {
+                expect(result.current.selectedServer).toBe(refreshedChild);
+            });
+        });
+    });
+
+    describe('hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useClusterSelection());
+                }).toThrow(
+                    'useClusterSelection must be used within a ClusterSelectionProvider',
+                );
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});

--- a/client/src/contexts/__tests__/ClusterSelectionContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterSelectionContext.test.tsx
@@ -233,8 +233,8 @@ describe('ClusterSelectionContext', () => {
 
             const { result } = renderHook(() => useClusterSelection(), { wrapper });
 
-            // Give the effect a chance to run.
-            await new Promise((r) => setTimeout(r, 20));
+            // Wait for the effect to call the API, then verify state remains null.
+            await waitFor(() => expect(mockApiGet).toHaveBeenCalled());
             expect(result.current.selectedServer).toBeNull();
         });
     });

--- a/client/src/contexts/__tests__/ConnectionStatusContext.test.tsx
+++ b/client/src/contexts/__tests__/ConnectionStatusContext.test.tsx
@@ -1,0 +1,155 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - ConnectionStatusContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { AuthProvider } from '../AuthContext';
+import {
+    ConnectionStatusProvider,
+    useConnectionStatus,
+} from '../ConnectionStatusContext';
+
+// Capture the disconnect listener registered by the provider so tests
+// can invoke it directly.
+let capturedListener: ((reason: string) => void) | null = null;
+const unsubscribeSpy = vi.fn();
+const resetConnectionHealthSpy = vi.fn();
+
+vi.mock('../../utils/apiClient', () => ({
+    onDisconnect: (listener: (reason: string) => void) => {
+        capturedListener = listener;
+        return unsubscribeSpy;
+    },
+    resetConnectionHealth: () => resetConnectionHealthSpy(),
+}));
+
+// Mock AuthContext so ConnectionStatusProvider can pull forceLogout.
+const forceLogoutMock = vi.fn();
+vi.mock('../AuthContext', () => ({
+    AuthProvider: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+    ),
+    useAuth: () => ({
+        forceLogout: forceLogoutMock,
+    }),
+}));
+
+describe('ConnectionStatusContext', () => {
+    beforeEach(() => {
+        capturedListener = null;
+        unsubscribeSpy.mockClear();
+        resetConnectionHealthSpy.mockClear();
+        forceLogoutMock.mockClear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <AuthProvider>
+            <ConnectionStatusProvider>{children}</ConnectionStatusProvider>
+        </AuthProvider>
+    );
+
+    describe('default state', () => {
+        it('starts connected with empty reason', () => {
+            const { result } = renderHook(() => useConnectionStatus(), { wrapper });
+
+            expect(result.current.disconnected).toBe(false);
+            expect(result.current.reason).toBe('');
+            expect(typeof result.current.reconnect).toBe('function');
+        });
+
+        it('registers a disconnect listener on mount', () => {
+            renderHook(() => useConnectionStatus(), { wrapper });
+            expect(capturedListener).not.toBeNull();
+        });
+
+        it('unsubscribes the listener on unmount', () => {
+            const { unmount } = renderHook(() => useConnectionStatus(), { wrapper });
+            unmount();
+            expect(unsubscribeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('disconnect events', () => {
+        it('transitions to disconnected state with the reason', () => {
+            const { result } = renderHook(() => useConnectionStatus(), { wrapper });
+
+            act(() => {
+                capturedListener?.('auth');
+            });
+
+            expect(result.current.disconnected).toBe(true);
+            expect(result.current.reason).toBe('auth');
+        });
+
+        it('captures different disconnect reasons', () => {
+            const { result } = renderHook(() => useConnectionStatus(), { wrapper });
+
+            act(() => {
+                capturedListener?.('network');
+            });
+
+            expect(result.current.reason).toBe('network');
+
+            // Reset state and check another reason.
+            act(() => {
+                result.current.reconnect();
+            });
+
+            act(() => {
+                capturedListener?.('server');
+            });
+
+            expect(result.current.reason).toBe('server');
+        });
+    });
+
+    describe('reconnect', () => {
+        it('resets disconnected state and calls forceLogout', () => {
+            const { result } = renderHook(() => useConnectionStatus(), { wrapper });
+
+            act(() => {
+                capturedListener?.('auth');
+            });
+
+            expect(result.current.disconnected).toBe(true);
+
+            act(() => {
+                result.current.reconnect();
+            });
+
+            expect(result.current.disconnected).toBe(false);
+            expect(result.current.reason).toBe('');
+            expect(resetConnectionHealthSpy).toHaveBeenCalled();
+            expect(forceLogoutMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useConnectionStatus());
+                }).toThrow(
+                    'useConnectionStatus must be used within a ConnectionStatusProvider',
+                );
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});

--- a/client/src/contexts/__tests__/DashboardContext.test.tsx
+++ b/client/src/contexts/__tests__/DashboardContext.test.tsx
@@ -1,0 +1,280 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - DashboardContext Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { DashboardProvider, useDashboard } from '../DashboardContext';
+import type { OverlayEntry } from '../../components/Dashboard/types';
+
+describe('DashboardContext', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DashboardProvider>{children}</DashboardProvider>
+    );
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe('Default state', () => {
+        it('starts with default time range of 1h', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            expect(result.current.timeRange).toEqual({ range: '1h' });
+        });
+
+        it('starts with auto refresh enabled at 30000ms', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            expect(result.current.autoRefresh).toEqual({
+                enabled: true,
+                intervalMs: 30000,
+            });
+        });
+
+        it('starts with empty overlay stack and null currentOverlay', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            expect(result.current.overlayStack).toEqual([]);
+            expect(result.current.currentOverlay).toBeNull();
+        });
+
+        it('starts with refreshTrigger of 0', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            expect(result.current.refreshTrigger).toBe(0);
+        });
+    });
+
+    describe('Time range', () => {
+        it('setTimeRange updates to a preset range and clears custom values', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.setCustomTimeRange('2026-01-01', '2026-01-02');
+            });
+
+            act(() => {
+                result.current.setTimeRange('24h');
+            });
+
+            expect(result.current.timeRange).toEqual({
+                range: '24h',
+                customStart: undefined,
+                customEnd: undefined,
+            });
+        });
+
+        it('setCustomTimeRange preserves the range and sets custom values', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.setCustomTimeRange('2026-01-01', '2026-01-02');
+            });
+
+            expect(result.current.timeRange.customStart).toBe('2026-01-01');
+            expect(result.current.timeRange.customEnd).toBe('2026-01-02');
+            expect(result.current.timeRange.range).toBe('1h');
+        });
+    });
+
+    describe('Auto refresh config', () => {
+        it('setAutoRefreshEnabled toggles the enabled flag', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.setAutoRefreshEnabled(false);
+            });
+
+            expect(result.current.autoRefresh.enabled).toBe(false);
+            expect(result.current.autoRefresh.intervalMs).toBe(30000);
+        });
+
+        it('setAutoRefreshInterval updates the interval', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.setAutoRefreshInterval(5000);
+            });
+
+            expect(result.current.autoRefresh.intervalMs).toBe(5000);
+            expect(result.current.autoRefresh.enabled).toBe(true);
+        });
+    });
+
+    describe('Overlay stack', () => {
+        const entry1: OverlayEntry = {
+            level: 'cluster',
+            title: 'Cluster A',
+            entityId: 1,
+            entityName: 'Cluster A',
+        };
+
+        const entry2: OverlayEntry = {
+            level: 'server',
+            title: 'Server B',
+            entityId: 2,
+            entityName: 'Server B',
+        };
+
+        it('pushOverlay adds to the stack and updates currentOverlay', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.pushOverlay(entry1);
+            });
+
+            expect(result.current.overlayStack).toEqual([entry1]);
+            expect(result.current.currentOverlay).toEqual(entry1);
+        });
+
+        it('pushOverlay stacks multiple entries; currentOverlay is last', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.pushOverlay(entry1);
+            });
+            act(() => {
+                result.current.pushOverlay(entry2);
+            });
+
+            expect(result.current.overlayStack).toEqual([entry1, entry2]);
+            expect(result.current.currentOverlay).toEqual(entry2);
+        });
+
+        it('popOverlay removes the last entry', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.pushOverlay(entry1);
+            });
+            act(() => {
+                result.current.pushOverlay(entry2);
+            });
+            act(() => {
+                result.current.popOverlay();
+            });
+
+            expect(result.current.overlayStack).toEqual([entry1]);
+            expect(result.current.currentOverlay).toEqual(entry1);
+        });
+
+        it('popOverlay on empty stack is a no-op', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.popOverlay();
+            });
+
+            expect(result.current.overlayStack).toEqual([]);
+            expect(result.current.currentOverlay).toBeNull();
+        });
+
+        it('clearOverlays empties the stack', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.pushOverlay(entry1);
+                result.current.pushOverlay(entry2);
+            });
+            act(() => {
+                result.current.clearOverlays();
+            });
+
+            expect(result.current.overlayStack).toEqual([]);
+            expect(result.current.currentOverlay).toBeNull();
+        });
+    });
+
+    describe('Refresh trigger', () => {
+        it('triggerRefresh increments the counter', () => {
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.triggerRefresh();
+            });
+
+            expect(result.current.refreshTrigger).toBe(1);
+
+            act(() => {
+                result.current.triggerRefresh();
+            });
+
+            expect(result.current.refreshTrigger).toBe(2);
+        });
+
+        it('auto-refresh interval calls triggerRefresh periodically', () => {
+            vi.useFakeTimers();
+
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            expect(result.current.refreshTrigger).toBe(0);
+
+            act(() => {
+                vi.advanceTimersByTime(30000);
+            });
+
+            expect(result.current.refreshTrigger).toBe(1);
+
+            act(() => {
+                vi.advanceTimersByTime(30000);
+            });
+
+            expect(result.current.refreshTrigger).toBe(2);
+        });
+
+        it('auto-refresh does not fire when disabled', () => {
+            vi.useFakeTimers();
+
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.setAutoRefreshEnabled(false);
+            });
+
+            act(() => {
+                vi.advanceTimersByTime(120000);
+            });
+
+            expect(result.current.refreshTrigger).toBe(0);
+        });
+
+        it('auto-refresh uses the updated interval', () => {
+            vi.useFakeTimers();
+
+            const { result } = renderHook(() => useDashboard(), { wrapper });
+
+            act(() => {
+                result.current.setAutoRefreshInterval(1000);
+            });
+
+            act(() => {
+                vi.advanceTimersByTime(1000);
+            });
+
+            expect(result.current.refreshTrigger).toBe(1);
+        });
+    });
+
+    describe('useDashboard hook outside provider', () => {
+        it('throws when used outside provider', () => {
+            const originalError = console.error;
+            console.error = vi.fn();
+            try {
+                expect(() => {
+                    renderHook(() => useDashboard());
+                }).toThrow('useDashboard must be used within a DashboardProvider');
+            } finally {
+                console.error = originalError;
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Raises test coverage in `client/src/contexts/` from two providers
(AuthContext, ClusterContext) to nine, covering every previously
untested provider called out in issue #113:

- AICapabilities
- Alerts
- Blackout
- Chat
- ClusterActions
- ClusterData
- ClusterSelection
- ConnectionStatus
- Dashboard

Each suite exercises provider initialization, user-gated fetching,
state transitions, hook-outside-provider guards, error paths, and
auto-refresh intervals. The non-trivial selection-filtering logic
in `BlackoutContext` and the re-sync-on-refresh behaviour in
`ClusterSelectionContext` get dedicated tests.

## Coverage

`cd client && npx vitest run --coverage src/contexts/`

```
 src/contexts                |   99.56 |    94.42 |     100 |   99.56
  AICapabilitiesContext.tsx  |     100 |      100 |     100 |     100
  AlertsContext.tsx          |     100 |      100 |     100 |     100
  AuthContext.tsx            |     100 |    89.74 |     100 |     100
  BlackoutContext.tsx        |   98.66 |    93.75 |     100 |   98.66
  ChatContext.tsx            |   99.35 |    97.14 |     100 |   99.35
  ClusterActionsContext.tsx  |     100 |      100 |     100 |     100
  ClusterContext.tsx         |     100 |      100 |     100 |     100
  ClusterDataContext.tsx     |     100 |    90.74 |     100 |     100
  ClusterSelectionContext.tsx|   98.34 |     85.1 |     100 |   98.34
  ConnectionStatusContext.tsx|     100 |      100 |     100 |     100
  DashboardContext.tsx       |     100 |      100 |     100 |     100
```

Every file clears the 90% line-coverage threshold; directory
averages 99.56% lines and 94.42% branches.

## Note on make test-all

The project worktree was shared with in-flight work from other
task workers (collector probe tests, hooks tests) that had
gofmt failures and failing unit tests. These are not within
the scope of this change. Running only the contexts test suite
(cd client && npx vitest run src/contexts/) reports
**207 passed / 207**.

Closes #113

## Test plan

- [x] cd client && npx vitest run src/contexts/ - 207 passed
- [x] cd client && npx vitest run --coverage src/contexts/ - >=90% per file
- [x] Branch pushed; PR opened

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for core context providers: AI capabilities, alerts, blackouts, chat, cluster actions, cluster data, cluster selection, connection status, and dashboard. These tests validate default states, API interactions, auth gating, CRUD flows, auto-refresh timers, selection syncing, and error handling to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->