### PR TITLE
Add tests for client hooks

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -160,6 +160,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -513,6 +514,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -561,6 +563,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -582,6 +585,7 @@
             "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
             "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@dnd-kit/accessibility": "^3.1.1",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -676,6 +680,7 @@
             "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
             "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -719,6 +724,7 @@
             "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
             "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -1506,6 +1512,7 @@
             "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
             "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@mui/core-downloads-tracker": "^5.18.0",
@@ -2350,6 +2357,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -2425,6 +2433,7 @@
             "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.58.2",
                 "@typescript-eslint/types": "8.58.2",
@@ -2858,6 +2867,7 @@
             "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/utils": "1.6.1",
                 "fast-glob": "^3.3.2",
@@ -2931,6 +2941,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3173,6 +3184,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -3912,6 +3924,7 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -4487,6 +4500,7 @@
             "integrity": "sha512-JzUXOh0wdNGY54oKng5hliuBkq/+aT1V3YpTM+lrN/GoLQTANZsMaIvmHiHe612rauHvPJnDZkZ+5GZR++1Abg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "css.escape": "^1.5.1",
                 "entities": "^4.5.0",
@@ -7133,6 +7147,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -7145,6 +7160,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -7949,6 +7965,7 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8113,6 +8130,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8314,6 +8332,7 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -8397,6 +8416,7 @@
             "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "1.6.1",
                 "@vitest/runner": "1.6.1",

--- a/client/src/hooks/__tests__/useAlertAnalysis.test.ts
+++ b/client/src/hooks/__tests__/useAlertAnalysis.test.ts
@@ -1,0 +1,425 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+    useAlertAnalysis,
+    clearAlertAnalysisCache,
+    AlertInput,
+} from '../useAlertAnalysis';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSetAnalysis = vi.fn();
+const mockSetLoading = vi.fn();
+const mockSetError = vi.fn();
+const mockSetProgressMessage = vi.fn();
+const mockSetActiveTools = vi.fn();
+const mockReset = vi.fn();
+
+let mockAnalysis: string | null = null;
+let mockLoading = false;
+let mockError: string | null = null;
+
+vi.mock('../useAnalysisState', () => ({
+    useAnalysisState: () => ({
+        state: {
+            analysis: mockAnalysis,
+            loading: mockLoading,
+            error: mockError,
+            progressMessage: 'Gathering context...',
+            activeTools: [],
+        },
+        setAnalysis: mockSetAnalysis,
+        setLoading: mockSetLoading,
+        setError: mockSetError,
+        setProgressMessage: mockSetProgressMessage,
+        setActiveTools: mockSetActiveTools,
+        reset: mockReset,
+    }),
+}));
+
+const mockMaxIterations = 10;
+
+vi.mock('../../contexts/AICapabilitiesContext', () => ({
+    useAICapabilities: () => ({ maxIterations: mockMaxIterations }),
+}));
+
+const mockApiGet = vi.fn();
+const mockApiPut = vi.fn();
+
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+}));
+
+vi.mock('../../utils/connectionContext', () => ({
+    formatConnectionContext: vi.fn().mockReturnValue('Connection context'),
+}));
+
+vi.mock('../../utils/mcpTools', () => ({
+    getKnowledgebaseTool: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../utils/analysisTools', () => ({
+    ALERT_ANALYSIS_TOOLS: [],
+}));
+
+const mockRunAgenticLoop = vi.fn();
+
+vi.mock('../../utils/agenticLoop', () => ({
+    runAgenticLoop: (...args: unknown[]) => mockRunAgenticLoop(...args),
+}));
+
+vi.mock('../../utils/timelineEvents', () => ({
+    fetchTimelineEventsCentered: vi.fn().mockResolvedValue(''),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let testCounter = 0;
+
+function makeAlertInput(overrides: Partial<AlertInput> = {}): AlertInput {
+    return {
+        id: testCounter,
+        alertType: 'threshold',
+        severity: 'warning',
+        title: 'High CPU Usage',
+        description: 'CPU usage exceeded threshold',
+        metricName: 'cpu_usage',
+        metricValue: 85.5,
+        operator: '>',
+        thresholdValue: 80,
+        connectionId: 1,
+        triggeredAt: '2024-01-01T12:00:00Z',
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAlertAnalysis', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        testCounter++;
+        mockAnalysis = null;
+        mockLoading = false;
+        mockError = null;
+        clearAlertAnalysisCache();
+        mockRunAgenticLoop.mockResolvedValue('Analysis complete.');
+        mockApiGet.mockResolvedValue({});
+        mockApiPut.mockResolvedValue({});
+    });
+
+    it('returns initial state with null analysis', () => {
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        expect(result.current.analysis).toBeNull();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(typeof result.current.analyze).toBe('function');
+        expect(typeof result.current.reset).toBe('function');
+    });
+
+    it('analyze sets loading to true and clears previous state', async () => {
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeAlertInput());
+        });
+
+        expect(mockSetLoading).toHaveBeenCalledWith(true);
+        expect(mockSetError).toHaveBeenCalledWith(null);
+        expect(mockSetAnalysis).toHaveBeenCalledWith(null);
+        expect(mockSetProgressMessage).toHaveBeenCalledWith('Gathering context...');
+        expect(mockSetActiveTools).toHaveBeenCalledWith([]);
+    });
+
+    it('analyze calls runAgenticLoop with correct parameters', async () => {
+        const { result } = renderHook(() => useAlertAnalysis());
+        const alert = makeAlertInput();
+
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+        expect(mockRunAgenticLoop).toHaveBeenCalledWith(
+            expect.objectContaining({
+                maxIterations: mockMaxIterations,
+                onActiveTools: mockSetActiveTools,
+                onProgress: mockSetProgressMessage,
+            }),
+        );
+
+        const callArgs = mockRunAgenticLoop.mock.calls[0][0];
+        expect(callArgs.messages).toHaveLength(1);
+        expect(callArgs.messages[0].role).toBe('user');
+        expect(callArgs.messages[0].content).toContain('High CPU Usage');
+        expect(callArgs.systemPrompt).toContain('PostgreSQL database expert');
+    });
+
+    it('analyze sets analysis result on success', async () => {
+        mockRunAgenticLoop.mockResolvedValueOnce('The alert analysis result.');
+
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeAlertInput());
+        });
+
+        expect(mockSetAnalysis).toHaveBeenCalledWith('The alert analysis result.');
+    });
+
+    it('analyze saves result to server when alert has id', async () => {
+        mockRunAgenticLoop.mockResolvedValueOnce('Analysis text');
+
+        const { result } = renderHook(() => useAlertAnalysis());
+        const alert = makeAlertInput({ id: 42, metricValue: 90 });
+
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        expect(mockApiPut).toHaveBeenCalledWith(
+            '/api/v1/alerts/analysis',
+            expect.objectContaining({
+                alert_id: 42,
+                analysis: 'Analysis text',
+                metric_value: 90,
+            }),
+        );
+    });
+
+    it('analyze does not save to server when alert has no id', async () => {
+        mockRunAgenticLoop.mockResolvedValueOnce('Analysis text');
+
+        const { result } = renderHook(() => useAlertAnalysis());
+        const alert = makeAlertInput({ id: undefined });
+
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        expect(mockApiPut).not.toHaveBeenCalled();
+    });
+
+    it('analyze sets error on runAgenticLoop failure', async () => {
+        mockRunAgenticLoop.mockRejectedValueOnce(new Error('LLM unavailable'));
+
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeAlertInput());
+        });
+
+        expect(mockSetError).toHaveBeenCalledWith('LLM unavailable');
+        expect(mockSetActiveTools).toHaveBeenCalledWith([]);
+    });
+
+    it('analyze sets loading to false in finally block', async () => {
+        mockRunAgenticLoop.mockResolvedValueOnce('Result');
+
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeAlertInput());
+        });
+
+        // setLoading(false) should be called at the end
+        expect(mockSetLoading).toHaveBeenLastCalledWith(false);
+    });
+
+    it('uses server-side cache when aiAnalysis is present and metric is close', async () => {
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        const alert = makeAlertInput({
+            aiAnalysis: 'Cached server analysis',
+            aiAnalysisMetricValue: 85,
+            metricValue: 86, // Within 10% of 85
+        });
+
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        // Should use cached analysis without calling runAgenticLoop
+        expect(mockRunAgenticLoop).not.toHaveBeenCalled();
+        expect(mockSetAnalysis).toHaveBeenCalledWith('Cached server analysis');
+        expect(mockSetLoading).toHaveBeenLastCalledWith(false);
+    });
+
+    it('does not use server cache when metric value differs by more than 10%', async () => {
+        mockRunAgenticLoop.mockResolvedValueOnce('Fresh analysis');
+
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        const alert = makeAlertInput({
+            aiAnalysis: 'Stale analysis',
+            aiAnalysisMetricValue: 50,
+            metricValue: 90, // More than 10% different from 50
+        });
+
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        // Should call runAgenticLoop because cached value is stale
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+        expect(mockSetAnalysis).toHaveBeenCalledWith('Fresh analysis');
+    });
+
+    it('uses client-side cache on second call with same alert id', async () => {
+        mockRunAgenticLoop.mockResolvedValueOnce('First analysis');
+
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        const alert = makeAlertInput({ id: 100, metricValue: 80 });
+
+        // First call
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+
+        // Second call with same alert and similar metric value
+        const alert2 = makeAlertInput({ id: 100, metricValue: 82 }); // Within 10%
+
+        await act(async () => {
+            await result.current.analyze(alert2);
+        });
+
+        // Should use cached analysis
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+        expect(mockSetAnalysis).toHaveBeenLastCalledWith('First analysis');
+    });
+
+    it('clearAlertAnalysisCache clears the client cache', async () => {
+        mockRunAgenticLoop.mockResolvedValue('Analysis');
+
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        const alert = makeAlertInput({ id: 200, metricValue: 50 });
+
+        // First call - should use runAgenticLoop
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+
+        // Clear cache
+        clearAlertAnalysisCache();
+
+        // Second call - should use runAgenticLoop again
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(2);
+    });
+
+    it('reset calls the reset function from useAnalysisState', () => {
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(mockReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes alert details in user message', async () => {
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        const alert = makeAlertInput({
+            alertType: 'anomaly',
+            severity: 'critical',
+            title: 'Memory pressure',
+            description: 'Unusual memory pattern',
+            metricName: 'memory_usage',
+            metricValue: 95,
+            operator: '>=',
+            thresholdValue: 90,
+            connectionId: 5,
+            triggeredAt: '2024-06-15T08:30:00Z',
+        });
+
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        const callArgs = mockRunAgenticLoop.mock.calls[0][0];
+        const userMessage = callArgs.messages[0].content;
+
+        expect(userMessage).toContain('Alert Type: anomaly');
+        expect(userMessage).toContain('Severity: critical');
+        expect(userMessage).toContain('Title: Memory pressure');
+        expect(userMessage).toContain('Description: Unusual memory pattern');
+        expect(userMessage).toContain('Metric: memory_usage');
+        expect(userMessage).toContain('Current Value: 95');
+        expect(userMessage).toContain('Threshold: >= 90');
+        expect(userMessage).toContain('Connection ID: 5');
+        expect(userMessage).toContain('Triggered At: 2024-06-15T08:30:00Z');
+    });
+
+    it('handles missing optional fields gracefully', async () => {
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        const alert: AlertInput = {
+            severity: 'warning',
+            title: 'Minimal alert',
+            connectionId: 1,
+        };
+
+        await act(async () => {
+            await result.current.analyze(alert);
+        });
+
+        const callArgs = mockRunAgenticLoop.mock.calls[0][0];
+        const userMessage = callArgs.messages[0].content;
+
+        expect(userMessage).toContain('Description: N/A');
+        expect(userMessage).toContain('Current Value: N/A');
+    });
+
+    it('fetches connection context', async () => {
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeAlertInput({ connectionId: 7 }));
+        });
+
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/7/context');
+    });
+
+    it('handles apiPut failure silently', async () => {
+        mockRunAgenticLoop.mockResolvedValueOnce('Analysis');
+        mockApiPut.mockRejectedValueOnce(new Error('Save failed'));
+
+        const { result } = renderHook(() => useAlertAnalysis());
+
+        // Should not throw
+        await act(async () => {
+            await result.current.analyze(makeAlertInput({ id: 1 }));
+        });
+
+        expect(mockSetAnalysis).toHaveBeenCalledWith('Analysis');
+        expect(mockSetError).not.toHaveBeenCalledWith('Save failed');
+    });
+});

--- a/client/src/hooks/__tests__/useAnalysisState.test.ts
+++ b/client/src/hooks/__tests__/useAnalysisState.test.ts
@@ -1,0 +1,231 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAnalysisState } from '../useAnalysisState';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAnalysisState', () => {
+    it('returns initial state with default progress message', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        expect(result.current.state.analysis).toBeNull();
+        expect(result.current.state.loading).toBe(false);
+        expect(result.current.state.error).toBeNull();
+        expect(result.current.state.progressMessage).toBe('Gathering context...');
+        expect(result.current.state.activeTools).toEqual([]);
+    });
+
+    it('returns initial state with custom progress message', () => {
+        const { result } = renderHook(() =>
+            useAnalysisState('Custom progress...')
+        );
+
+        expect(result.current.state.progressMessage).toBe('Custom progress...');
+    });
+
+    it('setAnalysis updates the analysis state', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        act(() => {
+            result.current.setAnalysis('Analysis complete');
+        });
+
+        expect(result.current.state.analysis).toBe('Analysis complete');
+    });
+
+    it('setAnalysis accepts null to clear analysis', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        act(() => {
+            result.current.setAnalysis('Some analysis');
+        });
+
+        expect(result.current.state.analysis).toBe('Some analysis');
+
+        act(() => {
+            result.current.setAnalysis(null);
+        });
+
+        expect(result.current.state.analysis).toBeNull();
+    });
+
+    it('setLoading updates the loading state', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        expect(result.current.state.loading).toBe(false);
+
+        act(() => {
+            result.current.setLoading(true);
+        });
+
+        expect(result.current.state.loading).toBe(true);
+
+        act(() => {
+            result.current.setLoading(false);
+        });
+
+        expect(result.current.state.loading).toBe(false);
+    });
+
+    it('setError updates the error state', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        act(() => {
+            result.current.setError('An error occurred');
+        });
+
+        expect(result.current.state.error).toBe('An error occurred');
+    });
+
+    it('setError accepts null to clear error', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        act(() => {
+            result.current.setError('Error message');
+        });
+
+        expect(result.current.state.error).toBe('Error message');
+
+        act(() => {
+            result.current.setError(null);
+        });
+
+        expect(result.current.state.error).toBeNull();
+    });
+
+    it('setProgressMessage updates the progress message', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        act(() => {
+            result.current.setProgressMessage('Processing...');
+        });
+
+        expect(result.current.state.progressMessage).toBe('Processing...');
+    });
+
+    it('setActiveTools updates the active tools array', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        act(() => {
+            result.current.setActiveTools(['tool1', 'tool2']);
+        });
+
+        expect(result.current.state.activeTools).toEqual(['tool1', 'tool2']);
+    });
+
+    it('setActiveTools can set an empty array', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        act(() => {
+            result.current.setActiveTools(['tool1']);
+        });
+
+        expect(result.current.state.activeTools).toEqual(['tool1']);
+
+        act(() => {
+            result.current.setActiveTools([]);
+        });
+
+        expect(result.current.state.activeTools).toEqual([]);
+    });
+
+    it('reset restores all state to initial values', () => {
+        const { result } = renderHook(() =>
+            useAnalysisState('Initial progress')
+        );
+
+        // Modify all state
+        act(() => {
+            result.current.setAnalysis('Some analysis');
+            result.current.setLoading(true);
+            result.current.setError('Some error');
+            result.current.setProgressMessage('Different progress');
+            result.current.setActiveTools(['tool1', 'tool2']);
+        });
+
+        // Verify all state is modified
+        expect(result.current.state.analysis).toBe('Some analysis');
+        expect(result.current.state.loading).toBe(true);
+        expect(result.current.state.error).toBe('Some error');
+        expect(result.current.state.progressMessage).toBe('Different progress');
+        expect(result.current.state.activeTools).toEqual(['tool1', 'tool2']);
+
+        // Reset
+        act(() => {
+            result.current.reset();
+        });
+
+        // Verify all state is reset
+        expect(result.current.state.analysis).toBeNull();
+        expect(result.current.state.loading).toBe(false);
+        expect(result.current.state.error).toBeNull();
+        expect(result.current.state.progressMessage).toBe('Initial progress');
+        expect(result.current.state.activeTools).toEqual([]);
+    });
+
+    it('reset uses the custom initial progress message', () => {
+        const { result } = renderHook(() =>
+            useAnalysisState('Custom initial message')
+        );
+
+        act(() => {
+            result.current.setProgressMessage('Changed message');
+        });
+
+        expect(result.current.state.progressMessage).toBe('Changed message');
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.state.progressMessage).toBe('Custom initial message');
+    });
+
+    it('multiple state updates can be batched', () => {
+        const { result } = renderHook(() => useAnalysisState());
+
+        act(() => {
+            result.current.setLoading(true);
+            result.current.setProgressMessage('Step 1');
+            result.current.setActiveTools(['tool1']);
+        });
+
+        expect(result.current.state.loading).toBe(true);
+        expect(result.current.state.progressMessage).toBe('Step 1');
+        expect(result.current.state.activeTools).toEqual(['tool1']);
+    });
+
+    it('returns stable function references', () => {
+        const { result, rerender } = renderHook(() => useAnalysisState());
+
+        const {
+            setAnalysis,
+            setLoading,
+            setError,
+            setProgressMessage,
+            setActiveTools,
+            reset,
+        } = result.current;
+
+        rerender();
+
+        expect(result.current.setAnalysis).toBe(setAnalysis);
+        expect(result.current.setLoading).toBe(setLoading);
+        expect(result.current.setError).toBe(setError);
+        expect(result.current.setProgressMessage).toBe(setProgressMessage);
+        expect(result.current.setActiveTools).toBe(setActiveTools);
+        expect(result.current.reset).toBe(reset);
+    });
+});

--- a/client/src/hooks/__tests__/useChartAnalysis.test.ts
+++ b/client/src/hooks/__tests__/useChartAnalysis.test.ts
@@ -1,0 +1,473 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+    useChartAnalysis,
+    clearChartAnalysisCache,
+    hasCachedAnalysis,
+    ChartAnalysisInput,
+} from '../useChartAnalysis';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSetAnalysis = vi.fn();
+const mockSetLoading = vi.fn();
+const mockSetError = vi.fn();
+const mockSetProgressMessage = vi.fn();
+const mockSetActiveTools = vi.fn();
+const mockReset = vi.fn();
+
+let mockAnalysis: string | null = null;
+let mockLoading = false;
+let mockError: string | null = null;
+
+vi.mock('../useAnalysisState', () => ({
+    useAnalysisState: () => ({
+        state: {
+            analysis: mockAnalysis,
+            loading: mockLoading,
+            error: mockError,
+            progressMessage: 'Preparing chart data...',
+            activeTools: [],
+        },
+        setAnalysis: mockSetAnalysis,
+        setLoading: mockSetLoading,
+        setError: mockSetError,
+        setProgressMessage: mockSetProgressMessage,
+        setActiveTools: mockSetActiveTools,
+        reset: mockReset,
+    }),
+}));
+
+const mockApiFetch = vi.fn();
+const mockApiGet = vi.fn();
+
+vi.mock('../../utils/apiClient', () => ({
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+}));
+
+vi.mock('../../utils/connectionContext', () => ({
+    formatConnectionContext: vi.fn().mockReturnValue('Connection context'),
+}));
+
+vi.mock('../../utils/timelineEvents', () => ({
+    fetchTimelineEventsForRange: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('../../utils/textHelpers', () => ({
+    stripPreamble: vi.fn((text: string) => text),
+    djb2Hash: vi.fn((str: string) => `hash_${str.substring(0, 10)}`),
+    ANALYSIS_CACHE_TTL_MS: 30 * 60 * 1000,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let testCounter = 0;
+
+function makeChartInput(overrides: Partial<ChartAnalysisInput> = {}): ChartAnalysisInput {
+    return {
+        metricDescription: `CPU Usage ${testCounter}`,
+        connectionId: 1,
+        connectionName: 'Production DB',
+        databaseName: 'testdb',
+        timeRange: '24h',
+        data: {
+            series: [
+                {
+                    name: 'cpu_usage',
+                    data: [10, 20, 30, 40, 50],
+                },
+            ],
+            categories: [
+                '2024-01-01T00:00:00Z',
+                '2024-01-01T06:00:00Z',
+                '2024-01-01T12:00:00Z',
+                '2024-01-01T18:00:00Z',
+                '2024-01-02T00:00:00Z',
+            ],
+        },
+        ...overrides,
+    };
+}
+
+function makeSuccessResponse(text: string = 'Chart analysis complete.') {
+    return {
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+        json: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text }],
+        }),
+    };
+}
+
+function makeErrorResponse(errorText: string = 'Internal Server Error') {
+    return {
+        ok: false,
+        text: vi.fn().mockResolvedValue(errorText),
+        json: vi.fn(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useChartAnalysis', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        testCounter++;
+        mockAnalysis = null;
+        mockLoading = false;
+        mockError = null;
+        clearChartAnalysisCache();
+        mockApiFetch.mockResolvedValue(makeSuccessResponse());
+        mockApiGet.mockResolvedValue({});
+    });
+
+    it('returns initial state with null analysis', () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        expect(result.current.analysis).toBeNull();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(typeof result.current.analyze).toBe('function');
+        expect(typeof result.current.reset).toBe('function');
+    });
+
+    it('analyze sets loading to true and clears previous state', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput());
+        });
+
+        expect(mockSetLoading).toHaveBeenCalledWith(true);
+        expect(mockSetError).toHaveBeenCalledWith(null);
+        expect(mockSetAnalysis).toHaveBeenCalledWith(null);
+        expect(mockSetProgressMessage).toHaveBeenCalledWith('Preparing chart data...');
+    });
+
+    it('analyze calls LLM API with correct parameters', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput());
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledWith(
+            '/api/v1/llm/chat',
+            expect.objectContaining({
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
+        const callArgs = mockApiFetch.mock.calls[0];
+        const body = JSON.parse(callArgs[1].body);
+
+        expect(body.system).toContain('PostgreSQL database expert');
+        expect(body.messages).toHaveLength(1);
+        expect(body.messages[0].role).toBe('user');
+    });
+
+    it('analyze includes chart data in user message', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput());
+        });
+
+        const body = JSON.parse(mockApiFetch.mock.calls[0][1].body);
+        const userMessage = body.messages[0].content;
+
+        expect(userMessage).toContain('CPU Usage');
+        expect(userMessage).toContain('Connection: Production DB');
+        expect(userMessage).toContain('Database: testdb');
+        expect(userMessage).toContain('Time Range: 24h');
+        expect(userMessage).toContain('Series "cpu_usage"');
+    });
+
+    it('analyze includes series statistics in user message', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        const input = makeChartInput({
+            data: {
+                series: [
+                    {
+                        name: 'test_metric',
+                        data: [10, 20, 30, 40, 50],
+                    },
+                ],
+            },
+        });
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        const body = JSON.parse(mockApiFetch.mock.calls[0][1].body);
+        const userMessage = body.messages[0].content;
+
+        expect(userMessage).toContain('Min: 10');
+        expect(userMessage).toContain('Max: 50');
+        expect(userMessage).toContain('Avg: 30.00');
+        expect(userMessage).toContain('Latest: 50');
+    });
+
+    it('analyze sets analysis result on success', async () => {
+        const analysisText = 'The chart shows normal patterns.';
+        mockApiFetch.mockResolvedValueOnce(makeSuccessResponse(analysisText));
+
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput());
+        });
+
+        expect(mockSetAnalysis).toHaveBeenCalledWith(analysisText);
+    });
+
+    it('analyze sets error on API failure', async () => {
+        mockApiFetch.mockResolvedValueOnce(makeErrorResponse('Service Unavailable'));
+
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput());
+        });
+
+        expect(mockSetError).toHaveBeenCalledWith(
+            expect.stringContaining('Service Unavailable'),
+        );
+    });
+
+    it('analyze sets error when apiFetch throws', async () => {
+        mockApiFetch.mockRejectedValueOnce(new Error('Network error'));
+
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput());
+        });
+
+        expect(mockSetError).toHaveBeenCalledWith('Network error');
+    });
+
+    it('analyze sets loading to false in finally block', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput());
+        });
+
+        expect(mockSetLoading).toHaveBeenLastCalledWith(false);
+    });
+
+    it('uses cache on second call with same parameters', async () => {
+        const analysisText = 'Cached result';
+        mockApiFetch.mockResolvedValue(makeSuccessResponse(analysisText));
+
+        const { result } = renderHook(() => useChartAnalysis());
+
+        const input = makeChartInput({ metricDescription: 'cached_metric' });
+
+        // First call
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+
+        // Second call with same input
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        // Should use cache, not call API again
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+        expect(mockSetAnalysis).toHaveBeenLastCalledWith(analysisText);
+    });
+
+    it('clearChartAnalysisCache clears the cache', async () => {
+        mockApiFetch.mockResolvedValue(makeSuccessResponse('Analysis'));
+
+        const { result } = renderHook(() => useChartAnalysis());
+
+        const input = makeChartInput({ metricDescription: 'clear_test' });
+
+        // First call
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+
+        // Clear cache
+        clearChartAnalysisCache();
+
+        // Second call should hit API again
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('hasCachedAnalysis returns true when cache exists', async () => {
+        mockApiFetch.mockResolvedValue(makeSuccessResponse());
+
+        const { result } = renderHook(() => useChartAnalysis());
+
+        const metricDescription = 'cache_check_metric';
+        const input = makeChartInput({
+            metricDescription,
+            connectionId: 99,
+            databaseName: 'checkdb',
+            timeRange: '1h',
+        });
+
+        // Before analysis - no cache
+        expect(hasCachedAnalysis(metricDescription, 99, 'checkdb', '1h')).toBe(false);
+
+        // Analyze
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        // After analysis - should have cache
+        expect(hasCachedAnalysis(metricDescription, 99, 'checkdb', '1h')).toBe(true);
+    });
+
+    it('reset calls the reset function from useAnalysisState', () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(mockReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles empty series gracefully', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        const input = makeChartInput({
+            data: {
+                series: [
+                    { name: 'empty_series', data: [] },
+                ],
+            },
+        });
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        const body = JSON.parse(mockApiFetch.mock.calls[0][1].body);
+        expect(body.messages[0].content).toContain('No data points');
+    });
+
+    it('fetches connection context when connectionId is provided', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput({ connectionId: 42 }));
+        });
+
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/42/context');
+    });
+
+    it('does not fetch connection context when connectionId is undefined', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput({ connectionId: undefined }));
+        });
+
+        expect(mockApiGet).not.toHaveBeenCalled();
+    });
+
+    it('updates progress messages during analysis', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput({ connectionId: 1 }));
+        });
+
+        // Should have progress messages
+        expect(mockSetProgressMessage).toHaveBeenCalledWith('Preparing chart data...');
+        expect(mockSetProgressMessage).toHaveBeenCalledWith('Analyzing data...');
+    });
+
+    it('sets activeTools during fetch phases', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeChartInput({ connectionId: 1 }));
+        });
+
+        expect(mockSetActiveTools).toHaveBeenCalledWith(['Preparing chart data']);
+        expect(mockSetActiveTools).toHaveBeenCalledWith([
+            'Fetching server context',
+            'Fetching timeline events',
+        ]);
+        expect(mockSetActiveTools).toHaveBeenCalledWith(['Analyzing data']);
+        expect(mockSetActiveTools).toHaveBeenCalledWith([]);
+    });
+
+    it('handles multiple series in chart data', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        const input = makeChartInput({
+            data: {
+                series: [
+                    { name: 'series1', data: [1, 2, 3] },
+                    { name: 'series2', data: [4, 5, 6] },
+                ],
+                categories: ['a', 'b', 'c'],
+            },
+        });
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        const body = JSON.parse(mockApiFetch.mock.calls[0][1].body);
+        const userMessage = body.messages[0].content;
+
+        expect(userMessage).toContain('Series "series1"');
+        expect(userMessage).toContain('Series "series2"');
+    });
+
+    it('handles missing optional fields in input', async () => {
+        const { result } = renderHook(() => useChartAnalysis());
+
+        const input: ChartAnalysisInput = {
+            metricDescription: 'Minimal metric',
+            data: {
+                series: [{ name: 'test', data: [1, 2, 3] }],
+            },
+        };
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+        // Should not throw and should call API
+    });
+});

--- a/client/src/hooks/__tests__/useChat.test.ts
+++ b/client/src/hooks/__tests__/useChat.test.ts
@@ -1,0 +1,700 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useChat } from '../useChat';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApiFetch = vi.fn();
+
+vi.mock('../../utils/apiClient', () => ({
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+const mockMaxIterations = 10;
+
+vi.mock('../../contexts/AICapabilitiesContext', () => ({
+    useAICapabilities: () => ({ maxIterations: mockMaxIterations }),
+}));
+
+// Mock localStorage
+const localStorageMock = (() => {
+    let store: Record<string, string> = {};
+    return {
+        getItem: vi.fn((key: string) => store[key] || null),
+        setItem: vi.fn((key: string, value: string) => {
+            store[key] = value;
+        }),
+        clear: vi.fn(() => {
+            store = {};
+        }),
+    };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+    value: localStorageMock,
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTextResponse(text: string = 'Hello!') {
+    return {
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+        json: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text }],
+            stop_reason: 'end_turn',
+        }),
+    };
+}
+
+function makeToolUseResponse(toolName: string = 'list_connections', toolId: string = 'tool_1') {
+    return {
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+        json: vi.fn().mockResolvedValue({
+            content: [
+                { type: 'tool_use', id: toolId, name: toolName, input: {} },
+            ],
+            stop_reason: 'tool_use',
+        }),
+    };
+}
+
+function makeToolCallResponse(text: string = 'Tool result', isError: boolean = false) {
+    return {
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+        json: vi.fn().mockResolvedValue({
+            content: [{ text }],
+            isError,
+        }),
+    };
+}
+
+function makeErrorResponse(errorText: string = 'Error occurred') {
+    return {
+        ok: false,
+        text: vi.fn().mockResolvedValue(errorText),
+        json: vi.fn(),
+    };
+}
+
+function makeToolsResponse() {
+    return {
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+        json: vi.fn().mockResolvedValue({
+            tools: [
+                {
+                    name: 'list_connections',
+                    description: 'List connections',
+                    inputSchema: { type: 'object', properties: {}, required: [] },
+                },
+            ],
+        }),
+    };
+}
+
+function makeConversationCreateResponse(id: string = 'conv-1') {
+    return {
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+        json: vi.fn().mockResolvedValue({
+            id,
+            title: 'New Conversation',
+        }),
+    };
+}
+
+function makeConversationLoadResponse() {
+    return {
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+        json: vi.fn().mockResolvedValue({
+            id: 'conv-1',
+            title: 'Loaded Conversation',
+            messages: [
+                { role: 'user', content: 'Previous message', timestamp: '2024-01-01T00:00:00Z' },
+                { role: 'assistant', content: 'Previous response', timestamp: '2024-01-01T00:01:00Z' },
+            ],
+        }),
+    };
+}
+
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useChat', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorageMock.clear();
+
+        // Default mock for tools fetch
+        mockApiFetch.mockImplementation((url: string) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('returns initial state', async () => {
+        const { result } = renderHook(() => useChat());
+
+        await waitFor(() => {
+            expect(result.current.messages).toEqual([]);
+        });
+
+        expect(result.current.activeTools).toEqual([]);
+        expect(result.current.currentConversationId).toBeNull();
+        expect(result.current.conversationId).toBeNull();
+        expect(result.current.conversationTitle).toBe('New Chat');
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(typeof result.current.sendMessage).toBe('function');
+        expect(typeof result.current.newChat).toBe('function');
+        expect(typeof result.current.loadConversation).toBe('function');
+        expect(typeof result.current.clearChat).toBe('function');
+    });
+
+    it('fetches available tools on mount', async () => {
+        renderHook(() => useChat());
+
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+        });
+    });
+
+    it('sendMessage does nothing for empty text', async () => {
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => {
+            await result.current.sendMessage('   ');
+        });
+
+        expect(result.current.messages).toEqual([]);
+        // Only the tools fetch should have been called
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('sendMessage adds user message and gets response', async () => {
+        mockApiFetch.mockImplementation((url: string, options?: RequestInit) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return Promise.resolve(makeTextResponse('Hello user!'));
+            }
+            if (url === '/api/v1/conversations' && options?.method === 'POST') {
+                return Promise.resolve(makeConversationCreateResponse());
+            }
+            if (url.startsWith('/api/v1/conversations/') && options?.method === 'PUT') {
+                return Promise.resolve({ ok: true, text: vi.fn(), json: vi.fn() });
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        // Wait for tools to load
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+        });
+
+        await act(async () => {
+            await result.current.sendMessage('Hello');
+        });
+
+        // Verify at least one message and assistant response is present
+        expect(result.current.messages.length).toBeGreaterThanOrEqual(1);
+
+        // Find the assistant message
+        const assistantMessage = result.current.messages.find(m => m.role === 'assistant');
+        expect(assistantMessage).toBeDefined();
+        expect(assistantMessage?.content).toBe('Hello user!');
+
+        // Verify LLM was called
+        const llmCalls = mockApiFetch.mock.calls.filter(
+            call => call[0] === '/api/v1/llm/chat'
+        );
+        expect(llmCalls.length).toBe(1);
+    });
+
+    it('sendMessage sets isLoading during API call', async () => {
+        let resolveChat: ((value: unknown) => void) | undefined;
+
+        mockApiFetch.mockImplementation((url: string) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return new Promise(resolve => {
+                    resolveChat = resolve;
+                });
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        let sendPromise: Promise<void>;
+        act(() => {
+            sendPromise = result.current.sendMessage('Test');
+        });
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(true);
+        });
+
+        await act(async () => {
+            resolveChat!(makeTextResponse());
+            await sendPromise;
+        });
+
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('sendMessage handles tool use response', async () => {
+        let callCount = 0;
+
+        mockApiFetch.mockImplementation((url: string, options?: RequestInit) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                callCount++;
+                if (callCount === 1) {
+                    return Promise.resolve(makeToolUseResponse('list_connections', 'tool_1'));
+                }
+                return Promise.resolve(makeTextResponse('Here are your connections.'));
+            }
+            if (url === '/api/v1/mcp/tools/call') {
+                return Promise.resolve(makeToolCallResponse('[{"id": 1, "name": "db1"}]'));
+            }
+            if (url === '/api/v1/conversations' && options?.method === 'POST') {
+                return Promise.resolve(makeConversationCreateResponse());
+            }
+            if (url.startsWith('/api/v1/conversations/') && options?.method === 'PUT') {
+                return Promise.resolve({ ok: true, text: vi.fn(), json: vi.fn() });
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        // Wait for tools to load
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+        });
+
+        await act(async () => {
+            await result.current.sendMessage('List my connections');
+        });
+
+        // LLM should be called twice: first returns tool_use, second returns text
+        const llmCalls = mockApiFetch.mock.calls.filter(
+            call => call[0] === '/api/v1/llm/chat'
+        );
+        expect(llmCalls.length).toBe(2);
+
+        // Tool should be called once
+        const toolCalls = mockApiFetch.mock.calls.filter(
+            call => call[0] === '/api/v1/mcp/tools/call'
+        );
+        expect(toolCalls.length).toBe(1);
+
+        // Verify we have messages (at least assistant message should be there)
+        expect(result.current.messages.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('sendMessage sets error on API failure', async () => {
+        mockApiFetch.mockImplementation((url: string) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return Promise.resolve(makeErrorResponse('Service unavailable'));
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => {
+            await result.current.sendMessage('Test');
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toContain('Service unavailable');
+        });
+
+        // Should add error message to conversation
+        expect(result.current.messages).toHaveLength(2);
+        expect(result.current.messages[1].isError).toBe(true);
+    });
+
+    it('sendMessage creates conversation on first response', async () => {
+        mockApiFetch.mockImplementation((url: string) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return Promise.resolve(makeTextResponse('Response'));
+            }
+            if (url === '/api/v1/conversations') {
+                return Promise.resolve(makeConversationCreateResponse('new-conv-123'));
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => {
+            await result.current.sendMessage('First message');
+        });
+
+        await waitFor(() => {
+            expect(result.current.currentConversationId).toBe('new-conv-123');
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledWith(
+            '/api/v1/conversations',
+            expect.objectContaining({ method: 'POST' }),
+        );
+    });
+
+    it('sendMessage updates existing conversation on subsequent messages', async () => {
+        mockApiFetch.mockImplementation((url: string, options?: { method?: string }) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return Promise.resolve(makeTextResponse('Response'));
+            }
+            if (url === '/api/v1/conversations' && options?.method === 'POST') {
+                return Promise.resolve(makeConversationCreateResponse('conv-xyz'));
+            }
+            if (url.startsWith('/api/v1/conversations/') && options?.method === 'PUT') {
+                return Promise.resolve({ ok: true, text: vi.fn(), json: vi.fn() });
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        // First message - creates conversation
+        await act(async () => {
+            await result.current.sendMessage('First');
+        });
+
+        await waitFor(() => {
+            expect(result.current.currentConversationId).toBe('conv-xyz');
+        });
+
+        // Second message - should update existing conversation
+        await act(async () => {
+            await result.current.sendMessage('Second');
+        });
+
+        const updateCalls = mockApiFetch.mock.calls.filter(
+            call => call[0] === '/api/v1/conversations/conv-xyz' && call[1]?.method === 'PUT'
+        );
+        expect(updateCalls.length).toBe(1);
+    });
+
+    it('sendMessage saves input to history', async () => {
+        mockApiFetch.mockImplementation((url: string) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return Promise.resolve(makeTextResponse());
+            }
+            if (url === '/api/v1/conversations') {
+                return Promise.resolve(makeConversationCreateResponse());
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => {
+            await result.current.sendMessage('First query');
+        });
+
+        await act(async () => {
+            await result.current.sendMessage('Second query');
+        });
+
+        expect(result.current.inputHistory).toContain('First query');
+        expect(result.current.inputHistory).toContain('Second query');
+        expect(localStorageMock.setItem).toHaveBeenCalled();
+    });
+
+    it('newChat clears all state', async () => {
+        mockApiFetch.mockImplementation((url: string, options?: RequestInit) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return Promise.resolve(makeTextResponse('Response'));
+            }
+            if (url === '/api/v1/conversations' && options?.method === 'POST') {
+                return Promise.resolve(makeConversationCreateResponse('conv-1'));
+            }
+            if (url.startsWith('/api/v1/conversations/') && options?.method === 'PUT') {
+                return Promise.resolve({ ok: true, text: vi.fn(), json: vi.fn() });
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        // Wait for tools to load
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+        });
+
+        // Send a message first
+        await act(async () => {
+            await result.current.sendMessage('Hello');
+        });
+
+        // Verify at least one message was added
+        expect(result.current.messages.length).toBeGreaterThanOrEqual(1);
+
+        // Clear chat
+        act(() => {
+            result.current.newChat();
+        });
+
+        expect(result.current.messages).toEqual([]);
+        expect(result.current.currentConversationId).toBeNull();
+        expect(result.current.conversationTitle).toBe('New Chat');
+        expect(result.current.error).toBeNull();
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('clearChat is an alias for newChat', () => {
+        const { result } = renderHook(() => useChat());
+
+        expect(result.current.clearChat).toBe(result.current.newChat);
+    });
+
+    it('loadConversation fetches and sets conversation data', async () => {
+        mockApiFetch.mockImplementation((url: string) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/conversations/conv-load') {
+                return Promise.resolve(makeConversationLoadResponse());
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => {
+            await result.current.loadConversation('conv-load');
+        });
+
+        await waitFor(() => {
+            expect(result.current.messages).toHaveLength(2);
+        });
+
+        expect(result.current.currentConversationId).toBe('conv-load');
+        expect(result.current.conversationTitle).toBe('Loaded Conversation');
+        expect(result.current.messages[0].content).toBe('Previous message');
+    });
+
+    it('loadConversation sets error on failure', async () => {
+        mockApiFetch.mockImplementation((url: string) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url.startsWith('/api/v1/conversations/')) {
+                return Promise.resolve(makeErrorResponse('Conversation not found'));
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => {
+            await result.current.loadConversation('invalid-id');
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toContain('Conversation not found');
+        });
+    });
+
+    it('loads input history from localStorage on mount', () => {
+        const savedHistory = ['previous query 1', 'previous query 2'];
+        localStorageMock.getItem.mockReturnValue(JSON.stringify(savedHistory));
+
+        const { result } = renderHook(() => useChat());
+
+        expect(result.current.inputHistory).toEqual(savedHistory);
+    });
+
+    it('handles corrupted localStorage gracefully', () => {
+        localStorageMock.getItem.mockReturnValue('not valid json');
+
+        const { result } = renderHook(() => useChat());
+
+        expect(result.current.inputHistory).toEqual([]);
+    });
+
+    it('handles tool execution error', async () => {
+        let callCount = 0;
+
+        mockApiFetch.mockImplementation((url: string, options?: RequestInit) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                callCount++;
+                if (callCount === 1) {
+                    return Promise.resolve(makeToolUseResponse());
+                }
+                return Promise.resolve(makeTextResponse('Done'));
+            }
+            if (url === '/api/v1/mcp/tools/call') {
+                return Promise.resolve(makeToolCallResponse('Tool error', true));
+            }
+            if (url === '/api/v1/conversations' && options?.method === 'POST') {
+                return Promise.resolve(makeConversationCreateResponse());
+            }
+            if (url.startsWith('/api/v1/conversations/') && options?.method === 'PUT') {
+                return Promise.resolve({ ok: true, text: vi.fn(), json: vi.fn() });
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        // Wait for tools to load
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+        });
+
+        await act(async () => {
+            await result.current.sendMessage('Run tool');
+        });
+
+        // Verify at least one message (assistant response)
+        expect(result.current.messages.length).toBeGreaterThanOrEqual(1);
+
+        // Should have called LLM twice (first for tool_use, second for final response)
+        const llmCalls = mockApiFetch.mock.calls.filter(
+            call => call[0] === '/api/v1/llm/chat'
+        );
+        expect(llmCalls.length).toBe(2);
+    });
+
+    it('limits iterations to maxIterations', async () => {
+        // Always return tool_use to force max iterations
+        let toolCallCount = 0;
+
+        mockApiFetch.mockImplementation((url: string, options?: RequestInit) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return Promise.resolve(makeToolUseResponse('list_connections', `tool_${toolCallCount++}`));
+            }
+            if (url === '/api/v1/mcp/tools/call') {
+                return Promise.resolve(makeToolCallResponse('Result'));
+            }
+            if (url === '/api/v1/conversations' && options?.method === 'POST') {
+                return Promise.resolve(makeConversationCreateResponse());
+            }
+            if (url.startsWith('/api/v1/conversations/') && options?.method === 'PUT') {
+                return Promise.resolve({ ok: true, text: vi.fn(), json: vi.fn() });
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        // Wait for tools to load
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+        });
+
+        await act(async () => {
+            await result.current.sendMessage('Loop forever');
+        });
+
+        // Should have at least 1 message (the error message about exceeding iterations)
+        expect(result.current.messages.length).toBeGreaterThanOrEqual(1);
+
+        // The last message should be an error about exceeding iterations
+        const lastMessage = result.current.messages[result.current.messages.length - 1];
+        expect(lastMessage.content).toContain('unable to complete');
+        expect(lastMessage.isError).toBe(true);
+
+        // LLM should have been called maxIterations times
+        const llmCalls = mockApiFetch.mock.calls.filter(
+            call => call[0] === '/api/v1/llm/chat'
+        );
+        expect(llmCalls.length).toBe(mockMaxIterations);
+    });
+
+    it('deduplicates input history entries', async () => {
+        mockApiFetch.mockImplementation((url: string) => {
+            if (url === '/api/v1/mcp/tools') {
+                return Promise.resolve(makeToolsResponse());
+            }
+            if (url === '/api/v1/llm/chat') {
+                return Promise.resolve(makeTextResponse());
+            }
+            if (url === '/api/v1/conversations') {
+                return Promise.resolve(makeConversationCreateResponse());
+            }
+            return Promise.resolve(makeTextResponse());
+        });
+
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => {
+            await result.current.sendMessage('duplicate');
+        });
+
+        await act(async () => {
+            await result.current.sendMessage('different');
+        });
+
+        await act(async () => {
+            await result.current.sendMessage('duplicate');
+        });
+
+        // 'duplicate' should only appear once (most recent)
+        const duplicateCount = result.current.inputHistory.filter(
+            h => h === 'duplicate'
+        ).length;
+        expect(duplicateCount).toBe(1);
+        expect(result.current.inputHistory[0]).toBe('duplicate'); // Most recent first
+    });
+});

--- a/client/src/hooks/__tests__/useMenu.test.ts
+++ b/client/src/hooks/__tests__/useMenu.test.ts
@@ -1,0 +1,121 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMenu } from '../useMenu';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useMenu', () => {
+    it('returns initial state with anchorEl as null and open as false', () => {
+        const { result } = renderHook(() => useMenu());
+
+        expect(result.current.anchorEl).toBeNull();
+        expect(result.current.open).toBe(false);
+        expect(typeof result.current.handleOpen).toBe('function');
+        expect(typeof result.current.handleClose).toBe('function');
+    });
+
+    it('sets anchorEl and opens menu when handleOpen is called', () => {
+        const { result } = renderHook(() => useMenu());
+
+        const mockElement = document.createElement('button');
+        const mockEvent = {
+            currentTarget: mockElement,
+        } as React.MouseEvent<HTMLElement>;
+
+        act(() => {
+            result.current.handleOpen(mockEvent);
+        });
+
+        expect(result.current.anchorEl).toBe(mockElement);
+        expect(result.current.open).toBe(true);
+    });
+
+    it('clears anchorEl and closes menu when handleClose is called', () => {
+        const { result } = renderHook(() => useMenu());
+
+        const mockElement = document.createElement('button');
+        const mockEvent = {
+            currentTarget: mockElement,
+        } as React.MouseEvent<HTMLElement>;
+
+        act(() => {
+            result.current.handleOpen(mockEvent);
+        });
+
+        expect(result.current.open).toBe(true);
+
+        act(() => {
+            result.current.handleClose();
+        });
+
+        expect(result.current.anchorEl).toBeNull();
+        expect(result.current.open).toBe(false);
+    });
+
+    it('handles multiple open/close cycles correctly', () => {
+        const { result } = renderHook(() => useMenu());
+
+        const mockElement1 = document.createElement('button');
+        const mockElement2 = document.createElement('div');
+
+        // First open
+        act(() => {
+            result.current.handleOpen({
+                currentTarget: mockElement1,
+            } as React.MouseEvent<HTMLElement>);
+        });
+        expect(result.current.anchorEl).toBe(mockElement1);
+        expect(result.current.open).toBe(true);
+
+        // Close
+        act(() => {
+            result.current.handleClose();
+        });
+        expect(result.current.open).toBe(false);
+
+        // Second open with different element
+        act(() => {
+            result.current.handleOpen({
+                currentTarget: mockElement2,
+            } as React.MouseEvent<HTMLElement>);
+        });
+        expect(result.current.anchorEl).toBe(mockElement2);
+        expect(result.current.open).toBe(true);
+    });
+
+    it('can change anchorEl by calling handleOpen again', () => {
+        const { result } = renderHook(() => useMenu());
+
+        const mockElement1 = document.createElement('button');
+        const mockElement2 = document.createElement('span');
+
+        act(() => {
+            result.current.handleOpen({
+                currentTarget: mockElement1,
+            } as React.MouseEvent<HTMLElement>);
+        });
+
+        expect(result.current.anchorEl).toBe(mockElement1);
+
+        act(() => {
+            result.current.handleOpen({
+                currentTarget: mockElement2,
+            } as React.MouseEvent<HTMLElement>);
+        });
+
+        expect(result.current.anchorEl).toBe(mockElement2);
+        expect(result.current.open).toBe(true);
+    });
+});

--- a/client/src/hooks/__tests__/useMetrics.test.ts
+++ b/client/src/hooks/__tests__/useMetrics.test.ts
@@ -1,0 +1,432 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useMetrics, useBaselines } from '../useMetrics';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApiGet = vi.fn();
+
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+}));
+
+const mockUser = { id: 1, username: 'testuser' };
+let mockRefreshTrigger = 0;
+
+vi.mock('../../contexts/AuthContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+
+vi.mock('../../contexts/DashboardContext', () => ({
+    useDashboard: () => ({ refreshTrigger: mockRefreshTrigger }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMetricSeries() {
+    return [
+        {
+            name: 'cpu_usage',
+            data: [10, 20, 30, 40, 50],
+            timestamps: ['2024-01-01T00:00:00Z', '2024-01-01T01:00:00Z'],
+        },
+    ];
+}
+
+function makeBaselines() {
+    return [
+        {
+            metric_name: 'cpu_usage',
+            mean: 30.5,
+            stddev: 10.2,
+            p50: 30,
+            p95: 48,
+            p99: 50,
+        },
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests - useMetrics
+// ---------------------------------------------------------------------------
+
+describe('useMetrics', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRefreshTrigger = 0;
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('returns initial state when params is null', () => {
+        const { result } = renderHook(() => useMetrics(null));
+
+        expect(result.current.data).toBeNull();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(typeof result.current.refetch).toBe('function');
+    });
+
+    it('fetches data when params are provided', async () => {
+        mockApiGet.mockResolvedValueOnce(makeMetricSeries());
+
+        const params = {
+            probeName: 'pg_stat_activity',
+            timeRange: '24h',
+            connectionId: 1,
+        };
+
+        const { result } = renderHook(() => useMetrics(params));
+
+        await waitFor(() => {
+            expect(result.current.data).not.toBeNull();
+        });
+
+        expect(mockApiGet).toHaveBeenCalledTimes(1);
+        expect(mockApiGet).toHaveBeenCalledWith(
+            expect.stringContaining('/api/v1/metrics/query?'),
+        );
+        expect(result.current.data).toEqual(makeMetricSeries());
+    });
+
+    it('builds URL with all parameters', async () => {
+        mockApiGet.mockResolvedValueOnce(makeMetricSeries());
+
+        const params = {
+            probeName: 'pg_stat_user_tables',
+            timeRange: '7d',
+            connectionId: 5,
+            databaseName: 'mydb',
+            schemaName: 'public',
+            tableName: 'users',
+            buckets: 60,
+            aggregation: 'avg',
+            metrics: ['seq_scan', 'idx_scan'],
+        };
+
+        renderHook(() => useMetrics(params));
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).toContain('probe_name=pg_stat_user_tables');
+        expect(url).toContain('time_range=7d');
+        expect(url).toContain('connection_id=5');
+        expect(url).toContain('database_name=mydb');
+        expect(url).toContain('schema_name=public');
+        expect(url).toContain('table_name=users');
+        expect(url).toContain('buckets=60');
+        expect(url).toContain('aggregation=avg');
+        expect(url).toContain('metrics=seq_scan%2Cidx_scan');
+    });
+
+    it('builds URL with connection_ids array', async () => {
+        mockApiGet.mockResolvedValueOnce(makeMetricSeries());
+
+        const params = {
+            probeName: 'pg_stat_activity',
+            timeRange: '24h',
+            connectionIds: [1, 2, 3],
+        };
+
+        renderHook(() => useMetrics(params));
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).toContain('connection_ids=1%2C2%2C3');
+    });
+
+    it('sets loading to true during initial fetch', async () => {
+        let resolvePromise: (value: unknown) => void;
+        mockApiGet.mockImplementationOnce(() =>
+            new Promise(resolve => {
+                resolvePromise = resolve;
+            }),
+        );
+
+        const params = {
+            probeName: 'pg_stat_activity',
+            timeRange: '24h',
+        };
+
+        const { result } = renderHook(() => useMetrics(params));
+
+        expect(result.current.loading).toBe(true);
+
+        await act(async () => {
+            resolvePromise!(makeMetricSeries());
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+    });
+
+    it('sets error on API failure', async () => {
+        mockApiGet.mockRejectedValueOnce(new Error('Network error'));
+
+        const params = {
+            probeName: 'pg_stat_activity',
+            timeRange: '24h',
+        };
+
+        const { result } = renderHook(() => useMetrics(params));
+
+        await waitFor(() => {
+            expect(result.current.error).toBe('Network error');
+        });
+
+        expect(result.current.data).toBeNull();
+        expect(result.current.loading).toBe(false);
+    });
+
+    it('refetch triggers a new API call', async () => {
+        mockApiGet.mockResolvedValue(makeMetricSeries());
+
+        const params = {
+            probeName: 'pg_stat_activity',
+            timeRange: '24h',
+        };
+
+        const { result } = renderHook(() => useMetrics(params));
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+        });
+
+        await act(async () => {
+            result.current.refetch();
+        });
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it('refetches when params change', async () => {
+        mockApiGet.mockResolvedValue(makeMetricSeries());
+
+        const { rerender } = renderHook(
+            ({ params }) => useMetrics(params),
+            {
+                initialProps: {
+                    params: {
+                        probeName: 'probe1',
+                        timeRange: '24h',
+                    },
+                },
+            },
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+        });
+
+        rerender({
+            params: {
+                probeName: 'probe2',
+                timeRange: '24h',
+            },
+        });
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it('does not flash loading on auto-refresh after initial load', async () => {
+        mockApiGet.mockResolvedValue(makeMetricSeries());
+
+        const params = {
+            probeName: 'pg_stat_activity',
+            timeRange: '24h',
+        };
+
+        const { result, rerender } = renderHook(() => useMetrics(params));
+
+        // Wait for initial load
+        await waitFor(() => {
+            expect(result.current.data).not.toBeNull();
+        });
+
+        expect(result.current.loading).toBe(false);
+
+        // Simulate refetch (after initial load)
+        await act(async () => {
+            result.current.refetch();
+        });
+
+        // Loading should not flash to true after initial load
+        // (due to initialLoadDoneRef pattern)
+        rerender();
+        expect(result.current.loading).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests - useBaselines
+// ---------------------------------------------------------------------------
+
+describe('useBaselines', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns initial state when probeName is null', () => {
+        const { result } = renderHook(() =>
+            useBaselines(null, 1),
+        );
+
+        expect(result.current.baselines).toBeNull();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('returns initial state when connectionId is null', () => {
+        const { result } = renderHook(() =>
+            useBaselines('pg_stat_activity', null),
+        );
+
+        expect(result.current.baselines).toBeNull();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('fetches baselines when probeName and connectionId are provided', async () => {
+        mockApiGet.mockResolvedValueOnce(makeBaselines());
+
+        const { result } = renderHook(() =>
+            useBaselines('pg_stat_activity', 1),
+        );
+
+        await waitFor(() => {
+            expect(result.current.baselines).not.toBeNull();
+        });
+
+        expect(mockApiGet).toHaveBeenCalledTimes(1);
+        expect(mockApiGet).toHaveBeenCalledWith(
+            expect.stringContaining('/api/v1/metrics/baselines?'),
+        );
+        expect(result.current.baselines).toEqual(makeBaselines());
+    });
+
+    it('builds URL with metrics parameter', async () => {
+        mockApiGet.mockResolvedValueOnce(makeBaselines());
+
+        renderHook(() =>
+            useBaselines('pg_stat_activity', 1, ['cpu_usage', 'memory']),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).toContain('probe_name=pg_stat_activity');
+        expect(url).toContain('connection_id=1');
+        expect(url).toContain('metrics=cpu_usage%2Cmemory');
+    });
+
+    it('sets loading to true during fetch', async () => {
+        let resolvePromise: (value: unknown) => void;
+        mockApiGet.mockImplementationOnce(() =>
+            new Promise(resolve => {
+                resolvePromise = resolve;
+            }),
+        );
+
+        const { result } = renderHook(() =>
+            useBaselines('pg_stat_activity', 1),
+        );
+
+        expect(result.current.loading).toBe(true);
+
+        await act(async () => {
+            resolvePromise!(makeBaselines());
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+    });
+
+    it('sets error on API failure', async () => {
+        mockApiGet.mockRejectedValueOnce(new Error('Baseline fetch failed'));
+
+        const { result } = renderHook(() =>
+            useBaselines('pg_stat_activity', 1),
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).toBe('Baseline fetch failed');
+        });
+
+        expect(result.current.baselines).toBeNull();
+        expect(result.current.loading).toBe(false);
+    });
+
+    it('refetches when connectionId changes', async () => {
+        mockApiGet.mockResolvedValue(makeBaselines());
+
+        const { rerender } = renderHook(
+            ({ connectionId }) => useBaselines('pg_stat_activity', connectionId),
+            { initialProps: { connectionId: 1 } },
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+        });
+
+        rerender({ connectionId: 2 });
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+
+        const url = mockApiGet.mock.calls[1][0];
+        expect(url).toContain('connection_id=2');
+    });
+
+    it('refetches when probeName changes', async () => {
+        mockApiGet.mockResolvedValue(makeBaselines());
+
+        const { rerender } = renderHook(
+            ({ probeName }) => useBaselines(probeName, 1),
+            { initialProps: { probeName: 'probe1' } },
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+        });
+
+        rerender({ probeName: 'probe2' });
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+
+        const url = mockApiGet.mock.calls[1][0];
+        expect(url).toContain('probe_name=probe2');
+    });
+});

--- a/client/src/hooks/__tests__/useServerAnalysis.test.ts
+++ b/client/src/hooks/__tests__/useServerAnalysis.test.ts
@@ -1,0 +1,472 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+    useServerAnalysis,
+    clearAnalysisCache,
+    hasCachedServerAnalysis,
+    ServerAnalysisInput,
+} from '../useServerAnalysis';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSetAnalysis = vi.fn();
+const mockSetLoading = vi.fn();
+const mockSetError = vi.fn();
+const mockSetProgressMessage = vi.fn();
+const mockSetActiveTools = vi.fn();
+const mockReset = vi.fn();
+
+let mockAnalysis: string | null = null;
+let mockLoading = false;
+let mockError: string | null = null;
+
+vi.mock('../useAnalysisState', () => ({
+    useAnalysisState: () => ({
+        state: {
+            analysis: mockAnalysis,
+            loading: mockLoading,
+            error: mockError,
+            progressMessage: 'Gathering context...',
+            activeTools: [],
+        },
+        setAnalysis: mockSetAnalysis,
+        setLoading: mockSetLoading,
+        setError: mockSetError,
+        setProgressMessage: mockSetProgressMessage,
+        setActiveTools: mockSetActiveTools,
+        reset: mockReset,
+    }),
+}));
+
+const mockMaxIterations = 10;
+
+vi.mock('../../contexts/AICapabilitiesContext', () => ({
+    useAICapabilities: () => ({ maxIterations: mockMaxIterations }),
+}));
+
+const mockApiGet = vi.fn();
+
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+}));
+
+vi.mock('../../utils/connectionContext', () => ({
+    formatConnectionContext: vi.fn().mockReturnValue('Connection context'),
+}));
+
+vi.mock('../../utils/mcpTools', () => ({
+    getKnowledgebaseTool: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../utils/analysisTools', () => ({
+    SERVER_ANALYSIS_TOOLS: [],
+}));
+
+const mockRunAgenticLoop = vi.fn();
+
+vi.mock('../../utils/agenticLoop', () => ({
+    runAgenticLoop: (...args: unknown[]) => mockRunAgenticLoop(...args),
+}));
+
+vi.mock('../../utils/timelineEvents', () => ({
+    fetchTimelineEventsCentered: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('../../utils/textHelpers', () => ({
+    ANALYSIS_CACHE_TTL_MS: 30 * 60 * 1000,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let testCounter = 0;
+
+function makeServerInput(overrides: Partial<ServerAnalysisInput> = {}): ServerAnalysisInput {
+    return {
+        type: 'server',
+        id: testCounter,
+        name: `Test Server ${testCounter}`,
+        ...overrides,
+    };
+}
+
+function makeClusterInput(overrides: Partial<ServerAnalysisInput> = {}): ServerAnalysisInput {
+    return {
+        type: 'cluster',
+        id: `cluster-${testCounter}`,
+        name: `Test Cluster ${testCounter}`,
+        servers: [
+            { id: 1, name: 'Primary' },
+            { id: 2, name: 'Replica' },
+        ],
+        serverIds: [1, 2],
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useServerAnalysis', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        testCounter++;
+        mockAnalysis = null;
+        mockLoading = false;
+        mockError = null;
+        clearAnalysisCache();
+        mockRunAgenticLoop.mockResolvedValue('Server analysis complete.');
+        mockApiGet.mockResolvedValue({});
+    });
+
+    it('returns initial state with null analysis', () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        expect(result.current.analysis).toBeNull();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(typeof result.current.analyze).toBe('function');
+        expect(typeof result.current.reset).toBe('function');
+    });
+
+    it('analyze sets loading to true and clears previous state', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput());
+        });
+
+        expect(mockSetLoading).toHaveBeenCalledWith(true);
+        expect(mockSetError).toHaveBeenCalledWith(null);
+        expect(mockSetAnalysis).toHaveBeenCalledWith(null);
+        expect(mockSetProgressMessage).toHaveBeenCalledWith('Gathering context...');
+        expect(mockSetActiveTools).toHaveBeenCalledWith([]);
+    });
+
+    it('analyze calls runAgenticLoop with correct parameters for server', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        const input = makeServerInput({ id: 42, name: 'Production Server' });
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+        expect(mockRunAgenticLoop).toHaveBeenCalledWith(
+            expect.objectContaining({
+                maxIterations: mockMaxIterations,
+                onActiveTools: mockSetActiveTools,
+                onProgress: mockSetProgressMessage,
+            }),
+        );
+
+        const callArgs = mockRunAgenticLoop.mock.calls[0][0];
+        expect(callArgs.messages).toHaveLength(1);
+        expect(callArgs.messages[0].role).toBe('user');
+        expect(callArgs.messages[0].content).toContain('Production Server');
+        expect(callArgs.messages[0].content).toContain('Connection ID: 42');
+        expect(callArgs.systemPrompt).toContain('PostgreSQL database expert');
+    });
+
+    it('analyze includes cluster addendum in system prompt for clusters', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeClusterInput());
+        });
+
+        const callArgs = mockRunAgenticLoop.mock.calls[0][0];
+        expect(callArgs.systemPrompt).toContain('CLUSTER analysis');
+        expect(callArgs.systemPrompt).toContain('connection_id');
+    });
+
+    it('analyze sets analysis result on success', async () => {
+        mockRunAgenticLoop.mockResolvedValueOnce('The server is healthy.');
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput());
+        });
+
+        expect(mockSetAnalysis).toHaveBeenCalledWith('The server is healthy.');
+    });
+
+    it('analyze sets error on runAgenticLoop failure', async () => {
+        mockRunAgenticLoop.mockRejectedValueOnce(new Error('Analysis failed'));
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput());
+        });
+
+        expect(mockSetError).toHaveBeenCalledWith('Analysis failed');
+        expect(mockSetActiveTools).toHaveBeenCalledWith([]);
+    });
+
+    it('analyze sets loading to false in finally block', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput());
+        });
+
+        expect(mockSetLoading).toHaveBeenLastCalledWith(false);
+    });
+
+    it('uses cache on second call with same server id', async () => {
+        mockRunAgenticLoop.mockResolvedValue('Cached analysis');
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        const input = makeServerInput({ type: 'server', id: 100, name: 'Cache Test' });
+
+        // First call
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+
+        // Second call with same input
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        // Should use cache
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+        expect(mockSetAnalysis).toHaveBeenLastCalledWith('Cached analysis');
+    });
+
+    it('clearAnalysisCache clears the cache', async () => {
+        mockRunAgenticLoop.mockResolvedValue('Analysis');
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        const input = makeServerInput({ id: 200 });
+
+        // First call
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+
+        // Clear cache
+        clearAnalysisCache();
+
+        // Second call should hit runAgenticLoop again
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(2);
+    });
+
+    it('hasCachedServerAnalysis returns true when cache exists', async () => {
+        mockRunAgenticLoop.mockResolvedValue('Analysis');
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        // Before analysis - no cache
+        expect(hasCachedServerAnalysis('server', 300)).toBe(false);
+
+        // Analyze
+        await act(async () => {
+            await result.current.analyze(makeServerInput({ type: 'server', id: 300 }));
+        });
+
+        // After analysis - should have cache
+        expect(hasCachedServerAnalysis('server', 300)).toBe(true);
+    });
+
+    it('hasCachedServerAnalysis returns false for different id', async () => {
+        mockRunAgenticLoop.mockResolvedValue('Analysis');
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput({ type: 'server', id: 400 }));
+        });
+
+        expect(hasCachedServerAnalysis('server', 400)).toBe(true);
+        expect(hasCachedServerAnalysis('server', 401)).toBe(false);
+    });
+
+    it('hasCachedServerAnalysis returns false for different type', async () => {
+        mockRunAgenticLoop.mockResolvedValue('Analysis');
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput({ type: 'server', id: 500 }));
+        });
+
+        expect(hasCachedServerAnalysis('server', 500)).toBe(true);
+        expect(hasCachedServerAnalysis('cluster', 500)).toBe(false);
+    });
+
+    it('reset calls the reset function from useAnalysisState', () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(mockReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches connection context for server analysis', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput({ id: 55 }));
+        });
+
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/55/context');
+    });
+
+    it('fetches connection context for all servers in cluster', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        const input = makeClusterInput({
+            servers: [
+                { id: 10, name: 'Server A' },
+                { id: 20, name: 'Server B' },
+                { id: 30, name: 'Server C' },
+            ],
+            serverIds: [10, 20, 30],
+        });
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/10/context');
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/20/context');
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/30/context');
+    });
+
+    it('includes server list in cluster analysis user message', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        const input = makeClusterInput({
+            name: 'Production Cluster',
+            servers: [
+                { id: 1, name: 'Primary' },
+                { id: 2, name: 'Replica' },
+            ],
+        });
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        const callArgs = mockRunAgenticLoop.mock.calls[0][0];
+        const userMessage = callArgs.messages[0].content;
+
+        expect(userMessage).toContain('Cluster Name: Production Cluster');
+        expect(userMessage).toContain('Primary (connection_id: 1)');
+        expect(userMessage).toContain('Replica (connection_id: 2)');
+    });
+
+    it('handles empty servers array for cluster', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        const input = makeClusterInput({
+            servers: [],
+            serverIds: [],
+        });
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        // Should not throw and should call runAgenticLoop
+        expect(mockRunAgenticLoop).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles serverIds without servers array', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        const input: ServerAnalysisInput = {
+            type: 'cluster',
+            id: 'cluster-test',
+            name: 'Test Cluster',
+            serverIds: [1, 2],
+        };
+
+        await act(async () => {
+            await result.current.analyze(input);
+        });
+
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/1/context');
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/connections/2/context');
+    });
+
+    it('updates progress message before starting analysis', async () => {
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput());
+        });
+
+        expect(mockSetProgressMessage).toHaveBeenCalledWith('Gathering context...');
+        expect(mockSetProgressMessage).toHaveBeenCalledWith('Starting analysis...');
+    });
+
+    it('handles apiGet failure gracefully', async () => {
+        mockApiGet.mockRejectedValue(new Error('Context fetch failed'));
+        mockRunAgenticLoop.mockResolvedValue('Analysis without context');
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        await act(async () => {
+            await result.current.analyze(makeServerInput());
+        });
+
+        // Should still complete analysis even if context fetch fails
+        expect(mockSetAnalysis).toHaveBeenCalledWith('Analysis without context');
+        // setError(null) is called during initialization, but no error message should be set
+        const errorCalls = mockSetError.mock.calls.filter(call => call[0] !== null);
+        expect(errorCalls).toHaveLength(0);
+    });
+
+    it('caches server and cluster analyses separately', async () => {
+        mockRunAgenticLoop.mockResolvedValue('Analysis');
+
+        const { result } = renderHook(() => useServerAnalysis());
+
+        // Analyze as server
+        await act(async () => {
+            await result.current.analyze(makeServerInput({ type: 'server', id: 1 }));
+        });
+
+        expect(hasCachedServerAnalysis('server', 1)).toBe(true);
+        expect(hasCachedServerAnalysis('cluster', 1)).toBe(false);
+
+        // Analyze as cluster with same id
+        await act(async () => {
+            await result.current.analyze(makeClusterInput({ type: 'cluster', id: 1 }));
+        });
+
+        expect(hasCachedServerAnalysis('server', 1)).toBe(true);
+        expect(hasCachedServerAnalysis('cluster', 1)).toBe(true);
+    });
+});

--- a/client/src/hooks/__tests__/useTimelineEvents.test.ts
+++ b/client/src/hooks/__tests__/useTimelineEvents.test.ts
@@ -1,0 +1,415 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useTimelineEvents, TimelineEvent, TimeRangePreset } from '../useTimelineEvents';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApiGet = vi.fn();
+
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+}));
+
+const mockUser = { id: 1, username: 'testuser' };
+
+vi.mock('../../contexts/AuthContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+
+let mockLastRefresh = 0;
+
+vi.mock('../../contexts/ClusterDataContext', () => ({
+    useClusterData: () => ({ lastRefresh: mockLastRefresh }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTimelineEvents(): TimelineEvent[] {
+    return [
+        {
+            id: 1,
+            event_type: 'alert',
+            connection_id: 1,
+            title: 'High CPU alert',
+            description: 'CPU usage exceeded 90%',
+            severity: 'warning',
+            timestamp: '2024-01-01T12:00:00Z',
+        },
+        {
+            id: 2,
+            event_type: 'restart',
+            connection_id: 1,
+            title: 'Server restart',
+            timestamp: '2024-01-01T11:00:00Z',
+        },
+    ];
+}
+
+function makeApiResponse(events: TimelineEvent[] = makeTimelineEvents()) {
+    return {
+        events,
+        total_count: events.length,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useTimelineEvents', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLastRefresh = 0;
+    });
+
+    it('returns initial state with default options', () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        const { result } = renderHook(() => useTimelineEvents());
+
+        expect(result.current.events).toEqual([]);
+        expect(result.current.totalCount).toBe(0);
+        expect(typeof result.current.refetch).toBe('function');
+    });
+
+    it('does not fetch when enabled is false', async () => {
+        const { result } = renderHook(() =>
+            useTimelineEvents({ enabled: false }),
+        );
+
+        // Wait a tick for any potential async operations
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 10));
+        });
+
+        expect(mockApiGet).not.toHaveBeenCalled();
+        expect(result.current.events).toEqual([]);
+    });
+
+    it('fetches events when enabled with default options', async () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        const { result } = renderHook(() =>
+            useTimelineEvents({ enabled: true }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.events).toHaveLength(2);
+        });
+
+        expect(mockApiGet).toHaveBeenCalledTimes(1);
+        expect(mockApiGet).toHaveBeenCalledWith(
+            expect.stringContaining('/api/v1/timeline/events?'),
+        );
+        expect(result.current.totalCount).toBe(2);
+    });
+
+    it('includes connectionId in query string', async () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        renderHook(() =>
+            useTimelineEvents({ connectionId: 5 }),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).toContain('connection_id=5');
+    });
+
+    it('includes connectionIds array in query string', async () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        renderHook(() =>
+            useTimelineEvents({ connectionIds: [1, 2, 3] }),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).toContain('connection_ids=1%2C2%2C3');
+    });
+
+    it('includes event types in query string when not "all"', async () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        renderHook(() =>
+            useTimelineEvents({ eventTypes: ['alert', 'restart'] }),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).toContain('event_types=alert%2Crestart');
+    });
+
+    it('does not include event_types when "all" is selected', async () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        renderHook(() =>
+            useTimelineEvents({ eventTypes: ['all'] }),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).not.toContain('event_types');
+    });
+
+    it('calculates time range correctly for preset values', async () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        renderHook(() =>
+            useTimelineEvents({ timeRange: '24h' }),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        const urlParams = new URLSearchParams(url.split('?')[1]);
+        const startTime = new Date(urlParams.get('start_time')!).getTime();
+        const endTime = new Date(urlParams.get('end_time')!).getTime();
+
+        // Check the time difference is approximately 24 hours
+        const diff = endTime - startTime;
+        const expectedMs = 24 * 60 * 60 * 1000;
+        expect(Math.abs(diff - expectedMs)).toBeLessThan(1000);
+    });
+
+    it('handles custom time range with start and end dates', async () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        const customRange = {
+            start: new Date('2024-01-01T00:00:00Z'),
+            end: new Date('2024-01-10T00:00:00Z'),
+        };
+
+        renderHook(() =>
+            useTimelineEvents({ timeRange: customRange }),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        const urlParams = new URLSearchParams(url.split('?')[1]);
+        expect(urlParams.get('start_time')).toBe('2024-01-01T00:00:00.000Z');
+        expect(urlParams.get('end_time')).toBe('2024-01-10T00:00:00.000Z');
+    });
+
+    it('sets loading to true during initial fetch', async () => {
+        let resolvePromise: (value: unknown) => void;
+        mockApiGet.mockImplementationOnce(() =>
+            new Promise(resolve => {
+                resolvePromise = resolve;
+            }),
+        );
+
+        const { result } = renderHook(() =>
+            useTimelineEvents({ connectionId: 1 }),
+        );
+
+        expect(result.current.loading).toBe(true);
+
+        await act(async () => {
+            resolvePromise!(makeApiResponse());
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+    });
+
+    it('sets error on API failure', async () => {
+        mockApiGet.mockRejectedValueOnce(new Error('Timeline fetch failed'));
+
+        const { result } = renderHook(() =>
+            useTimelineEvents({ connectionId: 1 }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).toBe('Timeline fetch failed');
+        });
+
+        expect(result.current.events).toEqual([]);
+        expect(result.current.totalCount).toBe(0);
+        expect(result.current.loading).toBe(false);
+    });
+
+    it('refetch triggers a new API call', async () => {
+        mockApiGet.mockResolvedValue(makeApiResponse());
+
+        const { result } = renderHook(() =>
+            useTimelineEvents({ connectionId: 1 }),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+        });
+
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        expect(mockApiGet).toHaveBeenCalledTimes(2);
+    });
+
+    it('refetches when connectionId changes', async () => {
+        mockApiGet.mockResolvedValue(makeApiResponse());
+
+        const { rerender } = renderHook(
+            ({ connectionId }) => useTimelineEvents({ connectionId }),
+            { initialProps: { connectionId: 1 } },
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+        });
+
+        rerender({ connectionId: 2 });
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+
+        const url = mockApiGet.mock.calls[1][0];
+        expect(url).toContain('connection_id=2');
+    });
+
+    it('refetches when timeRange changes', async () => {
+        mockApiGet.mockResolvedValue(makeApiResponse());
+
+        const { rerender } = renderHook(
+            ({ timeRange }) => useTimelineEvents({ timeRange, connectionId: 1 }),
+            { initialProps: { timeRange: '24h' as TimeRangePreset } },
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+        });
+
+        rerender({ timeRange: '7d' as TimeRangePreset });
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it('refetches when eventTypes change', async () => {
+        mockApiGet.mockResolvedValue(makeApiResponse());
+
+        const { rerender } = renderHook(
+            ({ eventTypes }) => useTimelineEvents({ eventTypes, connectionId: 1 }),
+            { initialProps: { eventTypes: ['alert'] } },
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+        });
+
+        rerender({ eventTypes: ['restart'] });
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+
+        const url = mockApiGet.mock.calls[1][0];
+        expect(url).toContain('event_types=restart');
+    });
+
+    it('handles empty events array from API', async () => {
+        mockApiGet.mockResolvedValueOnce({ events: [], total_count: 0 });
+
+        const { result } = renderHook(() =>
+            useTimelineEvents({ connectionId: 1 }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.events).toEqual([]);
+        expect(result.current.totalCount).toBe(0);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('handles missing events field in API response', async () => {
+        mockApiGet.mockResolvedValueOnce({});
+
+        const { result } = renderHook(() =>
+            useTimelineEvents({ connectionId: 1 }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.events).toEqual([]);
+        expect(result.current.totalCount).toBe(0);
+    });
+
+    it('does not flash loading on subsequent fetches', async () => {
+        mockApiGet.mockResolvedValue(makeApiResponse());
+
+        const { result } = renderHook(() =>
+            useTimelineEvents({ connectionId: 1 }),
+        );
+
+        // Wait for initial load
+        await waitFor(() => {
+            expect(result.current.events).toHaveLength(2);
+        });
+
+        // After initial load, loading should be false
+        expect(result.current.loading).toBe(false);
+
+        // Refetch should not set loading to true (initialLoadDoneRef pattern)
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        // Verify data is still present and loading is false
+        expect(result.current.loading).toBe(false);
+        expect(result.current.events).toHaveLength(2);
+    });
+
+    it('includes limit parameter in query string', async () => {
+        mockApiGet.mockResolvedValueOnce(makeApiResponse());
+
+        renderHook(() =>
+            useTimelineEvents({ connectionId: 1 }),
+        );
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).toContain('limit=500');
+    });
+});


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage for 8 previously untested React hooks
- Cover initialization, state transitions, cleanup, and error handling
- Achieve 96.85% statement coverage for `src/hooks/`

### Hooks tested:
- `useAlertAnalysis` - LLM-powered alert analysis with server/client caching
- `useAnalysisState` - Shared analysis state management
- `useChartAnalysis` - Chart data analysis via LLM
- `useChat` - Conversational AI interface with tool use
- `useMenu` - Simple menu anchor state management
- `useMetrics` - Metric time series and baseline fetching
- `useServerAnalysis` - Server/cluster analysis via agentic loop
- `useTimelineEvents` - Timeline event fetching with filters

## Test plan

- [x] All 182 hook tests pass
- [x] Coverage ≥90% for `src/hooks/` (achieved 96.85%)
- [x] Lint passes with no new errors

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)