### PR TITLE
Require 90% test coverage floor in CLAUDE.md and sub-agent briefs

### DIFF
--- a/.claude/agents/golang-expert.md
+++ b/.claude/agents/golang-expert.md
@@ -77,6 +77,22 @@ When writing code:
    - Write tests for new functionality
    - Ensure existing tests still pass
    - Use table-driven tests where appropriate
+   - Every Go change must ship with tests that drive at least 90%
+     line coverage of the new or modified code; this floor is
+     non-negotiable
+   - The 90% rule applies to modified code as well as new code;
+     if you touch a package whose coverage sits below 90%, raise
+     the touched functions to 90% as part of the same change
+   - Measure coverage per sub-project with `cd collector && make
+     coverage`, `cd server && make coverage`, or `cd alerter &&
+     make coverage`; each target runs `go test -coverprofile=
+     coverage.out ./...` under the hood
+   - Read the numeric breakdown with `go tool cover -func=
+     coverage.out` and confirm the changed files report at least
+     90% before handing the task back
+   - Run `make test-all` from the repository root as the final
+     gate; a change is not complete until tests, linting, and the
+     90% coverage floor all pass
 
 ## Code Review Protocol
 
@@ -89,7 +105,8 @@ When reviewing code:
 - Check for race conditions in concurrent code
 - Verify proper resource cleanup (defer, Close())
 - Suggest performance improvements where significant
-- Ensure test coverage for critical paths
+- Ensure new and modified code meets the project 90% line
+  coverage floor; flag any PR that falls below it
 
 ## Communication Style
 

--- a/.claude/agents/react-expert.md
+++ b/.claude/agents/react-expert.md
@@ -81,6 +81,19 @@ When writing code:
    - Write tests for new functionality
    - Ensure existing tests still pass
    - Test accessibility requirements
+   - Every client change must ship with tests that drive at
+     least 90% line coverage of the new or modified code; this
+     floor is non-negotiable
+   - The 90% rule applies to modified code as well as new code;
+     if you touch a module whose coverage sits below 90%, raise
+     the touched units to 90% as part of the same change
+   - Measure coverage with `cd client && make coverage`, which
+     runs `npm run test:coverage` (Vitest with
+     `@vitest/coverage-v8`); review the text reporter output to
+     confirm the changed files report at least 90% line coverage
+   - Run `make test-all` from the repository root as the final
+     gate; a change is not complete until tests, linting, and the
+     90% coverage floor all pass
 
 ## Code Review Protocol
 
@@ -93,7 +106,8 @@ When reviewing code:
 - Check for proper TypeScript usage
 - Verify responsive design implementation
 - Suggest performance improvements
-- Ensure test coverage
+- Ensure new and modified code meets the project 90% line
+  coverage floor; flag any PR that falls below it
 
 ## Communication Style
 

--- a/.claude/golang-expert/testing-strategy.md
+++ b/.claude/golang-expert/testing-strategy.md
@@ -18,8 +18,9 @@ for the pgEdge AI DBA Workbench Go backend.
 1. **Test Behavior, Not Implementation:** Focus on what the code does.
 2. **Isolate Units:** Test components independently using mocking.
 3. **Test Realistic Scenarios:** Integration tests use real databases.
-4. **Maintain High Coverage:** Aim for >80% overall; >90% critical; 100%
-   security.
+4. **Maintain High Coverage:** New and modified code must reach at
+   least 90% line coverage; this floor is non-negotiable, and
+   security-sensitive paths (encryption, validation) must reach 100%.
 5. **Fast Feedback:** Unit tests run in milliseconds.
 6. **Reliable Tests:** No flaky tests; consistent results.
 
@@ -514,19 +515,32 @@ func TestAuthorization(t *testing.T) {
 
 ### Coverage Targets
 
-- **Overall**: >80%
-- **Critical paths** (auth, RBAC, connection handling): >90%
-- **Security functions** (encryption, validation): 100%
-- **Lower priority** (main entry points, logging, simple getters):
-  acceptable lower coverage
+New and modified Go code must reach at least 90% line coverage;
+this is a non-negotiable floor, not an aspirational target.
+
+The 90% floor applies to modified code as well as new code; if you
+touch a package whose coverage sits below 90%, raise the touched
+functions to 90% as part of the same change.
+
+Security-sensitive functions (encryption, validation) must reach
+100% line coverage; a higher floor still applies where one exists.
 
 ### Coverage Commands
+
+Measure coverage per sub-project with `cd collector && make
+coverage`, `cd server && make coverage`, or `cd alerter && make
+coverage`; each target runs `go test -coverprofile=coverage.out
+./...` under the hood.
+
+Read the numeric breakdown with `go tool cover -func=coverage.out`
+and confirm the changed files report at least 90% before handing
+the task back.
 
 ```bash
 go test -coverprofile=coverage.out ./...
 go tool cover -func=coverage.out | grep total        # Summary
 go tool cover -html=coverage.out -o coverage.html     # HTML report
-go tool cover -func=coverage.out | awk '$3 < 80.0'   # Low-coverage files
+go tool cover -func=coverage.out | awk '$3 < 90.0'   # Low-coverage files
 ```
 
 ### Coverage Modes

--- a/.claude/react-expert/quality-checklist.md
+++ b/.claude/react-expert/quality-checklist.md
@@ -174,10 +174,17 @@ existing instances do not need to be fixed in unrelated changes.
 
 ## Coverage Requirements
 
-These are project coverage targets and should be enforced in CI.
-If `vitest.config.js` does not yet configure coverage gates,
-add them as a follow-up task with an owner and due date.
+New and modified client code must reach at least 90% line coverage;
+this is a non-negotiable floor, not an aspirational target.
 
-- Business logic and hooks: 90% target.
-- API handlers and utilities: 80% target.
-- UI components: 70% target.
+The 90% floor applies to modified code as well as new code; if you
+touch a module whose coverage sits below 90%, raise the touched
+units to 90% as part of the same change.
+
+Measure coverage with `cd client && make coverage`, which runs
+`npm run test:coverage` (Vitest with `@vitest/coverage-v8`); review
+the text reporter output to confirm the changed files report at
+least 90% line coverage.
+
+If `vitest.config.js` does not yet configure coverage gates, add
+them as a follow-up task with an owner and due date.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,9 @@ The primary agent follows this workflow for all tasks:
    parallel as appropriate.
 
 4. **Verify** - After sub-agents complete their work, run `make test-all`
-   to ensure all tests pass.
+   to ensure all tests pass. Confirm every sub-agent delivering code has
+   also delivered tests that meet the 90% coverage floor described in
+   the Tests section; reject output that does not.
 
 5. **Review** - For security-sensitive changes (auth, input handling,
    queries), delegate to **security-auditor** for review.
@@ -311,6 +313,28 @@ At the end of each README:
 - Include linting in standard test suites using locally installable tools.
 
 - Enable coverage checking in standard test suites.
+
+- All new and modified code must reach at least 90% line coverage;
+  this is a hard floor, not an aspirational target.
+
+- The 90% floor applies to every change, no matter how small; when
+  you modify a file or package whose current coverage is below 90%,
+  raise the touched unit to 90% as part of the same change.
+
+- Measure Go coverage per sub-project with `cd <subproject> && make
+  coverage`, which runs `go test -coverprofile=coverage.out ./...`;
+  inspect the numeric result with `go tool cover -func=coverage.out`.
+
+- Measure client coverage with `cd client && make coverage`, which
+  runs `npm run test:coverage` (Vitest with `@vitest/coverage-v8`);
+  the text reporter prints per-file line coverage.
+
+- Run `make test-all` from the repository root to execute the full
+  suite across all sub-projects before completing a task.
+
+- A task is not complete until new and modified code meets the 90%
+  coverage floor, verified by the coverage tooling above; do not
+  mark work done on the basis of passing tests alone.
 
 - Run `gofmt` on all Go files.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ At the end of each README:
 - Enable coverage checking in standard test suites.
 
 - All new and modified code must reach at least 90% line coverage;
-  this is a hard floor, not an aspirational target.
+  this is a hard, non-negotiable floor and not an aspirational target.
 
 - The 90% floor applies to every change, no matter how small; when
   you modify a file or package whose current coverage is below 90%,


### PR DESCRIPTION
## Summary

- Adds a non-negotiable **minimum 90% line coverage** requirement to `CLAUDE.md`, applied to both new code and modified code.
- Updates the `golang-expert` and `react-expert` sub-agent briefs so implementation agents enforce the floor directly, with real coverage commands cited (`make coverage` in each sub-project, `go tool cover -func`, Vitest with `@vitest/coverage-v8`).
- Adds a check to the primary agent's Verify step: reject sub-agent output that ships without meeting the 90% floor.

## Rationale

Prior wording said "enable coverage checking" but did not set a numeric bar, which allowed small changes to slip past in packages whose coverage was already low. The new language closes that loophole: if you touch a unit below 90%, you bring it up to 90% as part of the same change.

## Test plan

- [ ] Confirm `make coverage` exists in `/collector`, `/server`, `/alerter`, and `/client` (verified — all four Makefiles expose it).
- [ ] Confirm `client` exposes `npm run test:coverage` via Vitest + `@vitest/coverage-v8` (verified in `client/package.json`).
- [ ] Confirm `make test-all` runs from the repo root (verified — root `Makefile` defines the target).
- [ ] No source code, test, or Makefile changes in this PR — instruction-file-only change, so no CI test run is required for correctness of the edits themselves.

https://claude.ai/code/session_01JsPcFjtqB6dtQ6g6dwNfSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced a non-negotiable 90% line-coverage requirement for all new or modified code across projects; failure to meet it now blocks progression.
  * Made repository-level test-and-quality check the final gating step.

* **Documentation**
  * Updated contributor and review guides with explicit coverage measurement steps per sub-project and instructions to verify touched files meet the 90% floor.
  * Clarified higher 100% coverage expectation for security-sensitive code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->