### PR TITLE
Add unit tests for client utility modules

### DIFF
--- a/client/src/utils/__tests__/agenticLoop.test.ts
+++ b/client/src/utils/__tests__/agenticLoop.test.ts
@@ -1,0 +1,555 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runAgenticLoop, AgenticLoopOptions } from '../agenticLoop';
+
+// Mock dependencies
+vi.mock('../apiClient', () => ({
+    apiFetch: vi.fn(),
+}));
+
+vi.mock('../toolDisplayNames', () => ({
+    getToolDisplayName: vi.fn((name: string) => {
+        const displayNames: Record<string, string> = {
+            query_database: 'Querying database',
+            get_schema_info: 'Inspecting schema',
+        };
+        return displayNames[name] || name;
+    }),
+}));
+
+vi.mock('../textHelpers', () => ({
+    stripPreamble: vi.fn((text: string) => text),
+}));
+
+import { apiFetch } from '../apiClient';
+import { stripPreamble } from '../textHelpers';
+
+const mockApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+const mockStripPreamble = stripPreamble as ReturnType<typeof vi.fn>;
+
+describe('runAgenticLoop', () => {
+    const createMockResponse = (
+        data: unknown,
+        ok = true,
+    ): Partial<Response> => ({
+        ok,
+        json: vi.fn().mockResolvedValue(data),
+        text: vi.fn().mockResolvedValue(JSON.stringify(data)),
+    });
+
+    const baseOptions: AgenticLoopOptions = {
+        messages: [{ role: 'user', content: 'Test query' }],
+        tools: [],
+        systemPrompt: 'You are a helpful assistant.',
+        maxIterations: 5,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockStripPreamble.mockImplementation((text: string) => text);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('simple text responses', () => {
+        it('returns final text response when no tools are requested', async () => {
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Hello, how can I help?' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('Hello, how can I help?');
+        });
+
+        it('joins multiple text blocks', async () => {
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'text', text: 'First part.' },
+                        { type: 'text', text: 'Second part.' },
+                    ],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('First part.\nSecond part.');
+        });
+
+        it('returns empty string when no text content', async () => {
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [] }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('');
+        });
+
+        it('handles undefined content gracefully', async () => {
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({}),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('');
+        });
+
+        it('strips preamble from final response', async () => {
+            mockStripPreamble.mockReturnValue('## Stripped content');
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Preamble here\n## Stripped content' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(mockStripPreamble).toHaveBeenCalledWith('Preamble here\n## Stripped content');
+            expect(result).toBe('## Stripped content');
+        });
+    });
+
+    describe('tool execution loop', () => {
+        it('executes tool and continues loop', async () => {
+            // First call: LLM requests a tool
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        {
+                            type: 'tool_use',
+                            id: 'tool-1',
+                            name: 'query_database',
+                            input: { query: 'SELECT 1' },
+                        },
+                    ],
+                }),
+            );
+
+            // Tool execution
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ text: 'Query result: 1' }],
+                }),
+            );
+
+            // Second call: LLM returns final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'The result is 1.' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('The result is 1.');
+            expect(mockApiFetch).toHaveBeenCalledTimes(3);
+        });
+
+        it('handles multiple tool calls in one response', async () => {
+            // First call: LLM requests multiple tools
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                        { type: 'tool_use', id: 'tool-2', name: 'get_schema_info', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool executions
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result 1' }] }),
+            );
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result 2' }] }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Combined analysis.' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('Combined analysis.');
+            expect(mockApiFetch).toHaveBeenCalledTimes(4);
+        });
+
+        it('handles tool execution errors gracefully', async () => {
+            // First call: LLM requests a tool
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool execution fails
+            mockApiFetch.mockRejectedValueOnce(new Error('Tool failed'));
+
+            // LLM handles error and returns response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Error occurred.' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('Error occurred.');
+        });
+
+        it('handles tool returning isError flag', async () => {
+            // First call: LLM requests a tool
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool returns with isError
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    isError: true,
+                    content: [{ text: 'Database connection failed' }],
+                }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'I encountered an error.' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('I encountered an error.');
+        });
+
+        it('handles tool with no data returned', async () => {
+            // First call: LLM requests a tool
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool returns empty content
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [] }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'No data was returned.' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('No data was returned.');
+        });
+    });
+
+    describe('iteration limit', () => {
+        it('throws error when max iterations exceeded', async () => {
+            const options: AgenticLoopOptions = {
+                ...baseOptions,
+                maxIterations: 2,
+            };
+
+            // Both iterations return tool requests
+            mockApiFetch.mockResolvedValue(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                    ],
+                }),
+            );
+
+            await expect(runAgenticLoop(options)).rejects.toThrow(
+                'Analysis exceeded maximum iterations',
+            );
+        });
+    });
+
+    describe('API error handling', () => {
+        it('throws error when LLM API returns non-ok response', async () => {
+            mockApiFetch.mockResolvedValueOnce({
+                ok: false,
+                text: vi.fn().mockResolvedValue('Internal server error'),
+            });
+
+            await expect(runAgenticLoop(baseOptions)).rejects.toThrow(
+                'Analysis request failed: Internal server error',
+            );
+        });
+    });
+
+    describe('callbacks', () => {
+        it('calls onActiveTools with tool names during execution', async () => {
+            const onActiveTools = vi.fn();
+
+            // First call: LLM requests a tool
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool execution
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result' }] }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Done.' }],
+                }),
+            );
+
+            await runAgenticLoop({ ...baseOptions, onActiveTools });
+
+            expect(onActiveTools).toHaveBeenCalledWith(['Querying database']);
+            expect(onActiveTools).toHaveBeenCalledWith([]);
+        });
+
+        it('calls onActiveTools with empty array on final response', async () => {
+            const onActiveTools = vi.fn();
+
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Hello' }],
+                }),
+            );
+
+            await runAgenticLoop({ ...baseOptions, onActiveTools });
+
+            expect(onActiveTools).toHaveBeenCalledWith([]);
+        });
+
+        it('calls onProgress with single tool message', async () => {
+            const onProgress = vi.fn();
+
+            // First call: LLM requests a tool
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool execution
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result' }] }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Done.' }],
+                }),
+            );
+
+            await runAgenticLoop({ ...baseOptions, onProgress });
+
+            expect(onProgress).toHaveBeenCalledWith('Querying database...');
+            expect(onProgress).toHaveBeenCalledWith('Analyzing results...');
+        });
+
+        it('calls onProgress with multiple tools message', async () => {
+            const onProgress = vi.fn();
+
+            // First call: LLM requests multiple tools
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                        { type: 'tool_use', id: 'tool-2', name: 'get_schema_info', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool executions
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result 1' }] }),
+            );
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result 2' }] }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Done.' }],
+                }),
+            );
+
+            await runAgenticLoop({ ...baseOptions, onProgress });
+
+            expect(onProgress).toHaveBeenCalledWith('Running 2 tools...');
+        });
+
+        it('deduplicates tool names in onActiveTools', async () => {
+            const onActiveTools = vi.fn();
+
+            // LLM requests same tool twice
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', name: 'query_database', input: {} },
+                        { type: 'tool_use', id: 'tool-2', name: 'query_database', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool executions
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result 1' }] }),
+            );
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result 2' }] }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Done.' }],
+                }),
+            );
+
+            await runAgenticLoop({ ...baseOptions, onActiveTools });
+
+            // Should only have one unique tool name
+            expect(onActiveTools).toHaveBeenCalledWith(['Querying database']);
+        });
+    });
+
+    describe('message building', () => {
+        it('sends correct initial request body', async () => {
+            const tools = [
+                {
+                    name: 'test_tool',
+                    description: 'A test tool',
+                    inputSchema: { type: 'object', properties: {}, required: [] },
+                },
+            ];
+
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Response' }],
+                }),
+            );
+
+            await runAgenticLoop({ ...baseOptions, tools });
+
+            expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/llm/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    messages: baseOptions.messages,
+                    tools,
+                    system: baseOptions.systemPrompt,
+                }),
+            });
+        });
+
+        it('omits tools from request when tools array is empty', async () => {
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Response' }],
+                }),
+            );
+
+            await runAgenticLoop({ ...baseOptions, tools: [] });
+
+            const call = mockApiFetch.mock.calls[0];
+            const body = JSON.parse(call[1].body as string);
+
+            expect(body.tools).toBeUndefined();
+        });
+
+        it('handles tool_use with missing id', async () => {
+            // First call: LLM requests a tool without id
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', name: 'query_database', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool execution
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result' }] }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Done.' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('Done.');
+        });
+
+        it('handles tool_use with missing name', async () => {
+            // First call: LLM requests a tool without name
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [
+                        { type: 'tool_use', id: 'tool-1', input: {} },
+                    ],
+                }),
+            );
+
+            // Tool execution
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({ content: [{ text: 'Result' }] }),
+            );
+
+            // Final response
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Done.' }],
+                }),
+            );
+
+            const result = await runAgenticLoop(baseOptions);
+
+            expect(result).toBe('Done.');
+        });
+    });
+});

--- a/client/src/utils/__tests__/clusterHelpers.test.ts
+++ b/client/src/utils/__tests__/clusterHelpers.test.ts
@@ -1,0 +1,225 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { collectServers, ServerLike } from '../clusterHelpers';
+
+describe('collectServers', () => {
+    describe('flat server lists', () => {
+        it('returns empty array for empty input', () => {
+            expect(collectServers([])).toEqual([]);
+        });
+
+        it('returns single server unchanged', () => {
+            const servers: ServerLike[] = [
+                { id: 1, name: 'server1', status: 'healthy' },
+            ];
+            const result = collectServers(servers);
+            expect(result).toEqual(servers);
+            expect(result).toHaveLength(1);
+        });
+
+        it('returns multiple servers in order', () => {
+            const servers: ServerLike[] = [
+                { id: 1, name: 'server1' },
+                { id: 2, name: 'server2' },
+                { id: 3, name: 'server3' },
+            ];
+            const result = collectServers(servers);
+            expect(result).toHaveLength(3);
+            expect(result.map(s => s.id)).toEqual([1, 2, 3]);
+        });
+    });
+
+    describe('nested server hierarchies', () => {
+        it('flattens servers with children', () => {
+            const servers: ServerLike[] = [
+                {
+                    id: 1,
+                    name: 'parent',
+                    children: [
+                        { id: 2, name: 'child1' },
+                        { id: 3, name: 'child2' },
+                    ],
+                },
+            ];
+            const result = collectServers(servers);
+            expect(result).toHaveLength(3);
+            expect(result.map(s => s.id)).toEqual([1, 2, 3]);
+        });
+
+        it('preserves parent before children', () => {
+            const servers: ServerLike[] = [
+                {
+                    id: 1,
+                    name: 'parent',
+                    children: [{ id: 2, name: 'child' }],
+                },
+            ];
+            const result = collectServers(servers);
+            expect(result[0].name).toBe('parent');
+            expect(result[1].name).toBe('child');
+        });
+
+        it('handles deeply nested hierarchies', () => {
+            const servers: ServerLike[] = [
+                {
+                    id: 1,
+                    name: 'level1',
+                    children: [
+                        {
+                            id: 2,
+                            name: 'level2',
+                            children: [
+                                {
+                                    id: 3,
+                                    name: 'level3',
+                                    children: [{ id: 4, name: 'level4' }],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ];
+            const result = collectServers(servers);
+            expect(result).toHaveLength(4);
+            expect(result.map(s => s.name)).toEqual(['level1', 'level2', 'level3', 'level4']);
+        });
+
+        it('handles multiple top-level servers with children', () => {
+            const servers: ServerLike[] = [
+                {
+                    id: 1,
+                    name: 'parent1',
+                    children: [{ id: 2, name: 'child1' }],
+                },
+                {
+                    id: 3,
+                    name: 'parent2',
+                    children: [{ id: 4, name: 'child2' }],
+                },
+            ];
+            const result = collectServers(servers);
+            expect(result).toHaveLength(4);
+            expect(result.map(s => s.id)).toEqual([1, 2, 3, 4]);
+        });
+
+        it('handles mixed flat and nested servers', () => {
+            const servers: ServerLike[] = [
+                { id: 1, name: 'flat1' },
+                {
+                    id: 2,
+                    name: 'nested',
+                    children: [{ id: 3, name: 'child' }],
+                },
+                { id: 4, name: 'flat2' },
+            ];
+            const result = collectServers(servers);
+            expect(result).toHaveLength(4);
+            expect(result.map(s => s.id)).toEqual([1, 2, 3, 4]);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles servers with empty children array', () => {
+            const servers: ServerLike[] = [
+                { id: 1, name: 'server', children: [] },
+            ];
+            const result = collectServers(servers);
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('server');
+        });
+
+        it('handles servers without children property', () => {
+            const servers: ServerLike[] = [
+                { id: 1, name: 'server1' },
+                { id: 2, name: 'server2', children: undefined },
+            ];
+            const result = collectServers(servers);
+            expect(result).toHaveLength(2);
+        });
+
+        it('preserves all server properties', () => {
+            const servers: ServerLike[] = [
+                {
+                    id: 1,
+                    name: 'server',
+                    status: 'healthy',
+                    customProp: 'value',
+                    children: [
+                        {
+                            id: 2,
+                            name: 'child',
+                            status: 'warning',
+                            anotherProp: 123,
+                        },
+                    ],
+                },
+            ];
+            const result = collectServers(servers);
+            expect(result[0]).toHaveProperty('customProp', 'value');
+            expect(result[1]).toHaveProperty('anotherProp', 123);
+        });
+
+        it('handles complex hierarchies with varying depths', () => {
+            const servers: ServerLike[] = [
+                { id: 1, name: 'standalone' },
+                {
+                    id: 2,
+                    name: 'shallow',
+                    children: [{ id: 3, name: 'child-shallow' }],
+                },
+                {
+                    id: 4,
+                    name: 'deep',
+                    children: [
+                        {
+                            id: 5,
+                            name: 'level1',
+                            children: [
+                                {
+                                    id: 6,
+                                    name: 'level2',
+                                    children: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ];
+            const result = collectServers(servers);
+            expect(result).toHaveLength(6);
+            expect(result.map(s => s.id)).toEqual([1, 2, 3, 4, 5, 6]);
+        });
+    });
+
+    describe('type preservation', () => {
+        it('preserves generic type through recursion', () => {
+            interface ExtendedServer extends ServerLike {
+                region: string;
+            }
+
+            const servers: ExtendedServer[] = [
+                {
+                    id: 1,
+                    name: 'us-server',
+                    region: 'us-east-1',
+                    children: [
+                        { id: 2, name: 'replica1', region: 'us-east-1' },
+                    ],
+                },
+            ];
+
+            const result = collectServers(servers);
+            expect(result[0].region).toBe('us-east-1');
+            expect(result[1].region).toBe('us-east-1');
+        });
+    });
+});

--- a/client/src/utils/__tests__/colors.test.ts
+++ b/client/src/utils/__tests__/colors.test.ts
@@ -1,0 +1,141 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { blendColors } from '../colors';
+
+describe('blendColors', () => {
+    describe('with opacity 0 (fully transparent foreground)', () => {
+        it('returns the background color unchanged', () => {
+            expect(blendColors('#ffffff', '#000000', 0)).toBe('#ffffff');
+        });
+
+        it('works with colored backgrounds', () => {
+            expect(blendColors('#ff0000', '#00ff00', 0)).toBe('#ff0000');
+        });
+    });
+
+    describe('with opacity 1 (fully opaque foreground)', () => {
+        it('returns the foreground color unchanged', () => {
+            expect(blendColors('#ffffff', '#000000', 1)).toBe('#000000');
+        });
+
+        it('works with colored foregrounds', () => {
+            expect(blendColors('#ff0000', '#00ff00', 1)).toBe('#00ff00');
+        });
+    });
+
+    describe('with opacity 0.5 (50% blend)', () => {
+        it('blends black and white to gray', () => {
+            const result = blendColors('#ffffff', '#000000', 0.5);
+            expect(result).toBe('#808080');
+        });
+
+        it('blends white and black to gray', () => {
+            const result = blendColors('#000000', '#ffffff', 0.5);
+            expect(result).toBe('#808080');
+        });
+
+        it('blends red and blue to purple', () => {
+            const result = blendColors('#ff0000', '#0000ff', 0.5);
+            expect(result).toBe('#800080');
+        });
+
+        it('blends green and red', () => {
+            const result = blendColors('#00ff00', '#ff0000', 0.5);
+            expect(result).toBe('#808000');
+        });
+    });
+
+    describe('with varying opacity values', () => {
+        it('handles 0.25 opacity correctly', () => {
+            const result = blendColors('#ffffff', '#000000', 0.25);
+            // 255 * 0.75 = 191.25 -> 191 = 0xbf
+            expect(result).toBe('#bfbfbf');
+        });
+
+        it('handles 0.75 opacity correctly', () => {
+            const result = blendColors('#ffffff', '#000000', 0.75);
+            // 255 * 0.25 = 63.75 -> 64 = 0x40
+            expect(result).toBe('#404040');
+        });
+
+        it('handles small opacity values', () => {
+            const result = blendColors('#ffffff', '#000000', 0.1);
+            // 255 * 0.9 = 229.5 -> 230 = 0xe6
+            expect(result).toBe('#e6e6e6');
+        });
+
+        it('handles opacity close to 1', () => {
+            // bg * (1 - opacity) + fg * opacity
+            // 255 * 0.1 + 0 * 0.9 = 25.5 -> Math.round = 26 = 0x1a
+            // But JS Math.round(25.5) = 26, so we need to check actual output
+            const result = blendColors('#ffffff', '#000000', 0.9);
+            // Actual: Math.round(0 * 0.9 + 255 * 0.1) = Math.round(25.5) = 25 (banker's rounding)
+            expect(result).toBe('#191919');
+        });
+    });
+
+    describe('hex format handling', () => {
+        it('handles colors with hash prefix', () => {
+            expect(blendColors('#ff0000', '#0000ff', 0.5)).toBe('#800080');
+        });
+
+        it('handles colors without hash prefix', () => {
+            expect(blendColors('ff0000', '0000ff', 0.5)).toBe('#800080');
+        });
+
+        it('handles lowercase hex values', () => {
+            // aa=170, 11=17 -> (170+17)/2 = 93.5 -> 94 = 0x5e
+            // bb=187, 22=34 -> (187+34)/2 = 110.5 -> 111 = 0x6f
+            // cc=204, 33=51 -> (204+51)/2 = 127.5 -> 128 = 0x80
+            expect(blendColors('#aabbcc', '#112233', 0.5)).toBe('#5e6f80');
+        });
+
+        it('handles uppercase hex values', () => {
+            // Same calculation as lowercase
+            expect(blendColors('#AABBCC', '#112233', 0.5)).toBe('#5e6f80');
+        });
+    });
+
+    describe('specific color blends', () => {
+        it('blends two shades of blue', () => {
+            const result = blendColors('#0066cc', '#003366', 0.5);
+            expect(result).toBe('#004d99');
+        });
+
+        it('blends orange and yellow', () => {
+            const result = blendColors('#ff9900', '#ffff00', 0.5);
+            expect(result).toBe('#ffcc00');
+        });
+
+        it('blends with itself returns the same color', () => {
+            expect(blendColors('#123456', '#123456', 0.5)).toBe('#123456');
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles all zeros', () => {
+            expect(blendColors('#000000', '#000000', 0.5)).toBe('#000000');
+        });
+
+        it('handles all maxes', () => {
+            expect(blendColors('#ffffff', '#ffffff', 0.5)).toBe('#ffffff');
+        });
+
+        it('produces consistent output format with leading zeros', () => {
+            // 0a=10 -> 10/2 = 5 = 0x05
+            // 0b=11 -> 11/2 = 5.5 -> 6 = 0x06
+            // 0c=12 -> 12/2 = 6 = 0x06
+            const result = blendColors('#0a0b0c', '#000000', 0.5);
+            expect(result).toBe('#050606');
+        });
+    });
+});

--- a/client/src/utils/__tests__/connectionContext.test.ts
+++ b/client/src/utils/__tests__/connectionContext.test.ts
@@ -1,0 +1,301 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatConnectionContext } from '../connectionContext';
+
+describe('formatConnectionContext', () => {
+    describe('with empty or minimal context', () => {
+        it('returns empty string for empty context', () => {
+            expect(formatConnectionContext({})).toBe('');
+        });
+
+        it('returns empty string when no recognized fields exist', () => {
+            expect(formatConnectionContext({ foo: 'bar', baz: 123 })).toBe('');
+        });
+    });
+
+    describe('postgresql section', () => {
+        it('formats PostgreSQL version', () => {
+            const ctx = {
+                postgresql: { version: '16.2' },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('PostgreSQL Version: 16.2');
+        });
+
+        it('formats max_connections', () => {
+            const ctx = {
+                postgresql: { max_connections: 100 },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Max Connections: 100');
+        });
+
+        it('formats installed extensions', () => {
+            const ctx = {
+                postgresql: {
+                    installed_extensions: ['pg_stat_statements', 'pgcrypto', 'uuid-ossp'],
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Installed Extensions: pg_stat_statements, pgcrypto, uuid-ossp');
+        });
+
+        it('formats key settings', () => {
+            const ctx = {
+                postgresql: {
+                    settings: {
+                        shared_buffers: '256MB',
+                        work_mem: '4MB',
+                    },
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Key Settings:');
+            expect(result).toContain('shared_buffers = 256MB');
+            expect(result).toContain('work_mem = 4MB');
+        });
+
+        it('skips settings section when settings is empty', () => {
+            const ctx = {
+                postgresql: {
+                    version: '16.2',
+                    settings: {},
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).not.toContain('Key Settings:');
+        });
+
+        it('formats complete postgresql context', () => {
+            const ctx = {
+                postgresql: {
+                    version: '16.2',
+                    max_connections: 200,
+                    installed_extensions: ['postgis'],
+                    settings: {
+                        max_wal_size: '1GB',
+                    },
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('PostgreSQL Version: 16.2');
+            expect(result).toContain('Max Connections: 200');
+            expect(result).toContain('Installed Extensions: postgis');
+            expect(result).toContain('Key Settings:');
+            expect(result).toContain('max_wal_size = 1GB');
+        });
+    });
+
+    describe('system section', () => {
+        it('formats OS name and version', () => {
+            const ctx = {
+                system: {
+                    os_name: 'Ubuntu',
+                    os_version: '22.04',
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('OS: Ubuntu 22.04');
+        });
+
+        it('formats OS name without version', () => {
+            const ctx = {
+                system: {
+                    os_name: 'macOS',
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('OS: macOS');
+        });
+
+        it('formats architecture', () => {
+            const ctx = {
+                system: { architecture: 'aarch64' },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Architecture: aarch64');
+        });
+
+        it('formats CPU model', () => {
+            const ctx = {
+                system: {
+                    cpu: { model: 'Apple M2 Pro' },
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('CPU: Apple M2 Pro');
+        });
+
+        it('formats CPU cores with logical processors', () => {
+            const ctx = {
+                system: {
+                    cpu: {
+                        cores: 8,
+                        logical_processors: 16,
+                    },
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('CPU Cores: 8 (16 logical)');
+        });
+
+        it('formats CPU cores without logical_processors', () => {
+            const ctx = {
+                system: {
+                    cpu: {
+                        cores: 4,
+                    },
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('CPU Cores: 4 (4 logical)');
+        });
+
+        it('formats total memory in GB', () => {
+            const ctx = {
+                system: {
+                    memory: {
+                        total_bytes: 17179869184, // 16 GB
+                    },
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Total Memory: 16.0 GB');
+        });
+
+        it('formats memory with decimal precision', () => {
+            const ctx = {
+                system: {
+                    memory: {
+                        total_bytes: 34359738368, // 32 GB
+                    },
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Total Memory: 32.0 GB');
+        });
+
+        it('formats disk information', () => {
+            const ctx = {
+                system: {
+                    disks: [
+                        {
+                            mount_point: '/',
+                            total_bytes: 536870912000, // ~500 GB
+                            used_bytes: 214748364800, // ~200 GB
+                        },
+                    ],
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Disk /: 200.0/500.0 GB used');
+        });
+
+        it('formats multiple disks', () => {
+            const ctx = {
+                system: {
+                    disks: [
+                        {
+                            mount_point: '/',
+                            total_bytes: 107374182400, // 100 GB
+                            used_bytes: 53687091200, // 50 GB
+                        },
+                        {
+                            mount_point: '/data',
+                            total_bytes: 1099511627776, // 1 TB
+                            used_bytes: 549755813888, // 0.5 TB
+                        },
+                    ],
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Disk /: 50.0/100.0 GB used');
+            expect(result).toContain('Disk /data: 512.0/1024.0 GB used');
+        });
+
+        it('handles empty disks array', () => {
+            const ctx = {
+                system: {
+                    disks: [],
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toBe('');
+        });
+    });
+
+    describe('combined context', () => {
+        it('formats both postgresql and system sections', () => {
+            const ctx = {
+                postgresql: {
+                    version: '15.4',
+                    max_connections: 150,
+                },
+                system: {
+                    os_name: 'Debian',
+                    os_version: '12',
+                    architecture: 'x86_64',
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('Server Context:');
+            expect(result).toContain('PostgreSQL Version: 15.4');
+            expect(result).toContain('Max Connections: 150');
+            expect(result).toContain('OS: Debian 12');
+            expect(result).toContain('Architecture: x86_64');
+        });
+
+        it('starts with newline and Server Context header', () => {
+            const ctx = {
+                postgresql: { version: '16.0' },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result.startsWith('\nServer Context:\n')).toBe(true);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles undefined nested objects gracefully', () => {
+            const ctx = {
+                postgresql: undefined,
+                system: undefined,
+            };
+            const result = formatConnectionContext(ctx as Record<string, unknown>);
+            expect(result).toBe('');
+        });
+
+        it('handles missing cpu/memory/disks in system', () => {
+            const ctx = {
+                system: {
+                    os_name: 'Linux',
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).toContain('OS: Linux');
+            expect(result).not.toContain('CPU');
+            expect(result).not.toContain('Memory');
+            expect(result).not.toContain('Disk');
+        });
+
+        it('handles memory without total_bytes', () => {
+            const ctx = {
+                system: {
+                    memory: {
+                        available_bytes: 1000000,
+                    },
+                },
+            };
+            const result = formatConnectionContext(ctx);
+            expect(result).not.toContain('Total Memory');
+        });
+    });
+});

--- a/client/src/utils/__tests__/downloadMarkdown.test.ts
+++ b/client/src/utils/__tests__/downloadMarkdown.test.ts
@@ -1,0 +1,192 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, MockInstance } from 'vitest';
+import { downloadAsMarkdown } from '../downloadMarkdown';
+
+describe('downloadAsMarkdown', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockCreateElement: MockInstance<any[], any>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockAppendChild: MockInstance<any[], any>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockRemoveChild: MockInstance<any[], any>;
+    let mockCreateObjectURL: ReturnType<typeof vi.fn>;
+    let mockRevokeObjectURL: ReturnType<typeof vi.fn>;
+    let mockLink: HTMLAnchorElement;
+
+    beforeEach(() => {
+        // Create a mock anchor element
+        mockLink = {
+            href: '',
+            download: '',
+            click: vi.fn(),
+        } as unknown as HTMLAnchorElement;
+
+        mockCreateElement = vi.spyOn(document, 'createElement')
+            .mockReturnValue(mockLink as unknown as HTMLElement);
+
+        mockAppendChild = vi.spyOn(document.body, 'appendChild')
+            .mockReturnValue(mockLink as unknown as HTMLElement);
+
+        mockRemoveChild = vi.spyOn(document.body, 'removeChild')
+            .mockReturnValue(mockLink as unknown as HTMLElement);
+
+        // jsdom doesn't implement URL.createObjectURL, so we need to define it
+        mockCreateObjectURL = vi.fn()
+            .mockReturnValue('blob:http://localhost/test-uuid');
+        mockRevokeObjectURL = vi.fn();
+
+        (URL.createObjectURL as unknown) = mockCreateObjectURL;
+        (URL.revokeObjectURL as unknown) = mockRevokeObjectURL;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('basic functionality', () => {
+        it('creates an anchor element', () => {
+            downloadAsMarkdown('# Test Content', 'test.md');
+            expect(mockCreateElement).toHaveBeenCalledWith('a');
+        });
+
+        it('creates a Blob with text/markdown content type', () => {
+            const content = '# Test Content\n\nSome text here';
+            downloadAsMarkdown(content, 'test.md');
+
+            expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
+            const blobArg = mockCreateObjectURL.mock.calls[0][0] as Blob;
+            expect(blobArg).toBeInstanceOf(Blob);
+            expect(blobArg.type).toBe('text/markdown');
+        });
+
+        it('sets the href to the object URL', () => {
+            downloadAsMarkdown('content', 'file.md');
+            expect(mockLink.href).toBe('blob:http://localhost/test-uuid');
+        });
+
+        it('sets the download attribute to the filename', () => {
+            downloadAsMarkdown('content', 'my-document.md');
+            expect(mockLink.download).toBe('my-document.md');
+        });
+
+        it('triggers a click on the anchor element', () => {
+            downloadAsMarkdown('content', 'test.md');
+            expect(mockLink.click).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('DOM manipulation', () => {
+        it('appends the link to document.body', () => {
+            downloadAsMarkdown('content', 'test.md');
+            expect(mockAppendChild).toHaveBeenCalledWith(mockLink);
+        });
+
+        it('removes the link from document.body after clicking', () => {
+            downloadAsMarkdown('content', 'test.md');
+            expect(mockRemoveChild).toHaveBeenCalledWith(mockLink);
+        });
+
+        it('calls appendChild before click', () => {
+            const callOrder: string[] = [];
+            mockAppendChild.mockImplementation(() => {
+                callOrder.push('appendChild');
+                return mockLink;
+            });
+            (mockLink.click as ReturnType<typeof vi.fn>).mockImplementation(() => {
+                callOrder.push('click');
+            });
+
+            downloadAsMarkdown('content', 'test.md');
+            expect(callOrder.indexOf('appendChild')).toBeLessThan(callOrder.indexOf('click'));
+        });
+
+        it('calls removeChild after click', () => {
+            const callOrder: string[] = [];
+            (mockLink.click as ReturnType<typeof vi.fn>).mockImplementation(() => {
+                callOrder.push('click');
+            });
+            mockRemoveChild.mockImplementation(() => {
+                callOrder.push('removeChild');
+                return mockLink;
+            });
+
+            downloadAsMarkdown('content', 'test.md');
+            expect(callOrder.indexOf('click')).toBeLessThan(callOrder.indexOf('removeChild'));
+        });
+    });
+
+    describe('cleanup', () => {
+        it('revokes the object URL after download', () => {
+            downloadAsMarkdown('content', 'test.md');
+            expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/test-uuid');
+        });
+
+        it('revokes URL after removing the link', () => {
+            const callOrder: string[] = [];
+            mockRemoveChild.mockImplementation(() => {
+                callOrder.push('removeChild');
+                return mockLink;
+            });
+            mockRevokeObjectURL.mockImplementation(() => {
+                callOrder.push('revokeObjectURL');
+            });
+
+            downloadAsMarkdown('content', 'test.md');
+            expect(callOrder.indexOf('removeChild')).toBeLessThan(callOrder.indexOf('revokeObjectURL'));
+        });
+    });
+
+    describe('content handling', () => {
+        it('handles empty content', () => {
+            downloadAsMarkdown('', 'empty.md');
+            expect(mockCreateObjectURL).toHaveBeenCalled();
+            expect(mockLink.click).toHaveBeenCalled();
+        });
+
+        it('handles large content', () => {
+            const largeContent = '# Large File\n' + 'Lorem ipsum '.repeat(10000);
+            downloadAsMarkdown(largeContent, 'large.md');
+
+            const blobArg = mockCreateObjectURL.mock.calls[0][0] as Blob;
+            expect(blobArg.size).toBeGreaterThan(100000);
+        });
+
+        it('handles content with special characters', () => {
+            const specialContent = '# Test\n\nCode: `SELECT * FROM users;`\n\n```sql\nSELECT * FROM "table";\n```';
+            downloadAsMarkdown(specialContent, 'special.md');
+            expect(mockLink.click).toHaveBeenCalled();
+        });
+
+        it('handles unicode content', () => {
+            const unicodeContent = '# Unicode Test\n\n\u4e2d\u6587\u5185\u5bb9\n\nEmoji: \ud83d\udcca';
+            downloadAsMarkdown(unicodeContent, 'unicode.md');
+            expect(mockLink.click).toHaveBeenCalled();
+        });
+    });
+
+    describe('filename handling', () => {
+        it('handles filenames with spaces', () => {
+            downloadAsMarkdown('content', 'my document.md');
+            expect(mockLink.download).toBe('my document.md');
+        });
+
+        it('handles filenames without extension', () => {
+            downloadAsMarkdown('content', 'document');
+            expect(mockLink.download).toBe('document');
+        });
+
+        it('handles filenames with special characters', () => {
+            downloadAsMarkdown('content', 'report-2024-01-15.md');
+            expect(mockLink.download).toBe('report-2024-01-15.md');
+        });
+    });
+});

--- a/client/src/utils/__tests__/downloadMarkdown.test.ts
+++ b/client/src/utils/__tests__/downloadMarkdown.test.ts
@@ -22,6 +22,10 @@ describe('downloadAsMarkdown', () => {
     let mockRevokeObjectURL: ReturnType<typeof vi.fn>;
     let mockLink: HTMLAnchorElement;
 
+    // Save original URL methods to restore after tests
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+
     beforeEach(() => {
         // Create a mock anchor element
         mockLink = {
@@ -50,6 +54,9 @@ describe('downloadAsMarkdown', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+        // Restore original URL methods to prevent cross-test pollution
+        URL.createObjectURL = originalCreateObjectURL;
+        URL.revokeObjectURL = originalRevokeObjectURL;
     });
 
     describe('basic functionality', () => {

--- a/client/src/utils/__tests__/mcpTools.test.ts
+++ b/client/src/utils/__tests__/mcpTools.test.ts
@@ -1,0 +1,232 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getKnowledgebaseTool } from '../mcpTools';
+
+// Mock the apiClient module
+vi.mock('../apiClient', () => ({
+    apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '../apiClient';
+
+const mockApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+describe('getKnowledgebaseTool', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('successful responses', () => {
+        it('returns the search_knowledgebase tool when found', async () => {
+            const mockResponse = {
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    tools: [
+                        {
+                            name: 'search_knowledgebase',
+                            description: 'Search the knowledge base',
+                            inputSchema: {
+                                type: 'object',
+                                properties: {
+                                    query: { type: 'string', description: 'Search query' },
+                                },
+                                required: ['query'],
+                            },
+                        },
+                        {
+                            name: 'other_tool',
+                            description: 'Another tool',
+                            inputSchema: {
+                                type: 'object',
+                                properties: {},
+                            },
+                        },
+                    ],
+                }),
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result).not.toBeNull();
+            expect(result?.name).toBe('search_knowledgebase');
+            expect(result?.description).toBe('Search the knowledge base');
+            expect(result?.inputSchema.type).toBe('object');
+            expect(result?.inputSchema.properties).toHaveProperty('query');
+            expect(result?.inputSchema.required).toEqual(['query']);
+        });
+
+        it('returns correct inputSchema structure', async () => {
+            const mockResponse = {
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    tools: [
+                        {
+                            name: 'search_knowledgebase',
+                            description: 'Test description',
+                            inputSchema: {
+                                type: 'object',
+                                properties: {
+                                    query: { type: 'string', description: 'The query' },
+                                    limit: { type: 'number', description: 'Max results' },
+                                },
+                                required: ['query'],
+                            },
+                        },
+                    ],
+                }),
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result?.inputSchema.properties).toEqual({
+                query: { type: 'string', description: 'The query' },
+                limit: { type: 'number', description: 'Max results' },
+            });
+        });
+
+        it('defaults required to empty array when not provided', async () => {
+            const mockResponse = {
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    tools: [
+                        {
+                            name: 'search_knowledgebase',
+                            description: 'No required fields',
+                            inputSchema: {
+                                type: 'object',
+                                properties: {
+                                    optional: { type: 'string' },
+                                },
+                                // required is undefined
+                            },
+                        },
+                    ],
+                }),
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result?.inputSchema.required).toEqual([]);
+        });
+    });
+
+    describe('tool not found', () => {
+        it('returns null when search_knowledgebase is not in the list', async () => {
+            const mockResponse = {
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    tools: [
+                        {
+                            name: 'other_tool',
+                            description: 'Not the one we want',
+                            inputSchema: { type: 'object', properties: {} },
+                        },
+                    ],
+                }),
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when tools array is empty', async () => {
+            const mockResponse = {
+                ok: true,
+                json: vi.fn().mockResolvedValue({ tools: [] }),
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('error handling', () => {
+        it('returns null when response is not ok', async () => {
+            const mockResponse = {
+                ok: false,
+                status: 404,
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when fetch throws an error', async () => {
+            mockApiFetch.mockRejectedValue(new Error('Network error'));
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null on server error', async () => {
+            const mockResponse = {
+                ok: false,
+                status: 500,
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when JSON parsing fails', async () => {
+            const mockResponse = {
+                ok: true,
+                json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            const result = await getKnowledgebaseTool();
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('API call verification', () => {
+        it('calls apiFetch with correct endpoint', async () => {
+            const mockResponse = {
+                ok: true,
+                json: vi.fn().mockResolvedValue({ tools: [] }),
+            };
+
+            mockApiFetch.mockResolvedValue(mockResponse);
+
+            await getKnowledgebaseTool();
+
+            expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+            expect(mockApiFetch).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/client/src/utils/__tests__/textHelpers.test.ts
+++ b/client/src/utils/__tests__/textHelpers.test.ts
@@ -1,0 +1,336 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    stripPreamble,
+    truncateDescription,
+    djb2Hash,
+    slugify,
+    ANALYSIS_CACHE_TTL_MS,
+} from '../textHelpers';
+
+describe('stripPreamble', () => {
+    describe('text with markdown headings', () => {
+        it('strips preamble before a second-level heading', () => {
+            const input = 'Here is some intro text.\n\n## Heading\n\nContent';
+            const result = stripPreamble(input);
+            expect(result).toBe('## Heading\n\nContent');
+        });
+
+        it('strips multi-line preamble', () => {
+            const input = 'Line 1\nLine 2\nLine 3\n\n## Analysis\n\nDetails';
+            const result = stripPreamble(input);
+            expect(result).toBe('## Analysis\n\nDetails');
+        });
+
+        it('handles multiple headings and returns from the first', () => {
+            const input = 'Preamble\n## First\n\n## Second';
+            const result = stripPreamble(input);
+            expect(result).toBe('## First\n\n## Second');
+        });
+    });
+
+    describe('text without preamble', () => {
+        it('returns text unchanged when it starts with a heading', () => {
+            const input = '## Heading\n\nContent here';
+            const result = stripPreamble(input);
+            expect(result).toBe('## Heading\n\nContent here');
+        });
+
+        it('returns text unchanged when heading is at position 0', () => {
+            const input = '## Start';
+            const result = stripPreamble(input);
+            expect(result).toBe('## Start');
+        });
+    });
+
+    describe('text without headings', () => {
+        it('returns text unchanged when no heading exists', () => {
+            const input = 'This is just plain text without any headings.';
+            const result = stripPreamble(input);
+            expect(result).toBe(input);
+        });
+
+        it('handles empty string', () => {
+            expect(stripPreamble('')).toBe('');
+        });
+
+        it('ignores headings that are not second-level', () => {
+            const input = 'Preamble\n# First Level\n### Third Level';
+            const result = stripPreamble(input);
+            expect(result).toBe(input);
+        });
+    });
+
+    describe('edge cases with heading patterns', () => {
+        it('requires space after ## for valid heading', () => {
+            const input = 'Preamble\n##NoSpace';
+            const result = stripPreamble(input);
+            expect(result).toBe(input);
+        });
+
+        it('handles heading at start of a line (multiline flag)', () => {
+            const input = 'Some text\n## Heading on new line';
+            const result = stripPreamble(input);
+            expect(result).toBe('## Heading on new line');
+        });
+    });
+});
+
+describe('truncateDescription', () => {
+    describe('with normal inputs', () => {
+        it('returns the first line when under max length', () => {
+            const result = truncateDescription('Short description');
+            expect(result).toBe('Short description');
+        });
+
+        it('truncates long first lines with ellipsis', () => {
+            const longText = 'This is a very long description that exceeds the maximum allowed length for display';
+            const result = truncateDescription(longText);
+            // Truncates to first 60 chars then adds ...
+            expect(result).toBe('This is a very long description that exceeds the maximum all...');
+            expect(result.length).toBe(63); // 60 + '...'
+        });
+
+        it('returns only the first line of multiline text', () => {
+            const multiline = 'First line\nSecond line\nThird line';
+            const result = truncateDescription(multiline);
+            expect(result).toBe('First line');
+        });
+    });
+
+    describe('with custom max length', () => {
+        it('respects custom max length', () => {
+            const result = truncateDescription('Hello World', 5);
+            expect(result).toBe('Hello...');
+        });
+
+        it('returns full text when under custom max length', () => {
+            const result = truncateDescription('Hi', 10);
+            expect(result).toBe('Hi');
+        });
+
+        it('handles max length of 0', () => {
+            const result = truncateDescription('Test', 0);
+            expect(result).toBe('...');
+        });
+    });
+
+    describe('with edge cases', () => {
+        it('returns empty string for empty input', () => {
+            expect(truncateDescription('')).toBe('');
+        });
+
+        it('returns empty string for falsy input', () => {
+            // TypeScript would normally prevent this, but testing runtime behavior
+            expect(truncateDescription(null as unknown as string)).toBe('');
+            expect(truncateDescription(undefined as unknown as string)).toBe('');
+        });
+
+        it('handles text exactly at max length', () => {
+            const exactLength = 'a'.repeat(60);
+            const result = truncateDescription(exactLength);
+            expect(result).toBe(exactLength);
+            expect(result.length).toBe(60);
+        });
+
+        it('handles text one character over max length', () => {
+            const overLength = 'a'.repeat(61);
+            const result = truncateDescription(overLength);
+            expect(result).toBe('a'.repeat(60) + '...');
+        });
+
+        it('handles newline at beginning', () => {
+            const result = truncateDescription('\nSecond line');
+            expect(result).toBe('');
+        });
+    });
+});
+
+describe('djb2Hash', () => {
+    describe('hash consistency', () => {
+        it('returns the same hash for the same input', () => {
+            const hash1 = djb2Hash('test string');
+            const hash2 = djb2Hash('test string');
+            expect(hash1).toBe(hash2);
+        });
+
+        it('returns a string representation of the hash', () => {
+            const hash = djb2Hash('hello');
+            expect(typeof hash).toBe('string');
+            expect(Number.isNaN(Number(hash))).toBe(false);
+        });
+    });
+
+    describe('different inputs produce different hashes', () => {
+        it('hashes differ for different strings', () => {
+            const hash1 = djb2Hash('hello');
+            const hash2 = djb2Hash('world');
+            expect(hash1).not.toBe(hash2);
+        });
+
+        it('hashes differ for similar strings', () => {
+            const hash1 = djb2Hash('test1');
+            const hash2 = djb2Hash('test2');
+            expect(hash1).not.toBe(hash2);
+        });
+
+        it('hashes differ by case', () => {
+            const hash1 = djb2Hash('Hello');
+            const hash2 = djb2Hash('hello');
+            expect(hash1).not.toBe(hash2);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles empty string', () => {
+            const hash = djb2Hash('');
+            expect(hash).toBe('5381'); // Initial hash value
+        });
+
+        it('handles single character', () => {
+            const hash = djb2Hash('a');
+            expect(typeof hash).toBe('string');
+        });
+
+        it('handles long strings', () => {
+            const longString = 'a'.repeat(10000);
+            const hash = djb2Hash(longString);
+            expect(typeof hash).toBe('string');
+        });
+
+        it('handles special characters', () => {
+            const hash = djb2Hash('!@#$%^&*()');
+            expect(typeof hash).toBe('string');
+        });
+
+        it('handles unicode characters', () => {
+            const hash = djb2Hash('\u4e2d\u6587\u6d4b\u8bd5');
+            expect(typeof hash).toBe('string');
+        });
+
+        it('handles whitespace', () => {
+            const hash1 = djb2Hash('hello world');
+            const hash2 = djb2Hash('helloworld');
+            expect(hash1).not.toBe(hash2);
+        });
+    });
+
+    describe('hash properties', () => {
+        it('returns a non-negative number as string', () => {
+            const hash = djb2Hash('negative test');
+            expect(Number(hash)).toBeGreaterThanOrEqual(0);
+        });
+
+        it('returns unsigned 32-bit value as string', () => {
+            const hash = djb2Hash('overflow test');
+            const num = Number(hash);
+            expect(num).toBeLessThanOrEqual(4294967295); // 2^32 - 1
+        });
+    });
+});
+
+describe('slugify', () => {
+    describe('basic transformations', () => {
+        it('converts text to lowercase', () => {
+            expect(slugify('Hello World')).toBe('hello-world');
+        });
+
+        it('replaces spaces with hyphens', () => {
+            expect(slugify('some text here')).toBe('some-text-here');
+        });
+
+        it('handles single word', () => {
+            expect(slugify('Word')).toBe('word');
+        });
+    });
+
+    describe('special character handling', () => {
+        it('removes special characters', () => {
+            expect(slugify('Hello! World?')).toBe('hello-world');
+        });
+
+        it('removes punctuation', () => {
+            expect(slugify("it's a test.")).toBe('it-s-a-test');
+        });
+
+        it('replaces multiple non-alphanumeric chars with single hyphen', () => {
+            expect(slugify('hello   world')).toBe('hello-world');
+            expect(slugify('hello---world')).toBe('hello-world');
+            expect(slugify('hello!@#world')).toBe('hello-world');
+        });
+    });
+
+    describe('edge handling', () => {
+        it('removes leading hyphens', () => {
+            expect(slugify('---hello')).toBe('hello');
+        });
+
+        it('removes trailing hyphens', () => {
+            expect(slugify('hello---')).toBe('hello');
+        });
+
+        it('removes both leading and trailing hyphens', () => {
+            expect(slugify('---hello---')).toBe('hello');
+        });
+
+        it('handles leading special characters', () => {
+            expect(slugify('!@#$hello')).toBe('hello');
+        });
+
+        it('handles trailing special characters', () => {
+            expect(slugify('hello!@#$')).toBe('hello');
+        });
+    });
+
+    describe('number handling', () => {
+        it('preserves numbers', () => {
+            expect(slugify('test123')).toBe('test123');
+        });
+
+        it('handles text with numbers', () => {
+            expect(slugify('Version 2.0 Release')).toBe('version-2-0-release');
+        });
+
+        it('handles numeric strings', () => {
+            expect(slugify('12345')).toBe('12345');
+        });
+    });
+
+    describe('edge cases', () => {
+        it('returns empty string for empty input', () => {
+            expect(slugify('')).toBe('');
+        });
+
+        it('returns empty string for only special characters', () => {
+            expect(slugify('!@#$%^&*()')).toBe('');
+        });
+
+        it('returns empty string for only spaces', () => {
+            expect(slugify('     ')).toBe('');
+        });
+
+        it('handles already slugified text', () => {
+            expect(slugify('already-slugified')).toBe('already-slugified');
+        });
+
+        it('handles mixed case and special chars', () => {
+            expect(slugify('The Quick Brown Fox!')).toBe('the-quick-brown-fox');
+        });
+    });
+});
+
+describe('ANALYSIS_CACHE_TTL_MS', () => {
+    it('equals 30 minutes in milliseconds', () => {
+        expect(ANALYSIS_CACHE_TTL_MS).toBe(30 * 60 * 1000);
+        expect(ANALYSIS_CACHE_TTL_MS).toBe(1800000);
+    });
+});

--- a/client/src/utils/__tests__/timelineEvents.test.ts
+++ b/client/src/utils/__tests__/timelineEvents.test.ts
@@ -1,0 +1,449 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    fetchTimelineEventsCentered,
+    fetchTimelineEventsForRange,
+} from '../timelineEvents';
+
+// Mock the apiClient module
+vi.mock('../apiClient', () => ({
+    apiGet: vi.fn(),
+}));
+
+import { apiGet } from '../apiClient';
+
+const mockApiGet = apiGet as ReturnType<typeof vi.fn>;
+
+describe('fetchTimelineEventsCentered', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Fix the current time for consistent testing
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe('successful responses', () => {
+        it('returns formatted events string when events exist', async () => {
+            mockApiGet.mockResolvedValue({
+                events: [
+                    {
+                        event_type: 'alert',
+                        title: 'High CPU Usage',
+                        summary: 'CPU at 95%',
+                        occurred_at: '2024-06-15T10:30:00Z',
+                    },
+                    {
+                        event_type: 'metric',
+                        title: 'Memory Spike',
+                        occurred_at: '2024-06-15T11:00:00Z',
+                    },
+                ],
+            });
+
+            const result = await fetchTimelineEventsCentered(1);
+
+            expect(result).toContain('Timeline Events (24h window):');
+            expect(result).toContain('alert - High CPU Usage: CPU at 95%');
+            expect(result).toContain('metric - Memory Spike');
+        });
+
+        it('formats event time using toLocaleString', async () => {
+            mockApiGet.mockResolvedValue({
+                events: [
+                    {
+                        event_type: 'test',
+                        title: 'Test Event',
+                        occurred_at: '2024-06-15T10:30:00Z',
+                    },
+                ],
+            });
+
+            const result = await fetchTimelineEventsCentered(1);
+
+            // Should contain formatted time
+            expect(result).toContain('[');
+            expect(result).toContain(']');
+        });
+
+        it('handles events without summary', async () => {
+            mockApiGet.mockResolvedValue({
+                events: [
+                    {
+                        event_type: 'info',
+                        title: 'No Summary Event',
+                        occurred_at: '2024-06-15T10:00:00Z',
+                    },
+                ],
+            });
+
+            const result = await fetchTimelineEventsCentered(1);
+
+            expect(result).toContain('info - No Summary Event');
+            expect(result).not.toContain(': undefined');
+        });
+    });
+
+    describe('time range calculation', () => {
+        it('uses current time when no reference time provided', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsCentered(1);
+
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+
+            // Check that the URL contains ISO date strings
+            expect(callArg).toContain('start_time=');
+            expect(callArg).toContain('end_time=');
+
+            // Parse the start and end times from the URL
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            const endTimeParam = url.searchParams.get('end_time');
+            expect(startTimeParam).not.toBeNull();
+            expect(endTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+            const endTime = new Date(endTimeParam as string);
+
+            // Should be a 24-hour window centered on current time
+            const expectedStart = new Date('2024-06-15T00:00:00Z');
+            const expectedEnd = new Date('2024-06-16T00:00:00Z');
+
+            expect(startTime.toISOString()).toBe(expectedStart.toISOString());
+            expect(endTime.toISOString()).toBe(expectedEnd.toISOString());
+        });
+
+        it('uses provided reference time string', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsCentered(1, '2024-03-15T06:00:00Z');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            const endTimeParam = url.searchParams.get('end_time');
+            expect(startTimeParam).not.toBeNull();
+            expect(endTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+            const endTime = new Date(endTimeParam as string);
+
+            // 12 hours before and after 2024-03-15T06:00:00Z
+            expect(startTime.toISOString()).toBe('2024-03-14T18:00:00.000Z');
+            expect(endTime.toISOString()).toBe('2024-03-15T18:00:00.000Z');
+        });
+
+        it('uses provided reference time as Date object', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            const refTime = new Date('2024-01-01T12:00:00Z');
+            await fetchTimelineEventsCentered(1, refTime);
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            expect(startTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+
+            expect(startTime.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+        });
+
+        it('includes connection_id in request', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsCentered(42);
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            expect(callArg).toContain('connection_id=42');
+        });
+
+        it('requests up to 100 events', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsCentered(1);
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            expect(callArg).toContain('limit=100');
+        });
+    });
+
+    describe('error handling', () => {
+        it('returns empty string when API call fails', async () => {
+            mockApiGet.mockRejectedValue(new Error('Network error'));
+
+            const result = await fetchTimelineEventsCentered(1);
+
+            expect(result).toBe('');
+        });
+
+        it('returns empty string when events array is empty', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            const result = await fetchTimelineEventsCentered(1);
+
+            expect(result).toBe('');
+        });
+
+        it('returns empty string when events is undefined', async () => {
+            mockApiGet.mockResolvedValue({});
+
+            const result = await fetchTimelineEventsCentered(1);
+
+            expect(result).toBe('');
+        });
+
+        it('returns empty string when response is null', async () => {
+            mockApiGet.mockResolvedValue(null);
+
+            const result = await fetchTimelineEventsCentered(1);
+
+            expect(result).toBe('');
+        });
+    });
+});
+
+describe('fetchTimelineEventsForRange', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe('time range parsing', () => {
+        it('handles 1h range', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, '1h');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            expect(startTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+
+            expect(startTime.toISOString()).toBe('2024-06-15T11:00:00.000Z');
+        });
+
+        it('handles 6h range', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, '6h');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            expect(startTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+
+            expect(startTime.toISOString()).toBe('2024-06-15T06:00:00.000Z');
+        });
+
+        it('handles 24h range', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, '24h');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            expect(startTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+
+            expect(startTime.toISOString()).toBe('2024-06-14T12:00:00.000Z');
+        });
+
+        it('handles 7d range', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, '7d');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            expect(startTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+
+            expect(startTime.toISOString()).toBe('2024-06-08T12:00:00.000Z');
+        });
+
+        it('handles 30d range', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, '30d');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            expect(startTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+
+            expect(startTime.toISOString()).toBe('2024-05-16T12:00:00.000Z');
+        });
+
+        it('defaults to 24h for undefined range', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, undefined);
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            expect(startTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+
+            expect(startTime.toISOString()).toBe('2024-06-14T12:00:00.000Z');
+        });
+
+        it('defaults to 24h for unknown range values', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, 'unknown');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const startTimeParam = url.searchParams.get('start_time');
+            expect(startTimeParam).not.toBeNull();
+            const startTime = new Date(startTimeParam as string);
+
+            expect(startTime.toISOString()).toBe('2024-06-14T12:00:00.000Z');
+        });
+    });
+
+    describe('successful responses', () => {
+        it('returns formatted events with range label', async () => {
+            mockApiGet.mockResolvedValue({
+                events: [
+                    {
+                        event_type: 'alert',
+                        title: 'Test Alert',
+                        summary: 'Description',
+                        occurred_at: '2024-06-15T11:30:00Z',
+                    },
+                ],
+            });
+
+            const result = await fetchTimelineEventsForRange(1, '1h');
+
+            expect(result).toContain('Timeline Events (1h):');
+            expect(result).toContain('alert - Test Alert: Description');
+        });
+
+        it('uses provided range in label', async () => {
+            mockApiGet.mockResolvedValue({
+                events: [
+                    {
+                        event_type: 'info',
+                        title: 'Event',
+                        occurred_at: '2024-06-10T12:00:00Z',
+                    },
+                ],
+            });
+
+            const result = await fetchTimelineEventsForRange(1, '7d');
+
+            expect(result).toContain('Timeline Events (7d):');
+        });
+
+        it('uses 24h in label when range is undefined', async () => {
+            mockApiGet.mockResolvedValue({
+                events: [
+                    {
+                        event_type: 'info',
+                        title: 'Event',
+                        occurred_at: '2024-06-15T10:00:00Z',
+                    },
+                ],
+            });
+
+            const result = await fetchTimelineEventsForRange(1, undefined);
+
+            expect(result).toContain('Timeline Events (24h):');
+        });
+    });
+
+    describe('request parameters', () => {
+        it('includes connection_id in request', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(99, '1h');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            expect(callArg).toContain('connection_id=99');
+        });
+
+        it('includes end_time as current time', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, '1h');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            const url = new URL('http://test.com' + callArg);
+            const endTimeParam = url.searchParams.get('end_time');
+            expect(endTimeParam).not.toBeNull();
+            const endTime = new Date(endTimeParam as string);
+
+            expect(endTime.toISOString()).toBe('2024-06-15T12:00:00.000Z');
+        });
+
+        it('requests up to 100 events', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            await fetchTimelineEventsForRange(1, '24h');
+
+            const callArg = mockApiGet.mock.calls[0][0] as string;
+            expect(callArg).toContain('limit=100');
+        });
+    });
+
+    describe('error handling', () => {
+        it('returns empty string when API call fails', async () => {
+            mockApiGet.mockRejectedValue(new Error('Server error'));
+
+            const result = await fetchTimelineEventsForRange(1, '1h');
+
+            expect(result).toBe('');
+        });
+
+        it('returns empty string when events array is empty', async () => {
+            mockApiGet.mockResolvedValue({ events: [] });
+
+            const result = await fetchTimelineEventsForRange(1, '24h');
+
+            expect(result).toBe('');
+        });
+
+        it('returns empty string when events is undefined', async () => {
+            mockApiGet.mockResolvedValue({});
+
+            const result = await fetchTimelineEventsForRange(1, '7d');
+
+            expect(result).toBe('');
+        });
+
+        it('returns empty string when response is null', async () => {
+            mockApiGet.mockResolvedValue(null);
+
+            const result = await fetchTimelineEventsForRange(1, '30d');
+
+            expect(result).toBe('');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage for 8 client utility modules
- Increase overall utils coverage from 77.79% to 97%
- All 8 modules now achieve 100% coverage (or 99.34% for agenticLoop)

### Test files added:

| File | Coverage |
|------|----------|
| agenticLoop.test.ts | 99.34% |
| clusterHelpers.test.ts | 100% |
| colors.test.ts | 100% |
| connectionContext.test.ts | 100% |
| downloadMarkdown.test.ts | 100% |
| mcpTools.test.ts | 100% |
| textHelpers.test.ts | 100% |
| timelineEvents.test.ts | 100% |

## Test plan

- [x] All 792 tests pass
- [x] ESLint reports 0 errors
- [x] `make test-all` passes

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Vitest suites covering agentic loop behavior (control flow, tool handling, errors, callbacks, iteration limits, API responses), server-collection flattening, color blending, connection-context formatting, markdown download flow, knowledgebase tool retrieval, text utilities (preamble/slug/hash/truncate), and timeline event fetching. These tests exercise normal, edge, and error cases to improve reliability and guard expected output/formatting across utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->