### PR TITLE
Add tests for client Dashboard components

### DIFF
--- a/client/src/components/Dashboard/ClusterDashboard/__tests__/ClusterDashboard.test.tsx
+++ b/client/src/components/Dashboard/ClusterDashboard/__tests__/ClusterDashboard.test.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ClusterDashboard from '../index';
 
@@ -61,6 +61,10 @@ describe('ClusterDashboard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(localStorage.getItem).mockReturnValue(null);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('renders Replication Lag section', () => {

--- a/client/src/components/Dashboard/ClusterDashboard/__tests__/ClusterDashboard.test.tsx
+++ b/client/src/components/Dashboard/ClusterDashboard/__tests__/ClusterDashboard.test.tsx
@@ -1,0 +1,154 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import ClusterDashboard from '../index';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../ReplicationLagSection', () => ({
+    default: ({ serverIds }: { serverIds: number[] }) => (
+        <div data-testid="replication-lag-section" data-server-ids={serverIds.join(',')}>
+            Replication Lag Content
+        </div>
+    ),
+}));
+
+vi.mock('../ComparativeChartsSection', () => ({
+    default: ({ serverIds }: { serverIds: number[] }) => (
+        <div data-testid="comparative-charts-section" data-server-ids={serverIds.join(',')}>
+            Comparative Charts Content
+        </div>
+    ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const theme = createTheme();
+
+const createSelection = (serverIds: number[] = [1, 2, 3]) => ({
+    name: 'Test Cluster',
+    servers: serverIds.map(id => ({ id, name: `Server ${id}` })),
+});
+
+const renderClusterDashboard = (selection: Record<string, unknown> = createSelection()) => {
+    return render(
+        <ThemeProvider theme={theme}>
+            <ClusterDashboard selection={selection} />
+        </ThemeProvider>,
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ClusterDashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(localStorage.getItem).mockReturnValue(null);
+    });
+
+    it('renders Replication Lag section', () => {
+        renderClusterDashboard();
+
+        expect(screen.getByText('Replication Lag')).toBeInTheDocument();
+        expect(screen.getByTestId('replication-lag-section')).toBeInTheDocument();
+    });
+
+    it('renders Comparative Metrics section', () => {
+        renderClusterDashboard();
+
+        expect(screen.getByText('Comparative Metrics')).toBeInTheDocument();
+        expect(screen.getByTestId('comparative-charts-section')).toBeInTheDocument();
+    });
+
+    it('extracts server IDs from selection', () => {
+        const selection = createSelection([10, 20, 30]);
+        renderClusterDashboard(selection);
+
+        const replicationSection = screen.getByTestId('replication-lag-section');
+        expect(replicationSection).toHaveAttribute('data-server-ids', '10,20,30');
+
+        const chartsSection = screen.getByTestId('comparative-charts-section');
+        expect(chartsSection).toHaveAttribute('data-server-ids', '10,20,30');
+    });
+
+    it('handles nested server children', () => {
+        const selection = {
+            name: 'Cluster with nested servers',
+            servers: [
+                {
+                    id: 1,
+                    name: 'Primary',
+                    children: [
+                        { id: 2, name: 'Replica 1' },
+                        {
+                            id: 3,
+                            name: 'Replica 2',
+                            children: [{ id: 4, name: 'Cascading Replica' }],
+                        },
+                    ],
+                },
+            ],
+        };
+        renderClusterDashboard(selection);
+
+        const replicationSection = screen.getByTestId('replication-lag-section');
+        expect(replicationSection).toHaveAttribute('data-server-ids', '1,2,3,4');
+    });
+
+    it('handles empty servers array', () => {
+        const selection = { name: 'Empty Cluster', servers: [] };
+        renderClusterDashboard(selection);
+
+        const replicationSection = screen.getByTestId('replication-lag-section');
+        expect(replicationSection).toHaveAttribute('data-server-ids', '');
+    });
+
+    it('handles undefined servers', () => {
+        const selection = { name: 'Cluster without servers' };
+        renderClusterDashboard(selection);
+
+        const replicationSection = screen.getByTestId('replication-lag-section');
+        expect(replicationSection).toHaveAttribute('data-server-ids', '');
+    });
+
+    it('deduplicates server IDs', () => {
+        // Although unlikely, verify that IDs are unique via Set
+        const selection = {
+            name: 'Cluster',
+            servers: [
+                { id: 1, name: 'Server 1' },
+                { id: 2, name: 'Server 2' },
+                { id: 1, name: 'Duplicate' }, // duplicate ID
+            ],
+        };
+        renderClusterDashboard(selection);
+
+        const replicationSection = screen.getByTestId('replication-lag-section');
+        // The implementation uses Set, so duplicates should be removed
+        expect(replicationSection).toHaveAttribute('data-server-ids', '1,2');
+    });
+
+    it('renders all sections as expanded by default', () => {
+        renderClusterDashboard();
+
+        expect(screen.getByTestId('replication-lag-section')).toBeVisible();
+        expect(screen.getByTestId('comparative-charts-section')).toBeVisible();
+    });
+});

--- a/client/src/components/Dashboard/DatabaseDashboard/__tests__/DatabaseDashboard.test.tsx
+++ b/client/src/components/Dashboard/DatabaseDashboard/__tests__/DatabaseDashboard.test.tsx
@@ -1,0 +1,208 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import DatabaseDashboard from '../index';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../TimeRangeSelector', () => ({
+    default: () => <div data-testid="time-range-selector">Time Range Selector</div>,
+}));
+
+vi.mock('../PerformanceSection', () => ({
+    default: ({ connectionId, databaseName }: {
+        connectionId: number;
+        databaseName: string;
+    }) => (
+        <div
+            data-testid="performance-section"
+            data-connection-id={connectionId}
+            data-database-name={databaseName}
+        >
+            Performance Section Content
+        </div>
+    ),
+}));
+
+vi.mock('../TableLeaderboardSection', () => ({
+    default: ({ connectionId, databaseName }: {
+        connectionId: number;
+        databaseName: string;
+    }) => (
+        <div
+            data-testid="table-leaderboard-section"
+            data-connection-id={connectionId}
+            data-database-name={databaseName}
+        >
+            Table Leaderboard Content
+        </div>
+    ),
+}));
+
+vi.mock('../IndexLeaderboardSection', () => ({
+    default: ({ connectionId, databaseName }: {
+        connectionId: number;
+        databaseName: string;
+    }) => (
+        <div
+            data-testid="index-leaderboard-section"
+            data-connection-id={connectionId}
+            data-database-name={databaseName}
+        >
+            Index Leaderboard Content
+        </div>
+    ),
+}));
+
+vi.mock('../VacuumStatusSection', () => ({
+    default: ({ connectionId, databaseName }: {
+        connectionId: number;
+        databaseName: string;
+    }) => (
+        <div
+            data-testid="vacuum-status-section"
+            data-connection-id={connectionId}
+            data-database-name={databaseName}
+        >
+            Vacuum Status Content
+        </div>
+    ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const theme = createTheme();
+
+interface DatabaseDashboardProps {
+    connectionId: number;
+    connectionName?: string;
+    databaseName: string;
+}
+
+const defaultProps: DatabaseDashboardProps = {
+    connectionId: 1,
+    connectionName: 'Test Server',
+    databaseName: 'testdb',
+};
+
+const renderDatabaseDashboard = (props: Partial<DatabaseDashboardProps> = {}) => {
+    return render(
+        <ThemeProvider theme={theme}>
+            <DatabaseDashboard {...defaultProps} {...props} />
+        </ThemeProvider>,
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DatabaseDashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders database name in header', () => {
+        renderDatabaseDashboard({ databaseName: 'production_db' });
+
+        expect(screen.getByText('production_db')).toBeInTheDocument();
+    });
+
+    it('renders connection name in header', () => {
+        renderDatabaseDashboard({ connectionName: 'Production Server' });
+
+        expect(screen.getByText('Production Server')).toBeInTheDocument();
+    });
+
+    it('renders fallback connection label when connectionName is missing', () => {
+        renderDatabaseDashboard({ connectionId: 42, connectionName: undefined });
+
+        expect(screen.getByText('Connection 42')).toBeInTheDocument();
+    });
+
+    it('renders TimeRangeSelector', () => {
+        renderDatabaseDashboard();
+
+        expect(screen.getByTestId('time-range-selector')).toBeInTheDocument();
+    });
+
+    it('renders all sections', () => {
+        renderDatabaseDashboard();
+
+        expect(screen.getByTestId('performance-section')).toBeInTheDocument();
+        expect(screen.getByTestId('table-leaderboard-section')).toBeInTheDocument();
+        expect(screen.getByTestId('index-leaderboard-section')).toBeInTheDocument();
+        expect(screen.getByTestId('vacuum-status-section')).toBeInTheDocument();
+    });
+
+    it('passes connectionId and databaseName to all sections', () => {
+        renderDatabaseDashboard({
+            connectionId: 5,
+            databaseName: 'analytics',
+        });
+
+        expect(screen.getByTestId('performance-section')).toHaveAttribute(
+            'data-connection-id',
+            '5',
+        );
+        expect(screen.getByTestId('performance-section')).toHaveAttribute(
+            'data-database-name',
+            'analytics',
+        );
+
+        expect(screen.getByTestId('table-leaderboard-section')).toHaveAttribute(
+            'data-connection-id',
+            '5',
+        );
+        expect(screen.getByTestId('table-leaderboard-section')).toHaveAttribute(
+            'data-database-name',
+            'analytics',
+        );
+
+        expect(screen.getByTestId('index-leaderboard-section')).toHaveAttribute(
+            'data-connection-id',
+            '5',
+        );
+        expect(screen.getByTestId('index-leaderboard-section')).toHaveAttribute(
+            'data-database-name',
+            'analytics',
+        );
+
+        expect(screen.getByTestId('vacuum-status-section')).toHaveAttribute(
+            'data-connection-id',
+            '5',
+        );
+        expect(screen.getByTestId('vacuum-status-section')).toHaveAttribute(
+            'data-database-name',
+            'analytics',
+        );
+    });
+
+    it('shows "No database selected" when databaseName is empty', () => {
+        renderDatabaseDashboard({ databaseName: '' });
+
+        expect(screen.getByText('No database selected')).toBeInTheDocument();
+        expect(screen.queryByTestId('performance-section')).not.toBeInTheDocument();
+    });
+
+    it('does not render TimeRangeSelector when no database selected', () => {
+        renderDatabaseDashboard({ databaseName: '' });
+
+        expect(screen.queryByTestId('time-range-selector')).not.toBeInTheDocument();
+    });
+});

--- a/client/src/components/Dashboard/DatabaseDashboard/__tests__/DatabaseDashboard.test.tsx
+++ b/client/src/components/Dashboard/DatabaseDashboard/__tests__/DatabaseDashboard.test.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import DatabaseDashboard from '../index';
 
@@ -115,6 +115,10 @@ const renderDatabaseDashboard = (props: Partial<DatabaseDashboardProps> = {}) =>
 describe('DatabaseDashboard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('renders database name in header', () => {

--- a/client/src/components/Dashboard/EstateDashboard/__tests__/EstateDashboard.test.tsx
+++ b/client/src/components/Dashboard/EstateDashboard/__tests__/EstateDashboard.test.tsx
@@ -1,0 +1,182 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import EstateDashboard from '../index';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../HealthOverviewSection', () => ({
+    default: () => <div data-testid="health-overview-section">Health Overview Content</div>,
+}));
+
+vi.mock('../KpiTilesSection', () => ({
+    default: ({ serverIds }: { serverIds: number[] }) => (
+        <div data-testid="kpi-tiles-section" data-server-ids={serverIds.join(',')}>
+            KPI Tiles Content
+        </div>
+    ),
+}));
+
+vi.mock('../ClusterCardsSection', () => ({
+    default: () => <div data-testid="cluster-cards-section">Cluster Cards Content</div>,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const theme = createTheme();
+
+const createSelection = (serverIds: number[] = [1, 2, 3]) => ({
+    groups: [
+        {
+            name: 'Production',
+            clusters: [
+                {
+                    name: 'Cluster 1',
+                    servers: serverIds.map(id => ({ id, name: `Server ${id}` })),
+                },
+            ],
+        },
+    ],
+});
+
+const renderEstateDashboard = (selection: Record<string, unknown> = createSelection()) => {
+    return render(
+        <ThemeProvider theme={theme}>
+            <EstateDashboard selection={selection} />
+        </ThemeProvider>,
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EstateDashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(localStorage.getItem).mockReturnValue(null);
+    });
+
+    it('renders Health Overview section', () => {
+        renderEstateDashboard();
+
+        expect(screen.getByText('Health Overview')).toBeInTheDocument();
+        expect(screen.getByTestId('health-overview-section')).toBeInTheDocument();
+    });
+
+    it('renders Key Performance Indicators section', () => {
+        renderEstateDashboard();
+
+        expect(screen.getByText('Key Performance Indicators')).toBeInTheDocument();
+        expect(screen.getByTestId('kpi-tiles-section')).toBeInTheDocument();
+    });
+
+    it('renders Clusters section', () => {
+        renderEstateDashboard();
+
+        expect(screen.getByText('Clusters')).toBeInTheDocument();
+        expect(screen.getByTestId('cluster-cards-section')).toBeInTheDocument();
+    });
+
+    it('extracts server IDs from selection and passes to KpiTilesSection', () => {
+        const selection = createSelection([10, 20, 30]);
+        renderEstateDashboard(selection);
+
+        const kpiSection = screen.getByTestId('kpi-tiles-section');
+        expect(kpiSection).toHaveAttribute('data-server-ids', '10,20,30');
+    });
+
+    it('handles nested server children', () => {
+        const selection = {
+            groups: [
+                {
+                    name: 'Group 1',
+                    clusters: [
+                        {
+                            name: 'Cluster 1',
+                            servers: [
+                                {
+                                    id: 1,
+                                    name: 'Primary',
+                                    children: [
+                                        { id: 2, name: 'Replica 1' },
+                                        { id: 3, name: 'Replica 2' },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+        renderEstateDashboard(selection);
+
+        const kpiSection = screen.getByTestId('kpi-tiles-section');
+        expect(kpiSection).toHaveAttribute('data-server-ids', '1,2,3');
+    });
+
+    it('handles empty selection gracefully', () => {
+        const selection = { groups: [] };
+        renderEstateDashboard(selection);
+
+        const kpiSection = screen.getByTestId('kpi-tiles-section');
+        expect(kpiSection).toHaveAttribute('data-server-ids', '');
+    });
+
+    it('handles multiple groups and clusters', () => {
+        const selection = {
+            groups: [
+                {
+                    name: 'Group 1',
+                    clusters: [
+                        {
+                            name: 'Cluster 1',
+                            servers: [{ id: 1 }, { id: 2 }],
+                        },
+                    ],
+                },
+                {
+                    name: 'Group 2',
+                    clusters: [
+                        {
+                            name: 'Cluster 2',
+                            servers: [{ id: 3 }],
+                        },
+                        {
+                            name: 'Cluster 3',
+                            servers: [{ id: 4 }, { id: 5 }],
+                        },
+                    ],
+                },
+            ],
+        };
+        renderEstateDashboard(selection);
+
+        const kpiSection = screen.getByTestId('kpi-tiles-section');
+        expect(kpiSection).toHaveAttribute('data-server-ids', '1,2,3,4,5');
+    });
+
+    it('renders all sections as expanded by default', () => {
+        renderEstateDashboard();
+
+        // All sections should be expanded and visible
+        expect(screen.getByTestId('health-overview-section')).toBeVisible();
+        expect(screen.getByTestId('kpi-tiles-section')).toBeVisible();
+        expect(screen.getByTestId('cluster-cards-section')).toBeVisible();
+    });
+});

--- a/client/src/components/Dashboard/EstateDashboard/__tests__/EstateDashboard.test.tsx
+++ b/client/src/components/Dashboard/EstateDashboard/__tests__/EstateDashboard.test.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import EstateDashboard from '../index';
 
@@ -70,6 +70,10 @@ describe('EstateDashboard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(localStorage.getItem).mockReturnValue(null);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('renders Health Overview section', () => {

--- a/client/src/components/Dashboard/ObjectDashboard/__tests__/ObjectDashboard.test.tsx
+++ b/client/src/components/Dashboard/ObjectDashboard/__tests__/ObjectDashboard.test.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ObjectDashboard from '../index';
 import { ObjectType, OverlayEntry } from '../../types';
@@ -120,6 +120,10 @@ describe('ObjectDashboard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockCurrentOverlay = null;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     describe('header rendering', () => {

--- a/client/src/components/Dashboard/ObjectDashboard/__tests__/ObjectDashboard.test.tsx
+++ b/client/src/components/Dashboard/ObjectDashboard/__tests__/ObjectDashboard.test.tsx
@@ -1,0 +1,261 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import ObjectDashboard from '../index';
+import { ObjectType, OverlayEntry } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockCurrentOverlay: OverlayEntry | null = null;
+
+vi.mock('../../../../contexts/DashboardContext', () => ({
+    useDashboard: () => ({
+        currentOverlay: mockCurrentOverlay,
+    }),
+}));
+
+vi.mock('../TableDetail', () => ({
+    default: ({ connectionId, databaseName, schemaName, objectName }: {
+        connectionId: number;
+        databaseName: string;
+        schemaName?: string;
+        objectName: string;
+    }) => (
+        <div
+            data-testid="table-detail"
+            data-connection-id={connectionId}
+            data-database-name={databaseName}
+            data-schema-name={schemaName}
+            data-object-name={objectName}
+        >
+            Table Detail Content
+        </div>
+    ),
+}));
+
+vi.mock('../IndexDetail', () => ({
+    default: ({ connectionId, databaseName, schemaName, objectName }: {
+        connectionId: number;
+        databaseName: string;
+        schemaName?: string;
+        objectName: string;
+    }) => (
+        <div
+            data-testid="index-detail"
+            data-connection-id={connectionId}
+            data-database-name={databaseName}
+            data-schema-name={schemaName}
+            data-object-name={objectName}
+        >
+            Index Detail Content
+        </div>
+    ),
+}));
+
+vi.mock('../QueryDetail', () => ({
+    default: ({ connectionId, databaseName, objectName }: {
+        connectionId: number;
+        databaseName: string;
+        objectName: string;
+    }) => (
+        <div
+            data-testid="query-detail"
+            data-connection-id={connectionId}
+            data-database-name={databaseName}
+            data-object-name={objectName}
+        >
+            Query Detail Content
+        </div>
+    ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const theme = createTheme();
+
+interface ObjectDashboardProps {
+    connectionId: number;
+    databaseName: string;
+    objectType: ObjectType;
+    schemaName?: string;
+    objectName: string;
+}
+
+const defaultProps: ObjectDashboardProps = {
+    connectionId: 1,
+    databaseName: 'testdb',
+    objectType: 'table',
+    schemaName: 'public',
+    objectName: 'users',
+};
+
+const renderObjectDashboard = (props: Partial<ObjectDashboardProps> = {}) => {
+    return render(
+        <ThemeProvider theme={theme}>
+            <ObjectDashboard {...defaultProps} {...props} />
+        </ThemeProvider>,
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ObjectDashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCurrentOverlay = null;
+    });
+
+    describe('header rendering', () => {
+        it('renders type badge for table', () => {
+            renderObjectDashboard({ objectType: 'table' });
+
+            expect(screen.getByText('Table')).toBeInTheDocument();
+        });
+
+        it('renders type badge for index', () => {
+            renderObjectDashboard({ objectType: 'index' });
+
+            expect(screen.getByText('Index')).toBeInTheDocument();
+        });
+
+        it('renders type badge for query', () => {
+            renderObjectDashboard({ objectType: 'query' });
+
+            expect(screen.getByText('Query')).toBeInTheDocument();
+        });
+
+        it('renders database name in context label', () => {
+            renderObjectDashboard({ databaseName: 'production' });
+
+            expect(screen.getByText(/production/)).toBeInTheDocument();
+        });
+
+        it('renders connection name from overlay when available', () => {
+            mockCurrentOverlay = {
+                level: 'object',
+                title: 'Table: users',
+                entityId: 'users',
+                entityName: 'users',
+                connectionName: 'Production Server',
+            };
+            renderObjectDashboard();
+
+            expect(screen.getByText(/Production Server/)).toBeInTheDocument();
+        });
+
+        it('renders fallback connection label when no connectionName', () => {
+            mockCurrentOverlay = null;
+            renderObjectDashboard({ connectionId: 42 });
+
+            expect(screen.getByText(/Connection 42/)).toBeInTheDocument();
+        });
+    });
+
+    describe('table object type', () => {
+        it('renders TableDetail component', () => {
+            renderObjectDashboard({ objectType: 'table' });
+
+            expect(screen.getByTestId('table-detail')).toBeInTheDocument();
+            expect(screen.queryByTestId('index-detail')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('query-detail')).not.toBeInTheDocument();
+        });
+
+        it('passes correct props to TableDetail', () => {
+            renderObjectDashboard({
+                objectType: 'table',
+                connectionId: 5,
+                databaseName: 'mydb',
+                schemaName: 'custom',
+                objectName: 'orders',
+            });
+
+            const tableDetail = screen.getByTestId('table-detail');
+            expect(tableDetail).toHaveAttribute('data-connection-id', '5');
+            expect(tableDetail).toHaveAttribute('data-database-name', 'mydb');
+            expect(tableDetail).toHaveAttribute('data-schema-name', 'custom');
+            expect(tableDetail).toHaveAttribute('data-object-name', 'orders');
+        });
+    });
+
+    describe('index object type', () => {
+        it('renders IndexDetail component', () => {
+            renderObjectDashboard({ objectType: 'index' });
+
+            expect(screen.getByTestId('index-detail')).toBeInTheDocument();
+            expect(screen.queryByTestId('table-detail')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('query-detail')).not.toBeInTheDocument();
+        });
+
+        it('passes correct props to IndexDetail', () => {
+            renderObjectDashboard({
+                objectType: 'index',
+                connectionId: 3,
+                databaseName: 'analytics',
+                schemaName: 'reports',
+                objectName: 'idx_user_email',
+            });
+
+            const indexDetail = screen.getByTestId('index-detail');
+            expect(indexDetail).toHaveAttribute('data-connection-id', '3');
+            expect(indexDetail).toHaveAttribute('data-database-name', 'analytics');
+            expect(indexDetail).toHaveAttribute('data-schema-name', 'reports');
+            expect(indexDetail).toHaveAttribute('data-object-name', 'idx_user_email');
+        });
+    });
+
+    describe('query object type', () => {
+        it('renders QueryDetail component', () => {
+            renderObjectDashboard({ objectType: 'query' });
+
+            expect(screen.getByTestId('query-detail')).toBeInTheDocument();
+            expect(screen.queryByTestId('table-detail')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('index-detail')).not.toBeInTheDocument();
+        });
+
+        it('passes correct props to QueryDetail', () => {
+            renderObjectDashboard({
+                objectType: 'query',
+                connectionId: 7,
+                databaseName: 'logs',
+                objectName: 'abc123queryid',
+            });
+
+            const queryDetail = screen.getByTestId('query-detail');
+            expect(queryDetail).toHaveAttribute('data-connection-id', '7');
+            expect(queryDetail).toHaveAttribute('data-database-name', 'logs');
+            expect(queryDetail).toHaveAttribute('data-object-name', 'abc123queryid');
+        });
+    });
+
+    describe('empty state', () => {
+        it('shows "No object selected" when objectName is empty', () => {
+            renderObjectDashboard({ objectName: '' });
+
+            expect(screen.getByText('No object selected')).toBeInTheDocument();
+            expect(screen.queryByTestId('table-detail')).not.toBeInTheDocument();
+        });
+
+        it('does not show type badge when no object selected', () => {
+            renderObjectDashboard({ objectName: '' });
+
+            expect(screen.queryByText('Table')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/client/src/components/Dashboard/ServerDashboard/__tests__/ServerDashboard.test.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/__tests__/ServerDashboard.test.tsx
@@ -1,0 +1,172 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import ServerDashboard from '../index';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../SystemResourcesSection', () => ({
+    default: ({ connectionId, connectionName }: {
+        connectionId: number;
+        connectionName?: string;
+    }) => (
+        <div
+            data-testid="system-resources-section"
+            data-connection-id={connectionId}
+            data-connection-name={connectionName}
+        >
+            System Resources Content
+        </div>
+    ),
+}));
+
+vi.mock('../PostgresOverviewSection', () => ({
+    default: ({ connectionId }: { connectionId: number }) => (
+        <div data-testid="postgres-overview-section" data-connection-id={connectionId}>
+            PostgreSQL Overview Content
+        </div>
+    ),
+}));
+
+vi.mock('../WalReplicationSection', () => ({
+    default: ({ connectionId }: { connectionId: number }) => (
+        <div data-testid="wal-replication-section" data-connection-id={connectionId}>
+            WAL Replication Content
+        </div>
+    ),
+}));
+
+vi.mock('../DatabaseSummariesSection', () => ({
+    default: ({ connectionId }: { connectionId: number }) => (
+        <div data-testid="database-summaries-section" data-connection-id={connectionId}>
+            Database Summaries Content
+        </div>
+    ),
+}));
+
+vi.mock('../TopQueriesSection', () => ({
+    default: ({ connectionId }: { connectionId: number }) => (
+        <div data-testid="top-queries-section" data-connection-id={connectionId}>
+            Top Queries Content
+        </div>
+    ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const theme = createTheme();
+
+const createSelection = (id: number = 1, name?: string) => ({
+    id,
+    name,
+});
+
+const renderServerDashboard = (selection: Record<string, unknown> = createSelection()) => {
+    return render(
+        <ThemeProvider theme={theme}>
+            <ServerDashboard selection={selection} />
+        </ThemeProvider>,
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ServerDashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders all sections when valid selection is provided', () => {
+        renderServerDashboard(createSelection(1, 'Test Server'));
+
+        expect(screen.getByTestId('system-resources-section')).toBeInTheDocument();
+        expect(screen.getByTestId('postgres-overview-section')).toBeInTheDocument();
+        expect(screen.getByTestId('wal-replication-section')).toBeInTheDocument();
+        expect(screen.getByTestId('database-summaries-section')).toBeInTheDocument();
+        expect(screen.getByTestId('top-queries-section')).toBeInTheDocument();
+    });
+
+    it('passes connectionId to all sections', () => {
+        renderServerDashboard(createSelection(42, 'Test Server'));
+
+        expect(screen.getByTestId('system-resources-section')).toHaveAttribute(
+            'data-connection-id',
+            '42',
+        );
+        expect(screen.getByTestId('postgres-overview-section')).toHaveAttribute(
+            'data-connection-id',
+            '42',
+        );
+        expect(screen.getByTestId('wal-replication-section')).toHaveAttribute(
+            'data-connection-id',
+            '42',
+        );
+        expect(screen.getByTestId('database-summaries-section')).toHaveAttribute(
+            'data-connection-id',
+            '42',
+        );
+        expect(screen.getByTestId('top-queries-section')).toHaveAttribute(
+            'data-connection-id',
+            '42',
+        );
+    });
+
+    it('passes connectionName to SystemResourcesSection', () => {
+        renderServerDashboard(createSelection(1, 'Production Server'));
+
+        expect(screen.getByTestId('system-resources-section')).toHaveAttribute(
+            'data-connection-name',
+            'Production Server',
+        );
+    });
+
+    it('shows "No server selected" when id is missing', () => {
+        const selection = { name: 'Server without ID' };
+        renderServerDashboard(selection);
+
+        expect(screen.getByText('No server selected')).toBeInTheDocument();
+        expect(screen.queryByTestId('system-resources-section')).not.toBeInTheDocument();
+    });
+
+    it('shows "No server selected" when id is undefined', () => {
+        const selection = { id: undefined, name: 'Test' };
+        renderServerDashboard(selection);
+
+        expect(screen.getByText('No server selected')).toBeInTheDocument();
+    });
+
+    it('renders with connectionId of 0 (falsy but valid)', () => {
+        const selection = { id: 0, name: 'Server Zero' };
+        renderServerDashboard(selection);
+
+        expect(screen.getByTestId('system-resources-section')).toBeInTheDocument();
+        expect(screen.getByTestId('system-resources-section')).toHaveAttribute(
+            'data-connection-id',
+            '0',
+        );
+    });
+
+    it('handles missing connectionName gracefully', () => {
+        renderServerDashboard(createSelection(1));
+
+        // SystemResourcesSection should still render
+        expect(screen.getByTestId('system-resources-section')).toBeInTheDocument();
+    });
+});

--- a/client/src/components/Dashboard/ServerDashboard/__tests__/ServerDashboard.test.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/__tests__/ServerDashboard.test.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ServerDashboard from '../index';
 
@@ -91,6 +91,10 @@ const renderServerDashboard = (selection: Record<string, unknown> = createSelect
 describe('ServerDashboard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('renders all sections when valid selection is provided', () => {

--- a/client/src/components/Dashboard/__tests__/ChartPanel.test.tsx
+++ b/client/src/components/Dashboard/__tests__/ChartPanel.test.tsx
@@ -1,0 +1,104 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import ChartPanel from '../ChartPanel';
+
+const theme = createTheme();
+
+const renderChartPanel = (props: Partial<React.ComponentProps<typeof ChartPanel>> = {}) => {
+    const defaultProps = {
+        title: 'Test Chart',
+        loading: false,
+        hasData: true,
+        emptyMessage: 'No data available',
+        height: 200,
+        children: <div data-testid="chart-content">Chart Content</div>,
+    };
+
+    return render(
+        <ThemeProvider theme={theme}>
+            <ChartPanel {...defaultProps} {...props} />
+        </ThemeProvider>,
+    );
+};
+
+describe('ChartPanel', () => {
+    it('renders children when hasData is true and not loading', () => {
+        renderChartPanel();
+
+        expect(screen.getByTestId('chart-content')).toBeInTheDocument();
+        expect(screen.getByText('Chart Content')).toBeInTheDocument();
+    });
+
+    it('does not render title wrapper when hasData is true and not loading', () => {
+        renderChartPanel();
+
+        // The title should not be visible since children are rendered directly
+        expect(screen.queryByText('Test Chart')).not.toBeInTheDocument();
+    });
+
+    it('renders loading spinner when loading is true', () => {
+        renderChartPanel({ loading: true, hasData: false });
+
+        expect(screen.getByLabelText('Loading chart')).toBeInTheDocument();
+        expect(screen.queryByTestId('chart-content')).not.toBeInTheDocument();
+    });
+
+    it('renders title when loading', () => {
+        renderChartPanel({ loading: true, hasData: false });
+
+        expect(screen.getByText('Test Chart')).toBeInTheDocument();
+    });
+
+    it('renders empty message when hasData is false and not loading', () => {
+        renderChartPanel({ hasData: false, loading: false });
+
+        expect(screen.getByText('No data available')).toBeInTheDocument();
+        expect(screen.queryByTestId('chart-content')).not.toBeInTheDocument();
+    });
+
+    it('renders title when showing empty state', () => {
+        renderChartPanel({ hasData: false, loading: false });
+
+        expect(screen.getByText('Test Chart')).toBeInTheDocument();
+    });
+
+    it('prioritizes loading state over hasData', () => {
+        // Even if hasData is true, loading should show the spinner
+        renderChartPanel({ loading: true, hasData: true });
+
+        expect(screen.getByLabelText('Loading chart')).toBeInTheDocument();
+        expect(screen.queryByTestId('chart-content')).not.toBeInTheDocument();
+    });
+
+    it('renders custom empty message', () => {
+        renderChartPanel({
+            hasData: false,
+            loading: false,
+            emptyMessage: 'Custom empty message for testing',
+        });
+
+        expect(screen.getByText('Custom empty message for testing')).toBeInTheDocument();
+    });
+
+    it('renders custom title', () => {
+        renderChartPanel({
+            hasData: false,
+            loading: false,
+            title: 'Custom Chart Title',
+        });
+
+        expect(screen.getByText('Custom Chart Title')).toBeInTheDocument();
+    });
+});

--- a/client/src/components/Dashboard/__tests__/MetricOverlay.test.tsx
+++ b/client/src/components/Dashboard/__tests__/MetricOverlay.test.tsx
@@ -1,0 +1,180 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import MetricOverlay from '../MetricOverlay';
+import { OverlayEntry } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPopOverlay = vi.fn();
+const mockClearOverlays = vi.fn();
+let mockCurrentOverlay: OverlayEntry | null = null;
+let mockOverlayStack: OverlayEntry[] = [];
+
+vi.mock('../../../contexts/DashboardContext', () => ({
+    useDashboard: () => ({
+        currentOverlay: mockCurrentOverlay,
+        overlayStack: mockOverlayStack,
+        popOverlay: mockPopOverlay,
+        clearOverlays: mockClearOverlays,
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const theme = createTheme();
+
+const renderMetricOverlay = (children: React.ReactNode = <div>Overlay Content</div>) => {
+    return render(
+        <ThemeProvider theme={theme}>
+            <MetricOverlay>{children}</MetricOverlay>
+        </ThemeProvider>,
+    );
+};
+
+const createOverlayEntry = (overrides: Partial<OverlayEntry> = {}): OverlayEntry => ({
+    level: 'server',
+    title: 'Test Overlay',
+    entityId: 1,
+    entityName: 'Test Entity',
+    ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MetricOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCurrentOverlay = null;
+        mockOverlayStack = [];
+    });
+
+    it('renders nothing when currentOverlay is null', () => {
+        const { container } = renderMetricOverlay();
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders overlay content when currentOverlay exists', () => {
+        const overlay = createOverlayEntry({ title: 'Server Details' });
+        mockCurrentOverlay = overlay;
+        mockOverlayStack = [overlay];
+
+        renderMetricOverlay(<div>Server Content</div>);
+
+        expect(screen.getByText('Server Content')).toBeInTheDocument();
+    });
+
+    it('renders the overlay title', () => {
+        const overlay = createOverlayEntry({ title: 'Database Performance' });
+        mockCurrentOverlay = overlay;
+        mockOverlayStack = [overlay];
+
+        renderMetricOverlay();
+
+        expect(screen.getByText('Database Performance')).toBeInTheDocument();
+    });
+
+    it('renders close button', () => {
+        const overlay = createOverlayEntry();
+        mockCurrentOverlay = overlay;
+        mockOverlayStack = [overlay];
+
+        renderMetricOverlay();
+
+        expect(screen.getByRole('button', { name: /close overlay/i })).toBeInTheDocument();
+    });
+
+    it('calls clearOverlays when close button is clicked', () => {
+        const overlay = createOverlayEntry();
+        mockCurrentOverlay = overlay;
+        mockOverlayStack = [overlay];
+
+        renderMetricOverlay();
+
+        const closeButton = screen.getByRole('button', { name: /close overlay/i });
+        fireEvent.click(closeButton);
+
+        expect(mockClearOverlays).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render back button when overlay stack has only one entry', () => {
+        const overlay = createOverlayEntry();
+        mockCurrentOverlay = overlay;
+        mockOverlayStack = [overlay];
+
+        renderMetricOverlay();
+
+        expect(screen.queryByRole('button', { name: /go back/i })).not.toBeInTheDocument();
+    });
+
+    it('renders back button when overlay stack has multiple entries', () => {
+        const overlay1 = createOverlayEntry({ title: 'First Overlay' });
+        const overlay2 = createOverlayEntry({ title: 'Second Overlay' });
+        mockCurrentOverlay = overlay2;
+        mockOverlayStack = [overlay1, overlay2];
+
+        renderMetricOverlay();
+
+        expect(screen.getByRole('button', { name: /go back/i })).toBeInTheDocument();
+    });
+
+    it('calls popOverlay when back button is clicked', () => {
+        const overlay1 = createOverlayEntry({ title: 'First Overlay' });
+        const overlay2 = createOverlayEntry({ title: 'Second Overlay' });
+        mockCurrentOverlay = overlay2;
+        mockOverlayStack = [overlay1, overlay2];
+
+        renderMetricOverlay();
+
+        const backButton = screen.getByRole('button', { name: /go back/i });
+        fireEvent.click(backButton);
+
+        expect(mockPopOverlay).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders children content', () => {
+        const overlay = createOverlayEntry();
+        mockCurrentOverlay = overlay;
+        mockOverlayStack = [overlay];
+
+        renderMetricOverlay(
+            <div>
+                <h2>Custom Content</h2>
+                <p>Some details here</p>
+            </div>,
+        );
+
+        expect(screen.getByText('Custom Content')).toBeInTheDocument();
+        expect(screen.getByText('Some details here')).toBeInTheDocument();
+    });
+
+    it('renders backdrop element', () => {
+        const overlay = createOverlayEntry();
+        mockCurrentOverlay = overlay;
+        mockOverlayStack = [overlay];
+
+        const { container } = renderMetricOverlay();
+
+        // MUI Backdrop creates a div with role="presentation"
+        const backdrop = container.querySelector('.MuiBackdrop-root');
+        expect(backdrop).toBeInTheDocument();
+    });
+});

--- a/client/src/components/Dashboard/__tests__/MetricOverlay.test.tsx
+++ b/client/src/components/Dashboard/__tests__/MetricOverlay.test.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import MetricOverlay from '../MetricOverlay';
 import { OverlayEntry } from '../types';
@@ -64,6 +64,10 @@ describe('MetricOverlay', () => {
         vi.clearAllMocks();
         mockCurrentOverlay = null;
         mockOverlayStack = [];
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('renders nothing when currentOverlay is null', () => {

--- a/client/src/components/Dashboard/__tests__/Sparkline.test.tsx
+++ b/client/src/components/Dashboard/__tests__/Sparkline.test.tsx
@@ -1,0 +1,152 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Sparkline from '../Sparkline';
+import { MetricDataPoint } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock the Chart component to avoid echarts complexity in tests
+vi.mock('../../Chart', () => ({
+    Chart: (props: Record<string, unknown>) => (
+        <div
+            data-testid="chart-mock"
+            data-height={props.height}
+            data-type={props.type}
+            data-smooth={props.smooth}
+            data-area-fill={props.areaFill}
+            data-show-toolbar={props.showToolbar}
+            data-show-legend={props.showLegend}
+            data-show-tooltip={props.showTooltip}
+            {...(props.colorPalette !== undefined && {
+                'data-color-palette': JSON.stringify(props.colorPalette),
+            })}
+        />
+    ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const createDataPoints = (count: number): MetricDataPoint[] => {
+    return Array.from({ length: count }, (_, i) => ({
+        time: `2025-01-01T${String(i).padStart(2, '0')}:00:00Z`,
+        value: Math.random() * 100,
+    }));
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Sparkline', () => {
+    it('renders nothing when data is empty', () => {
+        const { container } = render(<Sparkline data={[]} />);
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    // Note: The component expects data to always be provided (not undefined)
+    // This test verifies behavior with an empty array instead
+
+    it('renders Chart component when data is provided', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        expect(getByTestId('chart-mock')).toBeInTheDocument();
+    });
+
+    it('passes correct chart type', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-type', 'line');
+    });
+
+    it('uses default height of 40', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-height', '40');
+    });
+
+    it('uses custom height when provided', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} height={60} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-height', '60');
+    });
+
+    it('enables smooth lines by default', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-smooth', 'true');
+    });
+
+    it('enables area fill by default', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-area-fill', 'true');
+    });
+
+    it('disables area fill when showArea is false', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} showArea={false} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-area-fill', 'false');
+    });
+
+    it('disables toolbar', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-show-toolbar', 'false');
+    });
+
+    it('disables legend', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-show-legend', 'false');
+    });
+
+    it('enables tooltip', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute('data-show-tooltip', 'true');
+    });
+
+    it('does not pass color palette when color is not provided', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} />);
+
+        // When colorPalette is undefined, the attribute is not set at all
+        expect(getByTestId('chart-mock')).not.toHaveAttribute('data-color-palette');
+    });
+
+    it('passes color palette when color is provided', () => {
+        const data = createDataPoints(5);
+        const { getByTestId } = render(<Sparkline data={data} color="#ff5722" />);
+
+        expect(getByTestId('chart-mock')).toHaveAttribute(
+            'data-color-palette',
+            JSON.stringify(['#ff5722']),
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Adds comprehensive test coverage for Dashboard components including ChartPanel, MetricOverlay, Sparkline, and all dashboard level components (Estate, Cluster, Server, Database, Object)
- Tests rendering, loading/empty states, data display, user interactions, and prop passing
- Adds 77 new tests bringing improved coverage to the Dashboard component tree

Closes #117

## Test plan

- [x] All new tests pass (77 tests)
- [x] ESLint passes with no new warnings
- [x] Existing tests unaffected

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for Dashboard-area components (cluster, database, estate, object, server) plus ChartPanel, MetricOverlay, Sparkline, and ChartPanel behaviors.
  * Tests verify rendering, prop/ID propagation, conditional and empty states, overlay navigation, chart/sparkline options, and deduplication/flattening of nested selections to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->