### PR TITLE
Add tests for client AdminPanel components

### DIFF
--- a/client/src/components/AdminPanel/AdminAlertRules.tsx
+++ b/client/src/components/AdminPanel/AdminAlertRules.tsx
@@ -296,6 +296,7 @@ const AdminAlertRules: React.FC = () => {
                             checked={editEnabled}
                             onChange={(e) => setEditEnabled(e.target.checked)}
                             disabled={saving}
+                            inputProps={{ 'aria-label': 'Enabled' }}
                         />
                     </Box>
                     <TextField

--- a/client/src/components/AdminPanel/EffectivePermissionsPanel.tsx
+++ b/client/src/components/AdminPanel/EffectivePermissionsPanel.tsx
@@ -37,11 +37,12 @@ const ADMIN_PERMISSION_LABELS: Record<string, string> = {
 interface CategoryCardProps {
     icon: SvgIconComponent;
     label: string;
+    testId?: string;
     children: React.ReactNode;
 }
 
-const CategoryCard: React.FC<CategoryCardProps> = ({ icon: Icon, label, children }) => (
-    <Box>
+const CategoryCard: React.FC<CategoryCardProps> = ({ icon: Icon, label, testId, children }) => (
+    <Box data-testid={testId}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
             <Icon sx={{ fontSize: 16, color: 'text.secondary' }} />
             <Typography sx={categoryLabelSx}>
@@ -125,7 +126,7 @@ const EffectivePermissionsPanel: React.FC<EffectivePermissionsPanelProps> = ({
             )}
 
             <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 2 }}>
-                <CategoryCard icon={ConnectionIcon} label="Connections">
+                <CategoryCard icon={ConnectionIcon} label="Connections" testId="connection-privileges-section">
                     {connArray.length > 0 ? (
                         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                             {connArray.map((cp, i) => (
@@ -144,7 +145,7 @@ const EffectivePermissionsPanel: React.FC<EffectivePermissionsPanelProps> = ({
                 </CategoryCard>
 
                 {isSuperuser && (
-                    <CategoryCard icon={AdminIcon} label="Admin">
+                    <CategoryCard icon={AdminIcon} label="Admin" testId="admin-permissions-section">
                         {adminPermissions && adminPermissions.length > 0 ? (
                             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                                 {adminPermissions.map((perm) => (
@@ -163,7 +164,7 @@ const EffectivePermissionsPanel: React.FC<EffectivePermissionsPanelProps> = ({
                     </CategoryCard>
                 )}
 
-                <CategoryCard icon={McpIcon} label="MCP">
+                <CategoryCard icon={McpIcon} label="MCP" testId="mcp-privileges-section">
                     {mcpPrivileges && mcpPrivileges.length > 0 ? (
                         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                             {mcpPrivileges.map((priv, i) => {

--- a/client/src/components/AdminPanel/EffectivePermissionsPanel.tsx
+++ b/client/src/components/AdminPanel/EffectivePermissionsPanel.tsx
@@ -60,13 +60,15 @@ const EmptyState = () => (
 );
 
 interface EffectivePermissionsPanelProps {
-    connectionPrivileges?: Record<string, string[]> | Array<{ server_id: number; privileges: string[] }>;
+    connectionPrivileges?:
+        | Record<string, string[]>
+        | Array<{ connection_id: string | number; access_level: string }>;
     adminPermissions?: string[];
-    mcpPrivileges?: Record<string, string[]> | Array<{ server_id: number; tools: string[] }>;
+    mcpPrivileges?: Array<string | { privilege?: string; name?: string }>;
     isSuperuser?: boolean;
     connections?: Array<{ id: number; name: string }>;
     isDark?: boolean;
-    groups?: Array<{ id: number; name: string }>;
+    groups?: string[];
 }
 
 const EffectivePermissionsPanel: React.FC<EffectivePermissionsPanelProps> = ({

--- a/client/src/components/AdminPanel/__tests__/AdminAlertRules.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminAlertRules.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from 'react';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import renderWithTheme from '../../../test/renderWithTheme';
@@ -152,7 +152,7 @@ describe('AdminAlertRules', () => {
         expect(screen.getByText('> 100')).toBeInTheDocument();
     });
 
-    it('displays severity chips with appropriate colors', async () => {
+    it('displays severity labels for each severity level', async () => {
         mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
 
         renderWithTheme(<AdminAlertRules />);
@@ -449,16 +449,11 @@ describe('AdminAlertRules', () => {
             expect(screen.getByLabelText('Threshold')).toBeInTheDocument();
         });
 
-        // Find the switch in the dialog
-        const switches = screen.getAllByRole('checkbox');
-        const enabledSwitch = switches.find((s) =>
-            s.closest('[class*="MuiDialogContent"]')
-        );
-        expect(enabledSwitch).toBeDefined();
+        // Find the switch in the dialog by its aria-label
+        const dialog = screen.getByRole('dialog');
+        const enabledSwitch = within(dialog).getByRole('checkbox', { name: /enabled/i });
         expect(enabledSwitch).toBeChecked();
-
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        await user.click(enabledSwitch!);
+        await user.click(enabledSwitch);
 
         await user.click(screen.getByRole('button', { name: /Save/i }));
 

--- a/client/src/components/AdminPanel/__tests__/AdminAlertRules.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminAlertRules.test.tsx
@@ -1,0 +1,474 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+const mockApiGet = vi.fn();
+const mockApiPut = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+}));
+
+import AdminAlertRules from '../AdminAlertRules';
+
+const MOCK_ALERT_RULES = [
+    {
+        id: 1,
+        name: 'high_cpu_usage',
+        category: 'System',
+        metric_name: 'cpu_usage_percent',
+        default_operator: '>',
+        default_threshold: 80,
+        default_severity: 'warning',
+        default_enabled: true,
+    },
+    {
+        id: 2,
+        name: 'disk_usage_critical',
+        category: 'System',
+        metric_name: 'disk_usage_percent',
+        default_operator: '>',
+        default_threshold: 90,
+        default_severity: 'critical',
+        default_enabled: true,
+    },
+    {
+        id: 3,
+        name: 'connection_utilization',
+        category: 'Database',
+        metric_name: 'connection_count',
+        default_operator: '>',
+        default_threshold: 100,
+        default_severity: 'info',
+        default_enabled: false,
+    },
+];
+
+describe('AdminAlertRules', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('displays loading state initially', () => {
+        mockApiGet.mockReturnValue(new Promise(() => {}));
+
+        renderWithTheme(<AdminAlertRules />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(screen.getByLabelText('Loading alert rules')).toBeInTheDocument();
+    });
+
+    it('renders alert rules from API', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Alert defaults')).toBeInTheDocument();
+        });
+
+        // Check table headers
+        expect(screen.getByText('Name')).toBeInTheDocument();
+        expect(screen.getByText('Metric')).toBeInTheDocument();
+        expect(screen.getByText('Condition')).toBeInTheDocument();
+        expect(screen.getByText('Severity')).toBeInTheDocument();
+        expect(screen.getByText('Enabled')).toBeInTheDocument();
+        expect(screen.getByText('Actions')).toBeInTheDocument();
+
+        // Check that rules are displayed with friendly names
+        // high_cpu_usage falls through to title-casing: "High Cpu Usage"
+        expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        // disk_usage_critical maps to "Critical Disk Usage" in FRIENDLY_ALERT_TITLES
+        expect(screen.getByText('Critical Disk Usage')).toBeInTheDocument();
+        // connection_utilization maps to "Connection Utilization" in FRIENDLY_ALERT_TITLES
+        expect(screen.getByText('Connection Utilization')).toBeInTheDocument();
+
+        // Verify API was called correctly
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/alert-rules');
+    });
+
+    it('handles API returning array directly', async () => {
+        mockApiGet.mockResolvedValue(MOCK_ALERT_RULES);
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+    });
+
+    it('displays categories as group headers', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('System')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('Database')).toBeInTheDocument();
+    });
+
+    it('displays metric names in the table', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage_percent')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('disk_usage_percent')).toBeInTheDocument();
+        expect(screen.getByText('connection_count')).toBeInTheDocument();
+    });
+
+    it('displays condition (operator and threshold) in the table', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('> 80')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('> 90')).toBeInTheDocument();
+        expect(screen.getByText('> 100')).toBeInTheDocument();
+    });
+
+    it('displays severity chips with appropriate colors', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('warning')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('critical')).toBeInTheDocument();
+        expect(screen.getByText('info')).toBeInTheDocument();
+    });
+
+    it('shows empty state when no rules exist', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: [] });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No alert rules found.')).toBeInTheDocument();
+        });
+    });
+
+    it('displays error message when API fails', async () => {
+        mockApiGet.mockRejectedValue(new Error('Network error'));
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Network error')).toBeInTheDocument();
+        });
+    });
+
+    it('opens edit dialog when edit button is clicked', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        // Find the edit button in the row for high_cpu_usage
+        const editButtons = screen.getAllByRole('button', { name: /edit alert rule/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit alert rule:/)).toBeInTheDocument();
+        });
+    });
+
+    it('pre-populates edit dialog with current values', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        // Categories are sorted alphabetically: Database, System
+        // First edit button is for connection_utilization (Database category, threshold: 100)
+        // We want to click on a specific rule, so find the row and its edit button
+        const highCpuRow = screen.getByText('High Cpu Usage').closest('tr');
+        expect(highCpuRow).not.toBeNull();
+        const editButton = (highCpuRow as HTMLElement).querySelector('[aria-label="edit alert rule"]');
+        expect(editButton).not.toBeNull();
+        await user.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('Threshold')).toHaveValue(80);
+        });
+
+        // Check that the operator select has the correct value
+        const operatorSelect = screen.getByLabelText('Operator');
+        expect(operatorSelect).toHaveTextContent('>');
+
+        // Check that the severity select has the correct value
+        const severitySelect = screen.getByLabelText('Severity');
+        expect(severitySelect).toHaveTextContent('warning');
+    });
+
+    it('closes edit dialog when Cancel is clicked', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit alert rule/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit alert rule:/)).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByText(/Edit alert rule:/)).not.toBeInTheDocument();
+        });
+    });
+
+    it('saves changes when Save is clicked with valid data', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        // Find the specific row and its edit button
+        const highCpuRow = screen.getByText('High Cpu Usage').closest('tr');
+        expect(highCpuRow).not.toBeNull();
+        const editButton = (highCpuRow as HTMLElement).querySelector('[aria-label="edit alert rule"]');
+        await user.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('Threshold')).toBeInTheDocument();
+        });
+
+        // Change the threshold
+        const thresholdInput = screen.getByLabelText('Threshold');
+        await user.clear(thresholdInput);
+        await user.type(thresholdInput, '85');
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/alert-rules/1',
+                expect.objectContaining({
+                    default_threshold: 85,
+                })
+            );
+        });
+    });
+
+    it('displays error when threshold is not a valid number', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit alert rule/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('Threshold')).toBeInTheDocument();
+        });
+
+        const thresholdInput = screen.getByLabelText('Threshold');
+        await user.clear(thresholdInput);
+        await user.type(thresholdInput, 'invalid');
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Threshold must be a valid number.')).toBeInTheDocument();
+        });
+
+        expect(mockApiPut).not.toHaveBeenCalled();
+    });
+
+    it('displays error message when save fails', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        mockApiPut.mockRejectedValue(new Error('Save failed'));
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit alert rule/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('Threshold')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Save failed')).toBeInTheDocument();
+        });
+    });
+
+    it('displays success message after successful save', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit alert rule/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('Threshold')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/updated successfully/)).toBeInTheDocument();
+        });
+    });
+
+    it('can dismiss error alerts', async () => {
+        mockApiGet.mockRejectedValue(new Error('Network error'));
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Network error')).toBeInTheDocument();
+        });
+
+        const closeButton = screen.getByRole('button', { name: /close/i });
+        fireEvent.click(closeButton);
+
+        await waitFor(() => {
+            expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+        });
+    });
+
+    it('can dismiss success alerts', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit alert rule/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('Threshold')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/updated successfully/)).toBeInTheDocument();
+        });
+
+        const closeButtons = screen.getAllByRole('button', { name: /close/i });
+        fireEvent.click(closeButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.queryByText(/updated successfully/)).not.toBeInTheDocument();
+        });
+    });
+
+    it('toggles enabled state in edit dialog', async () => {
+        mockApiGet.mockResolvedValue({ alert_rules: MOCK_ALERT_RULES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminAlertRules />);
+
+        await waitFor(() => {
+            expect(screen.getByText('High Cpu Usage')).toBeInTheDocument();
+        });
+
+        // Find the specific row and its edit button
+        const highCpuRow = screen.getByText('High Cpu Usage').closest('tr');
+        expect(highCpuRow).not.toBeNull();
+        const editButton = (highCpuRow as HTMLElement).querySelector('[aria-label="edit alert rule"]');
+        await user.click(editButton as HTMLElement);
+
+        // Wait for dialog to open
+        await waitFor(() => {
+            expect(screen.getByLabelText('Threshold')).toBeInTheDocument();
+        });
+
+        // Find the switch in the dialog
+        const switches = screen.getAllByRole('checkbox');
+        const enabledSwitch = switches.find((s) =>
+            s.closest('[class*="MuiDialogContent"]')
+        );
+        expect(enabledSwitch).toBeDefined();
+        expect(enabledSwitch).toBeChecked();
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        await user.click(enabledSwitch!);
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/alert-rules/1',
+                expect.objectContaining({
+                    default_enabled: false,
+                })
+            );
+        });
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminMemories.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminMemories.test.tsx
@@ -1,0 +1,380 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+const mockApiGet = vi.fn();
+const mockApiDelete = vi.fn();
+const mockApiPatch = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+    apiPatch: (...args: unknown[]) => mockApiPatch(...args),
+}));
+
+import AdminMemories from '../AdminMemories';
+
+const MOCK_MEMORIES = [
+    {
+        id: 1,
+        username: 'admin',
+        scope: 'system',
+        category: 'optimization',
+        content: 'Always use EXPLAIN ANALYZE for query optimization',
+        pinned: true,
+        model_name: 'claude-3',
+        created_at: '2024-01-15T10:30:00Z',
+        updated_at: '2024-01-15T10:30:00Z',
+    },
+    {
+        id: 2,
+        username: 'testuser',
+        scope: 'user',
+        category: 'best-practices',
+        content: 'Use connection pooling for high-concurrency applications. This is a very long piece of content that should be truncated in the display to prevent the table from becoming too wide and maintain readability.',
+        pinned: false,
+        model_name: 'claude-3',
+        created_at: '2024-01-16T14:20:00Z',
+        updated_at: '2024-01-16T14:20:00Z',
+    },
+    {
+        id: 3,
+        username: 'admin',
+        scope: 'system',
+        category: '',
+        content: 'Vacuum tables regularly to prevent bloat',
+        pinned: false,
+        model_name: 'claude-3',
+        created_at: '2024-01-17T09:00:00Z',
+        updated_at: '2024-01-17T09:00:00Z',
+    },
+];
+
+describe('AdminMemories', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('displays loading state initially', () => {
+        mockApiGet.mockReturnValue(new Promise(() => {}));
+
+        renderWithTheme(<AdminMemories />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(screen.getByLabelText('Loading memories')).toBeInTheDocument();
+    });
+
+    it('renders memories from API', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Memories')).toBeInTheDocument();
+        });
+
+        // Check table headers
+        expect(screen.getByText('Content')).toBeInTheDocument();
+        expect(screen.getByText('Category')).toBeInTheDocument();
+        expect(screen.getByText('Scope')).toBeInTheDocument();
+        expect(screen.getByText('Pinned')).toBeInTheDocument();
+        expect(screen.getByText('Created')).toBeInTheDocument();
+        expect(screen.getByText('Actions')).toBeInTheDocument();
+
+        // Check that memories are displayed
+        expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        expect(screen.getByText(/Vacuum tables regularly/)).toBeInTheDocument();
+
+        // Verify API was called correctly
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/memories?limit=1000');
+    });
+
+    it('truncates long content with ellipsis', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Memories')).toBeInTheDocument();
+        });
+
+        // The second memory has long content that should be truncated
+        const truncatedContent = screen.getByText(/Use connection pooling/);
+        expect(truncatedContent.textContent).toContain('\u2026');
+    });
+
+    it('displays scope chips correctly', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getAllByText('System').length).toBeGreaterThan(0);
+        });
+
+        expect(screen.getByText('User')).toBeInTheDocument();
+    });
+
+    it('displays categories in the table', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText('optimization')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('best-practices')).toBeInTheDocument();
+        // Empty category shows as dash
+        expect(screen.getByText('-')).toBeInTheDocument();
+    });
+
+    it('shows empty state when no memories exist', async () => {
+        mockApiGet.mockResolvedValue({ memories: [] });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No memories found.')).toBeInTheDocument();
+        });
+    });
+
+    it('displays error message when API fails', async () => {
+        mockApiGet.mockRejectedValue(new Error('Network error'));
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Network error')).toBeInTheDocument();
+        });
+    });
+
+    it('toggles pinned state optimistically', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        mockApiPatch.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        // Find the pinned switches - first one should be checked (pinned: true)
+        const pinnedSwitches = screen.getAllByRole('checkbox', { name: /toggle pinned/i });
+        expect(pinnedSwitches[0]).toBeChecked();
+
+        await user.click(pinnedSwitches[0]);
+
+        await waitFor(() => {
+            expect(mockApiPatch).toHaveBeenCalledWith(
+                '/api/v1/memories/1',
+                { pinned: false }
+            );
+        });
+    });
+
+    it('displays error when pin toggle fails', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        mockApiPatch.mockRejectedValue(new Error('Patch failed'));
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const pinnedSwitches = screen.getAllByRole('checkbox', { name: /toggle pinned/i });
+        await user.click(pinnedSwitches[0]);
+
+        // Error message should be displayed
+        await waitFor(() => {
+            expect(screen.getByText('Patch failed')).toBeInTheDocument();
+        });
+    });
+
+    it('opens delete confirmation dialog when delete button is clicked', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const deleteButtons = screen.getAllByRole('button', { name: /delete memory/i });
+        await user.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Delete Memory')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('Are you sure you want to delete this memory?')).toBeInTheDocument();
+    });
+
+    it('closes delete dialog when Cancel is clicked', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const deleteButtons = screen.getAllByRole('button', { name: /delete memory/i });
+        await user.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Delete Memory')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByText('Delete Memory')).not.toBeInTheDocument();
+        });
+    });
+
+    it('deletes memory when confirmed', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        mockApiDelete.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const deleteButtons = screen.getAllByRole('button', { name: /delete memory/i });
+        await user.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Delete Memory')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+        await waitFor(() => {
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/memories/1');
+        });
+    });
+
+    it('displays error when delete fails', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        mockApiDelete.mockRejectedValue(new Error('Delete failed'));
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const deleteButtons = screen.getAllByRole('button', { name: /delete memory/i });
+        await user.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Delete Memory')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Delete failed')).toBeInTheDocument();
+        });
+    });
+
+    it('refreshes memories list after successful delete', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        mockApiDelete.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const deleteButtons = screen.getAllByRole('button', { name: /delete memory/i });
+        await user.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Delete Memory')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+        await waitFor(() => {
+            // fetchMemories is called again after delete
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it('displays delete button for each memory row', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const deleteButtons = screen.getAllByRole('button', { name: /delete memory/i });
+        expect(deleteButtons).toHaveLength(3);
+    });
+
+    it('displays formatted dates', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Jan 15, 2024/)).toBeInTheDocument();
+        });
+    });
+
+    it('handles pinning an unpinned memory', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        mockApiPatch.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Use connection pooling/)).toBeInTheDocument();
+        });
+
+        // Second memory is unpinned
+        const pinnedSwitches = screen.getAllByRole('checkbox', { name: /toggle pinned/i });
+        expect(pinnedSwitches[1]).not.toBeChecked();
+
+        await user.click(pinnedSwitches[1]);
+
+        await waitFor(() => {
+            expect(mockApiPatch).toHaveBeenCalledWith(
+                '/api/v1/memories/2',
+                { pinned: true }
+            );
+        });
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminPanel.test.tsx
@@ -1,0 +1,245 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+import AdminPanel from '../index';
+
+// Mock the child admin components to isolate AdminPanel testing
+vi.mock('../AdminUsers', () => ({
+    default: () => <div data-testid="admin-users">Admin Users Component</div>,
+}));
+vi.mock('../AdminGroups', () => ({
+    default: () => <div data-testid="admin-groups">Admin Groups Component</div>,
+}));
+vi.mock('../AdminPermissions', () => ({
+    default: () => <div data-testid="admin-permissions">Admin Permissions Component</div>,
+}));
+vi.mock('../AdminTokenScopes', () => ({
+    default: () => <div data-testid="admin-token-scopes">Admin Token Scopes Component</div>,
+}));
+vi.mock('../AdminProbes', () => ({
+    default: () => <div data-testid="admin-probes">Admin Probes Component</div>,
+}));
+vi.mock('../AdminAlertRules', () => ({
+    default: () => <div data-testid="admin-alert-rules">Admin Alert Rules Component</div>,
+}));
+vi.mock('../AdminEmailChannels', () => ({
+    default: () => <div data-testid="admin-email-channels">Admin Email Channels Component</div>,
+}));
+vi.mock('../AdminSlackChannels', () => ({
+    default: () => <div data-testid="admin-slack-channels">Admin Slack Channels Component</div>,
+}));
+vi.mock('../AdminMattermostChannels', () => ({
+    default: () => <div data-testid="admin-mattermost-channels">Admin Mattermost Channels Component</div>,
+}));
+vi.mock('../AdminWebhookChannels', () => ({
+    default: () => <div data-testid="admin-webhook-channels">Admin Webhook Channels Component</div>,
+}));
+vi.mock('../AdminMemories', () => ({
+    default: () => <div data-testid="admin-memories">Admin Memories Component</div>,
+}));
+
+// Mock context hooks
+const mockUser = {
+    authenticated: true,
+    username: 'testuser',
+    isSuperuser: true,
+};
+
+const mockHasPermission = vi.fn(() => true);
+
+vi.mock('../../../contexts/AuthContext', () => ({
+    useAuth: () => ({
+        user: mockUser,
+        hasPermission: mockHasPermission,
+    }),
+}));
+
+vi.mock('../../../contexts/AICapabilitiesContext', () => ({
+    useAICapabilities: () => ({
+        aiEnabled: true,
+        maxIterations: 50,
+        loading: false,
+    }),
+}));
+
+describe('AdminPanel', () => {
+    const mockOnClose = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockHasPermission.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders the panel when open is true', () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        expect(screen.getByText('Administration')).toBeInTheDocument();
+    });
+
+    it('does not render content when open is false', () => {
+        renderWithTheme(
+            <AdminPanel open={false} onClose={mockOnClose} />
+        );
+
+        expect(screen.queryByText('Administration')).not.toBeInTheDocument();
+    });
+
+    it('renders the close button', () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        const closeButton = screen.getByRole('button', { name: /close administration/i });
+        expect(closeButton).toBeInTheDocument();
+    });
+
+    it('calls onClose when the close button is clicked', () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        const closeButton = screen.getByRole('button', { name: /close administration/i });
+        fireEvent.click(closeButton);
+
+        expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders Security section with navigation items', () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        expect(screen.getByText('Security')).toBeInTheDocument();
+        expect(screen.getByText('Users')).toBeInTheDocument();
+        expect(screen.getByText('Groups')).toBeInTheDocument();
+        expect(screen.getByText('Permissions')).toBeInTheDocument();
+        expect(screen.getByText('Tokens')).toBeInTheDocument();
+    });
+
+    it('renders Monitoring section with navigation items', () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        expect(screen.getByText('Monitoring')).toBeInTheDocument();
+        expect(screen.getByText('Probe Defaults')).toBeInTheDocument();
+        expect(screen.getByText('Alert Defaults')).toBeInTheDocument();
+    });
+
+    it('renders Notifications section with navigation items', () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        expect(screen.getByText('Notifications')).toBeInTheDocument();
+        expect(screen.getByText('Email Channels')).toBeInTheDocument();
+        expect(screen.getByText('Slack Channels')).toBeInTheDocument();
+        expect(screen.getByText('Mattermost Channels')).toBeInTheDocument();
+        expect(screen.getByText('Webhook Channels')).toBeInTheDocument();
+    });
+
+    it('renders AI section when aiEnabled is true', () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        expect(screen.getByText('AI')).toBeInTheDocument();
+        expect(screen.getByText('Memories')).toBeInTheDocument();
+    });
+
+    it('shows the first component when dialog opens', async () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        // Wait for the first component (Users) to be selected and rendered
+        await waitFor(() => {
+            expect(screen.getByTestId('admin-users')).toBeInTheDocument();
+        });
+    });
+
+    it('all navigation buttons exist and are clickable', async () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        // Wait for initial render - Users should be selected
+        await waitFor(() => {
+            expect(screen.getByTestId('admin-users')).toBeInTheDocument();
+        });
+
+        const usersButton = screen.getByRole('button', { name: 'Users' });
+        const groupsButton = screen.getByRole('button', { name: 'Groups' });
+
+        // Initially Users is selected
+        expect(usersButton.className).toContain('Mui-selected');
+        expect(groupsButton.className).not.toContain('Mui-selected');
+
+        // Verify both buttons are in the document and clickable
+        expect(usersButton).toBeEnabled();
+        expect(groupsButton).toBeEnabled();
+    });
+
+    it('nav buttons have correct role and are accessible', async () => {
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('admin-users')).toBeInTheDocument();
+        });
+
+        // All nav items should be buttons
+        expect(screen.getByRole('button', { name: 'Users' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Groups' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Permissions' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Tokens' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Probe Defaults' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Alert Defaults' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Memories' })).toBeInTheDocument();
+    });
+});
+
+describe('AdminPanel - Permission filtering', () => {
+    const mockOnClose = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('filters navigation items based on permissions', () => {
+        // Only allow manage_users permission
+        mockHasPermission.mockImplementation((perm: string) => {
+            return perm === 'manage_users';
+        });
+
+        renderWithTheme(
+            <AdminPanel open={true} onClose={mockOnClose} />
+        );
+
+        expect(screen.getByText('Users')).toBeInTheDocument();
+        // Groups requires manage_groups permission which is not granted
+        expect(screen.queryByText('Groups')).not.toBeInTheDocument();
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminPanel.test.tsx
@@ -76,6 +76,12 @@ vi.mock('../../../contexts/AICapabilitiesContext', () => ({
 describe('AdminPanel', () => {
     const mockOnClose = vi.fn();
 
+    // Small helper to reduce repetition of the renderWithTheme(<AdminPanel ... />)
+    // call. `open` defaults to true; pass `{ open: false }` to test the
+    // closed state.
+    const renderAdminPanel = ({ open = true }: { open?: boolean } = {}) =>
+        renderWithTheme(<AdminPanel open={open} onClose={mockOnClose} />);
+
     beforeEach(() => {
         vi.clearAllMocks();
         mockHasPermission.mockReturnValue(true);
@@ -86,34 +92,26 @@ describe('AdminPanel', () => {
     });
 
     it('renders the panel when open is true', () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         expect(screen.getByText('Administration')).toBeInTheDocument();
     });
 
     it('does not render content when open is false', () => {
-        renderWithTheme(
-            <AdminPanel open={false} onClose={mockOnClose} />
-        );
+        renderAdminPanel({ open: false });
 
         expect(screen.queryByText('Administration')).not.toBeInTheDocument();
     });
 
     it('renders the close button', () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         const closeButton = screen.getByRole('button', { name: /close administration/i });
         expect(closeButton).toBeInTheDocument();
     });
 
     it('calls onClose when the close button is clicked', () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         const closeButton = screen.getByRole('button', { name: /close administration/i });
         fireEvent.click(closeButton);
@@ -122,9 +120,7 @@ describe('AdminPanel', () => {
     });
 
     it('renders Security section with navigation items', () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         expect(screen.getByText('Security')).toBeInTheDocument();
         expect(screen.getByText('Users')).toBeInTheDocument();
@@ -134,9 +130,7 @@ describe('AdminPanel', () => {
     });
 
     it('renders Monitoring section with navigation items', () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         expect(screen.getByText('Monitoring')).toBeInTheDocument();
         expect(screen.getByText('Probe Defaults')).toBeInTheDocument();
@@ -144,9 +138,7 @@ describe('AdminPanel', () => {
     });
 
     it('renders Notifications section with navigation items', () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         expect(screen.getByText('Notifications')).toBeInTheDocument();
         expect(screen.getByText('Email Channels')).toBeInTheDocument();
@@ -156,18 +148,14 @@ describe('AdminPanel', () => {
     });
 
     it('renders AI section when aiEnabled is true', () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         expect(screen.getByText('AI')).toBeInTheDocument();
         expect(screen.getByText('Memories')).toBeInTheDocument();
     });
 
     it('shows the first component when dialog opens', async () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         // Wait for the first component (Users) to be selected and rendered
         await waitFor(() => {
@@ -175,32 +163,28 @@ describe('AdminPanel', () => {
         });
     });
 
-    it('all navigation buttons exist and are clickable', async () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+    it('navigates to Groups when the Groups button is clicked', async () => {
+        renderAdminPanel();
 
         // Wait for initial render - Users should be selected
         await waitFor(() => {
             expect(screen.getByTestId('admin-users')).toBeInTheDocument();
         });
 
-        const usersButton = screen.getByRole('button', { name: 'Users' });
-        const groupsButton = screen.getByRole('button', { name: 'Groups' });
+        // Click the Groups nav item. MUI's ListItemButton renders as a div
+        // with role="button" and accepts regular DOM click events.
+        fireEvent.click(screen.getByText('Groups'));
 
-        // Initially Users is selected
-        expect(usersButton.className).toContain('Mui-selected');
-        expect(groupsButton.className).not.toContain('Mui-selected');
-
-        // Verify both buttons are in the document and clickable
-        expect(usersButton).toBeEnabled();
-        expect(groupsButton).toBeEnabled();
+        // After clicking Groups, the Groups component should render and the
+        // Users component should no longer be in the document.
+        await waitFor(() => {
+            expect(screen.getByTestId('admin-groups')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('admin-users')).not.toBeInTheDocument();
     });
 
     it('nav buttons have correct role and are accessible', async () => {
-        renderWithTheme(
-            <AdminPanel open={true} onClose={mockOnClose} />
-        );
+        renderAdminPanel();
 
         await waitFor(() => {
             expect(screen.getByTestId('admin-users')).toBeInTheDocument();

--- a/client/src/components/AdminPanel/__tests__/AdminProbes.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminProbes.test.tsx
@@ -1,0 +1,442 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+const mockApiGet = vi.fn();
+const mockApiPut = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+}));
+
+import AdminProbes from '../AdminProbes';
+
+const MOCK_PROBES = [
+    {
+        id: 1,
+        name: 'pg_stat_activity',
+        description: 'Current database connections and queries',
+        is_enabled: true,
+        collection_interval_seconds: 60,
+        retention_days: 7,
+        connection_id: null,
+    },
+    {
+        id: 2,
+        name: 'pg_stat_database',
+        description: 'Per-database statistics',
+        is_enabled: true,
+        collection_interval_seconds: 300,
+        retention_days: 30,
+        connection_id: null,
+    },
+    {
+        id: 3,
+        name: 'pg_stat_replication',
+        description: 'Replication status and lag',
+        is_enabled: false,
+        collection_interval_seconds: 120,
+        retention_days: 14,
+        connection_id: null,
+    },
+];
+
+describe('AdminProbes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('displays loading state initially', () => {
+        mockApiGet.mockReturnValue(new Promise(() => {}));
+
+        renderWithTheme(<AdminProbes />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(screen.getByLabelText('Loading probes')).toBeInTheDocument();
+    });
+
+    it('renders probes from API', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Probe defaults')).toBeInTheDocument();
+        });
+
+        // Check table headers
+        expect(screen.getByText('Name')).toBeInTheDocument();
+        expect(screen.getByText('Description')).toBeInTheDocument();
+        expect(screen.getByText('Enabled')).toBeInTheDocument();
+        expect(screen.getByText('Interval')).toBeInTheDocument();
+        expect(screen.getByText('Retention (days)')).toBeInTheDocument();
+        expect(screen.getByText('Actions')).toBeInTheDocument();
+
+        // Check that probes are displayed with friendly names
+        // These are the friendly names from FRIENDLY_PROBE_NAMES
+        expect(screen.getByText('Database Activity')).toBeInTheDocument(); // pg_stat_activity
+        expect(screen.getByText('Database Statistics')).toBeInTheDocument(); // pg_stat_database
+        expect(screen.getByText('Replication Status')).toBeInTheDocument(); // pg_stat_replication
+
+        // Verify API was called correctly
+        expect(mockApiGet).toHaveBeenCalledWith('/api/v1/probe-configs');
+    });
+
+    it('handles API returning probe_configs wrapped', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+    });
+
+    it('displays probe names with technical names as caption', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('pg_stat_activity')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('pg_stat_database')).toBeInTheDocument();
+        expect(screen.getByText('pg_stat_replication')).toBeInTheDocument();
+    });
+
+    it('displays collection intervals in the table', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('60s')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('300s')).toBeInTheDocument();
+        expect(screen.getByText('120s')).toBeInTheDocument();
+    });
+
+    it('displays retention days in the table', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('7')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('30')).toBeInTheDocument();
+        expect(screen.getByText('14')).toBeInTheDocument();
+    });
+
+    it('shows empty state when no probes exist', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: [] });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No probe configurations found.')).toBeInTheDocument();
+        });
+    });
+
+    it('displays error message when API fails', async () => {
+        mockApiGet.mockRejectedValue(new Error('Network error'));
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Network error')).toBeInTheDocument();
+        });
+    });
+
+    it('opens edit dialog when edit button is clicked', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit probe:/)).toBeInTheDocument();
+        });
+    });
+
+    it('pre-populates edit dialog with current values', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Collection Interval/i)).toHaveValue(60);
+        });
+
+        expect(screen.getByLabelText(/Retention Days/i)).toHaveValue(7);
+    });
+
+    it('closes edit dialog when Cancel is clicked', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit probe:/)).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByText(/Edit probe:/)).not.toBeInTheDocument();
+        });
+    });
+
+    it('saves changes when Save is clicked', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Collection Interval/i)).toBeInTheDocument();
+        });
+
+        // Change the interval
+        const intervalInput = screen.getByLabelText(/Collection Interval/i);
+        await user.clear(intervalInput);
+        await user.type(intervalInput, '90');
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/probe-configs/1',
+                expect.objectContaining({
+                    collection_interval_seconds: 90,
+                })
+            );
+        });
+    });
+
+    it('displays error message when save fails', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        mockApiPut.mockRejectedValue(new Error('Save failed'));
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Collection Interval/i)).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Save failed')).toBeInTheDocument();
+        });
+    });
+
+    it('displays success message after successful save', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Collection Interval/i)).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/updated successfully/)).toBeInTheDocument();
+        });
+    });
+
+    it('can dismiss error alerts', async () => {
+        mockApiGet.mockRejectedValue(new Error('Network error'));
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Network error')).toBeInTheDocument();
+        });
+
+        const closeButton = screen.getByRole('button', { name: /close/i });
+        fireEvent.click(closeButton);
+
+        await waitFor(() => {
+            expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+        });
+    });
+
+    it('can dismiss success alerts', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Collection Interval/i)).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/updated successfully/)).toBeInTheDocument();
+        });
+
+        const closeButtons = screen.getAllByRole('button', { name: /close/i });
+        fireEvent.click(closeButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.queryByText(/updated successfully/)).not.toBeInTheDocument();
+        });
+    });
+
+    it('toggles enabled state in edit dialog', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        // Wait for dialog to open by looking for the Collection Interval field
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Collection Interval/i)).toBeInTheDocument();
+        });
+
+        // Find the switch in the dialog
+        const switches = screen.getAllByRole('checkbox');
+        const enabledSwitch = switches.find((s) =>
+            s.closest('[class*="MuiDialogContent"]')
+        );
+        expect(enabledSwitch).toBeDefined();
+        expect(enabledSwitch).toBeChecked();
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        await user.click(enabledSwitch!);
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/probe-configs/1',
+                expect.objectContaining({
+                    is_enabled: false,
+                })
+            );
+        });
+    });
+
+    it('updates retention days in edit dialog', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Retention Days/i)).toBeInTheDocument();
+        });
+
+        const retentionInput = screen.getByLabelText(/Retention Days/i);
+        await user.clear(retentionInput);
+        await user.type(retentionInput, '14');
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/probe-configs/1',
+                expect.objectContaining({
+                    retention_days: 14,
+                })
+            );
+        });
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminProbes.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminProbes.test.tsx
@@ -99,14 +99,19 @@ describe('AdminProbes', () => {
         expect(mockApiGet).toHaveBeenCalledWith('/api/v1/probe-configs');
     });
 
-    it('handles API returning probe_configs wrapped', async () => {
-        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+    it('handles API returning a raw array response', async () => {
+        // Exercise the fallback branch in AdminProbes where the response is
+        // not wrapped in `probe_configs` but is a raw array instead.
+        mockApiGet.mockResolvedValue(MOCK_PROBES);
 
         renderWithTheme(<AdminProbes />);
 
         await waitFor(() => {
             expect(screen.getByText('Database Activity')).toBeInTheDocument();
         });
+
+        expect(screen.getByText('Database Statistics')).toBeInTheDocument();
+        expect(screen.getByText('Replication Status')).toBeInTheDocument();
     });
 
     it('displays probe names with technical names as caption', async () => {

--- a/client/src/components/AdminPanel/__tests__/EffectivePermissionsPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/EffectivePermissionsPanel.test.tsx
@@ -216,9 +216,7 @@ describe('EffectivePermissionsPanel', () => {
     });
 
     it('displays groups when provided', () => {
-        // The component expects groups as string array despite the interface
-        // (the actual usage shows key={g} and label={g} expecting strings)
-        const groups = ['Admins', 'Developers'] as unknown as Array<{ id: number; name: string }>;
+        const groups = ['Admins', 'Developers'];
 
         renderWithTheme(
             <EffectivePermissionsPanel groups={groups} />

--- a/client/src/components/AdminPanel/__tests__/EffectivePermissionsPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/EffectivePermissionsPanel.test.tsx
@@ -1,0 +1,274 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+import EffectivePermissionsPanel from '../EffectivePermissionsPanel';
+
+describe('EffectivePermissionsPanel', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders with minimal props', () => {
+        renderWithTheme(<EffectivePermissionsPanel />);
+
+        expect(screen.getByText('Connections')).toBeInTheDocument();
+        expect(screen.getByText('MCP')).toBeInTheDocument();
+    });
+
+    it('displays "None" when no connection privileges exist', () => {
+        renderWithTheme(
+            <EffectivePermissionsPanel connectionPrivileges={{}} />
+        );
+
+        // Should show None for empty connections
+        const noneElements = screen.getAllByText('None');
+        expect(noneElements.length).toBeGreaterThan(0);
+    });
+
+    it('displays connection privileges when provided as object', () => {
+        const connectionPrivileges = {
+            '1': ['read', 'write'],
+            '2': ['read'],
+        };
+
+        const connections = [
+            { id: 1, name: 'Primary DB' },
+            { id: 2, name: 'Replica DB' },
+        ];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                connectionPrivileges={connectionPrivileges}
+                connections={connections}
+            />
+        );
+
+        expect(screen.getByText('Connections')).toBeInTheDocument();
+    });
+
+    it('displays connection privileges when provided as array', () => {
+        const connectionPrivileges = [
+            { connection_id: '1', access_level: 'read' },
+            { connection_id: '2', access_level: 'write' },
+        ];
+
+        const connections = [
+            { id: 1, name: 'Primary DB' },
+            { id: 2, name: 'Replica DB' },
+        ];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                connectionPrivileges={connectionPrivileges}
+                connections={connections}
+            />
+        );
+
+        expect(screen.getByText(/Primary DB/)).toBeInTheDocument();
+        expect(screen.getByText(/Replica DB/)).toBeInTheDocument();
+    });
+
+    it('displays "All Connections" for connection_id 0', () => {
+        const connectionPrivileges = [
+            { connection_id: '0', access_level: 'read' },
+        ];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel connectionPrivileges={connectionPrivileges} />
+        );
+
+        expect(screen.getByText(/All Connections/)).toBeInTheDocument();
+    });
+
+    it('displays admin permissions when isSuperuser is true', () => {
+        const adminPermissions = ['manage_users', 'manage_groups'];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                adminPermissions={adminPermissions}
+                isSuperuser={true}
+            />
+        );
+
+        expect(screen.getByText('Admin')).toBeInTheDocument();
+        expect(screen.getByText('Manage Users')).toBeInTheDocument();
+        expect(screen.getByText('Manage Groups')).toBeInTheDocument();
+    });
+
+    it('does not display admin permissions when isSuperuser is false', () => {
+        const adminPermissions = ['manage_users', 'manage_groups'];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                adminPermissions={adminPermissions}
+                isSuperuser={false}
+            />
+        );
+
+        expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+    });
+
+    it('displays "All Admin Permissions" for wildcard permission', () => {
+        const adminPermissions = ['*'];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                adminPermissions={adminPermissions}
+                isSuperuser={true}
+            />
+        );
+
+        expect(screen.getByText('All Admin Permissions')).toBeInTheDocument();
+    });
+
+    it('displays all known admin permission labels', () => {
+        const adminPermissions = [
+            'manage_blackouts',
+            'manage_connections',
+            'manage_groups',
+            'manage_permissions',
+            'manage_probes',
+            'manage_alert_rules',
+            'manage_token_scopes',
+            'manage_notification_channels',
+            'manage_users',
+        ];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                adminPermissions={adminPermissions}
+                isSuperuser={true}
+            />
+        );
+
+        expect(screen.getByText('Manage Blackouts')).toBeInTheDocument();
+        expect(screen.getByText('Manage Connections')).toBeInTheDocument();
+        expect(screen.getByText('Manage Groups')).toBeInTheDocument();
+        expect(screen.getByText('Manage Permissions')).toBeInTheDocument();
+        expect(screen.getByText('Manage Probes')).toBeInTheDocument();
+        expect(screen.getByText('Manage Alert Rules')).toBeInTheDocument();
+        expect(screen.getByText('Manage Token Scopes')).toBeInTheDocument();
+        expect(screen.getByText('Manage Notification Channels')).toBeInTheDocument();
+        expect(screen.getByText('Manage Users')).toBeInTheDocument();
+    });
+
+    it('displays MCP privileges when provided as array', () => {
+        const mcpPrivileges = [
+            { privilege: 'query_read' },
+            { privilege: 'query_write' },
+        ];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel mcpPrivileges={mcpPrivileges} />
+        );
+
+        expect(screen.getByText('MCP')).toBeInTheDocument();
+        expect(screen.getByText('query read')).toBeInTheDocument();
+        expect(screen.getByText('query write')).toBeInTheDocument();
+    });
+
+    it('displays MCP privileges when provided as strings', () => {
+        const mcpPrivileges = ['query_read', 'schema_read'];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel mcpPrivileges={mcpPrivileges} />
+        );
+
+        expect(screen.getByText('query read')).toBeInTheDocument();
+        expect(screen.getByText('schema read')).toBeInTheDocument();
+    });
+
+    it('displays "All MCP Privileges" for wildcard', () => {
+        const mcpPrivileges = ['*'];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel mcpPrivileges={mcpPrivileges} />
+        );
+
+        expect(screen.getByText('All MCP Privileges')).toBeInTheDocument();
+    });
+
+    it('displays "None" when no MCP privileges exist', () => {
+        renderWithTheme(
+            <EffectivePermissionsPanel mcpPrivileges={[]} />
+        );
+
+        const noneElements = screen.getAllByText('None');
+        expect(noneElements.length).toBeGreaterThan(0);
+    });
+
+    it('displays groups when provided', () => {
+        // The component expects groups as string array despite the interface
+        // (the actual usage shows key={g} and label={g} expecting strings)
+        const groups = ['Admins', 'Developers'] as unknown as Array<{ id: number; name: string }>;
+
+        renderWithTheme(
+            <EffectivePermissionsPanel groups={groups} />
+        );
+
+        expect(screen.getByText('Groups:')).toBeInTheDocument();
+        expect(screen.getByText('Admins')).toBeInTheDocument();
+        expect(screen.getByText('Developers')).toBeInTheDocument();
+    });
+
+    it('does not display groups section when groups is empty', () => {
+        renderWithTheme(
+            <EffectivePermissionsPanel groups={[]} />
+        );
+
+        expect(screen.queryByText('Groups:')).not.toBeInTheDocument();
+    });
+
+    it('handles unknown admin permissions gracefully', () => {
+        const adminPermissions = ['unknown_permission'];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                adminPermissions={adminPermissions}
+                isSuperuser={true}
+            />
+        );
+
+        // Unknown permissions should display as-is
+        expect(screen.getByText('unknown_permission')).toBeInTheDocument();
+    });
+
+    it('falls back to connection ID when name not found', () => {
+        const connectionPrivileges = [
+            { connection_id: '999', access_level: 'read' },
+        ];
+
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                connectionPrivileges={connectionPrivileges}
+                connections={[]}
+            />
+        );
+
+        expect(screen.getByText(/Connection 999/)).toBeInTheDocument();
+    });
+
+    it('renders all three category cards', () => {
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                isSuperuser={true}
+                adminPermissions={['manage_users']}
+            />
+        );
+
+        expect(screen.getByText('Connections')).toBeInTheDocument();
+        expect(screen.getByText('Admin')).toBeInTheDocument();
+        expect(screen.getByText('MCP')).toBeInTheDocument();
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/EffectivePermissionsPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/EffectivePermissionsPanel.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import renderWithTheme from '../../../test/renderWithTheme';
 import EffectivePermissionsPanel from '../EffectivePermissionsPanel';
@@ -31,9 +31,10 @@ describe('EffectivePermissionsPanel', () => {
             <EffectivePermissionsPanel connectionPrivileges={{}} />
         );
 
-        // Should show None for empty connections
-        const noneElements = screen.getAllByText('None');
-        expect(noneElements.length).toBeGreaterThan(0);
+        // Scope the assertion to the Connections section so we verify the
+        // empty state renders in the correct card.
+        const connectionsSection = screen.getByTestId('connection-privileges-section');
+        expect(within(connectionsSection).getByText('None')).toBeInTheDocument();
     });
 
     it('displays connection privileges when provided as object', () => {
@@ -54,7 +55,11 @@ describe('EffectivePermissionsPanel', () => {
             />
         );
 
-        expect(screen.getByText('Connections')).toBeInTheDocument();
+        // Verify the object-based branch actually rendered the connection
+        // names inside the Connections section.
+        const connectionsSection = screen.getByTestId('connection-privileges-section');
+        expect(within(connectionsSection).getByText(/Primary DB/)).toBeInTheDocument();
+        expect(within(connectionsSection).getByText(/Replica DB/)).toBeInTheDocument();
     });
 
     it('displays connection privileges when provided as array', () => {
@@ -204,8 +209,10 @@ describe('EffectivePermissionsPanel', () => {
             <EffectivePermissionsPanel mcpPrivileges={[]} />
         );
 
-        const noneElements = screen.getAllByText('None');
-        expect(noneElements.length).toBeGreaterThan(0);
+        // Scope the assertion to the MCP section so we verify the empty
+        // state renders in the correct card.
+        const mcpSection = screen.getByTestId('mcp-privileges-section');
+        expect(within(mcpSection).getByText('None')).toBeInTheDocument();
     });
 
     it('displays groups when provided', () => {

--- a/client/src/test/ImmediateTransition.tsx
+++ b/client/src/test/ImmediateTransition.tsx
@@ -41,20 +41,42 @@ const ImmediateTransition = React.forwardRef<
         onExited,
     } = props;
 
+    // Keep the latest callback refs without making the lifecycle effect
+    // depend on their identity. Parent components often pass fresh
+    // function identities on every render (e.g., `TransitionProps={{
+    // onEnter: handleEnter }}` with a non-memoised handler), which would
+    // otherwise cause this effect to re-fire on every parent render and
+    // clobber state changes that happened after the initial enter.
+    const onEnterRef = React.useRef(onEnter);
+    const onEnteringRef = React.useRef(onEntering);
+    const onEnteredRef = React.useRef(onEntered);
+    const onExitRef = React.useRef(onExit);
+    const onExitingRef = React.useRef(onExiting);
+    const onExitedRef = React.useRef(onExited);
+    React.useEffect(() => {
+        onEnterRef.current = onEnter;
+        onEnteringRef.current = onEntering;
+        onEnteredRef.current = onEntered;
+        onExitRef.current = onExit;
+        onExitingRef.current = onExiting;
+        onExitedRef.current = onExited;
+    });
+
     // useLayoutEffect runs synchronously inside the same commit that
     // userEvent's act() wraps, so the setState calls that Modal/Dialog
     // fire from these lifecycle callbacks stay inside the act boundary.
+    // Only fire when `inProp` toggles, not on every render.
     React.useLayoutEffect(() => {
         if (inProp) {
-            onEnter?.(null as unknown as HTMLElement, false);
-            onEntering?.(null as unknown as HTMLElement, false);
-            onEntered?.(null as unknown as HTMLElement, false);
+            onEnterRef.current?.(null as unknown as HTMLElement, false);
+            onEnteringRef.current?.(null as unknown as HTMLElement, false);
+            onEnteredRef.current?.(null as unknown as HTMLElement, false);
         } else {
-            onExit?.(null as unknown as HTMLElement);
-            onExiting?.(null as unknown as HTMLElement);
-            onExited?.(null as unknown as HTMLElement);
+            onExitRef.current?.(null as unknown as HTMLElement);
+            onExitingRef.current?.(null as unknown as HTMLElement);
+            onExitedRef.current?.(null as unknown as HTMLElement);
         }
-    }, [inProp, onEnter, onEntering, onEntered, onExit, onExiting, onExited]);
+    }, [inProp]);
 
     if (!inProp) {
         return null;

--- a/client/src/test/ImmediateTransition.tsx
+++ b/client/src/test/ImmediateTransition.tsx
@@ -53,7 +53,11 @@ const ImmediateTransition = React.forwardRef<
     const onExitRef = React.useRef(onExit);
     const onExitingRef = React.useRef(onExiting);
     const onExitedRef = React.useRef(onExited);
-    React.useEffect(() => {
+    // Use useLayoutEffect (not useEffect) so ref sync runs before the
+    // lifecycle useLayoutEffect below in the same commit. With useEffect,
+    // the lifecycle effect would fire against stale refs whenever handler
+    // identities change between renders.
+    React.useLayoutEffect(() => {
         onEnterRef.current = onEnter;
         onEnteringRef.current = onEntering;
         onEnteredRef.current = onEntered;


### PR DESCRIPTION
Closes #116

## Summary

- Adds 84 comprehensive tests for AdminPanel components
- Tests cover AdminPanel, AdminAlertRules, AdminProbes, AdminMemories, and EffectivePermissionsPanel
- Covers rendering, user interactions, form validation, API calls, and error states

### Test breakdown:
- **AdminPanel.test.tsx** (12 tests): Panel rendering, navigation, sections visibility, permission filtering
- **AdminAlertRules.test.tsx** (19 tests): Loading states, API calls, edit dialog, form validation, error handling
- **AdminProbes.test.tsx** (18 tests): Probe list, edit flow, enabled toggle, interval/retention updates
- **AdminMemories.test.tsx** (17 tests): Memory list, pin toggle, delete confirmation, optimistic updates
- **EffectivePermissionsPanel.test.tsx** (18 tests): Connection privileges, admin permissions, MCP privileges, groups

## Test plan

- [x] All 84 new tests pass
- [x] ESLint passes with no errors
- [x] Tests follow existing patterns using `renderWithTheme` and mocking API calls

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for admin panels: alert rules, memories, probes, effective permissions, and the main admin interface covering loading, rendering, empty/error states, interactions, and save/delete flows.
* **Accessibility**
  * Improved accessibility for the alert rule edit toggle control.
* **Refactor**
  * Stabilized transition lifecycle handling to avoid spurious re-invocations.
* **Chores**
  * Added test identifiers to permission panels to aid targeted testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->