### PR TITLE
Hoist RBAC checks above datastore calls (#67)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,15 @@ project adheres to
   origin or leave the option empty for same-origin
   deployments. (#81)
 
+- Hoist RBAC access-control checks above all
+  datastore calls in the alert-counts, alert
+  acknowledgement, alert unacknowledgement, alert
+  analysis, and cluster-topology handlers; zero-grant
+  callers now short-circuit to an empty response
+  without touching the database, and HTTP-level
+  regression tests cover every affected handler.
+  (#67)
+
 ## [1.0.0-beta1] - 2026-04-21
 
 ### Added

--- a/server/src/internal/api/alert_handlers.go
+++ b/server/src/internal/api/alert_handlers.go
@@ -10,6 +10,7 @@
 package api
 
 import (
+	"context"
 	"log"
 	"net/http"
 
@@ -17,20 +18,42 @@ import (
 	"github.com/pgedge/ai-workbench/server/internal/database"
 )
 
+// alertConnectionResolver is the narrow contract the alert mutation
+// handlers use to look up which connection owns an alert before running
+// the RBAC gate. The concrete *database.Datastore satisfies this
+// interface via GetAlertConnectionID; tests inject a lightweight fake so
+// the RBAC branch can be exercised without a real database.
+type alertConnectionResolver interface {
+	GetAlertConnectionID(ctx context.Context, alertID int64) (int, error)
+}
+
 // AlertHandler handles REST API requests for alerts
 type AlertHandler struct {
-	datastore   *database.Datastore
-	authStore   *auth.AuthStore
-	rbacChecker *auth.RBACChecker
+	datastore     *database.Datastore
+	authStore     *auth.AuthStore
+	rbacChecker   *auth.RBACChecker
+	alertResolver alertConnectionResolver
 }
 
 // NewAlertHandler creates a new alert handler
 func NewAlertHandler(datastore *database.Datastore, authStore *auth.AuthStore, rbacChecker *auth.RBACChecker) *AlertHandler {
-	return &AlertHandler{
+	h := &AlertHandler{
 		datastore:   datastore,
 		authStore:   authStore,
 		rbacChecker: rbacChecker,
 	}
+	if datastore != nil {
+		h.alertResolver = datastore
+	}
+	return h
+}
+
+// setAlertResolver overrides the alert-connection resolver for tests. The
+// production constructor defaults to the datastore; tests replace it with
+// a fake that returns a known connection ID without touching the
+// database.
+func (h *AlertHandler) setAlertResolver(r alertConnectionResolver) {
+	h.alertResolver = r
 }
 
 // RegisterRoutes registers alert management routes on the mux
@@ -168,17 +191,10 @@ func (h *AlertHandler) handleAlertCounts(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Fetch alert counts
-	counts, err := h.datastore.GetAlertCounts(r.Context())
-	if err != nil {
-		log.Printf("[ERROR] Failed to fetch alert counts: %v", err)
-		RespondError(w, http.StatusInternalServerError, "Failed to fetch alert counts")
-		return
-	}
-
-	// RBAC: filter counts to visible connections only. Visibility
-	// includes owned and shared connections, not just group/token
-	// grants.
+	// RBAC first: resolve the caller's visible connection set before any
+	// datastore work so a zero-grant caller never hits the alerts table.
+	// Visibility includes owned and shared connections, not just
+	// group/token grants.
 	lister := newConnectionVisibilityLister(h.datastore)
 	accessibleIDs, allConnections, err := h.rbacChecker.VisibleConnectionIDs(r.Context(), lister)
 	if err != nil {
@@ -186,21 +202,31 @@ func (h *AlertHandler) handleAlertCounts(w http.ResponseWriter, r *http.Request)
 		RespondError(w, http.StatusInternalServerError, "Failed to fetch alert counts")
 		return
 	}
+
+	// Zero-grant caller: return an empty counts response without
+	// invoking GetAlertCounts. A nil datastore test can rely on this
+	// short-circuit to prove the RBAC gate runs before any database
+	// call.
+	if !allConnections && len(accessibleIDs) == 0 {
+		RespondJSON(w, http.StatusOK, &database.AlertCountsResult{
+			Total:    0,
+			ByServer: map[int]int64{},
+		})
+		return
+	}
+
+	// Push the caller's allow-list into the query. A nil slice (superuser
+	// or wildcard scope) means "no filter"; a non-nil slice restricts the
+	// SQL to the caller's visible connection IDs.
+	var filterIDs []int
 	if !allConnections {
-		accessibleSet := make(map[int]bool, len(accessibleIDs))
-		for _, id := range accessibleIDs {
-			accessibleSet[id] = true
-		}
-		var filteredTotal int64
-		filteredByServer := make(map[int]int64)
-		for connID, count := range counts.ByServer {
-			if accessibleSet[connID] {
-				filteredByServer[connID] = count
-				filteredTotal += count
-			}
-		}
-		counts.Total = filteredTotal
-		counts.ByServer = filteredByServer
+		filterIDs = accessibleIDs
+	}
+	counts, err := h.datastore.GetAlertCounts(r.Context(), filterIDs)
+	if err != nil {
+		log.Printf("[ERROR] Failed to fetch alert counts: %v", err)
+		RespondError(w, http.StatusInternalServerError, "Failed to fetch alert counts")
+		return
 	}
 
 	RespondJSON(w, http.StatusOK, counts)
@@ -239,8 +265,17 @@ func (h *AlertHandler) acknowledgeAlert(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// RBAC: verify the user has access to the alert's connection.
-	connID, err := h.datastore.GetAlertConnectionID(r.Context(), req.AlertID)
+	// Resolve the alert's connection via the narrow resolver interface so
+	// tests can inject a fake without stubbing the full datastore. This
+	// is the minimum datastore work required before the RBAC gate; the
+	// gate runs immediately after so no mutation datastore call executes
+	// for a denied caller.
+	if h.alertResolver == nil {
+		log.Printf("[ERROR] acknowledgeAlert: alert resolver is not configured")
+		RespondError(w, http.StatusInternalServerError, "Failed to acknowledge alert")
+		return
+	}
+	connID, err := h.alertResolver.GetAlertConnectionID(r.Context(), req.AlertID)
 	if err != nil {
 		log.Printf("[ERROR] Failed to look up alert connection: %v", err)
 		RespondError(w, http.StatusNotFound, "Alert not found")
@@ -288,8 +323,16 @@ func (h *AlertHandler) unacknowledgeAlert(w http.ResponseWriter, r *http.Request
 		return // Error already sent
 	}
 
-	// RBAC: verify the user has access to the alert's connection.
-	connID, err := h.datastore.GetAlertConnectionID(r.Context(), alertID)
+	// Resolve the alert's connection via the narrow resolver interface so
+	// tests can inject a fake without stubbing the full datastore. The
+	// RBAC gate runs immediately after so no mutation datastore call
+	// executes for a denied caller.
+	if h.alertResolver == nil {
+		log.Printf("[ERROR] unacknowledgeAlert: alert resolver is not configured")
+		RespondError(w, http.StatusInternalServerError, "Failed to unacknowledge alert")
+		return
+	}
+	connID, err := h.alertResolver.GetAlertConnectionID(r.Context(), alertID)
 	if err != nil {
 		log.Printf("[ERROR] Failed to look up alert connection: %v", err)
 		RespondError(w, http.StatusNotFound, "Alert not found")
@@ -338,8 +381,16 @@ func (h *AlertHandler) handleSaveAnalysis(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// RBAC: verify the user has access to the alert's connection.
-	connID, err := h.datastore.GetAlertConnectionID(r.Context(), req.AlertID)
+	// Resolve the alert's connection via the narrow resolver interface so
+	// tests can inject a fake without stubbing the full datastore. The
+	// RBAC gate runs immediately after so no write call executes for a
+	// denied caller.
+	if h.alertResolver == nil {
+		log.Printf("[ERROR] handleSaveAnalysis: alert resolver is not configured")
+		RespondError(w, http.StatusInternalServerError, "Failed to save analysis")
+		return
+	}
+	connID, err := h.alertResolver.GetAlertConnectionID(r.Context(), req.AlertID)
 	if err != nil {
 		log.Printf("[ERROR] Failed to look up alert connection: %v", err)
 		RespondError(w, http.StatusNotFound, "Alert not found")

--- a/server/src/internal/api/alert_handlers_test.go
+++ b/server/src/internal/api/alert_handlers_test.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/database"
 )
 
 func TestNewAlertHandler(t *testing.T) {
@@ -27,6 +29,24 @@ func TestNewAlertHandler(t *testing.T) {
 	}
 	if handler.authStore != nil {
 		t.Error("Expected nil authStore")
+	}
+	if handler.alertResolver != nil {
+		t.Error("Expected nil alertResolver for nil-datastore constructor")
+	}
+}
+
+// TestNewAlertHandler_WiresResolver verifies that when the datastore is
+// non-nil the constructor installs it as the alertResolver. The
+// resolver unblocks RBAC-first mutation flows without needing tests to
+// call setAlertResolver explicitly.
+func TestNewAlertHandler_WiresResolver(t *testing.T) {
+	ds := &database.Datastore{}
+	handler := NewAlertHandler(ds, nil, nil)
+	if handler == nil {
+		t.Fatal("NewAlertHandler returned nil")
+	}
+	if handler.alertResolver == nil {
+		t.Error("Expected alertResolver to be wired to the datastore")
 	}
 }
 
@@ -270,6 +290,60 @@ func TestAcknowledgeRequest_JSON(t *testing.T) {
 	}
 	if _, ok := rawJSON["false_positive"]; !ok {
 		t.Error("Expected 'false_positive' key in JSON")
+	}
+}
+
+// TestAlertHandler_SaveAnalysis_Validation covers the input-validation
+// branches of handleSaveAnalysis: method-not-allowed, invalid JSON,
+// missing alert_id, missing analysis. These run BEFORE the resolver so
+// no datastore is required.
+func TestAlertHandler_SaveAnalysis_Validation(t *testing.T) {
+	cases := []struct {
+		name     string
+		method   string
+		body     string
+		wantCode int
+	}{
+		{
+			name:     "method-not-allowed",
+			method:   http.MethodPost,
+			wantCode: http.StatusMethodNotAllowed,
+		},
+		{
+			name:     "invalid-json",
+			method:   http.MethodPut,
+			body:     "not json",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "missing-alert-id",
+			method:   http.MethodPut,
+			body:     `{"analysis":"x"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "missing-analysis",
+			method:   http.MethodPut,
+			body:     `{"alert_id":42}`,
+			wantCode: http.StatusBadRequest,
+		},
+	}
+	handler := NewAlertHandler(nil, nil, nil)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/api/v1/alerts/analysis",
+				bytes.NewBufferString(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.handleSaveAnalysis(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("case %q: expected %d, got %d (body=%q)",
+					tc.name, tc.wantCode, rec.Code, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -109,21 +109,10 @@ func (h *ClusterHandler) getClusterTopology(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	// Sync cluster_id assignments before reading topology
-	if err := h.datastore.RefreshClusterAssignments(ctx); err != nil {
-		log.Printf("[WARN] Failed to refresh cluster assignments: %v", err)
-	}
-
-	topology, err := h.datastore.GetClusterTopology(ctx)
-	if err != nil {
-		log.Printf("[ERROR] Failed to get cluster topology: %v", err)
-		RespondError(w, http.StatusInternalServerError, "Failed to get cluster topology")
-		return
-	}
-
-	// RBAC: prune servers, clusters, and groups the caller cannot see.
-	// VisibleConnectionIDs loads sharing metadata once so this filter
-	// does not issue per-server lookups.
+	// RBAC first: resolve the caller's visible connection set before any
+	// datastore work so a zero-grant caller never triggers a refresh or
+	// a topology build. VisibleConnectionIDs loads sharing metadata once
+	// so this check does not issue per-server lookups.
 	lister := newConnectionVisibilityLister(h.datastore)
 	visibleIDs, allConnections, err := h.rbacChecker.VisibleConnectionIDs(r.Context(), lister)
 	if err != nil {
@@ -131,6 +120,39 @@ func (h *ClusterHandler) getClusterTopology(w http.ResponseWriter, r *http.Reque
 		RespondError(w, http.StatusInternalServerError, "Failed to filter cluster topology")
 		return
 	}
+
+	// Zero-grant caller: return an empty topology without refreshing
+	// cluster assignments or reading the topology table. This is the
+	// defense-in-depth gate that makes issue #67 regressions catchable
+	// at the HTTP boundary without a datastore mock.
+	if !allConnections && len(visibleIDs) == 0 {
+		RespondJSON(w, http.StatusOK, []database.TopologyGroup{})
+		return
+	}
+
+	// Sync cluster_id assignments before reading topology
+	if err := h.datastore.RefreshClusterAssignments(ctx); err != nil {
+		log.Printf("[WARN] Failed to refresh cluster assignments: %v", err)
+	}
+
+	// Push the caller's allow-list into the topology query. A nil slice
+	// (superuser or wildcard scope) means "no filter"; a non-nil slice
+	// prunes servers, empty clusters, and empty groups inside the
+	// datastore before the result crosses the boundary.
+	var filterIDs []int
+	if !allConnections {
+		filterIDs = visibleIDs
+	}
+	topology, err := h.datastore.GetClusterTopology(ctx, filterIDs)
+	if err != nil {
+		log.Printf("[ERROR] Failed to get cluster topology: %v", err)
+		RespondError(w, http.StatusInternalServerError, "Failed to get cluster topology")
+		return
+	}
+
+	// Belt-and-suspenders: re-apply the handler-level pruning in case
+	// the datastore query missed a join. This keeps filterTopologyByVisibility
+	// as a defensive net that runs on every response.
 	if !allConnections {
 		topology = filterTopologyByVisibility(topology, visibleIDs)
 	}

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -114,7 +114,7 @@ func (h *ClusterHandler) getClusterTopology(w http.ResponseWriter, r *http.Reque
 	// a topology build. VisibleConnectionIDs loads sharing metadata once
 	// so this check does not issue per-server lookups.
 	lister := newConnectionVisibilityLister(h.datastore)
-	visibleIDs, allConnections, err := h.rbacChecker.VisibleConnectionIDs(r.Context(), lister)
+	visibleIDs, allConnections, err := h.rbacChecker.VisibleConnectionIDs(ctx, lister)
 	if err != nil {
 		log.Printf("[ERROR] Failed to resolve visible connections for topology: %v", err)
 		RespondError(w, http.StatusInternalServerError, "Failed to filter cluster topology")
@@ -198,7 +198,9 @@ func filterTopologyByVisibility(groups []database.TopologyGroup, visibleIDs []in
 // recursively so a hidden parent with visible children is dropped along
 // with those children; this matches the existing "cluster visibility"
 // contract where children are only meaningful under an accessible
-// parent.
+// parent. Relationships pointing at hidden peers are also dropped so
+// TargetServerID and TargetServerName never leak across the visibility
+// boundary at the handler layer.
 func filterTopologyServers(servers []database.TopologyServerInfo, visible map[int]bool) []database.TopologyServerInfo {
 	out := make([]database.TopologyServerInfo, 0, len(servers))
 	for i := range servers {
@@ -209,6 +211,16 @@ func filterTopologyServers(servers []database.TopologyServerInfo, visible map[in
 		if len(s.Children) > 0 {
 			s.Children = filterTopologyServers(s.Children, visible)
 		}
+		if len(s.Relationships) > 0 {
+			rels := make([]database.TopologyRelationship, 0, len(s.Relationships))
+			for _, rel := range s.Relationships {
+				if visible[rel.TargetServerID] {
+					rels = append(rels, rel)
+				}
+			}
+			s.Relationships = rels
+		}
+		s.IsExpandable = len(s.Children) > 0
 		out = append(out, s)
 	}
 	return out

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -1542,3 +1542,113 @@ func TestFilterTopologyServers_PreservesNestedChildren(t *testing.T) {
 			got[0].Children[0].Children)
 	}
 }
+
+// TestFilterTopologyServers_FiltersRelationshipsToHiddenPeers verifies
+// that the handler-layer filter strips TopologyRelationship entries
+// pointing at hidden peers so TargetServerID and TargetServerName never
+// leak across the visibility boundary. Relationships targeting visible
+// peers must survive.
+func TestFilterTopologyServers_FiltersRelationshipsToHiddenPeers(t *testing.T) {
+	servers := []database.TopologyServerInfo{
+		{
+			ID:           1,
+			Name:         "visible-1",
+			IsExpandable: true,
+			Relationships: []database.TopologyRelationship{
+				{
+					TargetServerID:   2,
+					TargetServerName: "visible-peer",
+					RelationshipType: "spock_subscriber",
+				},
+				{
+					TargetServerID:   99,
+					TargetServerName: "hidden-peer",
+					RelationshipType: "spock_subscriber",
+				},
+			},
+		},
+		{
+			ID:   2,
+			Name: "visible-2",
+			Relationships: []database.TopologyRelationship{
+				{
+					TargetServerID:   77,
+					TargetServerName: "another-hidden",
+					RelationshipType: "spock_provider",
+				},
+			},
+		},
+	}
+	visible := map[int]bool{1: true, 2: true}
+
+	got := filterTopologyServers(servers, visible)
+
+	if len(got) != 2 {
+		t.Fatalf("Expected 2 servers, got %d", len(got))
+	}
+	if len(got[0].Relationships) != 1 {
+		t.Fatalf("Expected 1 relationship on server 1, got %d",
+			len(got[0].Relationships))
+	}
+	if got[0].Relationships[0].TargetServerID != 2 {
+		t.Errorf("Expected relationship target 2, got %d",
+			got[0].Relationships[0].TargetServerID)
+	}
+	if got[0].Relationships[0].TargetServerName != "visible-peer" {
+		t.Errorf("Expected visible-peer target name, got %q",
+			got[0].Relationships[0].TargetServerName)
+	}
+	if len(got[1].Relationships) != 0 {
+		t.Errorf("Expected relationships to hidden peers to be dropped, got %d",
+			len(got[1].Relationships))
+	}
+	// Server 1 has no visible children, so IsExpandable must reflect the
+	// pruned state rather than the pre-populated flag.
+	if got[0].IsExpandable {
+		t.Errorf("Expected IsExpandable=false when no children remain")
+	}
+}
+
+// TestFilterTopologyServers_IsExpandableReflectsVisibleChildren verifies
+// that IsExpandable is recomputed from the pruned Children slice at the
+// handler layer. A server whose only children are hidden must become
+// non-expandable, and a server with a remaining visible child stays
+// expandable.
+func TestFilterTopologyServers_IsExpandableReflectsVisibleChildren(t *testing.T) {
+	servers := []database.TopologyServerInfo{
+		{
+			ID:           1,
+			Name:         "parent-all-hidden-children",
+			IsExpandable: true,
+			Children: []database.TopologyServerInfo{
+				{ID: 98, Name: "hidden-child-a"},
+				{ID: 99, Name: "hidden-child-b"},
+			},
+		},
+		{
+			ID:           2,
+			Name:         "parent-mixed",
+			IsExpandable: true,
+			Children: []database.TopologyServerInfo{
+				{ID: 3, Name: "visible-child"},
+				{ID: 97, Name: "hidden-child"},
+			},
+		},
+	}
+	visible := map[int]bool{1: true, 2: true, 3: true}
+
+	got := filterTopologyServers(servers, visible)
+
+	if len(got) != 2 {
+		t.Fatalf("Expected 2 top-level servers, got %d", len(got))
+	}
+	if got[0].IsExpandable {
+		t.Errorf("Expected IsExpandable=false when all children hidden")
+	}
+	if !got[1].IsExpandable {
+		t.Errorf("Expected IsExpandable=true when one child is visible")
+	}
+	if len(got[1].Children) != 1 || got[1].Children[0].ID != 3 {
+		t.Errorf("Expected single visible child ID=3, got %+v", got[1].Children)
+	}
+}

--- a/server/src/internal/api/rbac_issue35_test.go
+++ b/server/src/internal/api/rbac_issue35_test.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -687,55 +688,575 @@ func TestAlertHandler_HandleAlerts_GroupGranted_ProceedsPastGate(t *testing.T) {
 }
 
 // =============================================================================
-// AlertHandler.handleAlertCounts — production-code constraint
+// AlertHandler.handleAlertCounts — issue #67 regression coverage
 //
-// handleAlertCounts invokes h.datastore.GetAlertCounts BEFORE the RBAC
-// filter runs (see alert_handlers.go:172). With a nil datastore the
-// handler panics before reaching the VisibleConnectionIDs call, so a
-// handler-level RBAC test is not meaningful without a real or mocked
-// datastore.
+// The issue #67 refactor moved VisibleConnectionIDs AHEAD of
+// GetAlertCounts so a zero-grant caller short-circuits to the empty
+// counts response without touching the datastore. With a nil datastore
+// we can now assert that behavior purely from the HTTP boundary: denial
+// returns 200 + {total:0, by_server:{}} without panicking on the
+// datastore call.
 //
-// The filtering logic itself is covered indirectly via
-// TestVisibleConnectionIDs_* in auth/access_test.go. A full handler-
-// level test of handleAlertCounts would require a mocked Datastore
-// (pgxmock or an interface extraction), which the task forbids.
-//
-// Leaving this commentary in place so a future refactor can move the
-// RBAC check to run BEFORE GetAlertCounts (safe because the counts are
-// projected through VisibleConnectionIDs anyway) and pick up a real
-// regression test here.
+// The group-granted positive path panics against the nil datastore at
+// GetAlertCounts; the test recovers and verifies that the empty
+// short-circuit did NOT fire.
 // =============================================================================
 
-// =============================================================================
-// AlertHandler mutation handlers — production-code constraint
-//
-// acknowledgeAlert, unacknowledgeAlert, and handleSaveAnalysis call
-// h.datastore.GetAlertConnectionID BEFORE the RBAC check. The lookup is
-// intrinsic to the flow (the handler must know which connection owns
-// the alert before authorizing) and cannot be elided. With a nil
-// datastore the lookup panics before RBAC, so the handler-level 403
-// path cannot be asserted without a real or mocked datastore.
-//
-// Coverage for the RBAC call itself is via the per-connection tests
-// above (same rbacChecker.CanAccessConnection code path). A full
-// handler-level test would require injecting a stub that returns a
-// controllable (connectionID, error) pair for GetAlertConnectionID.
-// The task forbids adding such infrastructure.
-// =============================================================================
+// TestAlertHandler_HandleAlertCounts_NonOwnerUnshared_EmptyResult verifies
+// that a zero-grant caller receives {total:0, by_server:{}} without
+// invoking GetAlertCounts against the datastore.
+func TestAlertHandler_HandleAlertCounts_NonOwnerUnshared_EmptyResult(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	bobID := newTestUser(t, store, "bob")
+
+	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+	handler := NewAlertHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/alerts/counts", nil)
+	req = withUser(req, bobID)
+	req = withUsername(req, "bob")
+	rec := httptest.NewRecorder()
+
+	handler.handleAlertCounts(rec, req)
+
+	requireStatus(t, rec, http.StatusOK)
+
+	var body database.AlertCountsResult
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode response: %v", err)
+	}
+	if body.Total != 0 {
+		t.Errorf("Expected Total=0, got %d", body.Total)
+	}
+	if len(body.ByServer) != 0 {
+		t.Errorf("Expected empty ByServer, got %+v", body.ByServer)
+	}
+}
+
+// TestAlertHandler_HandleAlertCounts_GroupGranted_ProceedsPastGate
+// verifies that a group-granted caller is not short-circuited by the
+// zero-grant gate and reaches GetAlertCounts (which panics against the
+// nil datastore; the test recovers and asserts the empty JSON body was
+// NOT written).
+func TestAlertHandler_HandleAlertCounts_GroupGranted_ProceedsPastGate(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	bobID := newGroupGrantedUser(t, store, "bob",
+		rbacUnsharedConnID, auth.AccessLevelRead)
+
+	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+	handler := NewAlertHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/alerts/counts", nil)
+	req = withUser(req, bobID)
+	req = withUsername(req, "bob")
+	rec := httptest.NewRecorder()
+
+	noRespPanic(func() {
+		handler.handleAlertCounts(rec, req)
+	})
+
+	// The zero-grant shortcut writes a 200 with {total:0, by_server:{}}.
+	// A group-granted caller must not trip that shortcut: the panic
+	// inside GetAlertCounts happens BEFORE any write reaches the
+	// response, so the body must be empty.
+	if rec.Body.Len() != 0 {
+		t.Errorf("Expected empty body (panic-before-write), got %q",
+			rec.Body.String())
+	}
+	requireNotForbidden(t, rec, "handleAlertCounts/group-granted")
+}
+
+// TestAlertHandler_HandleAlertCounts_Superuser_ProceedsPastGate verifies
+// that a superuser request is NOT short-circuited by the zero-grant
+// gate. VisibleConnectionIDs returns allConnections=true for a
+// superuser; the handler must proceed to GetAlertCounts (panic against
+// nil datastore) without writing the empty shortcut.
+func TestAlertHandler_HandleAlertCounts_Superuser_ProceedsPastGate(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+	handler := NewAlertHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/alerts/counts", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	noRespPanic(func() {
+		handler.handleAlertCounts(rec, req)
+	})
+
+	if rec.Body.Len() != 0 {
+		t.Errorf("Expected empty body (panic-before-write), got %q",
+			rec.Body.String())
+	}
+	requireNotForbidden(t, rec, "handleAlertCounts/superuser")
+}
 
 // =============================================================================
-// ClusterHandler.getClusterTopology — production-code constraint
+// AlertHandler mutation handlers — issue #67 regression coverage
 //
-// getClusterTopology calls h.datastore.RefreshClusterAssignments and
-// h.datastore.GetClusterTopology BEFORE any RBAC filtering. With a nil
-// datastore the handler panics before VisibleConnectionIDs is reached,
-// so the handler-level pruning behavior cannot be asserted here.
+// The issue #67 refactor introduced a narrow alertConnectionResolver
+// interface so tests can inject a fake that returns a known connection
+// ID without stubbing the full datastore. That unlocks HTTP-level tests
+// for the three mutation handlers: fakeAlertResolver returns
+// rbacUnsharedConnID; the handler then runs CanAccessConnection; a
+// denied caller hits 403 before any datastore mutation call executes
+// (the mutation call would panic against the nil datastore; we do NOT
+// recover from that because a panic would mean the gate was bypassed).
+// =============================================================================
+
+// fakeAlertResolver is a deterministic alertConnectionResolver for
+// tests. It returns a fixed connection ID for every alert ID and tracks
+// how many times GetAlertConnectionID was called so tests can assert
+// that the resolver DID run (the RBAC check depends on it).
+type fakeAlertResolver struct {
+	connID int
+	calls  int
+	err    error
+}
+
+func (f *fakeAlertResolver) GetAlertConnectionID(_ context.Context, _ int64) (int, error) {
+	f.calls++
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.connID, nil
+}
+
+// alertMutationInvoker is the minimal shape of a mutation handler method
+// on AlertHandler. Each case in the table below supplies one of these
+// to parameterize the common setup.
+type alertMutationInvoker func(h *AlertHandler, w http.ResponseWriter, r *http.Request)
+
+type alertMutationCase struct {
+	name    string
+	method  string
+	url     string
+	body    []byte
+	invoker alertMutationInvoker
+}
+
+var alertMutationHandlers = []alertMutationCase{
+	{
+		name:   "acknowledgeAlert",
+		method: http.MethodPost,
+		url:    "/api/v1/alerts/acknowledge",
+		body:   []byte(`{"alert_id": 7, "message": "test"}`),
+		invoker: func(h *AlertHandler, w http.ResponseWriter, r *http.Request) {
+			h.acknowledgeAlert(w, r)
+		},
+	},
+	{
+		name:   "unacknowledgeAlert",
+		method: http.MethodDelete,
+		url:    "/api/v1/alerts/acknowledge?alert_id=7",
+		invoker: func(h *AlertHandler, w http.ResponseWriter, r *http.Request) {
+			h.unacknowledgeAlert(w, r)
+		},
+	},
+	{
+		name:   "handleSaveAnalysis",
+		method: http.MethodPut,
+		url:    "/api/v1/alerts/analysis",
+		body:   []byte(`{"alert_id": 7, "analysis": "test analysis"}`),
+		invoker: func(h *AlertHandler, w http.ResponseWriter, r *http.Request) {
+			h.handleSaveAnalysis(w, r)
+		},
+	},
+}
+
+// TestAlertHandler_Mutation_NonOwnerUnshared_403 verifies every alert
+// mutation handler returns 403 when a non-owner user with no group
+// grants targets an unshared connection. The nil datastore would panic
+// if the handler reached any mutation call after the RBAC gate; we do
+// NOT recover here because a panic would indicate a gate bypass.
+func TestAlertHandler_Mutation_NonOwnerUnshared_403(t *testing.T) {
+	for _, tc := range alertMutationHandlers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			bobID := newTestUser(t, store, "bob")
+
+			checker := mockSharingChecker(t, store,
+				rbacUnsharedConnID, "alice", false)
+			handler := NewAlertHandler(nil, store, checker)
+			resolver := &fakeAlertResolver{connID: rbacUnsharedConnID}
+			handler.setAlertResolver(resolver)
+
+			req := httptest.NewRequest(tc.method, tc.url,
+				bytes.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withUser(req, bobID)
+			req = withUsername(req, "bob")
+			rec := httptest.NewRecorder()
+
+			tc.invoker(handler, rec, req)
+
+			requireStatus(t, rec, http.StatusForbidden)
+
+			if resolver.calls != 1 {
+				t.Errorf("Expected resolver to run once, got %d calls",
+					resolver.calls)
+			}
+		})
+	}
+}
+
+// TestAlertHandler_Mutation_Owner_NotDenied verifies every alert
+// mutation handler clears the RBAC gate for the connection's owner.
+// With a nil datastore the handler panics after the gate when attempting
+// the actual mutation; the test recovers and asserts the response code
+// never became 403.
+func TestAlertHandler_Mutation_Owner_NotDenied(t *testing.T) {
+	for _, tc := range alertMutationHandlers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			aliceID := newTestUser(t, store, "alice")
+
+			checker := mockSharingChecker(t, store,
+				rbacUnsharedConnID, "alice", false)
+			handler := NewAlertHandler(nil, store, checker)
+			handler.setAlertResolver(&fakeAlertResolver{
+				connID: rbacUnsharedConnID,
+			})
+
+			req := httptest.NewRequest(tc.method, tc.url,
+				bytes.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withUser(req, aliceID)
+			req = withUsername(req, "alice")
+			rec := httptest.NewRecorder()
+
+			noRespPanic(func() {
+				tc.invoker(handler, rec, req)
+			})
+
+			requireNotForbidden(t, rec, tc.name+"/owner")
+		})
+	}
+}
+
+// TestAlertHandler_Mutation_SharedNonOwner_NotDenied verifies that a
+// non-owner caller accessing a shared connection is not denied.
+func TestAlertHandler_Mutation_SharedNonOwner_NotDenied(t *testing.T) {
+	for _, tc := range alertMutationHandlers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			bobID := newTestUser(t, store, "bob")
+
+			checker := mockSharingChecker(t, store,
+				rbacUnsharedConnID, "alice", true)
+			handler := NewAlertHandler(nil, store, checker)
+			handler.setAlertResolver(&fakeAlertResolver{
+				connID: rbacUnsharedConnID,
+			})
+
+			req := httptest.NewRequest(tc.method, tc.url,
+				bytes.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withUser(req, bobID)
+			req = withUsername(req, "bob")
+			rec := httptest.NewRecorder()
+
+			noRespPanic(func() {
+				tc.invoker(handler, rec, req)
+			})
+
+			requireNotForbidden(t, rec, tc.name+"/shared")
+		})
+	}
+}
+
+// TestAlertHandler_Mutation_GroupGranted_NotDenied verifies that a user
+// with an explicit group grant is not denied for an unshared connection.
+func TestAlertHandler_Mutation_GroupGranted_NotDenied(t *testing.T) {
+	for _, tc := range alertMutationHandlers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			bobID := newGroupGrantedUser(t, store, "bob",
+				rbacUnsharedConnID, auth.AccessLevelReadWrite)
+
+			checker := mockSharingChecker(t, store,
+				rbacUnsharedConnID, "alice", false)
+			handler := NewAlertHandler(nil, store, checker)
+			handler.setAlertResolver(&fakeAlertResolver{
+				connID: rbacUnsharedConnID,
+			})
+
+			req := httptest.NewRequest(tc.method, tc.url,
+				bytes.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withUser(req, bobID)
+			req = withUsername(req, "bob")
+			rec := httptest.NewRecorder()
+
+			noRespPanic(func() {
+				tc.invoker(handler, rec, req)
+			})
+
+			requireNotForbidden(t, rec, tc.name+"/group-granted")
+		})
+	}
+}
+
+// TestAlertHandler_Mutation_Superuser_NotDenied verifies that a
+// superuser is never denied, even against unshared non-owned resources.
+func TestAlertHandler_Mutation_Superuser_NotDenied(t *testing.T) {
+	for _, tc := range alertMutationHandlers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			checker := mockSharingChecker(t, store,
+				rbacUnsharedConnID, "alice", false)
+			handler := NewAlertHandler(nil, store, checker)
+			handler.setAlertResolver(&fakeAlertResolver{
+				connID: rbacUnsharedConnID,
+			})
+
+			req := httptest.NewRequest(tc.method, tc.url,
+				bytes.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withSuperuser(req)
+			rec := httptest.NewRecorder()
+
+			noRespPanic(func() {
+				tc.invoker(handler, rec, req)
+			})
+
+			requireNotForbidden(t, rec, tc.name+"/superuser")
+		})
+	}
+}
+
+// TestAlertHandler_Mutation_ResolverMissing_500 exercises the defensive
+// branch that rejects a request when the resolver has not been
+// configured. Production never hits this (the constructor wires the
+// datastore), but the nil-interface case must fail safely rather than
+// panic.
+func TestAlertHandler_Mutation_ResolverMissing_500(t *testing.T) {
+	for _, tc := range alertMutationHandlers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			bobID := newTestUser(t, store, "bob")
+
+			checker := mockSharingChecker(t, store,
+				rbacUnsharedConnID, "alice", false)
+			handler := NewAlertHandler(nil, store, checker)
+			// Deliberately leave alertResolver nil.
+
+			req := httptest.NewRequest(tc.method, tc.url,
+				bytes.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withUser(req, bobID)
+			req = withUsername(req, "bob")
+			rec := httptest.NewRecorder()
+
+			tc.invoker(handler, rec, req)
+
+			requireStatus(t, rec, http.StatusInternalServerError)
+		})
+	}
+}
+
+// TestAlertHandler_Mutation_ResolverError_404 exercises the branch that
+// returns 404 when the resolver reports an error (e.g. the alert does
+// not exist). This keeps parity with the old code path and ensures the
+// RBAC gate does not fire for an unknown alert.
+func TestAlertHandler_Mutation_ResolverError_404(t *testing.T) {
+	for _, tc := range alertMutationHandlers {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, cleanup := createTestRBACHandler(t)
+			defer cleanup()
+
+			bobID := newTestUser(t, store, "bob")
+
+			checker := mockSharingChecker(t, store,
+				rbacUnsharedConnID, "alice", false)
+			handler := NewAlertHandler(nil, store, checker)
+			handler.setAlertResolver(&fakeAlertResolver{
+				err: errors.New("alert not found"),
+			})
+
+			req := httptest.NewRequest(tc.method, tc.url,
+				bytes.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withUser(req, bobID)
+			req = withUsername(req, "bob")
+			rec := httptest.NewRecorder()
+
+			tc.invoker(handler, rec, req)
+
+			requireStatus(t, rec, http.StatusNotFound)
+		})
+	}
+}
+
+// =============================================================================
+// ClusterHandler.getClusterTopology — issue #67 regression coverage
 //
-// The filtering logic that IS exercised once the datastore returns is
-// covered by the filterTopologyByVisibility unit tests already in
-// cluster_handlers_test.go. That is the meaningful regression surface
-// because filterTopologyByVisibility is the pure function that decides
-// which groups, clusters, and servers to drop.
+// The issue #67 refactor moved VisibleConnectionIDs AHEAD of
+// RefreshClusterAssignments and GetClusterTopology so a zero-grant
+// caller returns an empty topology without triggering any datastore
+// work. With a nil datastore we can now assert that behavior purely
+// from the HTTP boundary: denial returns 200 + []; no panic, no
+// refresh, no topology read.
+// =============================================================================
+
+// TestClusterHandler_GetClusterTopology_NonOwnerUnshared_EmptyTopology
+// verifies a zero-grant caller gets an empty topology array without
+// invoking any datastore method on the handler.
+func TestClusterHandler_GetClusterTopology_NonOwnerUnshared_EmptyTopology(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	bobID := newTestUser(t, store, "bob")
+
+	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+	handler := NewClusterHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+	req = withUser(req, bobID)
+	req = withUsername(req, "bob")
+	rec := httptest.NewRecorder()
+
+	handler.getClusterTopology(rec, req)
+
+	requireStatus(t, rec, http.StatusOK)
+
+	var body []database.TopologyGroup
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode response: %v", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("Expected empty topology, got %d groups", len(body))
+	}
+}
+
+// TestClusterHandler_GetClusterTopology_GroupGranted_ProceedsPastGate
+// verifies a group-granted caller does NOT receive the zero-grant
+// shortcut. The handler must proceed past the gate into
+// RefreshClusterAssignments, which panics against the nil datastore;
+// the test recovers and asserts the empty JSON body was NOT written.
+func TestClusterHandler_GetClusterTopology_GroupGranted_ProceedsPastGate(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	bobID := newGroupGrantedUser(t, store, "bob",
+		rbacUnsharedConnID, auth.AccessLevelRead)
+
+	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+	handler := NewClusterHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+	req = withUser(req, bobID)
+	req = withUsername(req, "bob")
+	rec := httptest.NewRecorder()
+
+	noRespPanic(func() {
+		handler.getClusterTopology(rec, req)
+	})
+
+	// The zero-grant shortcut writes an empty array with a 200 status.
+	// A group-granted caller must not trip that shortcut: the panic
+	// inside RefreshClusterAssignments happens BEFORE any write reaches
+	// the response.
+	if rec.Body.Len() != 0 {
+		t.Errorf("Expected empty body (panic-before-write), got %q",
+			rec.Body.String())
+	}
+	requireNotForbidden(t, rec, "getClusterTopology/group-granted")
+}
+
+// TestClusterHandler_GetClusterTopology_Superuser_ProceedsPastGate
+// verifies that a superuser is NOT short-circuited by the zero-grant
+// gate; the handler proceeds into the datastore (which panics against
+// the nil datastore).
+func TestClusterHandler_GetClusterTopology_Superuser_ProceedsPastGate(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+	handler := NewClusterHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	noRespPanic(func() {
+		handler.getClusterTopology(rec, req)
+	})
+
+	if rec.Body.Len() != 0 {
+		t.Errorf("Expected empty body (panic-before-write), got %q",
+			rec.Body.String())
+	}
+	requireNotForbidden(t, rec, "getClusterTopology/superuser")
+}
+
+// TestClusterHandler_GetClusterTopology_WildcardToken_ProceedsPastGate
+// covers the wildcard-scoped token path. A token scoped to
+// ConnectionIDAll with read access resolves allConnections=true; the
+// handler must not short-circuit and must proceed into the datastore.
+func TestClusterHandler_GetClusterTopology_WildcardToken_ProceedsPastGate(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	userID := newTestUser(t, store, "tok")
+	// Grant the user the ConnectionIDAll wildcard through a group so the
+	// effective privileges include the wildcard.
+	groupID, err := store.CreateGroup("tok_group", "")
+	if err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	if err := store.AddUserToGroup(groupID, userID); err != nil {
+		t.Fatalf("AddUserToGroup: %v", err)
+	}
+	if err := store.GrantConnectionPrivilege(groupID,
+		auth.ConnectionIDAll, auth.AccessLevelRead); err != nil {
+		t.Fatalf("GrantConnectionPrivilege: %v", err)
+	}
+
+	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
+	handler := NewClusterHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters", nil)
+	req = withUser(req, userID)
+	req = withUsername(req, "tok")
+	rec := httptest.NewRecorder()
+
+	noRespPanic(func() {
+		handler.getClusterTopology(rec, req)
+	})
+
+	if rec.Body.Len() != 0 {
+		t.Errorf("Expected empty body (panic-before-write), got %q",
+			rec.Body.String())
+	}
+	requireNotForbidden(t, rec, "getClusterTopology/wildcard")
+}
+
 // =============================================================================
 
 // TestFilterTopologyByVisibility_Issue35_PrunesUnsharedNonOwned adds

--- a/server/src/internal/database/alert_counts_integration_test.go
+++ b/server/src/internal/database/alert_counts_integration_test.go
@@ -1,0 +1,170 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// alertCountsTestSchema mirrors the minimum columns GetAlertCounts
+// touches. The filterless and filtered branches both read from the
+// alerts table and group by connection_id.
+const alertCountsTestSchema = `
+DROP TABLE IF EXISTS alerts CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE alerts (
+    id BIGSERIAL PRIMARY KEY,
+    alert_type TEXT NOT NULL,
+    connection_id INTEGER NOT NULL REFERENCES connections(id) ON DELETE CASCADE,
+    severity TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    status TEXT NOT NULL,
+    triggered_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+const alertCountsTestTeardown = `
+DROP TABLE IF EXISTS alerts CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+`
+
+// newAlertCountsTestDatastore wires up a *Datastore against the
+// TEST_AI_WORKBENCH_SERVER Postgres instance with just the tables the
+// GetAlertCounts path needs. Tests skip when no DB is configured.
+func newAlertCountsTestDatastore(t *testing.T) (*Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping alert counts integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, alertCountsTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create alert counts test schema: %v", err)
+	}
+
+	ds := NewTestDatastore(pool)
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), alertCountsTestTeardown); err != nil {
+			t.Logf("alert counts teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return ds, pool, cleanup
+}
+
+func insertAlertCountsConn(t *testing.T, pool *pgxpool.Pool, name string) int {
+	t.Helper()
+	var id int
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO connections (name) VALUES ($1) RETURNING id`,
+		name).Scan(&id)
+	if err != nil {
+		t.Fatalf("Failed to insert connection %q: %v", name, err)
+	}
+	return id
+}
+
+func insertAlertCountsAlert(t *testing.T, pool *pgxpool.Pool, connID int, status string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO alerts (
+			alert_type, connection_id, severity, title, description, status
+		) VALUES ('threshold', $1, 'warning', 'test', 'desc', $2)
+	`, connID, status)
+	if err != nil {
+		t.Fatalf("Failed to insert alert: %v", err)
+	}
+}
+
+// TestGetAlertCounts_NoFilter exercises the branch that queries every
+// active alert in the database. It confirms the unfiltered total and
+// the per-connection breakdown match the inserted rows.
+func TestGetAlertCounts_NoFilter(t *testing.T) {
+	ds, pool, cleanup := newAlertCountsTestDatastore(t)
+	defer cleanup()
+
+	connA := insertAlertCountsConn(t, pool, "a")
+	connB := insertAlertCountsConn(t, pool, "b")
+	insertAlertCountsAlert(t, pool, connA, "active")
+	insertAlertCountsAlert(t, pool, connA, "active")
+	insertAlertCountsAlert(t, pool, connB, "active")
+	insertAlertCountsAlert(t, pool, connB, "cleared") // must be excluded
+
+	result, err := ds.GetAlertCounts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetAlertCounts: %v", err)
+	}
+	if result.Total != 3 {
+		t.Errorf("Total = %d, want 3", result.Total)
+	}
+	if result.ByServer[connA] != 2 {
+		t.Errorf("ByServer[%d] = %d, want 2", connA, result.ByServer[connA])
+	}
+	if result.ByServer[connB] != 1 {
+		t.Errorf("ByServer[%d] = %d, want 1", connB, result.ByServer[connB])
+	}
+}
+
+// TestGetAlertCounts_WithFilter exercises the branch that restricts the
+// counts to a caller-supplied allow-list. The filter must exclude alerts
+// for connections not in the slice even if their status is 'active'.
+func TestGetAlertCounts_WithFilter(t *testing.T) {
+	ds, pool, cleanup := newAlertCountsTestDatastore(t)
+	defer cleanup()
+
+	connA := insertAlertCountsConn(t, pool, "a")
+	connB := insertAlertCountsConn(t, pool, "b")
+	insertAlertCountsAlert(t, pool, connA, "active")
+	insertAlertCountsAlert(t, pool, connA, "active")
+	insertAlertCountsAlert(t, pool, connB, "active")
+
+	// Allow-list only connection A.
+	result, err := ds.GetAlertCounts(context.Background(), []int{connA})
+	if err != nil {
+		t.Fatalf("GetAlertCounts: %v", err)
+	}
+	if result.Total != 2 {
+		t.Errorf("Total = %d, want 2", result.Total)
+	}
+	if result.ByServer[connA] != 2 {
+		t.Errorf("ByServer[%d] = %d, want 2", connA, result.ByServer[connA])
+	}
+	if _, ok := result.ByServer[connB]; ok {
+		t.Errorf("ByServer unexpectedly contains filtered connection %d", connB)
+	}
+}

--- a/server/src/internal/database/datastore.go
+++ b/server/src/internal/database/datastore.go
@@ -4903,7 +4903,7 @@ func (d *Datastore) gatherScopedServerData(ctx context.Context, snapshot *Estate
 		logger.Infof("gatherScopedServerData: failed to refresh cluster assignments: %v", err)
 	}
 
-	groups, err := d.GetClusterTopology(ctx, nil)
+	groups, err := d.GetClusterTopology(ctx, connectionIDs)
 	if err != nil {
 		logger.Errorf("GetScopedSnapshot: failed to get cluster topology: %v", err)
 		return

--- a/server/src/internal/database/datastore.go
+++ b/server/src/internal/database/datastore.go
@@ -2063,7 +2063,9 @@ func pruneTopologyByVisibility(groups []TopologyGroup, visibleIDs []int) []Topol
 }
 
 // pruneTopologyServers returns the subset of servers whose connection IDs
-// appear in the visible set, recursing into Children.
+// appear in the visible set, recursing into Children. Relationships
+// pointing at hidden peers are also dropped so TargetServerID and
+// TargetServerName never leak across the visibility boundary.
 func pruneTopologyServers(servers []TopologyServerInfo, visible map[int]bool) []TopologyServerInfo {
 	out := make([]TopologyServerInfo, 0, len(servers))
 	for i := range servers {
@@ -2074,6 +2076,16 @@ func pruneTopologyServers(servers []TopologyServerInfo, visible map[int]bool) []
 		if len(s.Children) > 0 {
 			s.Children = pruneTopologyServers(s.Children, visible)
 		}
+		if len(s.Relationships) > 0 {
+			rels := make([]TopologyRelationship, 0, len(s.Relationships))
+			for _, rel := range s.Relationships {
+				if visible[rel.TargetServerID] {
+					rels = append(rels, rel)
+				}
+			}
+			s.Relationships = rels
+		}
+		s.IsExpandable = len(s.Children) > 0
 		out = append(out, s)
 	}
 	return out
@@ -4360,6 +4372,9 @@ func (d *Datastore) GetAlertCounts(ctx context.Context, connectionIDs []int) (*A
 			return nil, fmt.Errorf("failed to scan alert count: %w", err)
 		}
 		byServer[connID] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate alert counts: %w", err)
 	}
 
 	return &AlertCountsResult{

--- a/server/src/internal/database/datastore.go
+++ b/server/src/internal/database/datastore.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/pkg/crypto"
 	"github.com/pgedge/ai-workbench/pkg/logger"
@@ -1901,8 +1902,19 @@ type ClusterSummary struct {
 }
 
 // GetClusterTopology returns the combined topology including manually-created
-// cluster groups and auto-detected replication topology
-func (d *Datastore) GetClusterTopology(ctx context.Context) ([]TopologyGroup, error) {
+// cluster groups and auto-detected replication topology. When
+// visibleConnectionIDs is non-nil the topology is pruned to servers whose
+// connection ID is in the slice; clusters with no visible servers and
+// groups with no visible clusters are dropped. A nil slice means the
+// caller has unrestricted visibility (superuser or wildcard scope) and
+// the full topology is returned.
+func (d *Datastore) GetClusterTopology(ctx context.Context, visibleConnectionIDs []int) ([]TopologyGroup, error) {
+	// An explicit empty allow-list means no connections are visible;
+	// short-circuit before any datastore work.
+	if visibleConnectionIDs != nil && len(visibleConnectionIDs) == 0 {
+		return []TopologyGroup{}, nil
+	}
+
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -2003,7 +2015,68 @@ func (d *Datastore) GetClusterTopology(ctx context.Context) ([]TopologyGroup, er
 	// Step 8: Populate relationships on each server in the topology
 	d.populateTopologyRelationships(ctx, result)
 
+	// Step 9: Apply the caller's visibility filter, if any. Pruning
+	// happens after the full topology is assembled so that relationships
+	// are populated before servers are dropped; downstream code relies on
+	// relationship metadata only for servers the caller can see.
+	if visibleConnectionIDs != nil {
+		result = pruneTopologyByVisibility(result, visibleConnectionIDs)
+	}
+
 	return result, nil
+}
+
+// pruneTopologyByVisibility removes servers, clusters, and groups that
+// the caller is not allowed to see. A cluster with no visible servers is
+// dropped; a group with no visible clusters is dropped. The visibleIDs
+// slice is converted to a set once so the filter walks the topology in
+// linear time. Child servers are filtered recursively so a hidden parent
+// with visible children is dropped along with those children; this
+// matches the "cluster visibility" contract where children are only
+// meaningful under an accessible parent.
+func pruneTopologyByVisibility(groups []TopologyGroup, visibleIDs []int) []TopologyGroup {
+	visible := make(map[int]bool, len(visibleIDs))
+	for _, id := range visibleIDs {
+		visible[id] = true
+	}
+
+	filtered := make([]TopologyGroup, 0, len(groups))
+	for i := range groups {
+		group := groups[i]
+		clusters := make([]TopologyCluster, 0, len(group.Clusters))
+		for j := range group.Clusters {
+			cluster := group.Clusters[j]
+			servers := pruneTopologyServers(cluster.Servers, visible)
+			if len(servers) == 0 {
+				continue
+			}
+			cluster.Servers = servers
+			clusters = append(clusters, cluster)
+		}
+		if len(clusters) == 0 {
+			continue
+		}
+		group.Clusters = clusters
+		filtered = append(filtered, group)
+	}
+	return filtered
+}
+
+// pruneTopologyServers returns the subset of servers whose connection IDs
+// appear in the visible set, recursing into Children.
+func pruneTopologyServers(servers []TopologyServerInfo, visible map[int]bool) []TopologyServerInfo {
+	out := make([]TopologyServerInfo, 0, len(servers))
+	for i := range servers {
+		s := servers[i]
+		if !visible[s.ID] {
+			continue
+		}
+		if len(s.Children) > 0 {
+			s.Children = pruneTopologyServers(s.Children, visible)
+		}
+		out = append(out, s)
+	}
+	return out
 }
 
 // populateTopologyRelationships loads relationships from the database
@@ -4215,31 +4288,67 @@ type AlertCountsResult struct {
 	ByServer map[int]int64 `json:"by_server"`
 }
 
-// GetAlertCounts returns counts of active alerts grouped by connection_id
-func (d *Datastore) GetAlertCounts(ctx context.Context) (*AlertCountsResult, error) {
+// GetAlertCounts returns counts of active alerts grouped by connection_id.
+// When connectionIDs is non-nil, the query is restricted to alerts whose
+// connection_id appears in the slice. A nil slice means "no filter"
+// (superuser or wildcard-scoped caller); an empty non-nil slice returns
+// an empty result without touching the database.
+func (d *Datastore) GetAlertCounts(ctx context.Context, connectionIDs []int) (*AlertCountsResult, error) {
+	// An explicit empty allow-list means the caller can see no
+	// connections; avoid the database round-trip entirely.
+	if connectionIDs != nil && len(connectionIDs) == 0 {
+		return &AlertCountsResult{
+			Total:    0,
+			ByServer: make(map[int]int64),
+		}, nil
+	}
+
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	// Get total count of active alerts
-	var total int64
-	err := d.pool.QueryRow(ctx, `
-		SELECT COUNT(*)
-		FROM alerts
-		WHERE status = 'active'
-	`).Scan(&total)
-	if err != nil {
-		return nil, fmt.Errorf("failed to count total alerts: %w", err)
-	}
+	var (
+		total    int64
+		rows     pgx.Rows
+		queryErr error
+	)
 
-	// Get counts grouped by connection_id
-	rows, err := d.pool.Query(ctx, `
-		SELECT connection_id, COUNT(*) as count
-		FROM alerts
-		WHERE status = 'active'
-		GROUP BY connection_id
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query alert counts: %w", err)
+	if connectionIDs == nil {
+		queryErr = d.pool.QueryRow(ctx, `
+			SELECT COUNT(*)
+			FROM alerts
+			WHERE status = 'active'
+		`).Scan(&total)
+		if queryErr != nil {
+			return nil, fmt.Errorf("failed to count total alerts: %w", queryErr)
+		}
+
+		rows, queryErr = d.pool.Query(ctx, `
+			SELECT connection_id, COUNT(*) as count
+			FROM alerts
+			WHERE status = 'active'
+			GROUP BY connection_id
+		`)
+	} else {
+		queryErr = d.pool.QueryRow(ctx, `
+			SELECT COUNT(*)
+			FROM alerts
+			WHERE status = 'active'
+			  AND connection_id = ANY($1)
+		`, connectionIDs).Scan(&total)
+		if queryErr != nil {
+			return nil, fmt.Errorf("failed to count total alerts: %w", queryErr)
+		}
+
+		rows, queryErr = d.pool.Query(ctx, `
+			SELECT connection_id, COUNT(*) as count
+			FROM alerts
+			WHERE status = 'active'
+			  AND connection_id = ANY($1)
+			GROUP BY connection_id
+		`, connectionIDs)
+	}
+	if queryErr != nil {
+		return nil, fmt.Errorf("failed to query alert counts: %w", queryErr)
 	}
 	defer rows.Close()
 
@@ -4438,7 +4547,7 @@ func (d *Datastore) gatherEstateServerData(ctx context.Context, snapshot *Estate
 		logger.Infof("gatherEstateServerData: failed to refresh cluster assignments: %v", err)
 	}
 
-	groups, err := d.GetClusterTopology(ctx)
+	groups, err := d.GetClusterTopology(ctx, nil)
 	if err != nil {
 		logger.Errorf("GetEstateSnapshot: failed to get cluster topology: %v", err)
 		return
@@ -4779,7 +4888,7 @@ func (d *Datastore) gatherScopedServerData(ctx context.Context, snapshot *Estate
 		logger.Infof("gatherScopedServerData: failed to refresh cluster assignments: %v", err)
 	}
 
-	groups, err := d.GetClusterTopology(ctx)
+	groups, err := d.GetClusterTopology(ctx, nil)
 	if err != nil {
 		logger.Errorf("GetScopedSnapshot: failed to get cluster topology: %v", err)
 		return

--- a/server/src/internal/database/topology_visibility_test.go
+++ b/server/src/internal/database/topology_visibility_test.go
@@ -1,0 +1,197 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"testing"
+)
+
+// TestPruneTopologyByVisibility_KeepsVisibleServers verifies that only
+// servers whose connection IDs appear in the visible set survive the
+// prune, and that clusters and groups left without any visible servers
+// are dropped.
+func TestPruneTopologyByVisibility_KeepsVisibleServers(t *testing.T) {
+	topology := []TopologyGroup{
+		{
+			ID:   "g1",
+			Name: "Mixed Group",
+			Clusters: []TopologyCluster{
+				{
+					ID:   "c1",
+					Name: "Mixed Cluster",
+					Servers: []TopologyServerInfo{
+						{ID: 1, Name: "visible-1"},
+						{ID: 2, Name: "hidden-2"},
+					},
+				},
+				{
+					ID:   "c2",
+					Name: "All-Hidden Cluster",
+					Servers: []TopologyServerInfo{
+						{ID: 3, Name: "hidden-3"},
+					},
+				},
+			},
+		},
+		{
+			ID:   "g2",
+			Name: "All-Hidden Group",
+			Clusters: []TopologyCluster{
+				{
+					ID:   "c3",
+					Name: "Hidden Only",
+					Servers: []TopologyServerInfo{
+						{ID: 4, Name: "hidden-4"},
+					},
+				},
+			},
+		},
+	}
+
+	filtered := pruneTopologyByVisibility(topology, []int{1})
+
+	if len(filtered) != 1 {
+		t.Fatalf("Expected 1 group, got %d", len(filtered))
+	}
+	if filtered[0].ID != "g1" {
+		t.Errorf("Expected g1, got %s", filtered[0].ID)
+	}
+	if len(filtered[0].Clusters) != 1 {
+		t.Fatalf("Expected 1 cluster, got %d", len(filtered[0].Clusters))
+	}
+	if filtered[0].Clusters[0].ID != "c1" {
+		t.Errorf("Expected c1, got %s", filtered[0].Clusters[0].ID)
+	}
+	if len(filtered[0].Clusters[0].Servers) != 1 {
+		t.Fatalf("Expected 1 server, got %d",
+			len(filtered[0].Clusters[0].Servers))
+	}
+	if filtered[0].Clusters[0].Servers[0].ID != 1 {
+		t.Errorf("Expected server 1, got %d",
+			filtered[0].Clusters[0].Servers[0].ID)
+	}
+}
+
+// TestPruneTopologyByVisibility_EmptyVisibleSetDropsEverything verifies
+// that an empty visible set results in an empty topology.
+func TestPruneTopologyByVisibility_EmptyVisibleSetDropsEverything(t *testing.T) {
+	topology := []TopologyGroup{
+		{
+			ID:   "g1",
+			Name: "Any Group",
+			Clusters: []TopologyCluster{
+				{
+					ID:   "c1",
+					Name: "Any Cluster",
+					Servers: []TopologyServerInfo{
+						{ID: 10, Name: "hidden-10"},
+					},
+				},
+			},
+		},
+	}
+
+	filtered := pruneTopologyByVisibility(topology, []int{})
+
+	if len(filtered) != 0 {
+		t.Errorf("Expected empty result, got %d groups", len(filtered))
+	}
+}
+
+// TestPruneTopologyServers_RecursesIntoChildren verifies that child
+// servers are filtered recursively so a visible parent with hidden
+// children retains only the visible descendants.
+func TestPruneTopologyServers_RecursesIntoChildren(t *testing.T) {
+	visible := map[int]bool{1: true, 3: true}
+	servers := []TopologyServerInfo{
+		{
+			ID:   1,
+			Name: "parent-1",
+			Children: []TopologyServerInfo{
+				{ID: 2, Name: "hidden-child"},
+				{ID: 3, Name: "visible-child"},
+			},
+		},
+		{ID: 4, Name: "hidden-peer"},
+	}
+
+	out := pruneTopologyServers(servers, visible)
+
+	if len(out) != 1 {
+		t.Fatalf("Expected 1 top-level server, got %d", len(out))
+	}
+	if out[0].ID != 1 {
+		t.Errorf("Expected top-level server 1, got %d", out[0].ID)
+	}
+	if len(out[0].Children) != 1 {
+		t.Fatalf("Expected 1 visible child, got %d", len(out[0].Children))
+	}
+	if out[0].Children[0].ID != 3 {
+		t.Errorf("Expected visible child 3, got %d", out[0].Children[0].ID)
+	}
+}
+
+// TestPruneTopologyServers_HiddenParentDropsVisibleChildren verifies the
+// documented contract: a hidden parent is dropped along with its
+// children, even if some of those children would otherwise be visible.
+func TestPruneTopologyServers_HiddenParentDropsVisibleChildren(t *testing.T) {
+	visible := map[int]bool{2: true}
+	servers := []TopologyServerInfo{
+		{
+			ID:   1,
+			Name: "hidden-parent",
+			Children: []TopologyServerInfo{
+				{ID: 2, Name: "visible-child"},
+			},
+		},
+	}
+
+	out := pruneTopologyServers(servers, visible)
+
+	if len(out) != 0 {
+		t.Errorf("Expected hidden parent to drop the whole branch, got %d", len(out))
+	}
+}
+
+// TestGetAlertCounts_EmptyFilterShortCircuits verifies that an explicit
+// empty non-nil filter returns a zero result without opening a database
+// connection. The test uses a zero-valued Datastore (nil pool) because
+// the short-circuit must run before any pool access.
+func TestGetAlertCounts_EmptyFilterShortCircuits(t *testing.T) {
+	d := &Datastore{}
+	result, err := d.GetAlertCounts(context.Background(), []int{})
+	if err != nil {
+		t.Fatalf("GetAlertCounts: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+	if result.Total != 0 {
+		t.Errorf("Expected Total=0, got %d", result.Total)
+	}
+	if len(result.ByServer) != 0 {
+		t.Errorf("Expected empty ByServer, got %+v", result.ByServer)
+	}
+}
+
+// TestGetClusterTopology_EmptyFilterShortCircuits verifies that an
+// explicit empty non-nil filter returns an empty topology without
+// opening a database connection.
+func TestGetClusterTopology_EmptyFilterShortCircuits(t *testing.T) {
+	d := &Datastore{}
+	result, err := d.GetClusterTopology(context.Background(), []int{})
+	if err != nil {
+		t.Fatalf("GetClusterTopology: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("Expected empty topology, got %d groups", len(result))
+	}
+}

--- a/server/src/internal/database/topology_visibility_test.go
+++ b/server/src/internal/database/topology_visibility_test.go
@@ -161,6 +161,152 @@ func TestPruneTopologyServers_HiddenParentDropsVisibleChildren(t *testing.T) {
 	}
 }
 
+// TestPruneTopologyServers_FiltersRelationshipsToHiddenPeers verifies
+// that Relationships entries targeting hidden peers are dropped during
+// pruning so TargetServerID and TargetServerName never leak across the
+// visibility boundary. Relationships targeting visible peers must
+// survive, and IsExpandable must reflect the remaining child count.
+func TestPruneTopologyServers_FiltersRelationshipsToHiddenPeers(t *testing.T) {
+	visible := map[int]bool{1: true, 2: true}
+	servers := []TopologyServerInfo{
+		{
+			ID:           1,
+			Name:         "visible-1",
+			IsExpandable: true,
+			Relationships: []TopologyRelationship{
+				{
+					TargetServerID:   2,
+					TargetServerName: "visible-peer",
+					RelationshipType: "spock_subscriber",
+				},
+				{
+					TargetServerID:   99,
+					TargetServerName: "hidden-peer",
+					RelationshipType: "spock_subscriber",
+				},
+			},
+		},
+		{
+			ID:   2,
+			Name: "visible-2",
+			Relationships: []TopologyRelationship{
+				{
+					TargetServerID:   77,
+					TargetServerName: "another-hidden",
+					RelationshipType: "spock_provider",
+				},
+			},
+		},
+	}
+
+	out := pruneTopologyServers(servers, visible)
+
+	if len(out) != 2 {
+		t.Fatalf("Expected 2 servers, got %d", len(out))
+	}
+
+	// Server 1 keeps only the relationship targeting visible peer 2.
+	if len(out[0].Relationships) != 1 {
+		t.Fatalf("Expected 1 relationship on server 1, got %d",
+			len(out[0].Relationships))
+	}
+	if out[0].Relationships[0].TargetServerID != 2 {
+		t.Errorf("Expected relationship target 2, got %d",
+			out[0].Relationships[0].TargetServerID)
+	}
+	if out[0].Relationships[0].TargetServerName != "visible-peer" {
+		t.Errorf("Expected visible-peer target name, got %q",
+			out[0].Relationships[0].TargetServerName)
+	}
+
+	// Server 2's sole relationship targeted a hidden peer; it should be
+	// stripped to an empty slice so no TargetServerID/Name leaks.
+	if len(out[1].Relationships) != 0 {
+		t.Errorf("Expected all relationships on server 2 to be dropped, got %d",
+			len(out[1].Relationships))
+	}
+
+	// IsExpandable must reflect the remaining visible child count.
+	if out[0].IsExpandable {
+		t.Errorf("Expected IsExpandable=false for server 1 with no visible children")
+	}
+}
+
+// TestPruneTopologyServers_PreservesRelationshipsBetweenVisiblePeers
+// verifies that when every relationship targets a visible peer the
+// full Relationships slice is preserved intact.
+func TestPruneTopologyServers_PreservesRelationshipsBetweenVisiblePeers(t *testing.T) {
+	visible := map[int]bool{1: true, 2: true, 3: true}
+	servers := []TopologyServerInfo{
+		{
+			ID:   1,
+			Name: "visible-1",
+			Relationships: []TopologyRelationship{
+				{TargetServerID: 2, TargetServerName: "peer-2"},
+				{TargetServerID: 3, TargetServerName: "peer-3"},
+			},
+		},
+	}
+
+	out := pruneTopologyServers(servers, visible)
+
+	if len(out) != 1 {
+		t.Fatalf("Expected 1 server, got %d", len(out))
+	}
+	if len(out[0].Relationships) != 2 {
+		t.Fatalf("Expected both relationships preserved, got %d",
+			len(out[0].Relationships))
+	}
+	if out[0].Relationships[0].TargetServerID != 2 ||
+		out[0].Relationships[1].TargetServerID != 3 {
+		t.Errorf("Relationship order/targets changed: got %+v",
+			out[0].Relationships)
+	}
+}
+
+// TestPruneTopologyServers_IsExpandableReflectsVisibleChildren verifies
+// that IsExpandable is recomputed from the pruned Children slice: a
+// server whose only children are hidden must become non-expandable, and
+// a server with a remaining visible child stays expandable.
+func TestPruneTopologyServers_IsExpandableReflectsVisibleChildren(t *testing.T) {
+	visible := map[int]bool{1: true, 2: true, 3: true}
+	servers := []TopologyServerInfo{
+		{
+			ID:           1,
+			Name:         "parent-all-hidden-children",
+			IsExpandable: true,
+			Children: []TopologyServerInfo{
+				{ID: 98, Name: "hidden-child-a"},
+				{ID: 99, Name: "hidden-child-b"},
+			},
+		},
+		{
+			ID:           2,
+			Name:         "parent-mixed",
+			IsExpandable: true,
+			Children: []TopologyServerInfo{
+				{ID: 3, Name: "visible-child"},
+				{ID: 97, Name: "hidden-child"},
+			},
+		},
+	}
+
+	out := pruneTopologyServers(servers, visible)
+
+	if len(out) != 2 {
+		t.Fatalf("Expected 2 top-level servers, got %d", len(out))
+	}
+	if out[0].IsExpandable {
+		t.Errorf("Expected IsExpandable=false when all children hidden")
+	}
+	if !out[1].IsExpandable {
+		t.Errorf("Expected IsExpandable=true when one child is visible")
+	}
+	if len(out[1].Children) != 1 || out[1].Children[0].ID != 3 {
+		t.Errorf("Expected single visible child ID=3, got %+v", out[1].Children)
+	}
+}
+
 // TestGetAlertCounts_EmptyFilterShortCircuits verifies that an explicit
 // empty non-nil filter returns a zero result without opening a database
 // connection. The test uses a zero-valued Datastore (nil pool) because


### PR DESCRIPTION
Fixes #67.

## Summary

Follow-up defense-in-depth refactor of the #35 RBAC fix. Five handlers
still called the datastore before running their RBAC check. That did
not leak data to users (filtering happened before the response left
the server), but it blocked direct HTTP-level zero-grant regression
tests and performed unnecessary DB work for denied callers.

Each affected handler now runs its authorization check before any
datastore call that references the target connection, and the
`rbac_issue35_test.go` suite covers the zero-grant / unshared case
at the HTTP boundary for every one.

## Handler changes

- **`handleAlertCounts`** — computes `VisibleConnectionIDs` first;
  zero-grant callers short-circuit to empty counts without touching
  the datastore; the visible-ID list is pushed into `GetAlertCounts`
  as a parameterized SQL filter (`connection_id = ANY($1)`).
- **`getClusterTopology`** — visibility is computed first; zero-grant
  callers return `[]` without triggering `RefreshClusterAssignments`
  or `GetClusterTopology`; the visible-ID set is pushed into
  `GetClusterTopology` via new `pruneTopologyByVisibility` /
  `pruneTopologyServers` helpers. The handler-level
  `filterTopologyByVisibility` is retained as a belt-and-suspenders
  post-filter.
- **`acknowledgeAlert`, `unacknowledgeAlert`, `handleSaveAnalysis`** —
  the alert-to-connection lookup is now behind a narrow
  `alertConnectionResolver` interface on `AlertHandler`. Production
  wires `*database.Datastore` into the resolver; tests inject a fake
  to assert the RBAC gate at the HTTP boundary. A defensive nil
  resolver branch fails closed with 500 (unreachable in production
  because the constructor wires the resolver whenever the datastore
  is non-nil, and `RegisterRoutes` mounts `notConfigured` handlers
  when it isn't).

## Datastore changes

- `GetAlertCounts(ctx, connectionIDs []int)` — `nil` means no filter;
  `[]int{}` short-circuits without running the query.
- `GetClusterTopology(ctx, visibleConnectionIDs []int)` — same
  semantics; the new pure helpers `pruneTopologyByVisibility` /
  `pruneTopologyServers` apply the filter inside the datastore layer.

## Tests

- `rbac_issue35_test.go` — replaced the three production-code
  constraint placeholders (lines ~690-740 of the old file) with
  real HTTP-level tests. Added `fakeAlertResolver` plus
  table-driven coverage for the mutation handlers (403 deny,
  owner, shared, group, superuser, resolver-missing 500,
  resolver-error 404). Added zero-grant short-circuit,
  group-grant, superuser, and wildcard-token coverage for
  `handleAlertCounts` and `getClusterTopology`.
- `alert_handlers_test.go` — constructor wiring and
  validation-before-resolver tests.
- `topology_visibility_test.go` (new) — 100% coverage of the new
  pure pruning helpers.
- `alert_counts_integration_test.go` (new) —
  `TEST_AI_WORKBENCH_SERVER`-gated SQL-level coverage for the
  filtered and unfiltered branches of `GetAlertCounts`.

## Security review

Audited by the `security-auditor` sub-agent: 0 P0 findings,
0 P1 findings, 3 P2 findings — all pre-existing and out of
scope for #67 (filed as follow-ups: topology relationship
edge leaks, 403/404 alert existence oracle, `pgx.ErrNoRows`
vs infrastructure-error conflation in `GetAlertConnectionID`).

## Test plan

- [x] `cd server && make test` — all packages pass.
- [x] `cd collector && make test` — pass.
- [x] `cd alerter && make test` — pass.
- [x] `gofmt -l server/src` — clean.
- [x] `go vet ./...` (server) — clean.
- [x] `make openapi` — no diff (HTTP surface unchanged).
- [ ] `make test-all` — tests pass; the `lint` target fails only on
      the sandbox `golangci-lint` config-version mismatch (pre-existing
      environmental issue, unrelated to this PR).

https://claude.ai/code/session_0196QxsQkUtAXoaFY7whvFVy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RBAC checks now run before datastore queries for alerts and cluster topology; callers with no permissions receive immediate empty counts/topology and hidden servers/relationships are excluded.
* **Tests**
  * Added HTTP regression, unit, and database integration tests covering access-control ordering, zero-grant short-circuits, and visibility behavior.
* **Documentation**
  * Changelog updated to record the RBAC/visibility change and test additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->