### PR TITLE
Reject cors_origin "*" at startup when auth is enabled (#81)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,12 +13,11 @@ project adheres to
 ### Changed
 
 - Reject `cors_origin: "*"` at server startup when
-  authentication is enabled; browsers discard
+  authentication is enabled. Browsers discard
   credentialed responses that combine
   `Access-Control-Allow-Origin: *` with
   `Access-Control-Allow-Credentials: true` per the
-  Fetch spec, so the server now fails fast and
-  instructs the operator to configure an explicit
+  Fetch spec. Operators should configure an explicit
   origin or leave the option empty for same-origin
   deployments. (#81)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,18 @@ project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Reject `cors_origin: "*"` at server startup when
+  authentication is enabled; browsers discard
+  credentialed responses that combine
+  `Access-Control-Allow-Origin: *` with
+  `Access-Control-Allow-Credentials: true` per the
+  Fetch spec, so the server now fails fast and
+  instructs the operator to configure an explicit
+  origin or leave the option empty for same-origin
+  deployments. (#81)
+
 ## [1.0.0-beta1] - 2026-04-21
 
 ### Added

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -286,6 +286,43 @@ builtins:
 | `auth.rate_limit_window_minutes` | int | `15` | Rate limit window |
 | `auth.rate_limit_max_attempts` | int | `10` | Max attempts per window |
 
+#### CORS Origin (`cors_origin`)
+
+The `cors_origin` option sets the value the server
+returns in the `Access-Control-Allow-Origin` response
+header for cross-origin browser requests. The empty
+default is appropriate for same-origin deployments,
+where the web client and the server share a single
+origin; the server then omits CORS headers entirely.
+
+Set `cors_origin` to an explicit origin, such as
+`https://workbench.example.com`, when the web client
+runs on a different origin than the server. The server
+also enables credentialed CORS responses by returning
+`Access-Control-Allow-Credentials: true`, which lets
+the browser attach session cookies to cross-origin
+requests.
+
+The server rejects a `cors_origin` value of `"*"` at
+startup when authentication is enabled. Browsers reject
+the combination of `Access-Control-Allow-Origin: *` and
+`Access-Control-Allow-Credentials: true` per the Fetch
+spec, so the wildcard would silently break every
+authenticated cross-origin response. Use an explicit
+origin instead, or leave the option empty for
+same-origin deployments.
+
+In the following example, the `http` section allows
+cross-origin requests from a dedicated workbench host:
+
+```yaml
+http:
+  address: ":8443"
+  cors_origin: "https://workbench.example.com"
+  auth:
+    enabled: true
+```
+
 ### Connection Security (`connection_security`)
 
 The connection security section controls SSRF

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -288,29 +288,25 @@ builtins:
 
 #### CORS Origin (`cors_origin`)
 
-The `cors_origin` option sets the value the server
-returns in the `Access-Control-Allow-Origin` response
-header for cross-origin browser requests. The empty
-default is appropriate for same-origin deployments,
-where the web client and the server share a single
-origin; the server then omits CORS headers entirely.
+The `cors_origin` option sets the value for the
+`Access-Control-Allow-Origin` response header. The empty
+default suits same-origin deployments, where the web
+client and the server share an origin. The server omits
+CORS headers entirely in that case.
 
-Set `cors_origin` to an explicit origin, such as
-`https://workbench.example.com`, when the web client
-runs on a different origin than the server. The server
-also enables credentialed CORS responses by returning
-`Access-Control-Allow-Credentials: true`, which lets
-the browser attach session cookies to cross-origin
-requests.
+Set `cors_origin` to an explicit origin when the web
+client runs on a different origin than the server. For
+example, use `https://workbench.example.com` as the
+value. The server returns
+`Access-Control-Allow-Credentials: true` so browsers can
+attach session cookies to cross-origin requests.
 
 The server rejects a `cors_origin` value of `"*"` at
-startup when authentication is enabled. Browsers reject
-the combination of `Access-Control-Allow-Origin: *` and
+startup when authentication is enabled. Browsers disallow
+combining `Access-Control-Allow-Origin: *` with
 `Access-Control-Allow-Credentials: true` per the Fetch
-spec, so the wildcard would silently break every
-authenticated cross-origin response. Use an explicit
-origin instead, or leave the option empty for
-same-origin deployments.
+spec. Use an explicit origin, or leave the option empty
+for same-origin deployments.
 
 In the following example, the `http` section allows
 cross-origin requests from a dedicated workbench host:

--- a/server/src/internal/mcp/http_server.go
+++ b/server/src/internal/mcp/http_server.go
@@ -83,6 +83,17 @@ func (s *Server) RunHTTP(config *HTTPConfig) error {
 		}
 	}
 
+	// Validate CORS configuration before binding any listener so
+	// misconfigurations fail fast at startup rather than producing
+	// browsers that silently reject responses at runtime.
+	// Auth is enabled whenever AuthStore is non-nil: AuthMiddleware below
+	// is always constructed with enabled=true, so it authenticates every
+	// request (issuing Set-Cookie / reading Authorization headers)
+	// precisely when AuthStore != nil.
+	if err := validateCORSOrigin(config.CORSOrigin, config.AuthStore != nil); err != nil {
+		return err
+	}
+
 	// Wrap with auth middleware
 	var handler http.Handler = mux
 	handler = auth.AuthMiddleware(config.AuthStore, true)(handler)
@@ -92,15 +103,6 @@ func (s *Server) RunHTTP(config *HTTPConfig) error {
 
 	// Apply CORS middleware if an origin is configured (skip for same-origin deployments)
 	if config.CORSOrigin != "" {
-		if config.CORSOrigin == "*" {
-			fmt.Fprintf(os.Stderr, "WARNING: CORS origin is set to wildcard (*). "+
-				"Using a wildcard origin with credentials is not recommended "+
-				"for production deployments.\n")
-		} else {
-			if _, err := url.ParseRequestURI(config.CORSOrigin); err != nil {
-				return fmt.Errorf("invalid CORS origin %q: %w", config.CORSOrigin, err)
-			}
-		}
 		handler = CORSMiddleware(config.CORSOrigin)(handler)
 	}
 
@@ -512,6 +514,35 @@ func MaxBytesMiddleware(maxBytes int64) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// validateCORSOrigin validates a configured CORS origin. An empty origin
+// is allowed (same-origin deployments skip CORS entirely). A wildcard
+// origin ("*") is rejected when auth is enabled because the Fetch spec
+// forbids combining Access-Control-Allow-Origin: * with
+// Access-Control-Allow-Credentials: true, causing browsers to silently
+// drop responses. Any non-wildcard origin must parse as a valid URI.
+func validateCORSOrigin(origin string, authEnabled bool) error {
+	if origin == "" {
+		return nil
+	}
+	if origin == "*" {
+		if authEnabled {
+			return fmt.Errorf(
+				"cors_origin %q cannot be used when authentication is "+
+					"enabled: browsers reject Access-Control-Allow-Origin: * "+
+					"with Access-Control-Allow-Credentials: true (per the "+
+					"Fetch spec). Set cors_origin to an explicit origin "+
+					"(e.g., https://dba.example.com) or leave it empty for "+
+					"same-origin deployments.",
+				origin)
+		}
+		return nil
+	}
+	if _, err := url.ParseRequestURI(origin); err != nil {
+		return fmt.Errorf("invalid CORS origin %q: %w", origin, err)
+	}
+	return nil
 }
 
 // CORSMiddleware adds Cross-Origin Resource Sharing headers for the specified origin.

--- a/server/src/internal/mcp/http_server_test.go
+++ b/server/src/internal/mcp/http_server_test.go
@@ -16,7 +16,10 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
 )
 
 func TestHandleHealthCheck(t *testing.T) {
@@ -718,6 +721,159 @@ func TestRunHTTP_NilConfig(t *testing.T) {
 	err := server.RunHTTP(nil)
 	if err == nil {
 		t.Error("expected error for nil config")
+	}
+}
+
+// TestValidateCORSOrigin exercises the pure CORS validation helper used by
+// RunHTTP. Each case covers one branch: empty (same-origin), explicit URL
+// (with and without auth), wildcard with and without auth, and a malformed
+// URL. The wildcard+auth case is the fix for issue #81: browsers silently
+// reject Access-Control-Allow-Origin: * paired with
+// Access-Control-Allow-Credentials: true, so the server must fail fast.
+func TestValidateCORSOrigin(t *testing.T) {
+	tests := []struct {
+		name        string
+		origin      string
+		authEnabled bool
+		wantErr     bool
+		wantSubstr  []string // substrings expected in the error message
+	}{
+		{
+			name:        "empty origin with auth",
+			origin:      "",
+			authEnabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "empty origin without auth",
+			origin:      "",
+			authEnabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "explicit origin with auth",
+			origin:      "https://dba.example.com",
+			authEnabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "explicit origin without auth",
+			origin:      "https://dba.example.com",
+			authEnabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "wildcard with auth enabled rejected",
+			origin:      "*",
+			authEnabled: true,
+			wantErr:     true,
+			wantSubstr: []string{
+				`cors_origin "*"`,
+				"authentication is enabled",
+				"Access-Control-Allow-Origin: *",
+				"Access-Control-Allow-Credentials: true",
+				"Fetch spec",
+				"https://dba.example.com",
+				"same-origin",
+			},
+		},
+		{
+			name:        "wildcard without auth allowed",
+			origin:      "*",
+			authEnabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "invalid origin rejected",
+			origin:      "not a url",
+			authEnabled: true,
+			wantErr:     true,
+			wantSubstr:  []string{"invalid CORS origin"},
+		},
+		{
+			name:        "invalid origin rejected without auth",
+			origin:      "not a url",
+			authEnabled: false,
+			wantErr:     true,
+			wantSubstr:  []string{"invalid CORS origin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCORSOrigin(tt.origin, tt.authEnabled)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validateCORSOrigin(%q, %v): expected error, got nil",
+						tt.origin, tt.authEnabled)
+				}
+				for _, sub := range tt.wantSubstr {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error message %q does not contain %q",
+							err.Error(), sub)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("validateCORSOrigin(%q, %v): unexpected error: %v",
+						tt.origin, tt.authEnabled, err)
+				}
+			}
+		})
+	}
+}
+
+// TestRunHTTP_WildcardCORSWithAuthRejected verifies that RunHTTP returns an
+// error (before binding any listener) when CORSOrigin == "*" and an
+// AuthStore is configured. This ensures the fail-fast behavior is wired
+// into the startup path, not only the pure helper.
+func TestRunHTTP_WildcardCORSWithAuthRejected(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	config := &HTTPConfig{
+		Addr:       ":0",
+		CORSOrigin: "*",
+		AuthStore:  &auth.AuthStore{}, // non-nil => auth enabled in this path
+	}
+
+	err := server.RunHTTP(config)
+	if err == nil {
+		t.Fatal("expected RunHTTP to reject wildcard CORS with auth enabled")
+	}
+
+	msg := err.Error()
+	wantSubstrs := []string{
+		`cors_origin "*"`,
+		"authentication is enabled",
+		"Fetch spec",
+	}
+	for _, sub := range wantSubstrs {
+		if !strings.Contains(msg, sub) {
+			t.Errorf("error message %q does not contain %q", msg, sub)
+		}
+	}
+}
+
+// TestRunHTTP_InvalidCORSOriginRejected verifies that RunHTTP still rejects
+// a malformed non-wildcard origin before binding any listener, preserving
+// the pre-existing validation behavior.
+func TestRunHTTP_InvalidCORSOriginRejected(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	config := &HTTPConfig{
+		Addr:       ":0",
+		CORSOrigin: "not a url",
+		AuthStore:  &auth.AuthStore{},
+	}
+
+	err := server.RunHTTP(config)
+	if err == nil {
+		t.Fatal("expected RunHTTP to reject invalid CORS origin")
+	}
+	if !strings.Contains(err.Error(), "invalid CORS origin") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #81.

- The MCP HTTP server previously accepted `cors_origin: "*"` alongside credential-based auth, printing a stderr warning and then serving responses that browsers silently discard per the Fetch spec (`Access-Control-Allow-Origin: *` is incompatible with `Access-Control-Allow-Credentials: true`).
- `RunHTTP` now validates the CORS origin before binding any listener via a new pure helper `validateCORSOrigin(origin, authEnabled)`. When `cors_origin == "*"` and auth is enabled (`AuthStore != nil`), startup fails with a clear message pointing the operator to an explicit origin or the empty default.
- Non-wildcard origin validation (`url.ParseRequestURI`) and the empty-origin same-origin path are preserved.
- Docs updated: new `#### CORS Origin (cors_origin)` subsection in `docs/getting-started/configuration/server.md` and a `Changed` entry in `docs/changelog.md` under `[Unreleased]`.

## Error message

> cors_origin "*" cannot be used when authentication is enabled: browsers reject Access-Control-Allow-Origin: * with Access-Control-Allow-Credentials: true (per the Fetch spec). Set cors_origin to an explicit origin (e.g., https://dba.example.com) or leave it empty for same-origin deployments.

## Test plan

- [x] `TestValidateCORSOrigin` — 8 table-driven cases: empty, explicit, wildcard with/without auth, invalid URIs.
- [x] `TestRunHTTP_WildcardCORSWithAuthRejected` — asserts `RunHTTP` returns the expected error before binding.
- [x] `TestRunHTTP_InvalidCORSOriginRejected` — preserves prior behavior for malformed URIs.
- [x] `cd server && make test` — all 21 packages pass.
- [x] `gofmt -l` clean; `go vet ./internal/mcp/...` clean.
- [x] `validateCORSOrigin` line coverage: 100%.

Note: `make test-all` at repo root fails on an unrelated pre-existing collector `golangci-lint` config issue (`unsupported version of the configuration: ""`); no `.golangci.yml` exists in `collector/`. All tests in all subprojects pass.

https://claude.ai/code/session_01RWJvpWyoKpH9AA9TTXLuJ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added HTTP CORS origin guidance covering same-origin defaults, explicit origin configuration for cross-origin requests, and credentialed CORS behavior.

* **Changed**
  * Server now validates CORS origin at startup, rejecting wildcard ("*") when authentication is enabled and failing fast on malformed origin values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->