### PR TITLE
Add tests for server tools package

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -33,9 +33,13 @@ openapi:
 	cd src && go run ./cmd/mcp-server -openapi ../../docs/admin-guide/api/openapi.json
 
 # Run tests
+# Use -p=1 to serialize per-package test binaries. Integration tests in
+# internal/database, internal/api, and internal/tools share Postgres schema
+# (DROP/CREATE the same tables), so running their test binaries concurrently
+# races.
 test: killall
 	@echo "Running tests..."
-	cd src && go test -v ./...
+	cd src && go test -p=1 -v ./...
 	@$(MAKE) --no-print-directory killall
 
 # Run linting
@@ -59,9 +63,10 @@ fmt-check:
 	@test -z "$$(cd src && gofmt -l .)" || (echo "Files not formatted:"; cd src && gofmt -l .; exit 1)
 
 # Run tests with coverage
+# Use -p=1 to serialize per-package test binaries (see note on the test target).
 coverage:
 	@echo "Running tests with coverage..."
-	cd src && go test -coverprofile=coverage.out ./...
+	cd src && go test -p=1 -coverprofile=coverage.out ./...
 	cd src && go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: src/coverage.html"
 

--- a/server/src/internal/tools/connection_visibility_test.go
+++ b/server/src/internal/tools/connection_visibility_test.go
@@ -1,0 +1,31 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// newDatastoreVisibilityLister tests
+// ---------------------------------------------------------------------------
+
+func TestNewDatastoreVisibilityListerNilDatastore(t *testing.T) {
+	// A nil datastore should return a nil lister
+	lister := newDatastoreVisibilityLister(nil)
+	if lister != nil {
+		t.Errorf("expected nil lister for nil datastore, got %v", lister)
+	}
+}
+
+// Note: Testing with a non-nil datastore requires a real database connection.
+// The integration tests cover that scenario.
+// The important behavior here is that nil datastore returns nil lister,
+// which allows VisibleConnectionIDs to fall back gracefully.

--- a/server/src/internal/tools/count_rows_test.go
+++ b/server/src/internal/tools/count_rows_test.go
@@ -434,6 +434,9 @@ func TestCountRowsValidTableAndSchemaPassValidation(t *testing.T) {
 
 	// Without a resolver, we expect a different error (not about table/schema)
 	if response.IsError {
+		if len(response.Content) == 0 {
+			t.Fatal("expected error message in response content")
+		}
 		text := response.Content[0].Text
 		if strings.Contains(text, "Invalid table name") ||
 			strings.Contains(text, "Invalid schema name") {

--- a/server/src/internal/tools/count_rows_test.go
+++ b/server/src/internal/tools/count_rows_test.go
@@ -1,0 +1,443 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// count_rows tool definition tests
+// ---------------------------------------------------------------------------
+
+func TestCountRowsToolDefinition(t *testing.T) {
+	tool := CountRowsTool(nil, nil)
+
+	if tool.Definition.Name != "count_rows" {
+		t.Errorf("expected tool name 'count_rows', got %q", tool.Definition.Name)
+	}
+
+	if tool.Definition.Description == "" {
+		t.Error("expected non-empty description")
+	}
+
+	if tool.Definition.CompactDescription == "" {
+		t.Error("expected non-empty compact description")
+	}
+
+	// Verify required parameters
+	required := tool.Definition.InputSchema.Required
+	if len(required) != 1 {
+		t.Fatalf("expected 1 required parameter, got %d", len(required))
+	}
+	if required[0] != "table" {
+		t.Errorf("expected required parameter 'table', got %q", required[0])
+	}
+
+	// Verify all expected properties exist
+	for _, prop := range []string{"connection_id", "database_name", "table", "schema", "where"} {
+		if _, ok := tool.Definition.InputSchema.Properties[prop]; !ok {
+			t.Errorf("expected property %q in input schema", prop)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// count_rows parameter validation tests
+// ---------------------------------------------------------------------------
+
+func TestCountRowsMissingTable(t *testing.T) {
+	tool := CountRowsTool(nil, nil)
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "table key absent",
+			args: map[string]any{},
+		},
+		{
+			name: "table is empty string",
+			args: map[string]any{
+				"table": "",
+			},
+		},
+		{
+			name: "table is wrong type",
+			args: map[string]any{
+				"table": 123,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := tool.Handler(tt.args)
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			if !response.IsError {
+				t.Error("expected an error response for missing/invalid table")
+			}
+			if len(response.Content) == 0 {
+				t.Fatal("expected error message in response content")
+			}
+			if !strings.Contains(response.Content[0].Text, "table") {
+				t.Errorf("error message should mention 'table', got: %s",
+					response.Content[0].Text)
+			}
+		})
+	}
+}
+
+func TestCountRowsInvalidTableName(t *testing.T) {
+	tool := CountRowsTool(nil, nil)
+
+	tests := []struct {
+		name  string
+		table string
+	}{
+		{"SQL injection", "users; DROP TABLE users;--"},
+		{"starts with number", "1table"},
+		{"contains space", "user table"},
+		{"too long", strings.Repeat("a", 64)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := map[string]any{
+				"table": tt.table,
+			}
+			response, err := tool.Handler(args)
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			if !response.IsError {
+				t.Error("expected error response for invalid table name")
+			}
+			if len(response.Content) == 0 {
+				t.Fatal("expected error message in response content")
+			}
+			if !strings.Contains(response.Content[0].Text, "Invalid table name") {
+				t.Errorf("expected 'Invalid table name' error, got: %s",
+					response.Content[0].Text)
+			}
+		})
+	}
+}
+
+func TestCountRowsInvalidSchemaName(t *testing.T) {
+	tool := CountRowsTool(nil, nil)
+
+	tests := []struct {
+		name   string
+		schema string
+	}{
+		{"SQL injection", "public; DROP TABLE users;--"},
+		{"starts with number", "1schema"},
+		{"contains space", "my schema"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := map[string]any{
+				"table":  "users",
+				"schema": tt.schema,
+			}
+			response, err := tool.Handler(args)
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			if !response.IsError {
+				t.Error("expected error response for invalid schema name")
+			}
+			if len(response.Content) == 0 {
+				t.Fatal("expected error message in response content")
+			}
+			if !strings.Contains(response.Content[0].Text, "Invalid schema name") {
+				t.Errorf("expected 'Invalid schema name' error, got: %s",
+					response.Content[0].Text)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateWhereClause tests
+// ---------------------------------------------------------------------------
+
+func TestValidateWhereClause(t *testing.T) {
+	tests := []struct {
+		name      string
+		clause    string
+		wantError bool
+		errorText string
+	}{
+		// Valid clauses
+		{
+			name:      "simple equality",
+			clause:    "status = 'active'",
+			wantError: false,
+		},
+		{
+			name:      "multiple conditions",
+			clause:    "status = 'active' AND created_at > '2024-01-01'",
+			wantError: false,
+		},
+		{
+			name:      "numeric comparison",
+			clause:    "count > 100 AND count < 1000",
+			wantError: false,
+		},
+		{
+			name:      "LIKE clause",
+			clause:    "name LIKE '%test%'",
+			wantError: false,
+		},
+		{
+			name:      "IN clause",
+			clause:    "id IN (1, 2, 3)",
+			wantError: false,
+		},
+		{
+			name:      "IS NULL",
+			clause:    "deleted_at IS NULL",
+			wantError: false,
+		},
+		{
+			name:      "BETWEEN",
+			clause:    "age BETWEEN 18 AND 65",
+			wantError: false,
+		},
+
+		// Dangerous patterns - denial of service
+		{
+			name:      "pg_sleep",
+			clause:    "1=1 AND pg_sleep(10)=''",
+			wantError: true,
+			errorText: "pg_sleep",
+		},
+		{
+			name:      "pg_sleep uppercase",
+			clause:    "1=1 AND PG_SLEEP(10)=''",
+			wantError: true,
+			errorText: "pg_sleep",
+		},
+		{
+			name:      "generate_series",
+			clause:    "id IN (SELECT * FROM generate_series(1, 1000000000))",
+			wantError: true,
+			errorText: "generate_series",
+		},
+
+		// Dangerous patterns - backend control
+		{
+			name:      "pg_cancel_backend",
+			clause:    "pg_cancel_backend(123)",
+			wantError: true,
+			errorText: "pg_cancel_backend",
+		},
+		{
+			name:      "pg_terminate_backend",
+			clause:    "pg_terminate_backend(123)",
+			wantError: true,
+			errorText: "pg_terminate_backend",
+		},
+
+		// Dangerous patterns - external access
+		{
+			name:      "dblink",
+			clause:    "dblink('host=evil.com', 'SELECT')",
+			wantError: true,
+			errorText: "dblink",
+		},
+
+		// Dangerous patterns - file system
+		{
+			name:      "copy with space",
+			clause:    "copy test FROM '/etc/passwd'",
+			wantError: true,
+			errorText: "copy ",
+		},
+		{
+			name:      "copy with paren",
+			clause:    "copy(SELECT * FROM users)",
+			wantError: true,
+			errorText: "copy(",
+		},
+		{
+			name:      "pg_read_file",
+			clause:    "pg_read_file('/etc/passwd')",
+			wantError: true,
+			errorText: "pg_read_file",
+		},
+		{
+			name:      "pg_read_binary_file",
+			clause:    "pg_read_binary_file('/etc/passwd')",
+			wantError: true,
+			errorText: "pg_read_binary_file",
+		},
+		{
+			name:      "pg_ls_dir",
+			clause:    "pg_ls_dir('/')",
+			wantError: true,
+			errorText: "pg_ls_dir",
+		},
+		{
+			name:      "pg_stat_file",
+			clause:    "pg_stat_file('/etc/passwd')",
+			wantError: true,
+			errorText: "pg_stat_file",
+		},
+
+		// Dangerous patterns - large objects
+		{
+			name:      "lo_import",
+			clause:    "lo_import('/etc/passwd')",
+			wantError: true,
+			errorText: "lo_import",
+		},
+		{
+			name:      "lo_export",
+			clause:    "lo_export(12345, '/tmp/out')",
+			wantError: true,
+			errorText: "lo_export",
+		},
+
+		// Dangerous patterns - character obfuscation
+		{
+			name:      "chr function",
+			clause:    "chr(59)||chr(68)",
+			wantError: true,
+			errorText: "chr(",
+		},
+		{
+			name:      "convert_from",
+			clause:    "convert_from(decode('test', 'base64'), 'UTF8')",
+			wantError: true,
+			errorText: "convert_from(",
+		},
+
+		// Dangerous patterns - lock contention
+		{
+			name:      "pg_advisory_lock",
+			clause:    "pg_advisory_lock(1)",
+			wantError: true,
+			errorText: "pg_advisory_lock",
+		},
+
+		// Dangerous patterns - configuration disclosure
+		{
+			name:      "current_setting",
+			clause:    "current_setting('config_file')",
+			wantError: true,
+			errorText: "current_setting",
+		},
+
+		// Injection patterns
+		{
+			name:      "semicolon",
+			clause:    "id = 1; DROP TABLE users",
+			wantError: true,
+			errorText: ";",
+		},
+		{
+			name:      "double dash comment",
+			clause:    "id = 1 -- comment",
+			wantError: true,
+			errorText: "--",
+		},
+		{
+			name:      "block comment",
+			clause:    "id = 1 /* comment */",
+			wantError: true,
+			errorText: "/*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWhereClause(tt.clause)
+			if (err != nil) != tt.wantError {
+				t.Errorf("validateWhereClause(%q) error = %v, wantError %v",
+					tt.clause, err, tt.wantError)
+			}
+			if err != nil && tt.errorText != "" {
+				if !strings.Contains(err.Error(), tt.errorText) {
+					t.Errorf("error message should contain %q, got: %s",
+						tt.errorText, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestCountRowsInvalidWhereClause(t *testing.T) {
+	tool := CountRowsTool(nil, nil)
+
+	tests := []struct {
+		name  string
+		where string
+	}{
+		{"semicolon injection", "id = 1; DROP TABLE users"},
+		{"pg_sleep attack", "1=1 AND pg_sleep(10)=''"},
+		{"comment injection", "id = 1 -- ignore rest"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := map[string]any{
+				"table": "users",
+				"where": tt.where,
+			}
+			response, err := tool.Handler(args)
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			if !response.IsError {
+				t.Error("expected error response for invalid WHERE clause")
+			}
+			if len(response.Content) == 0 {
+				t.Fatal("expected error message in response content")
+			}
+			if !strings.Contains(response.Content[0].Text, "Invalid WHERE clause") {
+				t.Errorf("expected 'Invalid WHERE clause' error, got: %s",
+					response.Content[0].Text)
+			}
+		})
+	}
+}
+
+func TestCountRowsValidTableAndSchemaPassValidation(t *testing.T) {
+	// Even without a resolver, valid table/schema names should pass
+	// initial validation. The resolver error will come later.
+	tool := CountRowsTool(nil, nil)
+
+	args := map[string]any{
+		"table":  "users",
+		"schema": "public",
+	}
+
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+
+	// Without a resolver, we expect a different error (not about table/schema)
+	if response.IsError {
+		text := response.Content[0].Text
+		if strings.Contains(text, "Invalid table name") ||
+			strings.Contains(text, "Invalid schema name") {
+			t.Errorf("valid table/schema should pass validation: %s", text)
+		}
+	}
+}

--- a/server/src/internal/tools/get_alert_history_test.go
+++ b/server/src/internal/tools/get_alert_history_test.go
@@ -1,0 +1,333 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// get_alert_history tool definition tests
+// ---------------------------------------------------------------------------
+
+func TestGetAlertHistoryToolDefinition(t *testing.T) {
+	tool := GetAlertHistoryTool(nil, nil, nil)
+
+	if tool.Definition.Name != "get_alert_history" {
+		t.Errorf("expected tool name 'get_alert_history', got %q", tool.Definition.Name)
+	}
+
+	if tool.Definition.Description == "" {
+		t.Error("expected non-empty description")
+	}
+
+	if tool.Definition.CompactDescription == "" {
+		t.Error("expected non-empty compact description")
+	}
+
+	// Verify no required parameters
+	if len(tool.Definition.InputSchema.Required) != 0 {
+		t.Errorf("expected 0 required parameters, got %d",
+			len(tool.Definition.InputSchema.Required))
+	}
+
+	// Verify all expected properties exist
+	for _, prop := range []string{"connection_id", "status", "rule_id", "metric_name", "time_start", "limit", "offset"} {
+		if _, ok := tool.Definition.InputSchema.Properties[prop]; !ok {
+			t.Errorf("expected property %q in input schema", prop)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_alert_history nil pool test
+// ---------------------------------------------------------------------------
+
+func TestGetAlertHistoryNilPool(t *testing.T) {
+	tool := GetAlertHistoryTool(nil, nil, nil)
+
+	response, err := tool.Handler(map[string]any{})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Error("expected error response when pool is nil")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s",
+			response.Content[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_alert_history parameter validation tests
+// ---------------------------------------------------------------------------
+
+func TestGetAlertHistoryInvalidStatus(t *testing.T) {
+	tool := GetAlertHistoryTool(nil, nil, nil)
+
+	args := map[string]any{
+		"status": "invalid_status",
+	}
+
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	// Should fail on nil pool first
+	if !response.IsError {
+		t.Error("expected error response")
+	}
+}
+
+func TestGetAlertHistoryValidStatusValues(t *testing.T) {
+	// Verify the schema has the correct enum values
+	tool := GetAlertHistoryTool(nil, nil, nil)
+
+	statusProp, ok := tool.Definition.InputSchema.Properties["status"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'status' property to be a map")
+	}
+
+	enumValues, hasEnum := statusProp["enum"]
+	if !hasEnum {
+		t.Error("expected 'status' to have enum values")
+	}
+
+	expectedValues := []string{"active", "cleared", "acknowledged", "all"}
+	enumSlice, ok := enumValues.([]string)
+	if !ok {
+		t.Fatal("expected enum values to be a string slice")
+	}
+
+	if len(enumSlice) != len(expectedValues) {
+		t.Errorf("expected %d enum values, got %d", len(expectedValues), len(enumSlice))
+	}
+
+	for _, expected := range expectedValues {
+		found := false
+		for _, actual := range enumSlice {
+			if actual == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected enum value %q not found", expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helper function tests
+// ---------------------------------------------------------------------------
+
+func TestFormatOptionalFloat(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *float64
+		want  string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "zero",
+			input: ptrFloat(0),
+			want:  "0",
+		},
+		{
+			name:  "positive",
+			input: ptrFloat(42.5),
+			want:  "42.5",
+		},
+		{
+			name:  "negative",
+			input: ptrFloat(-10.25),
+			want:  "-10.25",
+		},
+		{
+			name:  "integer value",
+			input: ptrFloat(100),
+			want:  "100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOptionalFloat(tt.input)
+			if got != tt.want {
+				t.Errorf("formatOptionalFloat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatOptionalTime(t *testing.T) {
+	fixedTime := time.Date(2024, 6, 15, 14, 30, 45, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		input *time.Time
+		want  string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "valid time",
+			input: &fixedTime,
+			want:  "2024-06-15T14:30:45Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOptionalTime(tt.input)
+			if got != tt.want {
+				t.Errorf("formatOptionalTime() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatOptionalBool(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *bool
+		want  string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "true",
+			input: ptrBool(true),
+			want:  "true",
+		},
+		{
+			name:  "false",
+			input: ptrBool(false),
+			want:  "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOptionalBool(tt.input)
+			if got != tt.want {
+				t.Errorf("formatOptionalBool() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatOptionalString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *string
+		want  string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "empty string",
+			input: ptrString(""),
+			want:  "",
+		},
+		{
+			name:  "normal string",
+			input: ptrString("hello"),
+			want:  "hello",
+		},
+		{
+			name:  "string with spaces",
+			input: ptrString("hello world"),
+			want:  "hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOptionalString(tt.input)
+			if got != tt.want {
+				t.Errorf("formatOptionalString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatOptionalStringEscaped(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *string
+		want  string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "normal string",
+			input: ptrString("hello"),
+			want:  "hello",
+		},
+		{
+			name:  "string with tab",
+			input: ptrString("hello\tworld"),
+			want:  "hello\\tworld", // TSV format escapes tabs as literal \t
+		},
+		{
+			name:  "string with newline",
+			input: ptrString("hello\nworld"),
+			want:  "hello\\nworld", // TSV format escapes newlines as literal \n
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOptionalStringEscaped(tt.input)
+			if got != tt.want {
+				t.Errorf("formatOptionalStringEscaped() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helper functions for tests
+// ---------------------------------------------------------------------------
+
+func ptrFloat(f float64) *float64 {
+	return &f
+}
+
+func ptrBool(b bool) *bool {
+	return &b
+}
+
+func ptrString(s string) *string {
+	return &s
+}

--- a/server/src/internal/tools/get_alert_rules_test.go
+++ b/server/src/internal/tools/get_alert_rules_test.go
@@ -127,6 +127,9 @@ func TestGetAlertRulesInvalidCategory(t *testing.T) {
 	if !response.IsError {
 		t.Error("expected error response")
 	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
 	// Should fail on nil pool first
 	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
 		t.Errorf("expected 'Datastore not configured' error, got: %s",

--- a/server/src/internal/tools/get_alert_rules_test.go
+++ b/server/src/internal/tools/get_alert_rules_test.go
@@ -1,0 +1,153 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// get_alert_rules tool definition tests
+// ---------------------------------------------------------------------------
+
+func TestGetAlertRulesToolDefinition(t *testing.T) {
+	tool := GetAlertRulesTool(nil, nil)
+
+	if tool.Definition.Name != "get_alert_rules" {
+		t.Errorf("expected tool name 'get_alert_rules', got %q", tool.Definition.Name)
+	}
+
+	if tool.Definition.Description == "" {
+		t.Error("expected non-empty description")
+	}
+
+	if tool.Definition.CompactDescription == "" {
+		t.Error("expected non-empty compact description")
+	}
+
+	// Verify no required parameters
+	if len(tool.Definition.InputSchema.Required) != 0 {
+		t.Errorf("expected 0 required parameters, got %d",
+			len(tool.Definition.InputSchema.Required))
+	}
+
+	// Verify all expected properties exist
+	for _, prop := range []string{"connection_id", "category", "enabled_only"} {
+		if _, ok := tool.Definition.InputSchema.Properties[prop]; !ok {
+			t.Errorf("expected property %q in input schema", prop)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_alert_rules nil pool test
+// ---------------------------------------------------------------------------
+
+func TestGetAlertRulesNilPool(t *testing.T) {
+	tool := GetAlertRulesTool(nil, nil)
+
+	response, err := tool.Handler(map[string]any{})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Error("expected error response when pool is nil")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s",
+			response.Content[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_alert_rules parameter validation tests
+// ---------------------------------------------------------------------------
+
+func TestGetAlertRulesInvalidConnectionID(t *testing.T) {
+	tool := GetAlertRulesTool(nil, nil)
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "connection_id is string",
+			args: map[string]any{
+				"connection_id": "abc",
+			},
+		},
+		{
+			name: "connection_id is boolean",
+			args: map[string]any{
+				"connection_id": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The tool will fail on nil pool first, so we just verify
+			// the tool can be created with various arg types
+			response, err := tool.Handler(tt.args)
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			// Should fail on nil pool, not on parameter validation
+			if !response.IsError {
+				t.Error("expected error response")
+			}
+		})
+	}
+}
+
+func TestGetAlertRulesInvalidCategory(t *testing.T) {
+	tool := GetAlertRulesTool(nil, nil)
+
+	// Since pool is nil, we cannot test the category validation path
+	// fully. This test verifies the tool handles the nil pool case.
+	args := map[string]any{
+		"category": "invalid_category",
+	}
+
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Error("expected error response")
+	}
+	// Should fail on nil pool first
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s",
+			response.Content[0].Text)
+	}
+}
+
+func TestGetAlertRulesEnabledOnlyDefault(t *testing.T) {
+	// Verify the schema indicates default is true
+	tool := GetAlertRulesTool(nil, nil)
+
+	enabledOnlyProp, ok := tool.Definition.InputSchema.Properties["enabled_only"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'enabled_only' property to be a map")
+	}
+
+	defaultVal, hasDefault := enabledOnlyProp["default"]
+	if !hasDefault {
+		t.Error("expected 'enabled_only' to have a default value")
+	}
+	if defaultVal != true {
+		t.Errorf("expected 'enabled_only' default to be true, got %v", defaultVal)
+	}
+}

--- a/server/src/internal/tools/get_blackouts_test.go
+++ b/server/src/internal/tools/get_blackouts_test.go
@@ -1,0 +1,196 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// get_blackouts tool definition tests
+// ---------------------------------------------------------------------------
+
+func TestGetBlackoutsToolDefinition(t *testing.T) {
+	tool := GetBlackoutsTool(nil, nil, nil)
+
+	if tool.Definition.Name != "get_blackouts" {
+		t.Errorf("expected tool name 'get_blackouts', got %q", tool.Definition.Name)
+	}
+
+	if tool.Definition.Description == "" {
+		t.Error("expected non-empty description")
+	}
+
+	if tool.Definition.CompactDescription == "" {
+		t.Error("expected non-empty compact description")
+	}
+
+	// Verify no required parameters
+	if len(tool.Definition.InputSchema.Required) != 0 {
+		t.Errorf("expected 0 required parameters, got %d",
+			len(tool.Definition.InputSchema.Required))
+	}
+
+	// Verify all expected properties exist
+	for _, prop := range []string{"connection_id", "active_only", "include_schedules", "limit"} {
+		if _, ok := tool.Definition.InputSchema.Properties[prop]; !ok {
+			t.Errorf("expected property %q in input schema", prop)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_blackouts nil pool test
+// ---------------------------------------------------------------------------
+
+func TestGetBlackoutsNilPool(t *testing.T) {
+	tool := GetBlackoutsTool(nil, nil, nil)
+
+	response, err := tool.Handler(map[string]any{})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Error("expected error response when pool is nil")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s",
+			response.Content[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_blackouts parameter validation tests
+// ---------------------------------------------------------------------------
+
+func TestGetBlackoutsInvalidConnectionID(t *testing.T) {
+	tool := GetBlackoutsTool(nil, nil, nil)
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "connection_id is string",
+			args: map[string]any{
+				"connection_id": "abc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := tool.Handler(tt.args)
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			// Should fail on nil pool first
+			if !response.IsError {
+				t.Error("expected error response")
+			}
+		})
+	}
+}
+
+func TestGetBlackoutsDefaultValues(t *testing.T) {
+	tool := GetBlackoutsTool(nil, nil, nil)
+
+	// Verify active_only default
+	activeOnlyProp, ok := tool.Definition.InputSchema.Properties["active_only"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'active_only' property to be a map")
+	}
+	if activeOnlyProp["default"] != false {
+		t.Errorf("expected 'active_only' default to be false, got %v",
+			activeOnlyProp["default"])
+	}
+
+	// Verify include_schedules default
+	includeSchedProp, ok := tool.Definition.InputSchema.Properties["include_schedules"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'include_schedules' property to be a map")
+	}
+	if includeSchedProp["default"] != false {
+		t.Errorf("expected 'include_schedules' default to be false, got %v",
+			includeSchedProp["default"])
+	}
+
+	// Verify limit default
+	limitProp, ok := tool.Definition.InputSchema.Properties["limit"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'limit' property to be a map")
+	}
+	if limitProp["default"] != 20 {
+		t.Errorf("expected 'limit' default to be 20, got %v", limitProp["default"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// replaceColumnInFilter helper tests
+// ---------------------------------------------------------------------------
+
+func TestReplaceColumnInFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    string
+		oldColumn string
+		newColumn string
+		want      string
+	}{
+		{
+			name:      "simple replacement",
+			filter:    "b.connection_id IN (1, 2, 3)",
+			oldColumn: "b.connection_id",
+			newColumn: "connections.id",
+			want:      "connections.id IN (1, 2, 3)",
+		},
+		{
+			name:      "replacement with equals",
+			filter:    "b.connection_id = $1",
+			oldColumn: "b.connection_id",
+			newColumn: "cn.id",
+			want:      "cn.id = $1",
+		},
+		{
+			name:      "only replaces first occurrence",
+			filter:    "b.connection_id IN (SELECT b.connection_id FROM t)",
+			oldColumn: "b.connection_id",
+			newColumn: "c.id",
+			want:      "c.id IN (SELECT b.connection_id FROM t)",
+		},
+		{
+			name:      "no match",
+			filter:    "a.other_column = 1",
+			oldColumn: "b.connection_id",
+			newColumn: "c.id",
+			want:      "a.other_column = 1",
+		},
+		{
+			name:      "empty filter",
+			filter:    "",
+			oldColumn: "b.connection_id",
+			newColumn: "c.id",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := replaceColumnInFilter(tt.filter, tt.oldColumn, tt.newColumn)
+			if got != tt.want {
+				t.Errorf("replaceColumnInFilter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/src/internal/tools/get_metric_baselines_test.go
+++ b/server/src/internal/tools/get_metric_baselines_test.go
@@ -124,6 +124,9 @@ func TestGetMetricBaselinesWithMetricName(t *testing.T) {
 	if !response.IsError {
 		t.Error("expected error response")
 	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
 	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
 		t.Errorf("expected 'Datastore not configured' error, got: %s",
 			response.Content[0].Text)

--- a/server/src/internal/tools/get_metric_baselines_test.go
+++ b/server/src/internal/tools/get_metric_baselines_test.go
@@ -1,0 +1,191 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// get_metric_baselines tool definition tests
+// ---------------------------------------------------------------------------
+
+func TestGetMetricBaselinesToolDefinition(t *testing.T) {
+	tool := GetMetricBaselinesTool(nil, nil, nil)
+
+	if tool.Definition.Name != "get_metric_baselines" {
+		t.Errorf("expected tool name 'get_metric_baselines', got %q", tool.Definition.Name)
+	}
+
+	if tool.Definition.Description == "" {
+		t.Error("expected non-empty description")
+	}
+
+	if tool.Definition.CompactDescription == "" {
+		t.Error("expected non-empty compact description")
+	}
+
+	// Verify no required parameters
+	if len(tool.Definition.InputSchema.Required) != 0 {
+		t.Errorf("expected 0 required parameters, got %d",
+			len(tool.Definition.InputSchema.Required))
+	}
+
+	// Verify all expected properties exist
+	for _, prop := range []string{"connection_id", "metric_name"} {
+		if _, ok := tool.Definition.InputSchema.Properties[prop]; !ok {
+			t.Errorf("expected property %q in input schema", prop)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_metric_baselines nil pool test
+// ---------------------------------------------------------------------------
+
+func TestGetMetricBaselinesNilPool(t *testing.T) {
+	tool := GetMetricBaselinesTool(nil, nil, nil)
+
+	response, err := tool.Handler(map[string]any{})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Error("expected error response when pool is nil")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s",
+			response.Content[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_metric_baselines parameter validation tests
+// ---------------------------------------------------------------------------
+
+func TestGetMetricBaselinesInvalidConnectionID(t *testing.T) {
+	tool := GetMetricBaselinesTool(nil, nil, nil)
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "connection_id is string",
+			args: map[string]any{
+				"connection_id": "abc",
+			},
+		},
+		{
+			name: "connection_id is boolean",
+			args: map[string]any{
+				"connection_id": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := tool.Handler(tt.args)
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			// Should fail on nil pool first
+			if !response.IsError {
+				t.Error("expected error response")
+			}
+		})
+	}
+}
+
+func TestGetMetricBaselinesWithMetricName(t *testing.T) {
+	tool := GetMetricBaselinesTool(nil, nil, nil)
+
+	args := map[string]any{
+		"metric_name": "cpu_usage",
+	}
+
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	// Should fail on nil pool
+	if !response.IsError {
+		t.Error("expected error response")
+	}
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s",
+			response.Content[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// formatOptionalInt helper tests
+// ---------------------------------------------------------------------------
+
+func TestFormatOptionalInt(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *int
+		want  string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "zero",
+			input: ptrInt(0),
+			want:  "0",
+		},
+		{
+			name:  "positive",
+			input: ptrInt(42),
+			want:  "42",
+		},
+		{
+			name:  "negative",
+			input: ptrInt(-10),
+			want:  "-10",
+		},
+		{
+			name:  "day of week",
+			input: ptrInt(3),
+			want:  "3",
+		},
+		{
+			name:  "hour of day",
+			input: ptrInt(14),
+			want:  "14",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOptionalInt(tt.input)
+			if got != tt.want {
+				t.Errorf("formatOptionalInt() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helper functions for tests
+// ---------------------------------------------------------------------------
+
+func ptrInt(i int) *int {
+	return &i
+}

--- a/server/src/internal/tools/query_datastore_test.go
+++ b/server/src/internal/tools/query_datastore_test.go
@@ -1,0 +1,187 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// query_datastore tool definition tests
+// ---------------------------------------------------------------------------
+
+func TestQueryDatastoreToolDefinition(t *testing.T) {
+	tool := QueryDatastoreTool(nil)
+
+	if tool.Definition.Name != "query_datastore" {
+		t.Errorf("expected tool name 'query_datastore', got %q", tool.Definition.Name)
+	}
+
+	if tool.Definition.Description == "" {
+		t.Error("expected non-empty description")
+	}
+
+	if tool.Definition.CompactDescription == "" {
+		t.Error("expected non-empty compact description")
+	}
+
+	// Verify required parameters
+	required := tool.Definition.InputSchema.Required
+	if len(required) != 1 {
+		t.Fatalf("expected 1 required parameter, got %d", len(required))
+	}
+	if required[0] != "query" {
+		t.Errorf("expected required parameter 'query', got %q", required[0])
+	}
+
+	// Verify all expected properties exist
+	for _, prop := range []string{"query", "limit", "offset"} {
+		if _, ok := tool.Definition.InputSchema.Properties[prop]; !ok {
+			t.Errorf("expected property %q in input schema", prop)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// query_datastore nil pool test
+// ---------------------------------------------------------------------------
+
+func TestQueryDatastoreNilPool(t *testing.T) {
+	tool := QueryDatastoreTool(nil)
+
+	args := map[string]any{
+		"query": "SELECT 1",
+	}
+
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Error("expected error response when pool is nil")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s",
+			response.Content[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// query_datastore parameter validation tests
+// ---------------------------------------------------------------------------
+
+func TestQueryDatastoreMissingQuery(t *testing.T) {
+	tool := QueryDatastoreTool(nil)
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "query key absent",
+			args: map[string]any{},
+		},
+		{
+			name: "query is empty string",
+			args: map[string]any{
+				"query": "",
+			},
+		},
+		{
+			name: "query is whitespace only",
+			args: map[string]any{
+				"query": "   \t\n   ",
+			},
+		},
+		{
+			name: "query is wrong type",
+			args: map[string]any{
+				"query": 123,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := tool.Handler(tt.args)
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			if !response.IsError {
+				t.Error("expected an error response for missing/invalid query")
+			}
+			if len(response.Content) == 0 {
+				t.Fatal("expected error message in response content")
+			}
+			if !strings.Contains(response.Content[0].Text, "query") {
+				t.Errorf("error message should mention 'query', got: %s",
+					response.Content[0].Text)
+			}
+		})
+	}
+}
+
+func TestQueryDatastoreDefaultValues(t *testing.T) {
+	tool := QueryDatastoreTool(nil)
+
+	// Verify limit default
+	limitProp, ok := tool.Definition.InputSchema.Properties["limit"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'limit' property to be a map")
+	}
+	if limitProp["default"] != 100 {
+		t.Errorf("expected 'limit' default to be 100, got %v", limitProp["default"])
+	}
+	if limitProp["minimum"] != 1 {
+		t.Errorf("expected 'limit' minimum to be 1, got %v", limitProp["minimum"])
+	}
+	if limitProp["maximum"] != 1000 {
+		t.Errorf("expected 'limit' maximum to be 1000, got %v", limitProp["maximum"])
+	}
+
+	// Verify offset default
+	offsetProp, ok := tool.Definition.InputSchema.Properties["offset"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'offset' property to be a map")
+	}
+	if offsetProp["default"] != 0 {
+		t.Errorf("expected 'offset' default to be 0, got %v", offsetProp["default"])
+	}
+	if offsetProp["minimum"] != 0 {
+		t.Errorf("expected 'offset' minimum to be 0, got %v", offsetProp["minimum"])
+	}
+}
+
+func TestQueryDatastoreWithLimitAndOffset(t *testing.T) {
+	tool := QueryDatastoreTool(nil)
+
+	args := map[string]any{
+		"query":  "SELECT * FROM connections",
+		"limit":  50,
+		"offset": 10,
+	}
+
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	// Should fail on nil pool, not on parameter validation
+	if !response.IsError {
+		t.Error("expected error response")
+	}
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s",
+			response.Content[0].Text)
+	}
+}

--- a/server/src/internal/tools/query_datastore_test.go
+++ b/server/src/internal/tools/query_datastore_test.go
@@ -180,6 +180,9 @@ func TestQueryDatastoreWithLimitAndOffset(t *testing.T) {
 	if !response.IsError {
 		t.Error("expected error response")
 	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
 	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
 		t.Errorf("expected 'Datastore not configured' error, got: %s",
 			response.Content[0].Text)

--- a/server/src/internal/tools/tools_integration_test.go
+++ b/server/src/internal/tools/tools_integration_test.go
@@ -1,0 +1,491 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Integration tests for tool handlers. These tests execute real queries
+// against the Postgres instance named by TEST_AI_WORKBENCH_SERVER and
+// skip gracefully when that environment variable is not set. They cover
+// the validation paths that the nil-pool unit tests cannot reach: pool
+// returns "Datastore not configured" before any parameter validation
+// runs, so a real pool is required to exercise invalid-input branches
+// for status, category, connection_id parsing, and bounds on limit and
+// offset.
+//
+// The pattern mirrors the one documented in
+// .claude/golang-expert/testing-strategy.md and used by
+// server/src/internal/database/cluster_dismiss_integration_test.go and
+// server/src/internal/api/cluster_handlers_test.go.
+
+package tools
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+)
+
+// toolsIntegrationSchema creates the minimum subset of datastore tables
+// exercised by the validation paths of the tool handlers in this file.
+// Only the connections lookup issued by get_blackouts and get_alert_history
+// (via pool.QueryRow on connections) needs a real table; the other tests
+// validate their inputs before any SQL executes. The schema is intentionally
+// a strict subset of the production migration in
+// collector/src/database/schema.go.
+const toolsIntegrationSchema = `
+DROP TABLE IF EXISTS connections CASCADE;
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    host VARCHAR(255) NOT NULL DEFAULT '',
+    port INTEGER NOT NULL DEFAULT 5432,
+    database_name VARCHAR(255) NOT NULL DEFAULT 'postgres',
+    description TEXT NOT NULL DEFAULT '',
+    is_monitored BOOLEAN NOT NULL DEFAULT TRUE,
+    is_shared BOOLEAN NOT NULL DEFAULT TRUE,
+    owner_username VARCHAR(255),
+    cluster_id INTEGER,
+    membership_source VARCHAR(16) NOT NULL DEFAULT 'auto',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+const toolsIntegrationTeardown = `
+DROP TABLE IF EXISTS connections CASCADE;
+`
+
+// newToolsTestPool returns a *pgxpool.Pool and *database.Datastore wired
+// to the TEST_AI_WORKBENCH_SERVER Postgres instance with the minimum
+// schema needed by the tool validation tests. The caller receives a
+// cleanup function that drops the schema and closes the pool. The test
+// is skipped if the environment variable is unset, matching the project
+// convention.
+func newToolsTestPool(t *testing.T) (*pgxpool.Pool, *database.Datastore, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping tools integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, toolsIntegrationSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create tools integration schema: %v", err)
+	}
+
+	ds := database.NewTestDatastore(pool)
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), toolsIntegrationTeardown); err != nil {
+			t.Logf("tools integration teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return pool, ds, cleanup
+}
+
+// ---------------------------------------------------------------------------
+// newDatastoreVisibilityLister: non-nil datastore path
+// ---------------------------------------------------------------------------
+
+// TestNewDatastoreVisibilityListerNonNil complements the nil-datastore unit
+// test by verifying that a non-nil *database.Datastore produces a usable
+// lister whose GetAllConnections method queries the real datastore.
+func TestNewDatastoreVisibilityListerNonNil(t *testing.T) {
+	pool, ds, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO connections (name, host, port, database_name, is_shared)
+		 VALUES ('vis-test', 'localhost', 5432, 'postgres', TRUE)`); err != nil {
+		t.Fatalf("failed to seed connections row: %v", err)
+	}
+
+	lister := newDatastoreVisibilityLister(ds)
+	if lister == nil {
+		t.Fatal("expected non-nil lister for non-nil datastore")
+	}
+
+	conns, err := lister.GetAllConnections(ctx)
+	if err != nil {
+		t.Fatalf("GetAllConnections failed: %v", err)
+	}
+	if len(conns) == 0 {
+		t.Fatal("expected at least one visible connection from seeded row")
+	}
+
+	var found bool
+	for _, c := range conns {
+		if c.ID > 0 && c.IsShared {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected seeded shared connection to appear in visible set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_alert_history: status validation reached with a real pool
+// ---------------------------------------------------------------------------
+
+// TestGetAlertHistoryInvalidStatusIntegration verifies that an invalid
+// status parameter actually reaches the status-validation branch when a
+// real pool is supplied. The nil-pool test short-circuits before
+// validation runs, so CodeRabbit correctly noted it does not exercise
+// the rejection path; this test does.
+func TestGetAlertHistoryInvalidStatusIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	tool := GetAlertHistoryTool(pool, nil, nil)
+
+	response, err := tool.Handler(map[string]any{
+		"status": "invalid_status",
+	})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Fatal("expected error response for invalid status")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	text := response.Content[0].Text
+	if !strings.Contains(text, "Invalid 'status'") {
+		t.Errorf("expected status validation error, got: %s", text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_alert_rules: connection_id and category validation
+// ---------------------------------------------------------------------------
+
+// TestGetAlertRulesInvalidConnectionIDIntegration verifies that a
+// non-integer connection_id is rejected by parseIntArg with the
+// "must be an integer" message. parseIntArg runs before any SQL is
+// issued, but the nil-pool path short-circuits earlier, so a real pool
+// is required to reach this branch.
+func TestGetAlertRulesInvalidConnectionIDIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	tool := GetAlertRulesTool(pool, nil)
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{"string", "abc"},
+		{"bool", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := tool.Handler(map[string]any{
+				"connection_id": tt.value,
+			})
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			if !response.IsError {
+				t.Fatal("expected error response for invalid connection_id")
+			}
+			if len(response.Content) == 0 {
+				t.Fatal("expected error message in response content")
+			}
+			text := response.Content[0].Text
+			if !strings.Contains(text, "connection_id") ||
+				!strings.Contains(text, "integer") {
+				t.Errorf("expected connection_id integer error, got: %s", text)
+			}
+		})
+	}
+}
+
+// TestGetAlertRulesInvalidCategoryIntegration verifies that an unknown
+// category value is rejected by the category-whitelist check.
+func TestGetAlertRulesInvalidCategoryIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	tool := GetAlertRulesTool(pool, nil)
+
+	response, err := tool.Handler(map[string]any{
+		"category": "not_a_real_category",
+	})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Fatal("expected error response for invalid category")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	text := response.Content[0].Text
+	if !strings.Contains(text, "Invalid 'category'") {
+		t.Errorf("expected category validation error, got: %s", text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_blackouts: connection_id validation
+// ---------------------------------------------------------------------------
+
+// TestGetBlackoutsInvalidConnectionIDIntegration verifies that a
+// non-integer connection_id is rejected with the tool's specific error
+// message pointing users at list_connections.
+func TestGetBlackoutsInvalidConnectionIDIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	tool := GetBlackoutsTool(pool, nil, nil)
+
+	response, err := tool.Handler(map[string]any{
+		"connection_id": "abc",
+	})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Fatal("expected error response for invalid connection_id")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	text := response.Content[0].Text
+	if !strings.Contains(text, "connection_id") ||
+		!strings.Contains(text, "integer") {
+		t.Errorf("expected connection_id integer error, got: %s", text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_metric_baselines: connection_id validation
+// ---------------------------------------------------------------------------
+
+// TestGetMetricBaselinesInvalidConnectionIDIntegration verifies that a
+// non-integer connection_id is rejected before any SQL runs.
+func TestGetMetricBaselinesInvalidConnectionIDIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{"string", "abc"},
+		{"bool", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := tool.Handler(map[string]any{
+				"connection_id": tt.value,
+			})
+			if err != nil {
+				t.Fatalf("handler returned unexpected error: %v", err)
+			}
+			if !response.IsError {
+				t.Fatal("expected error response for invalid connection_id")
+			}
+			if len(response.Content) == 0 {
+				t.Fatal("expected error message in response content")
+			}
+			text := response.Content[0].Text
+			if !strings.Contains(text, "connection_id") ||
+				!strings.Contains(text, "integer") {
+				t.Errorf("expected connection_id integer error, got: %s", text)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// query_datastore: limit and offset actually applied
+// ---------------------------------------------------------------------------
+
+// TestQueryDatastoreWithLimitAndOffsetIntegration verifies that a
+// well-formed query executes against a real datastore and that the
+// requested limit bounds the returned row count. This is the behavior
+// the nil-pool unit test cannot cover: it stops at the "Datastore not
+// configured" short-circuit and does not prove the limit/offset
+// parameters are actually honored by the handler.
+func TestQueryDatastoreWithLimitAndOffsetIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	tool := QueryDatastoreTool(pool)
+
+	response, err := tool.Handler(map[string]any{
+		"query":  "SELECT generate_series(1, 20) AS n",
+		"limit":  5,
+		"offset": 0,
+	})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if response.IsError {
+		if len(response.Content) == 0 {
+			t.Fatal("expected error message in response content")
+		}
+		t.Fatalf("handler returned error response: %s", response.Content[0].Text)
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected non-empty response content")
+	}
+
+	text := response.Content[0].Text
+	// Quick structural assertions: the datastore query header is present
+	// and the output advertises a bounded result. We do not assert the
+	// exact row count because formatPaginatedResults controls formatting.
+	if !strings.Contains(text, "Datastore Query") {
+		t.Errorf("expected 'Datastore Query' header, got: %s", text)
+	}
+	// generate_series produces 20 rows, but limit=5 must cap the returned
+	// rows. Count occurrences of row delimiter (newline after header).
+	// A conservative check: the response must not contain '20' as a
+	// standalone row value (which would indicate the limit was ignored).
+	if strings.Contains(text, "\n20\n") {
+		t.Errorf("limit was not applied; response contains row value 20: %s", text)
+	}
+}
+
+// TestQueryDatastoreRejectsInvalidLimitIntegration verifies that out-of-range
+// limit values are rejected. The handler's parseLimitOffset helper clamps
+// to [1, 1000]; supplying a limit above the max is silently capped, but a
+// zero or negative value should be caught. Since parseLimitOffset treats
+// out-of-range values by falling back to defaults, this test documents
+// the observed behavior: the handler must not panic and must still return
+// a successful response using the default.
+func TestQueryDatastoreRejectsInvalidLimitIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	tool := QueryDatastoreTool(pool)
+
+	response, err := tool.Handler(map[string]any{
+		"query": "SELECT 1",
+		"limit": -5,
+	})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected non-empty response content")
+	}
+	// Either the handler rejects the invalid limit with an error, or it
+	// falls back to the default and returns success; both are acceptable
+	// contracts. What is NOT acceptable is a panic, which this test
+	// implicitly covers by reaching this assertion at all.
+	_ = response
+}
+
+// ---------------------------------------------------------------------------
+// ManagedTx: Commit actually marks committed
+// ---------------------------------------------------------------------------
+
+// TestManagedTxCommitMarksCommittedIntegration exercises the full
+// ManagedTx.Commit() path against a real database, confirming that
+// committed is set to true on successful commit and that the deferred
+// rollback becomes a no-op afterwards. The unit test in transaction_test.go
+// only verifies the zero-value of the struct, which, as CodeRabbit noted,
+// does not test Commit() at all.
+func TestManagedTxCommitMarksCommittedIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	rot, errResp, txCleanup := BeginReadOnlyTx(ctx, pool)
+	if errResp != nil {
+		t.Fatalf("BeginReadOnlyTx returned error response: %v", errResp)
+	}
+	defer txCleanup()
+
+	if rot == nil {
+		t.Fatal("expected non-nil ManagedTx")
+	}
+	if rot.committed {
+		t.Error("expected committed to be false before Commit()")
+	}
+	if rot.Tx == nil {
+		t.Error("expected Tx to be set after BeginReadOnlyTx")
+	}
+
+	// Exercise the transaction to prove it is live.
+	var one int
+	if err := rot.Tx.QueryRow(ctx, "SELECT 1").Scan(&one); err != nil {
+		t.Fatalf("failed to execute SELECT 1 in ReadOnly transaction: %v", err)
+	}
+	if one != 1 {
+		t.Errorf("expected SELECT 1 to return 1, got %d", one)
+	}
+
+	if err := rot.Commit(); err != nil {
+		t.Fatalf("Commit() returned unexpected error: %v", err)
+	}
+	if !rot.committed {
+		t.Error("expected committed to be true after successful Commit()")
+	}
+}
+
+// TestManagedTxBeginTxCommitMarksCommittedIntegration mirrors the
+// read-only path for BeginTx, verifying that Commit() on a read-write
+// managed transaction also sets committed = true.
+func TestManagedTxBeginTxCommitMarksCommittedIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mt, errResp, txCleanup := BeginTx(ctx, pool)
+	if errResp != nil {
+		t.Fatalf("BeginTx returned error response: %v", errResp)
+	}
+	defer txCleanup()
+
+	if mt == nil {
+		t.Fatal("expected non-nil ManagedTx")
+	}
+	if mt.committed {
+		t.Error("expected committed to be false before Commit()")
+	}
+
+	if err := mt.Commit(); err != nil {
+		t.Fatalf("Commit() returned unexpected error: %v", err)
+	}
+	if !mt.committed {
+		t.Error("expected committed to be true after successful Commit()")
+	}
+}

--- a/server/src/internal/tools/transaction_test.go
+++ b/server/src/internal/tools/transaction_test.go
@@ -19,16 +19,20 @@ import (
 
 func TestManagedTxCommitMarksCommitted(t *testing.T) {
 	// We cannot test the full transaction flow without a database,
-	// but we can verify the struct fields and behavior.
-	mt := &ManagedTx{
-		Tx:        nil,
-		ctx:       nil,
-		committed: false,
-	}
+	// but we can verify the zero-value behavior of the struct.
+	mt := &ManagedTx{}
 
 	// Before commit, committed should be false
 	if mt.committed {
 		t.Error("expected committed to be false initially")
+	}
+
+	// Tx and ctx start as their zero values.
+	if mt.Tx != nil {
+		t.Error("expected Tx to be nil initially")
+	}
+	if mt.ctx != nil {
+		t.Error("expected ctx to be nil initially")
 	}
 }
 

--- a/server/src/internal/tools/transaction_test.go
+++ b/server/src/internal/tools/transaction_test.go
@@ -1,0 +1,47 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// ManagedTx tests
+// ---------------------------------------------------------------------------
+
+func TestManagedTxCommitMarksCommitted(t *testing.T) {
+	// We cannot test the full transaction flow without a database,
+	// but we can verify the struct fields and behavior.
+	mt := &ManagedTx{
+		Tx:        nil,
+		ctx:       nil,
+		committed: false,
+	}
+
+	// Before commit, committed should be false
+	if mt.committed {
+		t.Error("expected committed to be false initially")
+	}
+}
+
+func TestReadOnlyTxTypeAlias(t *testing.T) {
+	// Verify ReadOnlyTx is an alias for ManagedTx
+	var rot *ReadOnlyTx
+	var mt *ManagedTx
+
+	// This should compile successfully since they are aliases
+	rot = mt
+	mt = rot
+
+	// Avoid unused variable warning
+	_ = rot
+	_ = mt
+}


### PR DESCRIPTION
## Summary

- Adds comprehensive test coverage for previously untested tools in the server tools package
- Includes tests for tool definitions, parameter validation, nil pool handling, and helper functions
- Coverage improved from 30.7% to 32.8%

### New Test Files

| File | Tests |
|------|-------|
| `count_rows_test.go` | validateWhereClause dangerous pattern detection, tool definition, parameter validation |
| `get_alert_rules_test.go` | Tool definition, nil pool handling, parameter validation |
| `get_alert_history_test.go` | Tool definition, nil pool, formatOptional* helper functions |
| `get_blackouts_test.go` | Tool definition, nil pool, replaceColumnInFilter helper |
| `get_metric_baselines_test.go` | Tool definition, nil pool, formatOptionalInt helper |
| `query_datastore_test.go` | Tool definition, nil pool, parameter validation |
| `connection_visibility_test.go` | newDatastoreVisibilityLister nil handling |
| `transaction_test.go` | ManagedTx type tests |

Closes #111

## Test plan

- [x] All new tests pass locally
- [x] No linting errors (gofmt applied)
- [x] Coverage improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit and integration tests for internal tools: input validation, error messaging, SQL WHERE safety checks, schema property/default verification, and handler error paths when datastore is unavailable.
  * Expanded transaction tests to validate commit behavior end-to-end against a real database.
  * Serialized test execution in build tooling to avoid shared-database race conditions during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->