### PR TITLE
Refactor ClusterNavigator group ID flow to keep string format (#63)

### DIFF
--- a/client/src/components/ClusterNavigator/GroupItem.tsx
+++ b/client/src/components/ClusterNavigator/GroupItem.tsx
@@ -28,7 +28,7 @@ import {
     Settings as SettingsIcon,
 } from '@mui/icons-material';
 import InlineEditText from '../InlineEditText';
-import { getClusterType, countServersRecursive } from './utils';
+import { getClusterType, countServersRecursive, parseGroupNumericId } from './utils';
 import ClusterContainer from './ClusterContainer';
 import ClusterItem from './ClusterItem';
 import ServerItem from './ServerItem';
@@ -183,7 +183,7 @@ const GroupItem = memo<GroupItemProps>(({
 
     // Superusers can edit both database-backed groups (ID: group-{number})
     // and auto-detected groups (groups with auto_group_key)
-    const isEditableGroup = /^group-\d+$/.test(group.id) || !!group.auto_group_key;
+    const isEditableGroup = parseGroupNumericId(group.id) !== undefined || !!group.auto_group_key;
     const canEditGroup = user?.isSuperuser && isEditableGroup;
     const totalServers = group.clusters?.reduce(
         (acc, c) => acc + countServersRecursive(c.servers),

--- a/client/src/components/ClusterNavigator/index.tsx
+++ b/client/src/components/ClusterNavigator/index.tsx
@@ -314,7 +314,7 @@ const ClusterNavigator: React.FC<ClusterNavigatorProps> = ({
     const [editingServer, setEditingServer] = useState<Record<string, unknown> | null>(null);
     const [groupDialogOpen, setGroupDialogOpen] = useState(false);
     const [groupDialogMode, setGroupDialogMode] = useState<'create' | 'edit'>('create');
-    const [editingGroup, setEditingGroup] = useState<Record<string, unknown> | null>(null);
+    const [editingGroup, setEditingGroup] = useState<(GroupData & { id: string }) | null>(null);
     const [groupDialogInitialTab, setGroupDialogInitialTab] = useState(0);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [deleteTarget, setDeleteTarget] = useState<{ type: string; item: { id: number | string; name?: string } } | null>(null);
@@ -544,7 +544,7 @@ const ClusterNavigator: React.FC<ClusterNavigatorProps> = ({
             await createGroup(groupData);
         } else {
             // For edit, we just update the name using existing function
-            await updateGroupName(editingGroup!.id as string, groupData.name);
+            await updateGroupName(editingGroup!.id, groupData.name);
         }
         setGroupDialogOpen(false);
     };
@@ -563,9 +563,7 @@ const ClusterNavigator: React.FC<ClusterNavigatorProps> = ({
 
     // Handler for configuring a group (opens edit dialog on Alert Overrides tab)
     const handleConfigureGroup = (group: GroupData) => {
-        const groupId = group.id as string;
-        const numericId = parseInt(groupId.replace('group-', ''), 10);
-        setEditingGroup({ ...group, id: numericId });
+        setEditingGroup(group);
         setGroupDialogMode('edit');
         setGroupDialogInitialTab(0);
         setGroupDialogOpen(true);
@@ -645,7 +643,7 @@ const ClusterNavigator: React.FC<ClusterNavigatorProps> = ({
             } else if (deleteTarget.type === 'cluster') {
                 await deleteCluster(deleteTarget.item.id as string);
             } else {
-                await deleteGroup(deleteTarget.item.id);
+                await deleteGroup(deleteTarget.item.id as string);
             }
             setDeleteDialogOpen(false);
             setDeleteTarget(null);

--- a/client/src/components/ClusterNavigator/utils.test.ts
+++ b/client/src/components/ClusterNavigator/utils.test.ts
@@ -1,0 +1,91 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseGroupNumericId } from './utils';
+
+describe('parseGroupNumericId', () => {
+    describe('matches database-backed ids', () => {
+        it.each([
+            ['group-0', 0],
+            ['group-1', 1],
+            ['group-42', 42],
+            ['group-12345', 12345],
+        ])('parses %s as %i', (input, expected) => {
+            expect(parseGroupNumericId(input)).toBe(expected);
+        });
+
+        it('returns a number, never NaN, for valid ids', () => {
+            const parsed = parseGroupNumericId('group-7');
+            expect(typeof parsed).toBe('number');
+            expect(Number.isNaN(parsed)).toBe(false);
+            expect(parsed).toBe(7);
+        });
+    });
+
+    describe('rejects non-matching inputs', () => {
+        it.each([
+            ['group-auto'],
+            ['group-auto-foo'],
+            ['group-auto-some-key'],
+            ['group-'],
+            ['group-1a'],
+            ['group-a1'],
+            ['group-Production'],
+            ['group-1.5'],
+            ['group- 1'],
+            ['group-1 '],
+            ['group'],
+            [''],
+            ['42'],
+            ['1'],
+            ['cluster-1'],
+            ['server-1'],
+        ])('returns undefined for %j', (input) => {
+            expect(parseGroupNumericId(input)).toBeUndefined();
+        });
+
+        it('returns undefined for undefined input', () => {
+            expect(parseGroupNumericId(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('return type guarantees', () => {
+        it('never returns NaN, always number or undefined', () => {
+            // Exercise a range of shapes and confirm the result is either
+            // a finite number or undefined; NaN must never leak through.
+            const inputs: Array<string | undefined> = [
+                undefined,
+                '',
+                'group-0',
+                'group-999999',
+                'group-auto',
+                'group-1a',
+                'group-',
+                'group-01', // leading zero numeric suffix still parses
+            ];
+            for (const input of inputs) {
+                const result = parseGroupNumericId(input);
+                if (result === undefined) {
+                    expect(result).toBeUndefined();
+                } else {
+                    expect(typeof result).toBe('number');
+                    expect(Number.isFinite(result)).toBe(true);
+                    expect(Number.isNaN(result)).toBe(false);
+                }
+            }
+        });
+
+        it('parses leading-zero numeric suffixes as plain numbers', () => {
+            // /^group-(\d+)$/ matches "group-01"; Number("01") === 1.
+            expect(parseGroupNumericId('group-01')).toBe(1);
+        });
+    });
+});

--- a/client/src/components/ClusterNavigator/utils.test.ts
+++ b/client/src/components/ClusterNavigator/utils.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseGroupNumericId } from './utils';
+import { parseGroupNumericId, isAutoGroupId } from './utils';
 
 describe('parseGroupNumericId', () => {
     describe('matches database-backed ids', () => {
@@ -86,6 +86,48 @@ describe('parseGroupNumericId', () => {
         it('parses leading-zero numeric suffixes as plain numbers', () => {
             // /^group-(\d+)$/ matches "group-01"; Number("01") === 1.
             expect(parseGroupNumericId('group-01')).toBe(1);
+        });
+    });
+});
+
+describe('isAutoGroupId', () => {
+    describe('matches the bare and suffixed auto forms', () => {
+        it.each([
+            ['group-auto'],
+            ['group-auto-foo'],
+            ['group-auto-some_key-123'],
+            ['group-auto-A_B-c_d'],
+            ['group-auto-0'],
+            ['group-auto-UPPER'],
+            ['group-auto-a'],
+            ['group-auto--'],
+        ])('returns true for %j', (input) => {
+            expect(isAutoGroupId(input)).toBe(true);
+        });
+    });
+
+    describe('rejects malformed or unrelated inputs', () => {
+        it.each([
+            ['group-autobad'],
+            ['group-automatic'],
+            ['group-auto_foo'],
+            ['group-auto-'],
+            ['group-auto/evil'],
+            ['group-auto-bad id'],
+            ['group-'],
+            ['group-5'],
+            ['group-1a'],
+            ['group-Production'],
+            ['not-a-group'],
+            ['auto'],
+            ['group'],
+            [''],
+        ])('returns false for %j', (input) => {
+            expect(isAutoGroupId(input)).toBe(false);
+        });
+
+        it('returns false for undefined input', () => {
+            expect(isAutoGroupId(undefined)).toBe(false);
         });
     });
 });

--- a/client/src/components/ClusterNavigator/utils.ts
+++ b/client/src/components/ClusterNavigator/utils.ts
@@ -179,3 +179,29 @@ export const formatRelativeTime = (date: Date | null | undefined): string => {
     const minutes = Math.floor(seconds / 60);
     return `${minutes}m ago`;
 };
+
+/**
+ * Parse the numeric database id from a "group-{id}" formatted string.
+ *
+ * Group ids flow through the client as strings of the form
+ * "group-{suffix}". The database-backed form has a bare numeric suffix
+ * (e.g. "group-42"); auto-detected buckets use a non-numeric suffix
+ * (e.g. "group-auto" or "group-auto-<key>"). Callers that need to
+ * address a group by its database row id must strip the prefix and
+ * reject every non-numeric shape.
+ *
+ * This helper is the single source of truth for that parsing. It
+ * matches only `/^group-(\d+)$/` and returns `undefined` for every
+ * other input, including `undefined`, the empty string, auto-detected
+ * ids, and partially-numeric suffixes like "group-1a". It also guards
+ * against `NaN` so the return type is truly `number | undefined`.
+ */
+export const parseGroupNumericId = (
+    id: string | undefined,
+): number | undefined => {
+    if (!id) {return undefined;}
+    const match = /^group-(\d+)$/.exec(id);
+    if (!match) {return undefined;}
+    const parsed = Number(match[1]);
+    return Number.isNaN(parsed) ? undefined : parsed;
+};

--- a/client/src/components/ClusterNavigator/utils.ts
+++ b/client/src/components/ClusterNavigator/utils.ts
@@ -205,3 +205,24 @@ export const parseGroupNumericId = (
     const parsed = Number(match[1]);
     return Number.isNaN(parsed) ? undefined : parsed;
 };
+
+/**
+ * Strict matcher for auto-detected group ids.
+ *
+ * Auto buckets arrive as either the bare token "group-auto" or as
+ * "group-auto-<suffix>" where the suffix is a url-safe token made up
+ * of letters, digits, underscores, and hyphens. Looser forms like
+ * `/^group-auto/` let malformed ids through (for example
+ * "group-autobad" or "group-auto_foo" with non-url-safe suffixes);
+ * this anchored, url-safe-suffix pattern rejects them.
+ *
+ * This helper is the single source of truth for the auto-form check
+ * so that every call site stays in lockstep if the pattern ever
+ * changes.
+ */
+const AUTO_GROUP_ID_REGEX = /^group-auto(?:-[A-Za-z0-9_-]+)?$/;
+
+export const isAutoGroupId = (id: string | undefined): boolean => {
+    if (!id) {return false;}
+    return AUTO_GROUP_ID_REGEX.test(id);
+};

--- a/client/src/components/GroupDialog.tsx
+++ b/client/src/components/GroupDialog.tsx
@@ -135,10 +135,24 @@ interface GroupDialogProps {
     onClose: () => void;
     onSave: (data: GroupData) => Promise<void>;
     mode?: 'create' | 'edit';
-    group?: { id?: number; name?: string; description?: string; is_shared?: boolean } | null;
+    group?: { id?: string; name?: string; description?: string; is_shared?: boolean } | null;
     isSuperuser?: boolean;
     initialTab?: number;
 }
+
+/**
+ * Extract the numeric scope id from a "group-{id}" formatted id.
+ * Override panel endpoints require a numeric scope id; the "group-auto"
+ * bucket has no backing database row and therefore no numeric id.
+ * Returns undefined when the id does not match the numeric shape.
+ */
+const extractNumericGroupId = (groupId?: string): number | undefined => {
+    if (!groupId) {return undefined;}
+    const match = /^group-(\d+)$/.exec(groupId);
+    if (!match) {return undefined;}
+    const parsed = parseInt(match[1], 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
+};
 
 /**
  * GroupDialog - Dialog for creating and editing cluster groups
@@ -160,6 +174,11 @@ const GroupDialog: React.FC<GroupDialogProps> = ({
     const [isSaving, setIsSaving] = useState(false);
     const [activeTab, setActiveTab] = useState(0);
     const prevOpenRef = useRef(false);
+
+    // Override panel endpoints address groups by their numeric database id.
+    // The group id arrives in the "group-{id}" form; extract the tail here
+    // so the string id can flow through the rest of the edit flow unchanged.
+    const numericGroupId = extractNumericGroupId(group?.id);
 
     // Reset form only when dialog opens (false -> true transition)
     useEffect(() => {
@@ -382,22 +401,40 @@ const GroupDialog: React.FC<GroupDialogProps> = ({
                         </Box>
                     )}
                     {activeTab === 1 && (
-                        <AlertOverridesPanel
-                            scope="group"
-                            scopeId={group?.id as number}
-                        />
+                        numericGroupId !== undefined ? (
+                            <AlertOverridesPanel
+                                scope="group"
+                                scopeId={numericGroupId}
+                            />
+                        ) : (
+                            <Alert severity="info" sx={alertSx}>
+                                Overrides are not available for auto-detected groups.
+                            </Alert>
+                        )
                     )}
                     {activeTab === 2 && (
-                        <ProbeOverridesPanel
-                            scope="group"
-                            scopeId={group?.id as number}
-                        />
+                        numericGroupId !== undefined ? (
+                            <ProbeOverridesPanel
+                                scope="group"
+                                scopeId={numericGroupId}
+                            />
+                        ) : (
+                            <Alert severity="info" sx={alertSx}>
+                                Overrides are not available for auto-detected groups.
+                            </Alert>
+                        )
                     )}
                     {activeTab === 3 && (
-                        <ChannelOverridesPanel
-                            scope="group"
-                            scopeId={group?.id as number}
-                        />
+                        numericGroupId !== undefined ? (
+                            <ChannelOverridesPanel
+                                scope="group"
+                                scopeId={numericGroupId}
+                            />
+                        ) : (
+                            <Alert severity="info" sx={alertSx}>
+                                Overrides are not available for auto-detected groups.
+                            </Alert>
+                        )
                     )}
                 </Box>
             </Dialog>

--- a/client/src/components/GroupDialog.tsx
+++ b/client/src/components/GroupDialog.tsx
@@ -37,6 +37,7 @@ import AlertOverridesPanel from './AlertOverridesPanel';
 import ProbeOverridesPanel from './ProbeOverridesPanel';
 import ChannelOverridesPanel from './ChannelOverridesPanel';
 import SlideTransition from './shared/SlideTransition';
+import { parseGroupNumericId } from './ClusterNavigator/utils';
 
 // --- Style constants (Issue 23) ---
 
@@ -141,20 +142,6 @@ interface GroupDialogProps {
 }
 
 /**
- * Extract the numeric scope id from a "group-{id}" formatted id.
- * Override panel endpoints require a numeric scope id; the "group-auto"
- * bucket has no backing database row and therefore no numeric id.
- * Returns undefined when the id does not match the numeric shape.
- */
-const extractNumericGroupId = (groupId?: string): number | undefined => {
-    if (!groupId) {return undefined;}
-    const match = /^group-(\d+)$/.exec(groupId);
-    if (!match) {return undefined;}
-    const parsed = parseInt(match[1], 10);
-    return Number.isNaN(parsed) ? undefined : parsed;
-};
-
-/**
  * GroupDialog - Dialog for creating and editing cluster groups
  */
 const GroupDialog: React.FC<GroupDialogProps> = ({
@@ -178,7 +165,7 @@ const GroupDialog: React.FC<GroupDialogProps> = ({
     // Override panel endpoints address groups by their numeric database id.
     // The group id arrives in the "group-{id}" form; extract the tail here
     // so the string id can flow through the rest of the edit flow unchanged.
-    const numericGroupId = extractNumericGroupId(group?.id);
+    const numericGroupId = parseGroupNumericId(group?.id);
 
     // Reset form only when dialog opens (false -> true transition)
     useEffect(() => {

--- a/client/src/components/__tests__/ClusterNavigator.test.tsx
+++ b/client/src/components/__tests__/ClusterNavigator.test.tsx
@@ -9,7 +9,8 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@mui/material/styles';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import ClusterNavigator from '../ClusterNavigator';
@@ -18,20 +19,53 @@ import { createPgedgeTheme } from '../../theme/pgedgeTheme';
 const lightTheme = createPgedgeTheme('light');
 const darkTheme = createPgedgeTheme('dark');
 
+// Hoisted mock handles so tests can assert on the calls made by handlers
+// inside the component.
+const {
+    mockUpdateGroupName,
+    mockUpdateClusterName,
+    mockUpdateServerName,
+    mockDeleteCluster,
+    mockCreateGroup,
+    mockDeleteGroup,
+    mockMoveClusterToGroup,
+    mockFetchClusterData,
+    mockUseAuth,
+} = vi.hoisted(() => ({
+    mockUpdateGroupName: vi.fn(),
+    mockUpdateClusterName: vi.fn(),
+    mockUpdateServerName: vi.fn(),
+    mockDeleteCluster: vi.fn(),
+    mockCreateGroup: vi.fn(),
+    mockDeleteGroup: vi.fn(),
+    mockMoveClusterToGroup: vi.fn(),
+    mockFetchClusterData: vi.fn(),
+    mockUseAuth: vi.fn(() => ({ user: { isSuperuser: false } })),
+}));
+
 // Mock the AuthContext
 vi.mock('../../contexts/AuthContext', () => ({
-    useAuth: () => ({
-        user: { isSuperuser: false },
-    }),
+    useAuth: () => mockUseAuth(),
 }));
 
 // Mock the ClusterContext
 vi.mock('../../contexts/ClusterContext', () => ({
     useCluster: () => ({
-        updateGroupName: vi.fn(),
-        updateClusterName: vi.fn(),
-        updateServerName: vi.fn(),
-        deleteCluster: vi.fn(),
+        updateGroupName: mockUpdateGroupName,
+        updateClusterName: mockUpdateClusterName,
+        updateServerName: mockUpdateServerName,
+        deleteCluster: mockDeleteCluster,
+        createGroup: mockCreateGroup,
+        deleteGroup: mockDeleteGroup,
+        moveClusterToGroup: mockMoveClusterToGroup,
+        fetchClusterData: mockFetchClusterData,
+        autoRefreshEnabled: false,
+        setAutoRefreshEnabled: vi.fn(),
+        lastRefresh: null,
+        getServer: vi.fn(),
+        createServer: vi.fn(),
+        updateServer: vi.fn(),
+        deleteServer: vi.fn(),
     }),
 }));
 
@@ -62,6 +96,31 @@ vi.mock('../../contexts/BlackoutContext', () => ({
         deleteBlackout: vi.fn(),
         fetchBlackouts: vi.fn(),
     }),
+}));
+
+// Mock override panels so they don't fetch data from the API
+vi.mock('../AlertOverridesPanel', () => ({
+    default: ({ scope, scopeId }: { scope: string; scopeId: number }) => (
+        <div data-testid="alert-overrides-panel">
+            AlertOverridesPanel: {scope} {scopeId}
+        </div>
+    ),
+}));
+
+vi.mock('../ProbeOverridesPanel', () => ({
+    default: ({ scope, scopeId }: { scope: string; scopeId: number }) => (
+        <div data-testid="probe-overrides-panel">
+            ProbeOverridesPanel: {scope} {scopeId}
+        </div>
+    ),
+}));
+
+vi.mock('../ChannelOverridesPanel', () => ({
+    default: ({ scope, scopeId }: { scope: string; scopeId: number }) => (
+        <div data-testid="channel-overrides-panel">
+            ChannelOverridesPanel: {scope} {scopeId}
+        </div>
+    ),
 }));
 
 // Mock data
@@ -113,6 +172,17 @@ describe('ClusterNavigator', () => {
     beforeEach(() => {
         onSelectServer = vi.fn();
         onRefresh = vi.fn();
+        mockUpdateGroupName.mockReset().mockResolvedValue(undefined);
+        mockUpdateClusterName.mockReset().mockResolvedValue(undefined);
+        mockUpdateServerName.mockReset().mockResolvedValue(undefined);
+        mockDeleteCluster.mockReset().mockResolvedValue(undefined);
+        mockCreateGroup.mockReset().mockResolvedValue({});
+        mockDeleteGroup.mockReset().mockResolvedValue(undefined);
+        mockMoveClusterToGroup.mockReset().mockResolvedValue(undefined);
+        mockFetchClusterData.mockReset().mockResolvedValue(undefined);
+        mockUseAuth.mockReset().mockReturnValue({
+            user: { isSuperuser: false },
+        });
     });
 
     it('renders the component with header', () => {
@@ -410,5 +480,145 @@ describe('ClusterNavigator', () => {
 
         // Verify scroll container exists
         expect(scrollContainer).toBeInTheDocument();
+    });
+
+    describe('configure group round-trip (issue #63)', () => {
+        it('passes the unchanged "group-{id}" string from configure to updateGroupName', async () => {
+            // Superuser is required to see the settings (configure) button
+            mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
+
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <ClusterNavigator
+                    data={mockClusterData}
+                    onSelectServer={onSelectServer}
+                    onRefresh={onRefresh}
+                />
+            );
+
+            // Open the configure dialog for the "Production" (group-1) group.
+            // The settings icon sits inside the action-buttons group on each
+            // row; click the first one which belongs to group-1.
+            const settingsButtons = document.querySelectorAll(
+                '.action-buttons button'
+            );
+            expect(settingsButtons.length).toBeGreaterThan(0);
+            fireEvent.click(settingsButtons[0]);
+
+            // Verify the edit dialog shows the correct group name
+            await waitFor(() => {
+                expect(
+                    screen.getByText(/Group Settings: Production/)
+                ).toBeInTheDocument();
+            });
+
+            // Name field should be pre-populated from the group data
+            const nameField = screen.getByRole('textbox', { name: /^name/i });
+            expect(nameField).toHaveValue('Production');
+
+            // Change the name and submit
+            await user.clear(nameField);
+            await user.type(nameField, 'Production Renamed');
+
+            const saveButton = screen.getByRole('button', { name: /^save$/i });
+            fireEvent.click(saveButton);
+
+            // Root-cause check: updateGroupName must receive the original
+            // "group-1" string, not "1" and not the number 1.
+            await waitFor(() => {
+                expect(mockUpdateGroupName).toHaveBeenCalledWith(
+                    'group-1',
+                    'Production Renamed'
+                );
+            });
+            // Type-level sanity: the first argument must be a string.
+            const [firstArg] = mockUpdateGroupName.mock.calls[0];
+            expect(typeof firstArg).toBe('string');
+            expect(firstArg).toBe('group-1');
+        });
+
+        it('calls createGroup (not updateGroupName) when saving from the Add Group flow', async () => {
+            mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
+
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <ClusterNavigator
+                    data={mockClusterData}
+                    onSelectServer={onSelectServer}
+                    onRefresh={onRefresh}
+                />
+            );
+
+            // Open the add menu via the "+" button in the header
+            const addButton = screen.getByRole('button', {
+                name: /add server or group/i,
+            });
+            fireEvent.click(addButton);
+
+            // Click the "Add Cluster Group" option in the menu
+            await waitFor(() => {
+                expect(
+                    screen.getByRole('menuitem', { name: /add cluster group/i })
+                ).toBeInTheDocument();
+            });
+            fireEvent.click(
+                screen.getByRole('menuitem', { name: /add cluster group/i })
+            );
+
+            // Dialog opens in create mode
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Add Cluster Group')
+                ).toBeInTheDocument();
+            });
+
+            const nameField = screen.getByRole('textbox', { name: /^name/i });
+            await user.type(nameField, 'New Group');
+
+            fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+            await waitFor(() => {
+                expect(mockCreateGroup).toHaveBeenCalledWith(
+                    expect.objectContaining({ name: 'New Group' })
+                );
+            });
+            expect(mockUpdateGroupName).not.toHaveBeenCalled();
+        });
+
+        it('renders the Alert overrides panel with a numeric scopeId extracted from "group-{id}"', async () => {
+            mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
+
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <ClusterNavigator
+                    data={mockClusterData}
+                    onSelectServer={onSelectServer}
+                    onRefresh={onRefresh}
+                />
+            );
+
+            const settingsButtons = document.querySelectorAll(
+                '.action-buttons button'
+            );
+            fireEvent.click(settingsButtons[0]);
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(/Group Settings: Production/)
+                ).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('tab', { name: /alert overrides/i })
+            );
+
+            // The panel mock echoes its scope/scopeId props; this asserts
+            // that the numeric 1 (not the string "group-1") reached the panel.
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('alert-overrides-panel')
+                ).toHaveTextContent('AlertOverridesPanel: group 1');
+            });
+        });
     });
 });

--- a/client/src/components/__tests__/ClusterNavigator.test.tsx
+++ b/client/src/components/__tests__/ClusterNavigator.test.tsx
@@ -10,7 +10,6 @@
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@mui/material/styles';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import ClusterNavigator from '../ClusterNavigator';
@@ -483,11 +482,23 @@ describe('ClusterNavigator', () => {
     });
 
     describe('configure group round-trip (issue #63)', () => {
+        // These tests intentionally avoid userEvent.type / userEvent.clear for
+        // the name field. Under v8 coverage instrumentation every keystroke
+        // re-enters heavily instrumented MUI transitions, and typing a full
+        // string character-by-character pushes the test past the default
+        // 5s timeout. fireEvent.change is equivalent for a controlled
+        // TextField (single synchronous state update) and is deterministic
+        // under both plain `npm test` and `npm run test:coverage`. The
+        // generous waitFor timeout is a belt-and-suspenders guard for the
+        // dialog's Grow/Collapse transitions, which are also slowed down
+        // significantly by v8 instrumentation.
+
+        const WAIT_TIMEOUT = 15000;
+
         it('passes the unchanged "group-{id}" string from configure to updateGroupName', async () => {
             // Superuser is required to see the settings (configure) button
             mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
 
-            const user = userEvent.setup({ delay: null });
             renderWithTheme(
                 <ClusterNavigator
                     data={mockClusterData}
@@ -505,42 +516,51 @@ describe('ClusterNavigator', () => {
             expect(settingsButtons.length).toBeGreaterThan(0);
             fireEvent.click(settingsButtons[0]);
 
-            // Verify the edit dialog shows the correct group name
-            await waitFor(() => {
-                expect(
-                    screen.getByText(/Group Settings: Production/)
-                ).toBeInTheDocument();
-            });
+            // Verify the edit dialog shows the correct group name.
+            await waitFor(
+                () => {
+                    expect(
+                        screen.getByText(/Group Settings: Production/)
+                    ).toBeInTheDocument();
+                },
+                { timeout: WAIT_TIMEOUT }
+            );
 
             // Name field should be pre-populated from the group data
             const nameField = screen.getByRole('textbox', { name: /^name/i });
             expect(nameField).toHaveValue('Production');
 
-            // Change the name and submit
-            await user.clear(nameField);
-            await user.type(nameField, 'Production Renamed');
+            // Change the name and submit. fireEvent.change is a single
+            // synchronous update that bypasses per-keystroke instrumentation
+            // overhead in v8 coverage runs.
+            fireEvent.change(nameField, {
+                target: { value: 'Production Renamed' },
+            });
+            expect(nameField).toHaveValue('Production Renamed');
 
             const saveButton = screen.getByRole('button', { name: /^save$/i });
             fireEvent.click(saveButton);
 
             // Root-cause check: updateGroupName must receive the original
             // "group-1" string, not "1" and not the number 1.
-            await waitFor(() => {
-                expect(mockUpdateGroupName).toHaveBeenCalledWith(
-                    'group-1',
-                    'Production Renamed'
-                );
-            });
+            await waitFor(
+                () => {
+                    expect(mockUpdateGroupName).toHaveBeenCalledWith(
+                        'group-1',
+                        'Production Renamed'
+                    );
+                },
+                { timeout: WAIT_TIMEOUT }
+            );
             // Type-level sanity: the first argument must be a string.
             const [firstArg] = mockUpdateGroupName.mock.calls[0];
             expect(typeof firstArg).toBe('string');
             expect(firstArg).toBe('group-1');
-        });
+        }, 20000);
 
         it('calls createGroup (not updateGroupName) when saving from the Add Group flow', async () => {
             mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
 
-            const user = userEvent.setup({ delay: null });
             renderWithTheme(
                 <ClusterNavigator
                     data={mockClusterData}
@@ -555,40 +575,46 @@ describe('ClusterNavigator', () => {
             });
             fireEvent.click(addButton);
 
-            // Click the "Add Cluster Group" option in the menu
-            await waitFor(() => {
-                expect(
-                    screen.getByRole('menuitem', { name: /add cluster group/i })
-                ).toBeInTheDocument();
-            });
-            fireEvent.click(
-                screen.getByRole('menuitem', { name: /add cluster group/i })
+            // Click the "Add Cluster Group" option in the menu (Grow
+            // transition can take noticeable time under v8 coverage).
+            const menuItem = await screen.findByRole(
+                'menuitem',
+                { name: /add cluster group/i },
+                { timeout: WAIT_TIMEOUT }
             );
+            fireEvent.click(menuItem);
 
             // Dialog opens in create mode
-            await waitFor(() => {
-                expect(
-                    screen.getByText('Add Cluster Group')
-                ).toBeInTheDocument();
-            });
+            await waitFor(
+                () => {
+                    expect(
+                        screen.getByText('Add Cluster Group')
+                    ).toBeInTheDocument();
+                },
+                { timeout: WAIT_TIMEOUT }
+            );
 
             const nameField = screen.getByRole('textbox', { name: /^name/i });
-            await user.type(nameField, 'New Group');
+            // Use fireEvent.change for the same reason as above.
+            fireEvent.change(nameField, { target: { value: 'New Group' } });
+            expect(nameField).toHaveValue('New Group');
 
             fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
-            await waitFor(() => {
-                expect(mockCreateGroup).toHaveBeenCalledWith(
-                    expect.objectContaining({ name: 'New Group' })
-                );
-            });
+            await waitFor(
+                () => {
+                    expect(mockCreateGroup).toHaveBeenCalledWith(
+                        expect.objectContaining({ name: 'New Group' })
+                    );
+                },
+                { timeout: WAIT_TIMEOUT }
+            );
             expect(mockUpdateGroupName).not.toHaveBeenCalled();
-        });
+        }, 20000);
 
         it('renders the Alert overrides panel with a numeric scopeId extracted from "group-{id}"', async () => {
             mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
 
-            const user = userEvent.setup({ delay: null });
             renderWithTheme(
                 <ClusterNavigator
                     data={mockClusterData}
@@ -602,23 +628,29 @@ describe('ClusterNavigator', () => {
             );
             fireEvent.click(settingsButtons[0]);
 
-            await waitFor(() => {
-                expect(
-                    screen.getByText(/Group Settings: Production/)
-                ).toBeInTheDocument();
-            });
+            await waitFor(
+                () => {
+                    expect(
+                        screen.getByText(/Group Settings: Production/)
+                    ).toBeInTheDocument();
+                },
+                { timeout: WAIT_TIMEOUT }
+            );
 
-            await user.click(
+            fireEvent.click(
                 screen.getByRole('tab', { name: /alert overrides/i })
             );
 
             // The panel mock echoes its scope/scopeId props; this asserts
             // that the numeric 1 (not the string "group-1") reached the panel.
-            await waitFor(() => {
-                expect(
-                    screen.getByTestId('alert-overrides-panel')
-                ).toHaveTextContent('AlertOverridesPanel: group 1');
-            });
-        });
+            await waitFor(
+                () => {
+                    expect(
+                        screen.getByTestId('alert-overrides-panel')
+                    ).toHaveTextContent('AlertOverridesPanel: group 1');
+                },
+                { timeout: WAIT_TIMEOUT }
+            );
+        }, 20000);
     });
 });

--- a/client/src/components/__tests__/GroupDialog.test.tsx
+++ b/client/src/components/__tests__/GroupDialog.test.tsx
@@ -119,7 +119,7 @@ describe('GroupDialog', () => {
 
     describe('edit mode rendering', () => {
         const editGroup = {
-            id: 1,
+            id: 'group-1',
             name: 'Production',
             description: 'Production cluster group',
             is_shared: true,
@@ -184,7 +184,7 @@ describe('GroupDialog', () => {
             );
         });
 
-        it('shows AlertOverridesPanel when Alert overrides tab is clicked', async () => {
+        it('shows AlertOverridesPanel with numeric scope id when Alert overrides tab is clicked', async () => {
             const user = userEvent.setup({ delay: null });
             renderWithTheme(
                 <GroupDialog
@@ -203,9 +203,13 @@ describe('GroupDialog', () => {
                     screen.getByTestId('alert-overrides-panel')
                 ).toBeInTheDocument();
             });
+            // Verify the string id "group-1" was converted to numeric 1
+            expect(screen.getByTestId('alert-overrides-panel')).toHaveTextContent(
+                'AlertOverridesPanel: group 1'
+            );
         });
 
-        it('shows ProbeOverridesPanel when Probe configuration tab is clicked', async () => {
+        it('shows ProbeOverridesPanel with numeric scope id when Probe configuration tab is clicked', async () => {
             const user = userEvent.setup({ delay: null });
             renderWithTheme(
                 <GroupDialog
@@ -224,9 +228,12 @@ describe('GroupDialog', () => {
                     screen.getByTestId('probe-overrides-panel')
                 ).toBeInTheDocument();
             });
+            expect(screen.getByTestId('probe-overrides-panel')).toHaveTextContent(
+                'ProbeOverridesPanel: group 1'
+            );
         });
 
-        it('shows ChannelOverridesPanel when Notification channels tab is clicked', async () => {
+        it('shows ChannelOverridesPanel with numeric scope id when Notification channels tab is clicked', async () => {
             const user = userEvent.setup({ delay: null });
             renderWithTheme(
                 <GroupDialog
@@ -245,6 +252,44 @@ describe('GroupDialog', () => {
                     screen.getByTestId('channel-overrides-panel')
                 ).toBeInTheDocument();
             });
+            expect(screen.getByTestId('channel-overrides-panel')).toHaveTextContent(
+                'ChannelOverridesPanel: group 1'
+            );
+        });
+
+        it('extracts multi-digit numeric ids at the panel boundary', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    group={{ ...editGroup, id: 'group-12345' }}
+                />
+            );
+
+            await user.click(
+                screen.getByRole('tab', { name: /alert overrides/i })
+            );
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('alert-overrides-panel')
+                ).toHaveTextContent('AlertOverridesPanel: group 12345');
+            });
+        });
+
+        it('handles edit mode with a group missing optional fields', () => {
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    group={{ id: 'group-7' }}
+                />
+            );
+            // Name field should be empty (group.name is undefined)
+            expect(getNameField()).toHaveValue('');
+            // Description field should be empty (group.description is undefined)
+            expect(getDescriptionField()).toHaveValue('');
         });
 
         it('renders close button in edit mode', () => {
@@ -257,6 +302,125 @@ describe('GroupDialog', () => {
             );
             expect(
                 screen.getByRole('button', { name: /close edit group/i })
+            ).toBeInTheDocument();
+        });
+    });
+
+    describe('override panels for non-numeric groups', () => {
+        const autoGroup = {
+            id: 'group-auto',
+            name: 'Auto-detected',
+            description: '',
+            is_shared: false,
+        };
+
+        it('shows info alert instead of AlertOverridesPanel for auto-detected group', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    group={autoGroup}
+                />
+            );
+
+            await user.click(
+                screen.getByRole('tab', { name: /alert overrides/i })
+            );
+
+            expect(
+                screen.queryByTestId('alert-overrides-panel')
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByText(/overrides are not available for auto-detected groups/i)
+            ).toBeInTheDocument();
+        });
+
+        it('shows info alert instead of ProbeOverridesPanel for auto-detected group', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    group={autoGroup}
+                />
+            );
+
+            await user.click(
+                screen.getByRole('tab', { name: /probe configuration/i })
+            );
+
+            expect(
+                screen.queryByTestId('probe-overrides-panel')
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByText(/overrides are not available for auto-detected groups/i)
+            ).toBeInTheDocument();
+        });
+
+        it('shows info alert instead of ChannelOverridesPanel for auto-detected group', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    group={autoGroup}
+                />
+            );
+
+            await user.click(
+                screen.getByRole('tab', { name: /notification channels/i })
+            );
+
+            expect(
+                screen.queryByTestId('channel-overrides-panel')
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByText(/overrides are not available for auto-detected groups/i)
+            ).toBeInTheDocument();
+        });
+
+        it('shows info alert when group id is undefined', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    group={{ name: 'No id', description: '', is_shared: false }}
+                />
+            );
+
+            await user.click(
+                screen.getByRole('tab', { name: /alert overrides/i })
+            );
+
+            expect(
+                screen.queryByTestId('alert-overrides-panel')
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByText(/overrides are not available for auto-detected groups/i)
+            ).toBeInTheDocument();
+        });
+
+        it('shows info alert when group id is a named (non-numeric) string', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    group={{ ...autoGroup, id: 'group-Production' }}
+                />
+            );
+
+            await user.click(
+                screen.getByRole('tab', { name: /alert overrides/i })
+            );
+
+            expect(
+                screen.queryByTestId('alert-overrides-panel')
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByText(/overrides are not available for auto-detected groups/i)
             ).toBeInTheDocument();
         });
     });
@@ -341,6 +505,23 @@ describe('GroupDialog', () => {
             });
         });
 
+        it('shows a fallback message when save rejects with a non-Error value', async () => {
+            const user = userEvent.setup({ delay: null });
+            const onSave = vi.fn().mockRejectedValue('some string reject');
+            renderWithTheme(
+                <GroupDialog {...defaultProps} onSave={onSave} />
+            );
+
+            await user.type(getNameField(), 'Test Group');
+            await user.click(screen.getByRole('button', { name: /save/i }));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(/failed to save group/i)
+                ).toBeInTheDocument();
+            });
+        });
+
         it('does not call onClose when save fails', async () => {
             const user = userEvent.setup({ delay: null });
             const onSave = vi.fn().mockRejectedValue(new Error('Save failed'));
@@ -379,6 +560,37 @@ describe('GroupDialog', () => {
 
             await waitFor(() => {
                 expect(getNameField()).toBeDisabled();
+            });
+
+            await act(async () => {
+                resolvePromise(undefined);
+                await savePromise;
+            });
+        });
+
+        it('shows the saving spinner in edit mode while save is in flight', async () => {
+            const user = userEvent.setup({ delay: null });
+            let resolvePromise: (value: unknown) => void = () => undefined;
+            const savePromise = new Promise((resolve) => {
+                resolvePromise = resolve;
+            });
+            const onSave = vi.fn().mockReturnValue(savePromise);
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    group={{ id: 'group-1', name: 'Production' }}
+                    onSave={onSave}
+                />
+            );
+
+            // Save button is on the Details tab in edit mode
+            await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText('Saving')
+                ).toBeInTheDocument();
             });
 
             await act(async () => {

--- a/client/src/contexts/ClusterActionsContext.tsx
+++ b/client/src/contexts/ClusterActionsContext.tsx
@@ -14,18 +14,7 @@ import { useAuth } from './AuthContext';
 import { useClusterData } from './ClusterDataContext';
 import { useClusterSelection } from './ClusterSelectionContext';
 import { apiGet, apiPost, apiPut, apiDelete } from '../utils/apiClient';
-import { parseGroupNumericId } from '../components/ClusterNavigator/utils';
-
-/**
- * Strict matcher for auto-detected group ids.
- *
- * The auto bucket arrives as either the bare token "group-auto" or as
- * "group-auto-<suffix>" where the suffix is a url-safe token. The
- * earlier, looser pattern /^group-auto/ also matched malformed ids
- * like "group-autobad"; this anchored form keeps the refactor's
- * explicit-rejection contract intact.
- */
-const AUTO_GROUP_ID = /^group-auto(?:-[A-Za-z0-9_-]+)?$/;
+import { parseGroupNumericId, isAutoGroupId } from '../components/ClusterNavigator/utils';
 
 export interface ServerData {
     name?: string;
@@ -87,7 +76,7 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
         // Anything else (missing prefix, malformed suffix like
         // "group-autobad", mixed alphanumerics like "group-1a") is
         // rejected outright so the server never receives an unknown shape.
-        if (!AUTO_GROUP_ID.test(groupId)) {
+        if (!isAutoGroupId(groupId)) {
             throw new Error('Invalid group ID');
         }
 
@@ -242,21 +231,40 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
     }, [user, fetchClusterData]);
 
     /**
-     * Move a cluster to a different group
-     * Supports both database-backed clusters and auto-detected clusters
+     * Move a cluster to a different group.
+     *
+     * The target group id can take three valid shapes:
+     *   1. `null`: an intentional ungroup; the server receives
+     *      `group_id: null`.
+     *   2. `"group-<numeric>"`: a database-backed group; the server
+     *      receives the parsed numeric id.
+     *   3. `"group-auto"` or `"group-auto-<key>"`: an auto-detected
+     *      bucket. The UI lets users drag clusters onto auto-groups so
+     *      they can correct a missed relationship, so this path is
+     *      preserved: `group_id` stays `null` and the server routes the
+     *      move through `auto_cluster_key`.
+     *
+     * Anything else (missing prefix, mixed alphanumeric suffix,
+     * malformed auto form, stray characters) is rejected so the server
+     * never receives an unknown shape.
      */
     const moveClusterToGroup = useCallback(async (clusterId: string, targetGroupId: string | null, autoClusterKey?: string, clusterName?: string): Promise<void> => {
         if (!user) {throw new Error('Not authenticated');}
 
         const clusterIdStr = clusterId.toString();
 
-        // Extract the target group's numeric ID from the group ID string (e.g., "group-123")
+        // Resolve the target group id to a numeric group_id or a null
+        // (ungroup / auto-bucket) payload. Reject every other shape.
         let numericGroupId: number | null = null;
-        if (targetGroupId) {
+        if (targetGroupId !== null) {
             const parsed = parseGroupNumericId(targetGroupId);
             if (parsed !== undefined) {
                 numericGroupId = parsed;
+            } else if (!isAutoGroupId(targetGroupId)) {
+                throw new Error('Invalid group ID');
             }
+            // Auto-group form: leave numericGroupId as null; the server
+            // uses auto_cluster_key to place the cluster.
         }
 
         // Build request body

--- a/client/src/contexts/ClusterActionsContext.tsx
+++ b/client/src/contexts/ClusterActionsContext.tsx
@@ -37,7 +37,7 @@ export interface ClusterActionsContextValue {
     deleteServer: (serverId: number) => Promise<void>;
     deleteCluster: (clusterId: string) => Promise<void>;
     createGroup: (groupData: GroupData) => Promise<unknown>;
-    deleteGroup: (groupId: string | number) => Promise<void>;
+    deleteGroup: (groupId: string) => Promise<void>;
     moveClusterToGroup: (clusterId: string, targetGroupId: string | null, autoClusterKey?: string, clusterName?: string) => Promise<void>;
 }
 
@@ -53,75 +53,73 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
     const { selectedServer, clearSelection } = useClusterSelection();
 
     /**
-     * Update a cluster group's name
-     * Handles both database-backed groups (group-{id}) and
-     * auto-detected groups (group-auto)
+     * Update a cluster group's name.
+     * Group ids always arrive as "group-{suffix}" strings, where the suffix
+     * is either the numeric database id (e.g. "group-42") or the auto-
+     * detected bucket key (e.g. "group-auto"). For database-backed groups
+     * the server expects a bare numeric id, so strip the prefix; the auto
+     * bucket is addressed by its full "group-auto..." form.
      */
     const updateGroupName = useCallback(async (groupId: string, newName: string): Promise<void> => {
         if (!user) {throw new Error('Not authenticated');}
 
-        const groupIdStr = groupId.toString();
-
-        // Check if it's an auto-detected group (group-auto)
-        const isAutoDetected = /^group-auto/.test(groupIdStr);
-
-        if (isAutoDetected) {
-            // Auto-detected groups: send the group ID as-is
-            await apiPut(`/api/v1/cluster-groups/${groupIdStr}`, { name: newName });
-        } else {
-            // Extract suffix after "group-" prefix
-            const suffix = groupIdStr.replace('group-', '');
-
-            // Use numeric ID for database-backed groups, full ID for named groups
-            const groupIdentifier = /^\d+$/.test(suffix)
-                ? parseInt(suffix, 10)
-                : groupIdStr;
-
-            await apiPut(`/api/v1/cluster-groups/${groupIdentifier}`, { name: newName });
+        if (!/^group-/.test(groupId)) {
+            throw new Error('Invalid group ID');
         }
+
+        const isAutoDetected = /^group-auto/.test(groupId);
+        const groupIdentifier = isAutoDetected
+            ? groupId
+            : groupId.slice('group-'.length);
+
+        if (!isAutoDetected && !/^\d+$/.test(groupIdentifier)) {
+            throw new Error('Invalid group ID');
+        }
+
+        await apiPut(`/api/v1/cluster-groups/${groupIdentifier}`, { name: newName });
 
         // Refresh cluster data to reflect the change
         await fetchClusterData();
     }, [user, fetchClusterData]);
 
     /**
-     * Update a cluster's name
-     * Handles both database-backed clusters (cluster-{id}) and
-     * auto-detected clusters (server-{id}, cluster-spock-{prefix})
+     * Update a cluster's name.
+     * Cluster ids arrive as either "cluster-{numeric}" (database-backed),
+     * "server-{numeric}", or "cluster-spock-{prefix}" (auto-detected);
+     * group ids always arrive as "group-{numeric}" strings.
      */
     const updateClusterName = useCallback(async (clusterId: string, newName: string, groupId: string, autoClusterKey?: string): Promise<void> => {
         if (!user) {throw new Error('Not authenticated');}
 
-        const clusterIdStr = clusterId.toString();
-
-        // Check if it's an auto-detected cluster
-        const isAutoDetected = /^(server-\d+|cluster-spock-.+)$/.test(clusterIdStr);
-
-        if (isAutoDetected) {
-            // Auto-detected clusters: send the cluster ID as-is and include auto_cluster_key
+        // Auto-detected clusters: send the cluster ID as-is so the server
+        // can match against server-{id} / cluster-spock-{prefix} shapes.
+        if (/^(server-\d+|cluster-spock-.+)$/.test(clusterId)) {
             const body: Record<string, unknown> = { name: newName };
             if (autoClusterKey) {
                 body.auto_cluster_key = autoClusterKey;
             }
 
-            await apiPut(`/api/v1/clusters/${clusterIdStr}`, body);
-        } else {
-            // Database-backed clusters: extract numeric IDs
-            const numericId = parseInt(clusterIdStr.replace('cluster-', ''), 10);
-            if (isNaN(numericId)) {
-                throw new Error('Invalid cluster ID');
-            }
-
-            // Extract numeric group ID
-            const numericGroupId = parseInt(groupId.toString().replace('group-', ''), 10);
-            if (isNaN(numericGroupId)) {
-                throw new Error('Invalid group ID');
-            }
-
-            await apiPut(`/api/v1/clusters/${numericId}`, { name: newName, group_id: numericGroupId });
+            await apiPut(`/api/v1/clusters/${clusterId}`, body);
+            await fetchClusterData();
+            return;
         }
 
-        // Refresh cluster data to reflect the change
+        // Database-backed clusters: extract numeric ids for both.
+        const clusterMatch = /^cluster-(\d+)$/.exec(clusterId);
+        if (!clusterMatch) {
+            throw new Error('Invalid cluster ID');
+        }
+
+        const groupMatch = /^group-(\d+)$/.exec(groupId);
+        if (!groupMatch) {
+            throw new Error('Invalid group ID');
+        }
+
+        await apiPut(`/api/v1/clusters/${clusterMatch[1]}`, {
+            name: newName,
+            group_id: parseInt(groupMatch[1], 10),
+        });
+
         await fetchClusterData();
     }, [user, fetchClusterData]);
 
@@ -210,17 +208,20 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
     }, [user, fetchClusterData]);
 
     /**
-     * Delete a cluster group
+     * Delete a cluster group.
+     * Group ids always arrive as "group-{numeric}" strings. Auto-detected
+     * groups are not deletable (the UI hides the delete affordance), so a
+     * bare numeric id is always the correct server-side addressing.
      */
-    const deleteGroup = useCallback(async (groupId: string | number): Promise<void> => {
+    const deleteGroup = useCallback(async (groupId: string): Promise<void> => {
         if (!user) {throw new Error('Not authenticated');}
 
-        // Extract numeric ID from group-{id} format if needed
-        const numericId = typeof groupId === 'string' && groupId.startsWith('group-')
-            ? parseInt(groupId.replace('group-', ''), 10)
-            : groupId;
+        const match = /^group-(\d+)$/.exec(groupId);
+        if (!match) {
+            throw new Error('Invalid group ID');
+        }
 
-        await apiDelete(`/api/v1/cluster-groups/${numericId}`);
+        await apiDelete(`/api/v1/cluster-groups/${match[1]}`);
 
         await fetchClusterData();
     }, [user, fetchClusterData]);

--- a/client/src/contexts/ClusterActionsContext.tsx
+++ b/client/src/contexts/ClusterActionsContext.tsx
@@ -253,7 +253,7 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
         // Extract the target group's numeric ID from the group ID string (e.g., "group-123")
         let numericGroupId: number | null = null;
         if (targetGroupId) {
-            const parsed = parseGroupNumericId(targetGroupId.toString());
+            const parsed = parseGroupNumericId(targetGroupId);
             if (parsed !== undefined) {
                 numericGroupId = parsed;
             }

--- a/client/src/contexts/ClusterActionsContext.tsx
+++ b/client/src/contexts/ClusterActionsContext.tsx
@@ -14,6 +14,18 @@ import { useAuth } from './AuthContext';
 import { useClusterData } from './ClusterDataContext';
 import { useClusterSelection } from './ClusterSelectionContext';
 import { apiGet, apiPost, apiPut, apiDelete } from '../utils/apiClient';
+import { parseGroupNumericId } from '../components/ClusterNavigator/utils';
+
+/**
+ * Strict matcher for auto-detected group ids.
+ *
+ * The auto bucket arrives as either the bare token "group-auto" or as
+ * "group-auto-<suffix>" where the suffix is a url-safe token. The
+ * earlier, looser pattern /^group-auto/ also matched malformed ids
+ * like "group-autobad"; this anchored form keeps the refactor's
+ * explicit-rejection contract intact.
+ */
+const AUTO_GROUP_ID = /^group-auto(?:-[A-Za-z0-9_-]+)?$/;
 
 export interface ServerData {
     name?: string;
@@ -63,20 +75,23 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
     const updateGroupName = useCallback(async (groupId: string, newName: string): Promise<void> => {
         if (!user) {throw new Error('Not authenticated');}
 
-        if (!/^group-/.test(groupId)) {
+        // Database-backed id: address the server row by its numeric id.
+        const numericId = parseGroupNumericId(groupId);
+        if (numericId !== undefined) {
+            await apiPut(`/api/v1/cluster-groups/${numericId}`, { name: newName });
+            await fetchClusterData();
+            return;
+        }
+
+        // Auto-detected bucket: forward the full "group-auto..." token.
+        // Anything else (missing prefix, malformed suffix like
+        // "group-autobad", mixed alphanumerics like "group-1a") is
+        // rejected outright so the server never receives an unknown shape.
+        if (!AUTO_GROUP_ID.test(groupId)) {
             throw new Error('Invalid group ID');
         }
 
-        const isAutoDetected = /^group-auto/.test(groupId);
-        const groupIdentifier = isAutoDetected
-            ? groupId
-            : groupId.slice('group-'.length);
-
-        if (!isAutoDetected && !/^\d+$/.test(groupIdentifier)) {
-            throw new Error('Invalid group ID');
-        }
-
-        await apiPut(`/api/v1/cluster-groups/${groupIdentifier}`, { name: newName });
+        await apiPut(`/api/v1/cluster-groups/${groupId}`, { name: newName });
 
         // Refresh cluster data to reflect the change
         await fetchClusterData();
@@ -110,14 +125,14 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
             throw new Error('Invalid cluster ID');
         }
 
-        const groupMatch = /^group-(\d+)$/.exec(groupId);
-        if (!groupMatch) {
+        const numericGroupId = parseGroupNumericId(groupId);
+        if (numericGroupId === undefined) {
             throw new Error('Invalid group ID');
         }
 
         await apiPut(`/api/v1/clusters/${clusterMatch[1]}`, {
             name: newName,
-            group_id: parseInt(groupMatch[1], 10),
+            group_id: numericGroupId,
         });
 
         await fetchClusterData();
@@ -216,12 +231,12 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
     const deleteGroup = useCallback(async (groupId: string): Promise<void> => {
         if (!user) {throw new Error('Not authenticated');}
 
-        const match = /^group-(\d+)$/.exec(groupId);
-        if (!match) {
+        const numericId = parseGroupNumericId(groupId);
+        if (numericId === undefined) {
             throw new Error('Invalid group ID');
         }
 
-        await apiDelete(`/api/v1/cluster-groups/${match[1]}`);
+        await apiDelete(`/api/v1/cluster-groups/${numericId}`);
 
         await fetchClusterData();
     }, [user, fetchClusterData]);
@@ -238,10 +253,9 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
         // Extract the target group's numeric ID from the group ID string (e.g., "group-123")
         let numericGroupId: number | null = null;
         if (targetGroupId) {
-            const groupIdStr = targetGroupId.toString();
-            const match = groupIdStr.match(/^group-(\d+)$/);
-            if (match) {
-                numericGroupId = parseInt(match[1], 10);
+            const parsed = parseGroupNumericId(targetGroupId.toString());
+            if (parsed !== undefined) {
+                numericGroupId = parsed;
             }
         }
 

--- a/client/src/contexts/ClusterActionsContext.tsx
+++ b/client/src/contexts/ClusterActionsContext.tsx
@@ -251,8 +251,6 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
     const moveClusterToGroup = useCallback(async (clusterId: string, targetGroupId: string | null, autoClusterKey?: string, clusterName?: string): Promise<void> => {
         if (!user) {throw new Error('Not authenticated');}
 
-        const clusterIdStr = clusterId.toString();
-
         // Resolve the target group id to a numeric group_id or a null
         // (ungroup / auto-bucket) payload. Reject every other shape.
         let numericGroupId: number | null = null;
@@ -277,7 +275,7 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
             body.name = clusterName;
         }
 
-        await apiPut(`/api/v1/clusters/${clusterIdStr}`, body);
+        await apiPut(`/api/v1/clusters/${clusterId}`, body);
 
         await fetchClusterData();
     }, [user, fetchClusterData]);

--- a/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
@@ -111,6 +111,22 @@ describe('ClusterActionsContext', () => {
             expect(mockFetchClusterData).toHaveBeenCalled();
         });
 
+        it('passes through auto-detected ids with a key suffix', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateGroupName(
+                    'group-auto-some-key',
+                    'Auto Prod',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/cluster-groups/group-auto-some-key',
+                { name: 'Auto Prod' },
+            );
+        });
+
         it('uses numeric id for database-backed groups', async () => {
             const { result } = renderHook(() => useClusterActions(), { wrapper });
 
@@ -124,17 +140,22 @@ describe('ClusterActionsContext', () => {
             );
         });
 
-        it('uses the full id for named (non-numeric) database groups', async () => {
+        it('rejects ids without the "group-" prefix', async () => {
             const { result } = renderHook(() => useClusterActions(), { wrapper });
 
-            await act(async () => {
-                await result.current.updateGroupName('group-named', 'X');
-            });
+            await expect(
+                result.current.updateGroupName('42', 'Bad'),
+            ).rejects.toThrow('Invalid group ID');
+            expect(mockApiPut).not.toHaveBeenCalled();
+        });
 
-            expect(mockApiPut).toHaveBeenCalledWith(
-                '/api/v1/cluster-groups/group-named',
-                { name: 'X' },
-            );
+        it('rejects ids with a non-numeric, non-auto suffix', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await expect(
+                result.current.updateGroupName('group-named', 'Bad'),
+            ).rejects.toThrow('Invalid group ID');
+            expect(mockApiPut).not.toHaveBeenCalled();
         });
     });
 
@@ -337,16 +358,25 @@ describe('ClusterActionsContext', () => {
             });
 
             expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/cluster-groups/42');
+            expect(mockFetchClusterData).toHaveBeenCalled();
         });
 
-        it('deleteGroup accepts raw numeric IDs', async () => {
+        it('deleteGroup rejects ids without a numeric suffix', async () => {
             const { result } = renderHook(() => useClusterActions(), { wrapper });
 
-            await act(async () => {
-                await result.current.deleteGroup(7);
-            });
+            await expect(
+                result.current.deleteGroup('group-auto'),
+            ).rejects.toThrow('Invalid group ID');
+            expect(mockApiDelete).not.toHaveBeenCalled();
+        });
 
-            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/cluster-groups/7');
+        it('deleteGroup rejects ids without the "group-" prefix', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await expect(
+                result.current.deleteGroup('42'),
+            ).rejects.toThrow('Invalid group ID');
+            expect(mockApiDelete).not.toHaveBeenCalled();
         });
     });
 

--- a/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
@@ -157,6 +157,56 @@ describe('ClusterActionsContext', () => {
             ).rejects.toThrow('Invalid group ID');
             expect(mockApiPut).not.toHaveBeenCalled();
         });
+
+        it.each([
+            ['group-autobad'],
+            ['group-automatic'],
+            ['group-auto_foo'],
+            ['group-auto/evil'],
+            ['group-auto-'],
+            ['group-auto-bad id'],
+        ])(
+            'rejects malformed auto-prefixed id %j and never forwards it',
+            async (malformed) => {
+                const { result } = renderHook(() => useClusterActions(), {
+                    wrapper,
+                });
+
+                await expect(
+                    result.current.updateGroupName(malformed, 'X'),
+                ).rejects.toThrow('Invalid group ID');
+                expect(mockApiPut).not.toHaveBeenCalled();
+            },
+        );
+
+        it('accepts the bare "group-auto" bucket id', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateGroupName('group-auto', 'Auto');
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/cluster-groups/group-auto',
+                { name: 'Auto' },
+            );
+        });
+
+        it('accepts "group-auto-<token>" with url-safe suffix', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateGroupName(
+                    'group-auto-some_key-123',
+                    'X',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/cluster-groups/group-auto-some_key-123',
+                { name: 'X' },
+            );
+        });
     });
 
     describe('updateClusterName', () => {

--- a/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
@@ -474,21 +474,80 @@ describe('ClusterActionsContext', () => {
             });
         });
 
-        it('leaves group_id null when target format is unrecognized', async () => {
+        it('sends group_id = null when dropping on the bare "group-auto" bucket', async () => {
             const { result } = renderHook(() => useClusterActions(), { wrapper });
 
             await act(async () => {
                 await result.current.moveClusterToGroup(
-                    'cluster-1',
-                    'not-a-group-ref',
+                    'server-3',
+                    'group-auto',
                 );
             });
 
-            expect(mockApiPut).toHaveBeenCalledWith(
-                '/api/v1/clusters/cluster-1',
-                { group_id: null },
-            );
+            expect(mockApiPut).toHaveBeenCalledWith('/api/v1/clusters/server-3', {
+                group_id: null,
+            });
         });
+
+        it('sends group_id = null when dropping on a "group-auto-<key>" bucket', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.moveClusterToGroup(
+                    'server-3',
+                    'group-auto-foo',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith('/api/v1/clusters/server-3', {
+                group_id: null,
+            });
+        });
+
+        it('forwards auto_cluster_key when dropping on an auto-group', async () => {
+            // The caller (handleDragEnd) passes the dragged cluster's own
+            // auto_cluster_key. Verify moveClusterToGroup forwards it
+            // verbatim so the server-side auto-group path receives it.
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.moveClusterToGroup(
+                    'server-3',
+                    'group-auto-foo',
+                    'caller-provided-key',
+                );
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith('/api/v1/clusters/server-3', {
+                group_id: null,
+                auto_cluster_key: 'caller-provided-key',
+            });
+        });
+
+        it.each([
+            ['group-foo'],
+            ['group-1a'],
+            ['group-'],
+            ['group-auto_bad'],
+            ['group-autobad'],
+            ['group-auto-'],
+            ['not-a-group'],
+            ['42'],
+            [''],
+        ])(
+            'throws "Invalid group ID" and does not call fetch for %j',
+            async (malformed) => {
+                const { result } = renderHook(() => useClusterActions(), {
+                    wrapper,
+                });
+
+                await expect(
+                    result.current.moveClusterToGroup('cluster-1', malformed),
+                ).rejects.toThrow('Invalid group ID');
+                expect(mockApiPut).not.toHaveBeenCalled();
+                expect(mockFetchClusterData).not.toHaveBeenCalled();
+            },
+        );
     });
 
     describe('hook outside provider', () => {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,22 @@ project adheres to
   regression tests cover every affected handler.
   (#67)
 
+### Fixed
+
+- Fix the ClusterNavigator group-editing flow
+  round-tripping string group ids (`"group-{x}"`)
+  through numeric parses; the string id now travels
+  unchanged through `handleConfigureGroup`,
+  `handleSaveGroup`, and the cluster actions context,
+  and the one `strconv.Atoi`-compatible conversion
+  happens at the `GroupDialog` override-panel
+  boundary. Auto-detected groups without a numeric
+  backing row now display an info alert explaining
+  that alert, probe, and channel overrides are
+  unavailable instead of silently passing `NaN` to
+  the override panels. This removes the root cause
+  patched symptomatically in #59. (#63)
+
 ## [1.0.0-beta1] - 2026-04-21
 
 ### Added


### PR DESCRIPTION
Fixes #63.

## Summary

- `handleConfigureGroup` no longer parses `"group-1"` into a number; the string id now travels unchanged through `handleConfigureGroup`, `handleSaveGroup`, and the `ClusterActionsContext` actions.
- `GroupDialog` narrows its `group.id` prop type from `number` to `string` and performs the single `"group-{n}"` → `n` extraction at the override-panel boundary. Auto-detected groups (`"group-auto"`) render an info alert explaining that alert, probe, and channel overrides are unavailable instead of silently passing `NaN` to the panels.
- `updateGroupName`, `deleteGroup`, and `updateClusterName` drop the dual-format parsing branches from #59 since they are now guaranteed to receive the `"group-{x}"` string form; they reject malformed ids explicitly.

## Why this approach

The issue recommended Option A (consistent string ids). The override panels stay on `scopeId: number` because their server endpoints parse the id with `strconv.Atoi` (`server/src/internal/api/alert_override_handlers.go`) and hard-fail on non-numeric ids. Collocating the one-line string-to-numeric conversion inside `GroupDialog` is smaller and cleaner than widening three unrelated panels and their fetch calls to accept strings.

## Test plan

- [x] `cd client && npm test` — 1437 / 1437 passing locally.
- [x] `cd client && npm run lint` — 0 errors (33 pre-existing non-null-assertion warnings in unrelated test files).
- [x] New round-trip test in `ClusterNavigator.test.tsx` asserts that clicking configure on `"group-1"` and submitting the dialog calls `updateGroupName` with exactly the string `"group-1"` — the behavior issue #63 wants.
- [x] New `GroupDialog.test.tsx` cases cover: numeric-id extraction, auto-detected-group alert fallback, multi-digit extraction, missing id, non-numeric named id, saving spinner, non-`Error` rejection, and missing optional fields.
- [x] `ClusterActionsContext.test.tsx` updated: removed tests for shapes the simplified code no longer accepts; added tests asserting the new validation rejects them.

## Coverage

- `client/src/contexts/ClusterActionsContext.tsx`: 100% lines, 100% branches.
- `client/src/components/GroupDialog.tsx`: 100% lines, 98.14% branches (the one uncovered branch is a defensive `Number.isNaN` fallback that the `/^group-(\d+)$/` regex makes unreachable).
- `client/src/components/ClusterNavigator/index.tsx`: the lines touched by this change are all covered by the new round-trip tests. The file-level coverage remains at its pre-existing ~73.67% baseline, driven by untested drag-and-drop, blackout-inheritance, and cluster-config handlers outside the scope of issue #63. Flagging for reviewer judgment; raising the whole file to 90% is a separate, substantially larger effort.

## Known pre-existing issues (not introduced here)

- `make test-all` from the repo root fails at the collector's `golangci-lint` step with `can't load config: unsupported version of the configuration`. No Go files are touched in this PR; the failure reproduces on a clean tree and is an infrastructure/config version mismatch.
- Prettier `format:check` reports drift across 267 files in the client (including the three I touched, which were already failing before this change); the `Makefile`'s `test-all` does not invoke prettier, so this is not a CI gate.

https://claude.ai/code/session_01Jc2hHuSaZXQNn4LAQMi2F2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented group ID corruption in edit/save flows, tightened ID validation, and ensured override panels only receive numeric IDs when applicable.
  * Show an informational message when overrides are unavailable for auto-detected groups.
  * Hardened add/delete/rename flows to reject malformed IDs and preserve correct ID shapes.

* **Tests**
  * Expanded coverage for ID parsing, edit/add flows, override panels, drag/drop semantics, and save/error states.

* **Documentation**
  * Added changelog entry describing these fixes and behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->