### PR TITLE
Migrate to golangci-lint v2 and fix surfaced findings (#66)

### DIFF
--- a/.github/workflows/ci-alerter.yml
+++ b/.github/workflows/ci-alerter.yml
@@ -68,7 +68,7 @@ jobs:
               if: matrix.go-version == '1.26.2' && matrix.postgres-version == '18'
               working-directory: alerter
               run: |
-                  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+                  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
                   echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
                   make lint
 

--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -68,7 +68,7 @@ jobs:
               if: matrix.go-version == '1.26.2' && matrix.postgres-version == '18'
               working-directory: collector
               run: |
-                  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+                  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
                   echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
                   make lint
 

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -68,7 +68,7 @@ jobs:
               if: matrix.go-version == '1.26.2' && matrix.postgres-version == '18'
               working-directory: server
               run: |
-                  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+                  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
                   echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
                   make lint
 

--- a/alerter/.golangci.yml
+++ b/alerter/.golangci.yml
@@ -7,9 +7,18 @@ version: "2"
 run:
   tests: true
 linters:
+  # In v2 `errcheck`, `govet`, `ineffassign`, `staticcheck`, and `unused`
+  # are default-enabled, but we list them explicitly so the
+  # `linters.settings.errcheck` and `linters.settings.govet` blocks below
+  # cannot silently become dead config if upstream defaults change.
   enable:
+    - errcheck
     - gosec
+    - govet
+    - ineffassign
     - misspell
+    - staticcheck
+    - unused
   settings:
     errcheck:
       check-type-assertions: true

--- a/alerter/.golangci.yml
+++ b/alerter/.golangci.yml
@@ -38,6 +38,13 @@ linters:
         text: Error return value of.*Close.*not checked
     paths:
       - vendor
+      # The following three entries are golangci-lint defaults retained
+      # for forward-compatibility. The `$` anchor means they only match
+      # paths ending in the name, so they would NOT exclude files inside
+      # those directories; none of these directories exist in this tree,
+      # so the patterns are effectively dead code kept to match upstream
+      # defaults. If any such directory is added, switch to `third_party/`
+      # (etc.) to match files inside it.
       - third_party$
       - builtin$
       - examples$
@@ -45,6 +52,8 @@ formatters:
   exclusions:
     generated: lax
     paths:
+      # See note above: these mirror upstream defaults and only match
+      # paths ending in these names, not files inside such directories.
       - third_party$
       - builtin$
       - examples$

--- a/alerter/.golangci.yml
+++ b/alerter/.golangci.yml
@@ -1,39 +1,50 @@
-linters-settings:
-    errcheck:
-        check-type-assertions: true
-        check-blank: true
-    govet:
-        enable-all: true
-        disable:
-            - fieldalignment
-            - shadow
-    misspell:
-        locale: US
-
-linters:
-    enable:
-        - errcheck      # Check for unchecked errors (enabled by default)
-        - govet         # Vet examines Go source code (enabled by default)
-        - ineffassign   # Detects unused assignments (enabled by default)
-        - staticcheck   # Advanced static analysis (enabled by default)
-        - unused        # Checks for unused code (enabled by default)
-        - misspell      # Finds commonly misspelled English words
-        - gosec         # Inspects source code for security problems
-
-issues:
-    exclude-dirs:
-        - vendor
-    exclude-rules:
-        # Exclude some linters from running on tests files
-        - path: _test\.go
-          linters:
-              - gosec
-        # Exclude known issues with defer Close() in tests
-        - path: _test\.go
-          linters:
-              - errcheck
-          text: "Error return value of.*Close.*not checked"
-
+# golangci-lint v2 configuration.
+# To install:
+#   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+# Migrated from v1 with `golangci-lint migrate`; the set of enabled linters
+# and per-path exclusions is preserved.
+version: "2"
 run:
-    timeout: 5m
-    tests: true
+  tests: true
+linters:
+  enable:
+    - gosec
+    - misspell
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: _test\.go
+      - linters:
+          - errcheck
+        path: _test\.go
+        text: Error return value of.*Close.*not checked
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/alerter/src/internal/llm/retry.go
+++ b/alerter/src/internal/llm/retry.go
@@ -55,7 +55,7 @@ func doRequestWithRetry(ctx context.Context, client *http.Client, req *http.Requ
 		// base URLs (openaiBaseURL, anthropicBaseURL, geminiBaseURL, or
 		// operator-supplied overrides) and is not influenced by end-user
 		// input, so SSRF via this call is not reachable.
-		resp, err := client.Do(req) //nolint:gosec // G704: URL is admin-controlled (see comment above)
+		resp, err := client.Do(req) //nolint:gosec // G704: URL is built from admin-configured BaseURL (e.g., cfg.LLM.OpenAI.BaseURL, cfg.LLM.Anthropic.BaseURL, cfg.LLM.Gemini.BaseURL); not reachable from user input.
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil, ErrContextCanceled

--- a/alerter/src/internal/llm/retry.go
+++ b/alerter/src/internal/llm/retry.go
@@ -51,7 +51,11 @@ func doRequestWithRetry(ctx context.Context, client *http.Client, req *http.Requ
 			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		}
 
-		resp, err := client.Do(req)
+		// The request URL is constructed from admin-configured provider
+		// base URLs (openaiBaseURL, anthropicBaseURL, geminiBaseURL, or
+		// operator-supplied overrides) and is not influenced by end-user
+		// input, so SSRF via this call is not reachable.
+		resp, err := client.Do(req) //nolint:gosec // G704: URL is admin-controlled (see comment above)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil, ErrContextCanceled

--- a/alerter/src/internal/notifications/email.go
+++ b/alerter/src/internal/notifications/email.go
@@ -166,13 +166,13 @@ func (n *emailNotifier) sendEmail(
 ) error {
 	// Build message with headers (sanitize to prevent header injection)
 	var msg strings.Builder
-	msg.WriteString(fmt.Sprintf("From: %s\r\n", sanitizeHeader(fromHeader)))
+	fmt.Fprintf(&msg, "From: %s\r\n", sanitizeHeader(fromHeader))
 	sanitizedTo := make([]string, len(to))
 	for i, addr := range to {
 		sanitizedTo[i] = sanitizeHeader(addr)
 	}
-	msg.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(sanitizedTo, ", ")))
-	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", sanitizeHeader(subject)))
+	fmt.Fprintf(&msg, "To: %s\r\n", strings.Join(sanitizedTo, ", "))
+	fmt.Fprintf(&msg, "Subject: %s\r\n", sanitizeHeader(subject))
 	msg.WriteString("MIME-Version: 1.0\r\n")
 	msg.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n")
 	msg.WriteString("\r\n")

--- a/collector/.golangci.yml
+++ b/collector/.golangci.yml
@@ -7,9 +7,18 @@ version: "2"
 run:
   tests: true
 linters:
+  # In v2 `errcheck`, `govet`, `ineffassign`, `staticcheck`, and `unused`
+  # are default-enabled, but we list them explicitly so the
+  # `linters.settings.errcheck` and `linters.settings.govet` blocks below
+  # cannot silently become dead config if upstream defaults change.
   enable:
+    - errcheck
     - gosec
+    - govet
+    - ineffassign
     - misspell
+    - staticcheck
+    - unused
   settings:
     errcheck:
       check-type-assertions: true

--- a/collector/.golangci.yml
+++ b/collector/.golangci.yml
@@ -38,6 +38,13 @@ linters:
         text: Error return value of.*Close.*not checked
     paths:
       - vendor
+      # The following three entries are golangci-lint defaults retained
+      # for forward-compatibility. The `$` anchor means they only match
+      # paths ending in the name, so they would NOT exclude files inside
+      # those directories; none of these directories exist in this tree,
+      # so the patterns are effectively dead code kept to match upstream
+      # defaults. If any such directory is added, switch to `third_party/`
+      # (etc.) to match files inside it.
       - third_party$
       - builtin$
       - examples$
@@ -45,6 +52,8 @@ formatters:
   exclusions:
     generated: lax
     paths:
+      # See note above: these mirror upstream defaults and only match
+      # paths ending in these names, not files inside such directories.
       - third_party$
       - builtin$
       - examples$

--- a/collector/.golangci.yml
+++ b/collector/.golangci.yml
@@ -1,39 +1,50 @@
-linters-settings:
-    errcheck:
-        check-type-assertions: true
-        check-blank: true
-    govet:
-        enable-all: true
-        disable:
-            - fieldalignment
-            - shadow
-    misspell:
-        locale: US
-
-linters:
-    enable:
-        - errcheck      # Check for unchecked errors (enabled by default)
-        - govet         # Vet examines Go source code (enabled by default)
-        - ineffassign   # Detects unused assignments (enabled by default)
-        - staticcheck   # Advanced static analysis (enabled by default)
-        - unused        # Checks for unused code (enabled by default)
-        - misspell      # Finds commonly misspelled English words
-        - gosec         # Inspects source code for security problems
-
-issues:
-    exclude-dirs:
-        - vendor
-    exclude-rules:
-        # Exclude some linters from running on tests files
-        - path: _test\.go
-          linters:
-              - gosec
-        # Exclude known issues with defer Close() in tests
-        - path: _test\.go
-          linters:
-              - errcheck
-          text: "Error return value of.*Close.*not checked"
-
+# golangci-lint v2 configuration.
+# To install:
+#   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+# Migrated from v1 with `golangci-lint migrate`; the set of enabled linters
+# and per-path exclusions is preserved.
+version: "2"
 run:
-    timeout: 5m
-    tests: true
+  tests: true
+linters:
+  enable:
+    - gosec
+    - misspell
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: _test\.go
+      - linters:
+          - errcheck
+        path: _test\.go
+        text: Error return value of.*Close.*not checked
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,24 @@ project adheres to
   Fetch spec. Operators should configure an explicit
   origin or leave the option empty for same-origin
   deployments. (#81)
+- Migrate the `collector`, `alerter`, and `server`
+  `.golangci.yml` configurations to the golangci-lint v2
+  format, and update the CI workflows to install
+  `golangci-lint/v2`; `make test-all` now works again on
+  developer machines that have golangci-lint v2
+  installed locally. (#66)
+
+### Security
+
+- Fix log, SQL, and SMTP injection findings surfaced by
+  the golangci-lint v2 upgrade; the knowledgebase search
+  now binds its filter values through `?` placeholders
+  instead of string concatenation, the email test sender
+  sanitizes envelope and header fields before writing
+  them to the SMTP connection, and user-tainted values
+  are escaped through a new `logging.SanitizeForLog`
+  helper at log sites across the api, auth, and config
+  packages. (#66)
 
 ## [1.0.0-beta1] - 2026-04-21
 

--- a/server/src/.golangci.yml
+++ b/server/src/.golangci.yml
@@ -1,77 +1,85 @@
-# golangci-lint configuration for v1.x
-# To install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-# Note: This config is NOT compatible with golangci-lint v2
-
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-      - shadow
-  gocyclo:
-    min-complexity: 50
-  dupl:
-    threshold: 150
-  goconst:
-    min-len: 3
-    min-occurrences: 5
-  misspell:
-    locale: US
-  lll:
-    line-length: 120
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - performance
-      - style
-    disabled-checks:
-      - commentedOutCode
-      - hugeParam
-      - octalLiteral
-      - httpNoBody
-      - paramTypeCombine
-      - appendCombine
-      - ifElseChain
-      - unnamedResult
-      - exitAfterDefer
-
+# golangci-lint v2 configuration.
+# To install:
+#   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+# Migrated from v1 with `golangci-lint migrate`; the set of enabled linters
+# and per-path exclusions is preserved.
+version: "2"
+run:
+  tests: true
 linters:
   enable:
-    - errcheck
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-    - misspell
     - gocritic
-    - gosec         # Inspects source code for security problems
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - dupl
-        - goconst
-        - errcheck
-        - gocritic
-        - gosec
-    - path: test/
-      linters:
-        - gocyclo
-        - dupl
-        - goconst
-        - errcheck
-        - gocritic
-  exclude-dirs:
-    - vendor
-    - bin
-  exclude-files:
-    - ".*\\.pb\\.go$"
-
-run:
-  timeout: 5m
-  tests: true
+    - gosec
+    - misspell
+  settings:
+    dupl:
+      threshold: 150
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+    gocritic:
+      disabled-checks:
+        - commentedOutCode
+        - hugeParam
+        - octalLiteral
+        - httpNoBody
+        - paramTypeCombine
+        - appendCombine
+        - ifElseChain
+        - unnamedResult
+        - exitAfterDefer
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 50
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    lll:
+      line-length: 120
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - goconst
+          - gocritic
+          - gocyclo
+          - gosec
+        path: _test\.go
+      - linters:
+          - dupl
+          - errcheck
+          - goconst
+          - gocritic
+          - gocyclo
+        path: test/
+    paths:
+      - .*\.pb\.go$
+      - vendor
+      - bin
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/server/src/.golangci.yml
+++ b/server/src/.golangci.yml
@@ -7,10 +7,19 @@ version: "2"
 run:
   tests: true
 linters:
+  # In v2 `errcheck`, `govet`, `ineffassign`, `staticcheck`, and `unused`
+  # are default-enabled, but we list them explicitly so the
+  # `linters.settings.errcheck` and `linters.settings.govet` blocks below
+  # cannot silently become dead config if upstream defaults change.
   enable:
+    - errcheck
     - gocritic
     - gosec
+    - govet
+    - ineffassign
     - misspell
+    - staticcheck
+    - unused
   settings:
     dupl:
       threshold: 150

--- a/server/src/.golangci.yml
+++ b/server/src/.golangci.yml
@@ -73,6 +73,13 @@ linters:
       - .*\.pb\.go$
       - vendor
       - bin
+      # The following three entries are golangci-lint defaults retained
+      # for forward-compatibility. The `$` anchor means they only match
+      # paths ending in the name, so they would NOT exclude files inside
+      # those directories; none of these directories exist in this tree,
+      # so the patterns are effectively dead code kept to match upstream
+      # defaults. If any such directory is added, switch to `third_party/`
+      # (etc.) to match files inside it.
       - third_party$
       - builtin$
       - examples$
@@ -80,6 +87,8 @@ formatters:
   exclusions:
     generated: lax
     paths:
+      # See note above: these mirror upstream defaults and only match
+      # paths ending in these names, not files inside such directories.
       - third_party$
       - builtin$
       - examples$

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/database"
+	"github.com/pgedge/ai-workbench/server/internal/logging"
 )
 
 // ClusterHandler handles REST API requests for cluster hierarchy management
@@ -849,7 +850,7 @@ func (h *ClusterHandler) updateAutoDetectedCluster(w http.ResponseWriter, r *htt
 	// Update cluster record (name and/or group_id)
 	cluster, err := h.datastore.UpsertAutoDetectedCluster(ctx, autoKey, req.Name, req.Description, req.GroupID)
 	if err != nil {
-		log.Printf("[ERROR] Failed to update auto-detected cluster %s: %v", clusterID, err)
+		log.Printf("[ERROR] Failed to update auto-detected cluster %s: %v", logging.SanitizeForLog(clusterID), err) //nolint:gosec // G706: clusterID passed through logging.SanitizeForLog
 		RespondError(w, http.StatusInternalServerError, "Failed to update auto-detected cluster")
 		return
 	}
@@ -909,7 +910,7 @@ func (h *ClusterHandler) updateAutoDetectedGroup(w http.ResponseWriter, r *http.
 	// Upsert group record with custom name
 	group, err := h.datastore.UpsertGroupByAutoKey(ctx, autoKey, req.Name)
 	if err != nil {
-		log.Printf("[ERROR] Failed to update auto-detected group %s: %v", groupID, err)
+		log.Printf("[ERROR] Failed to update auto-detected group %s: %v", logging.SanitizeForLog(groupID), err) //nolint:gosec // G706: groupID passed through logging.SanitizeForLog
 		RespondError(w, http.StatusInternalServerError, "Failed to update auto-detected group")
 		return
 	}

--- a/server/src/internal/api/connection_handlers.go
+++ b/server/src/internal/api/connection_handlers.go
@@ -610,7 +610,7 @@ func (h *ConnectionHandler) getCurrentConnection(w http.ResponseWriter, r *http.
 
 	conn, err := h.datastore.GetConnection(ctx, session.ConnectionID)
 	if err != nil {
-		log.Printf("[ERROR] Failed to get connection details (id=%d): %v", session.ConnectionID, err)
+		log.Printf("[ERROR] Failed to get connection details (id=%d): %v", session.ConnectionID, err) //nolint:gosec // G706: ConnectionID is an integer, cannot contain newlines
 		RespondError(w, http.StatusInternalServerError,
 			"Failed to get connection details")
 		return

--- a/server/src/internal/api/email_test_sender.go
+++ b/server/src/internal/api/email_test_sender.go
@@ -18,6 +18,14 @@ import (
 	"time"
 )
 
+// sanitizeSMTPHeader removes CR/LF characters from an SMTP header or
+// envelope value. Stripping control characters prevents SMTP command and
+// MIME header injection when user-supplied values are written to the
+// wire.
+func sanitizeSMTPHeader(s string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
+}
+
 // sendTestEmail sends a test email via SMTP to verify channel configuration.
 // It mirrors the alerter's SMTP logic but is self-contained with no
 // external dependencies beyond the standard library.
@@ -62,8 +70,12 @@ func sendTestEmail(
 // test email.
 func buildTestEmailMessage(fromHeader string, toAddresses []string) []byte {
 	var msg strings.Builder
-	msg.WriteString(fmt.Sprintf("From: %s\r\n", fromHeader))
-	msg.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(toAddresses, ", ")))
+	fmt.Fprintf(&msg, "From: %s\r\n", sanitizeSMTPHeader(fromHeader))
+	sanitizedTo := make([]string, len(toAddresses))
+	for i, addr := range toAddresses {
+		sanitizedTo[i] = sanitizeSMTPHeader(addr)
+	}
+	fmt.Fprintf(&msg, "To: %s\r\n", strings.Join(sanitizedTo, ", "))
 	msg.WriteString("Subject: AI DBA Workbench - Test Email\r\n")
 	msg.WriteString("MIME-Version: 1.0\r\n")
 	msg.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n")
@@ -121,7 +133,10 @@ func sendWithSTARTTLS(
 	msg []byte,
 	smtpHost string,
 ) error {
-	conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
+	// The SMTP host in `addr` is validated by the caller via
+	// hostValidator.ValidateHost before this function is invoked, so the
+	// connection target is not an unchecked user-controlled URL.
+	conn, err := net.DialTimeout("tcp", addr, 30*time.Second) //nolint:gosec // G704: SMTP host validated upstream; DNS rebinding between validation and dial is a known, admin-scope residual risk
 	if err != nil {
 		return fmt.Errorf("failed to connect to SMTP server: %w", err)
 	}
@@ -165,7 +180,10 @@ func sendPlainSMTP(
 	msg []byte,
 	smtpHost string,
 ) error {
-	conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
+	// The SMTP host in `addr` is validated by the caller via
+	// hostValidator.ValidateHost before this function is invoked, so the
+	// connection target is not an unchecked user-controlled URL.
+	conn, err := net.DialTimeout("tcp", addr, 30*time.Second) //nolint:gosec // G704: SMTP host validated upstream; DNS rebinding between validation and dial is a known, admin-scope residual risk
 	if err != nil {
 		return fmt.Errorf("failed to connect to SMTP server: %w", err)
 	}
@@ -191,14 +209,17 @@ func sendPlainSMTP(
 }
 
 // sendViaSMTPClient sends the email using an established SMTP client.
+// SMTP envelope addresses are sanitized before being issued as commands
+// to prevent SMTP command injection via CR/LF sequences.
 func sendViaSMTPClient(client *smtp.Client, from string, to []string, msg []byte) error {
-	if err := client.Mail(from); err != nil {
+	if err := client.Mail(sanitizeSMTPHeader(from)); err != nil { //nolint:gosec // G707: address sanitized via sanitizeSMTPHeader
 		return fmt.Errorf("SMTP MAIL FROM failed: %w", err)
 	}
 
 	for _, addr := range to {
-		if err := client.Rcpt(addr); err != nil {
-			return fmt.Errorf("SMTP RCPT TO failed for %s: %w", addr, err)
+		safeAddr := sanitizeSMTPHeader(addr)
+		if err := client.Rcpt(safeAddr); err != nil { //nolint:gosec // G707: address sanitized via sanitizeSMTPHeader
+			return fmt.Errorf("SMTP RCPT TO failed for %s: %w", safeAddr, err)
 		}
 	}
 

--- a/server/src/internal/api/email_test_sender_test.go
+++ b/server/src/internal/api/email_test_sender_test.go
@@ -1,0 +1,104 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeSMTPHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"plain address", "user@example.com", "user@example.com"},
+		{"with display name", "Alice <alice@example.com>", "Alice <alice@example.com>"},
+		{"strips CR", "user@example.com\rInjected", "user@example.comInjected"},
+		{"strips LF", "user@example.com\nInjected", "user@example.comInjected"},
+		{"strips CRLF", "user@example.com\r\nInjected", "user@example.comInjected"},
+		{
+			name:     "command injection attempt",
+			input:    "user@example.com\r\nRCPT TO:<evil@attacker.com>",
+			expected: "user@example.comRCPT TO:<evil@attacker.com>",
+		},
+		{
+			name:     "bare newline injection",
+			input:    "alice@example.com\nBcc: evil@attacker.com",
+			expected: "alice@example.comBcc: evil@attacker.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeSMTPHeader(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeSMTPHeader(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildTestEmailMessage(t *testing.T) {
+	from := "Alice <alice@example.com>"
+	to := []string{"bob@example.com", "carol@example.com"}
+
+	msg := string(buildTestEmailMessage(from, to))
+
+	if !strings.Contains(msg, "From: Alice <alice@example.com>\r\n") {
+		t.Errorf("expected From header, got: %q", msg)
+	}
+	if !strings.Contains(msg, "To: bob@example.com, carol@example.com\r\n") {
+		t.Errorf("expected To header, got: %q", msg)
+	}
+	if !strings.Contains(msg, "Subject: AI DBA Workbench - Test Email\r\n") {
+		t.Errorf("expected Subject header, got: %q", msg)
+	}
+	if !strings.Contains(msg, "MIME-Version: 1.0\r\n") {
+		t.Errorf("expected MIME-Version, got: %q", msg)
+	}
+	if !strings.Contains(msg, "Content-Type: text/html; charset=\"UTF-8\"\r\n") {
+		t.Errorf("expected Content-Type, got: %q", msg)
+	}
+	if !strings.Contains(msg, "<html><body>") {
+		t.Errorf("expected HTML body, got: %q", msg)
+	}
+}
+
+func TestBuildTestEmailMessage_SanitizesInjectionAttempts(t *testing.T) {
+	// Attacker-controlled addresses with CRLF should have control
+	// characters stripped before writing headers to prevent header
+	// injection. buildTestEmailMessage does not itself sanitize, but
+	// its callers pass values through sanitizeSMTPHeader first; verify
+	// that the sanitizer on its own removes the dangerous sequences so
+	// that any subsequent writer cannot inject a new header line.
+	rawFrom := "Alice\r\nBcc: attacker@evil.com <alice@example.com>"
+	rawTo := "bob@example.com\r\nBcc: other-attacker@evil.com"
+
+	safeFrom := sanitizeSMTPHeader(rawFrom)
+	safeTo := sanitizeSMTPHeader(rawTo)
+
+	if strings.ContainsAny(safeFrom, "\r\n") {
+		t.Errorf("sanitized From still contains CR/LF: %q", safeFrom)
+	}
+	if strings.ContainsAny(safeTo, "\r\n") {
+		t.Errorf("sanitized To still contains CR/LF: %q", safeTo)
+	}
+
+	msg := string(buildTestEmailMessage(safeFrom, []string{safeTo}))
+	// The only \r\n sequences in the resulting message must be the
+	// legitimate header separators; a raw injected header line would
+	// appear as "Bcc:..." immediately after a \r\n sequence.
+	if strings.Contains(msg, "\r\nBcc:") {
+		t.Errorf("injected Bcc header appeared after CRLF: %q", msg)
+	}
+}

--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/database"
+	"github.com/pgedge/ai-workbench/server/internal/logging"
 )
 
 // validTimeRanges maps time_range parameter values to their duration.
@@ -385,7 +386,7 @@ func (h *PerfSummaryHandler) getConnectionNames(
 	for _, id := range connectionIDs {
 		conn, err := h.datastore.GetConnection(ctx, id)
 		if err != nil {
-			log.Printf("[DEBUG] Could not look up connection %d: %v", id, err) //nolint:gosec // G706: id is an integer, cannot contain newlines
+			log.Printf("[DEBUG] Could not look up connection %d: %s", id, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: id is an integer and err is sanitized via logging.SanitizeForLog
 			names[id] = ""
 			continue
 		}
@@ -414,7 +415,7 @@ func (h *PerfSummaryHandler) queryXIDAage(
         ORDER BY age_datfrozenxid DESC
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No XID age data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No XID age data for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return []XIDAgeEntry{}
 	}
 	defer rows.Close()
@@ -463,7 +464,7 @@ func (h *PerfSummaryHandler) queryCacheHitCurrent(
           )
     `, connectionID).Scan(&blksHit, &blksRead)
 	if err != nil {
-		log.Printf("[DEBUG] No cache hit data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No cache hit data for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return 0, 0, 0
 	}
 
@@ -496,7 +497,7 @@ func (h *PerfSummaryHandler) queryCacheHitTimeSeries(
         ORDER BY bucket
     `, bucketInterval, startTime, connectionID, endTime)
 	if err != nil {
-		log.Printf("[DEBUG] No cache hit time series for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No cache hit time series for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return []CacheHitRatioPoint{}
 	}
 	defer rows.Close()
@@ -568,7 +569,7 @@ func (h *PerfSummaryHandler) queryTransactions(
         ORDER BY bucket
     `, bucketInterval, startTime, connectionID, endTime)
 	if err != nil {
-		log.Printf("[DEBUG] No transaction data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No transaction data for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return 0, 0, []TransactionPoint{}
 	}
 	defer rows.Close()
@@ -641,7 +642,7 @@ func (h *PerfSummaryHandler) queryCheckpoints(
         ORDER BY bucket
     `, bucketInterval, startTime, connectionID, endTime)
 	if err != nil {
-		log.Printf("[DEBUG] No checkpoint data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No checkpoint data for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return []CheckpointPoint{}
 	}
 	defer rows.Close()
@@ -783,7 +784,7 @@ func (h *PerfSummaryHandler) queryDatabaseSizes(
           AND datistemplate = false
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No database size data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No database size data for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return
 	}
 	defer rows.Close()
@@ -829,7 +830,7 @@ func (h *PerfSummaryHandler) queryDatabaseStats(
           )
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No pg_stat_database data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No pg_stat_database data for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return
 	}
 	defer rows.Close()
@@ -886,7 +887,7 @@ func (h *PerfSummaryHandler) queryDeadTupleRatios(
         GROUP BY database_name
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No dead tuple data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No dead tuple data for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return
 	}
 	defer rows.Close()
@@ -953,7 +954,7 @@ func (h *PerfSummaryHandler) queryTransactionRates(
         WHERE (p1.xact_commit - p2.xact_commit) >= 0
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No transaction rate data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No transaction rate data for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return
 	}
 	defer rows.Close()
@@ -1007,7 +1008,7 @@ func (h *PerfSummaryHandler) queryDatabaseCacheHitTimeSeries(
         ORDER BY datname, bucket
     `, bucketInterval, startTime, connectionID, endTime)
 	if err != nil {
-		log.Printf("[DEBUG] No cache hit time series for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
+		log.Printf("[DEBUG] No cache hit time series for connection %d: %s", connectionID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connectionID is an integer and err is sanitized via logging.SanitizeForLog
 		return
 	}
 	defer rows.Close()
@@ -1177,7 +1178,7 @@ func (h *PerfSummaryHandler) handleTopQueries(
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {
-		log.Printf("[DEBUG] No top queries data for connection %d: %v", connID, err) //nolint:gosec // G706: connID is an integer
+		log.Printf("[DEBUG] No top queries data for connection %d: %s", connID, logging.SanitizeForLog(err.Error())) //nolint:gosec // G706: connID is an integer and err is sanitized via logging.SanitizeForLog
 		RespondJSON(w, http.StatusOK, []TopQueryRow{})
 		return
 	}

--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -385,7 +385,7 @@ func (h *PerfSummaryHandler) getConnectionNames(
 	for _, id := range connectionIDs {
 		conn, err := h.datastore.GetConnection(ctx, id)
 		if err != nil {
-			log.Printf("[DEBUG] Could not look up connection %d: %v", id, err)
+			log.Printf("[DEBUG] Could not look up connection %d: %v", id, err) //nolint:gosec // G706: id is an integer, cannot contain newlines
 			names[id] = ""
 			continue
 		}
@@ -414,8 +414,7 @@ func (h *PerfSummaryHandler) queryXIDAage(
         ORDER BY age_datfrozenxid DESC
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No XID age data for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No XID age data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return []XIDAgeEntry{}
 	}
 	defer rows.Close()
@@ -464,8 +463,7 @@ func (h *PerfSummaryHandler) queryCacheHitCurrent(
           )
     `, connectionID).Scan(&blksHit, &blksRead)
 	if err != nil {
-		log.Printf("[DEBUG] No cache hit data for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No cache hit data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return 0, 0, 0
 	}
 
@@ -498,8 +496,7 @@ func (h *PerfSummaryHandler) queryCacheHitTimeSeries(
         ORDER BY bucket
     `, bucketInterval, startTime, connectionID, endTime)
 	if err != nil {
-		log.Printf("[DEBUG] No cache hit time series for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No cache hit time series for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return []CacheHitRatioPoint{}
 	}
 	defer rows.Close()
@@ -571,8 +568,7 @@ func (h *PerfSummaryHandler) queryTransactions(
         ORDER BY bucket
     `, bucketInterval, startTime, connectionID, endTime)
 	if err != nil {
-		log.Printf("[DEBUG] No transaction data for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No transaction data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return 0, 0, []TransactionPoint{}
 	}
 	defer rows.Close()
@@ -645,8 +641,7 @@ func (h *PerfSummaryHandler) queryCheckpoints(
         ORDER BY bucket
     `, bucketInterval, startTime, connectionID, endTime)
 	if err != nil {
-		log.Printf("[DEBUG] No checkpoint data for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No checkpoint data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return []CheckpointPoint{}
 	}
 	defer rows.Close()
@@ -788,8 +783,7 @@ func (h *PerfSummaryHandler) queryDatabaseSizes(
           AND datistemplate = false
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No database size data for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No database size data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return
 	}
 	defer rows.Close()
@@ -835,8 +829,7 @@ func (h *PerfSummaryHandler) queryDatabaseStats(
           )
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No pg_stat_database data for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No pg_stat_database data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return
 	}
 	defer rows.Close()
@@ -893,8 +886,7 @@ func (h *PerfSummaryHandler) queryDeadTupleRatios(
         GROUP BY database_name
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No dead tuple data for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No dead tuple data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return
 	}
 	defer rows.Close()
@@ -961,8 +953,7 @@ func (h *PerfSummaryHandler) queryTransactionRates(
         WHERE (p1.xact_commit - p2.xact_commit) >= 0
     `, connectionID)
 	if err != nil {
-		log.Printf("[DEBUG] No transaction rate data for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No transaction rate data for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return
 	}
 	defer rows.Close()
@@ -1016,8 +1007,7 @@ func (h *PerfSummaryHandler) queryDatabaseCacheHitTimeSeries(
         ORDER BY datname, bucket
     `, bucketInterval, startTime, connectionID, endTime)
 	if err != nil {
-		log.Printf("[DEBUG] No cache hit time series for connection %d: %v",
-			connectionID, err)
+		log.Printf("[DEBUG] No cache hit time series for connection %d: %v", connectionID, err) //nolint:gosec // G706: connectionID is an integer
 		return
 	}
 	defer rows.Close()
@@ -1187,8 +1177,7 @@ func (h *PerfSummaryHandler) handleTopQueries(
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {
-		log.Printf("[DEBUG] No top queries data for connection %d: %v",
-			connID, err)
+		log.Printf("[DEBUG] No top queries data for connection %d: %v", connID, err) //nolint:gosec // G706: connID is an integer
 		RespondJSON(w, http.StatusOK, []TopQueryRow{})
 		return
 	}

--- a/server/src/internal/api/query_handlers.go
+++ b/server/src/internal/api/query_handlers.go
@@ -80,7 +80,7 @@ func scanDollarTag(sql string, i int) string {
 		return ""
 	}
 	ch := sql[j]
-	if !((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch == '_') {
+	if (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') && ch != '_' {
 		return ""
 	}
 	j++
@@ -89,8 +89,8 @@ func scanDollarTag(sql string, i int) string {
 		if ch == '$' {
 			return sql[i : j+1]
 		}
-		if !((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') ||
-			(ch >= '0' && ch <= '9') || ch == '_') {
+		if (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') &&
+			(ch < '0' || ch > '9') && ch != '_' {
 			return ""
 		}
 		j++

--- a/server/src/internal/api/rbac_group_privilege_handlers.go
+++ b/server/src/internal/api/rbac_group_privilege_handlers.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 
 	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/logging"
 )
 
 // =============================================================================
@@ -59,7 +60,7 @@ func (h *RBACHandler) handleGroupMCPPrivileges(w http.ResponseWriter, r *http.Re
 			}
 
 			if err := h.authStore.GrantMCPPrivilegeByName(groupID, req.Privilege); err != nil {
-				log.Printf("[ERROR] Failed to grant MCP privilege %s to group %d: %v", req.Privilege, groupID, err)
+				log.Printf("[ERROR] Failed to grant MCP privilege %s to group %d: %v", logging.SanitizeForLog(req.Privilege), groupID, err) //nolint:gosec // G706: privilege passed through logging.SanitizeForLog
 				RespondError(w, http.StatusInternalServerError, "Failed to grant MCP privilege")
 				return
 			}
@@ -73,7 +74,7 @@ func (h *RBACHandler) handleGroupMCPPrivileges(w http.ResponseWriter, r *http.Re
 			}
 
 			if err := h.authStore.RevokeMCPPrivilegeByName(groupID, privilege); err != nil {
-				log.Printf("[ERROR] Failed to revoke MCP privilege %s from group %d: %v", privilege, groupID, err)
+				log.Printf("[ERROR] Failed to revoke MCP privilege %s from group %d: %v", logging.SanitizeForLog(privilege), groupID, err) //nolint:gosec // G706: privilege passed through logging.SanitizeForLog
 				RespondError(w, http.StatusInternalServerError, "Failed to revoke MCP privilege")
 				return
 			}
@@ -217,7 +218,7 @@ func (h *RBACHandler) grantGroupPermission(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := h.authStore.GrantAdminPermission(groupID, req.Permission); err != nil {
-		log.Printf("[ERROR] Failed to grant permission %s to group %d: %v", req.Permission, groupID, err)
+		log.Printf("[ERROR] Failed to grant permission %s to group %d: %v", logging.SanitizeForLog(req.Permission), groupID, err) //nolint:gosec // G706: permission passed through logging.SanitizeForLog
 		RespondError(w, http.StatusInternalServerError, "Failed to grant permission")
 		return
 	}
@@ -227,7 +228,7 @@ func (h *RBACHandler) grantGroupPermission(w http.ResponseWriter, r *http.Reques
 
 func (h *RBACHandler) revokeGroupPermission(w http.ResponseWriter, r *http.Request, groupID int64, permission string) {
 	if err := h.authStore.RevokeAdminPermission(groupID, permission); err != nil {
-		log.Printf("[ERROR] Failed to revoke permission %s from group %d: %v", permission, groupID, err)
+		log.Printf("[ERROR] Failed to revoke permission %s from group %d: %v", logging.SanitizeForLog(permission), groupID, err) //nolint:gosec // G706: permission passed through logging.SanitizeForLog
 		RespondError(w, http.StatusInternalServerError, "Failed to revoke permission")
 		return
 	}

--- a/server/src/internal/api/rbac_group_privilege_handlers_test.go
+++ b/server/src/internal/api/rbac_group_privilege_handlers_test.go
@@ -1,0 +1,684 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+)
+
+// =============================================================================
+// handleGroupPrivileges routing
+// =============================================================================
+
+// TestHandleGroupPrivileges_NoRemaining asserts that an empty path tail
+// returns 404 (no privilege category selected).
+func TestHandleGroupPrivileges_NoRemaining(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rbac/groups/1/privileges", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPrivileges(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupPrivileges_UnknownCategory asserts that an unknown
+// privilege category returns 404.
+func TestHandleGroupPrivileges_UnknownCategory(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rbac/groups/1/privileges/unknown", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPrivileges(rec, req, 1, []string{"unknown"})
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupPrivileges_PermissionDenied asserts that a non-superuser
+// lacking manage_permissions gets 403.
+func TestHandleGroupPrivileges_PermissionDenied(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	store.CreateUser("user", "Password1", "User", "", "")
+	userID, _ := store.GetUserID("user")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rbac/groups/1/privileges/mcp", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPrivileges(rec, req, 1, []string{"mcp"})
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rec.Code)
+	}
+}
+
+// =============================================================================
+// handleGroupMCPPrivileges
+// =============================================================================
+
+// TestHandleGroupMCPPrivileges_GrantSuccess verifies that POST with a
+// valid privilege name returns 204 and persists the grant.
+func TestHandleGroupMCPPrivileges_GrantSuccess(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+	if _, err := store.RegisterMCPPrivilege("test_tool", auth.MCPPrivilegeTypeTool, "Test tool", false); err != nil {
+		t.Fatalf("failed to register privilege: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"privilege": "test_tool"})
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/privileges/mcp", groupID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupMCPPrivileges(rec, req, groupID, []string{})
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	privs, _ := store.ListGroupMCPPrivileges(groupID)
+	if len(privs) != 1 || privs[0].Identifier != "test_tool" {
+		t.Errorf("expected privilege 'test_tool' granted, got %v", privs)
+	}
+}
+
+// TestHandleGroupMCPPrivileges_GrantMissingField verifies that a POST
+// body with an empty privilege string returns 400.
+func TestHandleGroupMCPPrivileges_GrantMissingField(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]string{"privilege": ""})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rbac/groups/1/privileges/mcp", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupMCPPrivileges(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupMCPPrivileges_GrantStoreError verifies that a store
+// error (unknown privilege name) results in 500 and that the log
+// sanitization path is exercised (the privilege value flows through
+// logging.SanitizeForLog).
+func TestHandleGroupMCPPrivileges_GrantStoreError(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+
+	// Request grant of a privilege that was never registered; use a
+	// payload containing CRLF to confirm sanitization does not panic.
+	body, _ := json.Marshal(map[string]string{"privilege": "unknown_tool\r\ninjected"})
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/privileges/mcp", groupID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupMCPPrivileges(rec, req, groupID, []string{})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 for unknown privilege, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupMCPPrivileges_RevokeSuccess verifies that DELETE with
+// ?name=<privilege> returns 204 and removes the grant.
+func TestHandleGroupMCPPrivileges_RevokeSuccess(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+	if _, err := store.RegisterMCPPrivilege("test_tool", auth.MCPPrivilegeTypeTool, "Test tool", false); err != nil {
+		t.Fatalf("failed to register privilege: %v", err)
+	}
+	if err := store.GrantMCPPrivilegeByName(groupID, "test_tool"); err != nil {
+		t.Fatalf("failed to grant privilege: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/privileges/mcp?name=test_tool", groupID), nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupMCPPrivileges(rec, req, groupID, []string{})
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+	privs, _ := store.ListGroupMCPPrivileges(groupID)
+	if len(privs) != 0 {
+		t.Errorf("expected 0 privileges after revoke, got %d", len(privs))
+	}
+}
+
+// TestHandleGroupMCPPrivileges_RevokeMissingQuery verifies that DELETE
+// without ?name= returns 400.
+func TestHandleGroupMCPPrivileges_RevokeMissingQuery(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/rbac/groups/1/privileges/mcp", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupMCPPrivileges(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupMCPPrivileges_RevokeStoreError verifies that attempting
+// to revoke a privilege that was never granted surfaces an internal
+// error; this exercises the revoke sanitization path.
+func TestHandleGroupMCPPrivileges_RevokeStoreError(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+
+	req := httptest.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/privileges/mcp?name=never_registered", groupID), nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupMCPPrivileges(rec, req, groupID, []string{})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupMCPPrivileges_MethodNotAllowed verifies that methods
+// other than POST/DELETE on /privileges/mcp return 405.
+func TestHandleGroupMCPPrivileges_MethodNotAllowed(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rbac/groups/1/privileges/mcp", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupMCPPrivileges(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+	allow := rec.Header().Get("Allow")
+	if allow != "POST, DELETE" {
+		t.Errorf("Allow header = %q, want 'POST, DELETE'", allow)
+	}
+}
+
+// TestHandleGroupMCPPrivileges_ExtraPath verifies that extra trailing
+// path segments return 404.
+func TestHandleGroupMCPPrivileges_ExtraPath(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rbac/groups/1/privileges/mcp/extra", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupMCPPrivileges(rec, req, 1, []string{"extra"})
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// =============================================================================
+// handleGroupConnectionPrivileges
+// =============================================================================
+
+// TestHandleGroupConnectionPrivileges_GrantSuccess verifies POST returns
+// 204 and persists the connection grant.
+func TestHandleGroupConnectionPrivileges_GrantSuccess(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+
+	body, _ := json.Marshal(map[string]any{
+		"connection_id": 42,
+		"access_level":  "read_write",
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/privileges/connections", groupID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupConnectionPrivileges(rec, req, groupID, []string{})
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleGroupConnectionPrivileges_InvalidConnectionID verifies that
+// a negative connection_id yields 400.
+func TestHandleGroupConnectionPrivileges_InvalidConnectionID(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]any{
+		"connection_id": -1,
+		"access_level":  "read",
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/rbac/groups/1/privileges/connections", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupConnectionPrivileges(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupConnectionPrivileges_InvalidAccessLevel verifies that
+// an unsupported access_level yields 400.
+func TestHandleGroupConnectionPrivileges_InvalidAccessLevel(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]any{
+		"connection_id": 1,
+		"access_level":  "write_only",
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/rbac/groups/1/privileges/connections", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupConnectionPrivileges(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupConnectionPrivileges_GrantMethodNotAllowed verifies
+// that non-POST methods on the collection return 405.
+func TestHandleGroupConnectionPrivileges_GrantMethodNotAllowed(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rbac/groups/1/privileges/connections", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupConnectionPrivileges(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupConnectionPrivileges_RevokeSuccess verifies DELETE with
+// an integer connection id in the path returns 204.
+func TestHandleGroupConnectionPrivileges_RevokeSuccess(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+	if err := store.GrantConnectionPrivilege(groupID, 42, "read"); err != nil {
+		t.Fatalf("failed to grant connection privilege: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/privileges/connections/42", groupID), nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupConnectionPrivileges(rec, req, groupID, []string{"42"})
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleGroupConnectionPrivileges_RevokeBadID verifies that a
+// non-numeric connection id in the path returns 400.
+func TestHandleGroupConnectionPrivileges_RevokeBadID(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/rbac/groups/1/privileges/connections/notanumber", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupConnectionPrivileges(rec, req, 1, []string{"notanumber"})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupConnectionPrivileges_RevokeMethodNotAllowed verifies
+// that non-DELETE methods on an individual connection resource return
+// 405.
+func TestHandleGroupConnectionPrivileges_RevokeMethodNotAllowed(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/rbac/groups/1/privileges/connections/42", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupConnectionPrivileges(rec, req, 1, []string{"42"})
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupConnectionPrivileges_ExtraPath verifies that more than
+// one trailing path segment returns 404.
+func TestHandleGroupConnectionPrivileges_ExtraPath(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/rbac/groups/1/privileges/connections/42/extra", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupConnectionPrivileges(rec, req, 1, []string{"42", "extra"})
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// =============================================================================
+// handleGroupPermissions routing
+// =============================================================================
+
+// TestHandleGroupPermissions_GetList verifies the GET branch routes to
+// listGroupPermissions.
+func TestHandleGroupPermissions_GetList(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+	store.GrantAdminPermission(groupID, auth.PermManageUsers)
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/permissions", groupID), nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPermissions(rec, req, groupID, []string{})
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupPermissions_PostGrant verifies the POST branch routes
+// to grantGroupPermission.
+func TestHandleGroupPermissions_PostGrant(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+
+	body, _ := json.Marshal(map[string]string{"permission": auth.PermManageUsers})
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/permissions", groupID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPermissions(rec, req, groupID, []string{})
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleGroupPermissions_MethodNotAllowed verifies that non-GET/POST
+// on the collection returns 405.
+func TestHandleGroupPermissions_MethodNotAllowed(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/rbac/groups/1/permissions", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPermissions(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupPermissions_DeleteIndividual verifies the DELETE branch
+// with a permission path segment routes to revokeGroupPermission.
+func TestHandleGroupPermissions_DeleteIndividual(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+	store.GrantAdminPermission(groupID, auth.PermManageUsers)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/permissions/manage_users", groupID), nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPermissions(rec, req, groupID, []string{auth.PermManageUsers})
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupPermissions_DeleteMethodNotAllowed verifies non-DELETE
+// on the individual resource returns 405.
+func TestHandleGroupPermissions_DeleteMethodNotAllowed(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/rbac/groups/1/permissions/manage_users", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPermissions(rec, req, 1, []string{auth.PermManageUsers})
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupPermissions_ExtraPath verifies that more than one
+// trailing path segment returns 404.
+func TestHandleGroupPermissions_ExtraPath(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/rbac/groups/1/permissions/manage_users/extra", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPermissions(rec, req, 1, []string{auth.PermManageUsers, "extra"})
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// TestHandleGroupPermissions_NonSuperuser verifies that a non-superuser
+// request is rejected by requireSuperuser.
+func TestHandleGroupPermissions_NonSuperuser(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	store.CreateUser("user", "Password1", "User", "", "")
+	userID, _ := store.GetUserID("user")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rbac/groups/1/permissions", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleGroupPermissions(rec, req, 1, []string{})
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rec.Code)
+	}
+}
+
+// =============================================================================
+// grantGroupPermission and revokeGroupPermission error paths
+// =============================================================================
+
+// TestGrantGroupPermission_MissingField verifies that an empty permission
+// string yields 400 without hitting the store.
+func TestGrantGroupPermission_MissingField(t *testing.T) {
+	handler, _, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]string{"permission": ""})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/rbac/groups/1/permissions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.grantGroupPermission(rec, req, 1)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+// TestGrantGroupPermission_StoreError verifies that a store error (here
+// forced by closing the underlying database) results in 500 and
+// exercises the logging.SanitizeForLog path on the CRLF-bearing
+// permission value without panicking.
+func TestGrantGroupPermission_StoreError(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+
+	// Close the store to force any subsequent DB operation to fail.
+	// cleanup() is idempotent: Close is a no-op after this, and
+	// RemoveAll will still run.
+	if err := store.Close(); err != nil {
+		t.Fatalf("failed to close store: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"permission": "manage_users\r\ninjected"})
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/permissions", groupID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.grantGroupPermission(rec, req, groupID)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 after store closed, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestRevokeGroupPermission_StoreError verifies that revoke errors are
+// surfaced as 500 and exercise the sanitization path. The permission
+// value embeds CRLF to confirm SanitizeForLog is effective.
+func TestRevokeGroupPermission_StoreError(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("target", "Target group")
+
+	req := httptest.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/permissions/bogus", groupID), nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.revokeGroupPermission(rec, req, groupID, "bogus_perm\r\ninjected")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 for unknown permission, got %d", rec.Code)
+	}
+}
+
+// TestListGroupPermissions_EmptyGroup verifies that a group with no
+// permissions returns an empty array rather than null.
+func TestListGroupPermissions_EmptyGroup(t *testing.T) {
+	handler, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("empty", "Empty group")
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v1/rbac/groups/%d/permissions", groupID), nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.listGroupPermissions(rec, req, groupID)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var resp struct {
+		GroupID     int64    `json:"group_id"`
+		Permissions []string `json:"permissions"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Permissions == nil {
+		t.Error("expected non-nil permissions slice")
+	}
+	if len(resp.Permissions) != 0 {
+		t.Errorf("expected 0 permissions, got %d", len(resp.Permissions))
+	}
+}

--- a/server/src/internal/api/rbac_group_privilege_handlers_test.go
+++ b/server/src/internal/api/rbac_group_privilege_handlers_test.go
@@ -354,6 +354,10 @@ func TestHandleGroupConnectionPrivileges_GrantMethodNotAllowed(t *testing.T) {
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected 405, got %d", rec.Code)
 	}
+	allow := rec.Header().Get("Allow")
+	if allow != "POST" {
+		t.Errorf("Allow header = %q, want 'POST'", allow)
+	}
 }
 
 // TestHandleGroupConnectionPrivileges_RevokeSuccess verifies DELETE with
@@ -413,6 +417,10 @@ func TestHandleGroupConnectionPrivileges_RevokeMethodNotAllowed(t *testing.T) {
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected 405, got %d", rec.Code)
+	}
+	allow := rec.Header().Get("Allow")
+	if allow != "DELETE" {
+		t.Errorf("Allow header = %q, want 'DELETE'", allow)
 	}
 }
 
@@ -495,6 +503,10 @@ func TestHandleGroupPermissions_MethodNotAllowed(t *testing.T) {
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected 405, got %d", rec.Code)
+	}
+	allow := rec.Header().Get("Allow")
+	if allow != "GET, POST" {
+		t.Errorf("Allow header = %q, want 'GET, POST'", allow)
 	}
 }
 

--- a/server/src/internal/api/rbac_group_privilege_handlers_test.go
+++ b/server/src/internal/api/rbac_group_privilege_handlers_test.go
@@ -131,10 +131,11 @@ func TestHandleGroupMCPPrivileges_GrantMissingField(t *testing.T) {
 	}
 }
 
-// TestHandleGroupMCPPrivileges_GrantStoreError verifies that a store
-// error (unknown privilege name) results in 500 and that the log
-// sanitization path is exercised (the privilege value flows through
-// logging.SanitizeForLog).
+// TestHandleGroupMCPPrivileges_GrantStoreError verifies that CRLF-bearing
+// input does not cause the handler to panic and that the handler returns
+// 500 when the privilege is unknown. This implicitly exercises the
+// sanitization path; verifying actual log output would require capturing
+// stderr.
 func TestHandleGroupMCPPrivileges_GrantStoreError(t *testing.T) {
 	handler, store, cleanup := createTestRBACHandler(t)
 	defer cleanup()
@@ -598,10 +599,11 @@ func TestGrantGroupPermission_MissingField(t *testing.T) {
 	}
 }
 
-// TestGrantGroupPermission_StoreError verifies that a store error (here
-// forced by closing the underlying database) results in 500 and
-// exercises the logging.SanitizeForLog path on the CRLF-bearing
-// permission value without panicking.
+// TestGrantGroupPermission_StoreError verifies that CRLF-bearing input
+// does not cause the handler to panic and that the handler returns 500
+// when the underlying store is closed. This implicitly exercises the
+// sanitization path; verifying actual log output would require capturing
+// stderr.
 func TestGrantGroupPermission_StoreError(t *testing.T) {
 	handler, store, cleanup := createTestRBACHandler(t)
 	defer cleanup()

--- a/server/src/internal/api/rbac_visibility.go
+++ b/server/src/internal/api/rbac_visibility.go
@@ -116,7 +116,7 @@ func scopeVisibleToCaller(ctx context.Context, w http.ResponseWriter, rbac *auth
 
 	visible, allConnections, err := resolveVisibleConnectionSet(ctx, rbac, ds)
 	if err != nil {
-		log.Printf("[ERROR] Failed to resolve visible connections for %s scope %d: %v", scope, scopeID, err)
+		log.Printf("[ERROR] Failed to resolve visible connections for %s scope %d: %v", scope, scopeID, err) //nolint:gosec // G706: scope validated against allowlist; scopeID is an integer
 		RespondError(w, http.StatusInternalServerError, "Failed to check scope visibility")
 		return false
 	}
@@ -134,7 +134,7 @@ func scopeVisibleToCaller(ctx context.Context, w http.ResponseWriter, rbac *auth
 		ok, err = groupHasVisibleConnectionFn(ctx, ds, scopeID, visible)
 	}
 	if err != nil {
-		log.Printf("[ERROR] Failed to check %s scope %d visibility: %v", scope, scopeID, err)
+		log.Printf("[ERROR] Failed to check %s scope %d visibility: %v", scope, scopeID, err) //nolint:gosec // G706: scope validated against allowlist; scopeID is an integer
 		RespondError(w, http.StatusInternalServerError, "Failed to check scope visibility")
 		return false
 	}

--- a/server/src/internal/api/webhook_test_sender.go
+++ b/server/src/internal/api/webhook_test_sender.go
@@ -23,6 +23,14 @@ import (
 func sendTestGenericWebhook(endpointURL, httpMethod string, headers map[string]string, authType, authCredentials string) error {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
+		// Refuse to follow redirects. hostValidator.ValidateHost is
+		// applied to the originally configured URL only; following a
+		// 3xx Location header would allow an attacker-controlled
+		// endpoint to bounce the request to a private/metadata host
+		// and bypass SSRF protections.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	if httpMethod == "" {
@@ -36,7 +44,11 @@ func sendTestGenericWebhook(endpointURL, httpMethod string, headers map[string]s
 		reqBody = strings.NewReader(body)
 	}
 
-	req, err := http.NewRequest(httpMethod, endpointURL, reqBody)
+	// The endpoint URL host is validated by hostValidator.ValidateHost at
+	// the call site to reject private/loopback/metadata endpoints before
+	// the request is ever dispatched, so this is not an unchecked
+	// user-supplied URL.
+	req, err := http.NewRequest(httpMethod, endpointURL, reqBody) //nolint:gosec // G704: URL host validated upstream; DNS rebinding between validation and dial is a known, admin-scope residual risk
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -69,7 +81,7 @@ func sendTestGenericWebhook(endpointURL, httpMethod string, headers map[string]s
 		}
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL host validated upstream and redirects disabled so the validated host cannot be bypassed via Location header; DNS rebinding between validation and dial is a known, admin-scope residual risk
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
@@ -90,6 +102,14 @@ func sendTestGenericWebhook(endpointURL, httpMethod string, headers map[string]s
 func sendTestWebhook(webhookURL string, channelType string) error {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
+		// Refuse to follow redirects. hostValidator.ValidateHost is
+		// applied to the originally configured URL only; following a
+		// 3xx Location header would allow an attacker-controlled
+		// endpoint to bounce the request to a private/metadata host
+		// and bypass SSRF protections.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	body := fmt.Sprintf(
@@ -97,13 +117,17 @@ func sendTestWebhook(webhookURL string, channelType string) error {
 		channelType,
 	)
 
-	req, err := http.NewRequest(http.MethodPost, webhookURL, strings.NewReader(body))
+	// The webhook URL host is validated by hostValidator.ValidateHost at
+	// the call site to reject private/loopback/metadata endpoints before
+	// the request is ever dispatched, so this is not an unchecked
+	// user-supplied URL.
+	req, err := http.NewRequest(http.MethodPost, webhookURL, strings.NewReader(body)) //nolint:gosec // G704: URL host validated upstream; DNS rebinding between validation and dial is a known, admin-scope residual risk
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL host validated upstream and redirects disabled so the validated host cannot be bypassed via Location header; DNS rebinding between validation and dial is a known, admin-scope residual risk
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}

--- a/server/src/internal/api/webhook_test_sender_test.go
+++ b/server/src/internal/api/webhook_test_sender_test.go
@@ -94,7 +94,11 @@ func TestSendTestWebhook_Success(t *testing.T) {
 	var gotContentType string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotContentType = r.Header.Get("Content-Type")
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			return
+		}
 		gotBody = string(body)
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -165,7 +169,11 @@ func TestSendTestGenericWebhook_DefaultMethodAndBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotContentType = r.Header.Get("Content-Type")
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			return
+		}
 		gotBody = string(body)
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -193,7 +201,11 @@ func TestSendTestGenericWebhook_GetNoBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotContentType = r.Header.Get("Content-Type")
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			return
+		}
 		gotBodyLen = len(body)
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -403,7 +415,11 @@ func TestSendTestGenericWebhook_PutAndPatch(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotMethod = r.Method
 				gotContentType = r.Header.Get("Content-Type")
-				body, _ := io.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("failed to read request body: %v", err)
+					return
+				}
 				gotBodyLen = len(body)
 				w.WriteHeader(http.StatusOK)
 			}))

--- a/server/src/internal/api/webhook_test_sender_test.go
+++ b/server/src/internal/api/webhook_test_sender_test.go
@@ -1,0 +1,426 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestSendTestWebhook_RefusesRedirect verifies that sendTestWebhook does
+// NOT follow an HTTP 302 redirect. A misconfigured (or malicious) webhook
+// endpoint could redirect to a metadata host such as 169.254.169.254 and
+// bypass the upstream hostValidator.ValidateHost check; the client must
+// treat the 3xx response as the final response rather than dialing the
+// Location target.
+func TestSendTestWebhook_RefusesRedirect(t *testing.T) {
+	var internalDialed atomic.Bool
+
+	// A fake "internal" host that should never be contacted. If the
+	// client follows the redirect this handler will run and flip the
+	// flag.
+	internalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		internalDialed.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer internalServer.Close()
+
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate an attacker-controlled webhook that 302-redirects to
+		// an internal metadata-style host.
+		w.Header().Set("Location", internalServer.URL+"/latest/meta-data/")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirectServer.Close()
+
+	err := sendTestWebhook(redirectServer.URL, "slack")
+	if err == nil {
+		t.Fatalf("expected error from non-2xx status, got nil")
+	}
+	if !strings.Contains(err.Error(), "302") {
+		t.Errorf("expected error to mention 302 status; got %q", err.Error())
+	}
+	if internalDialed.Load() {
+		t.Fatal("client followed redirect and dialed internal host; SSRF protection is broken")
+	}
+}
+
+// TestSendTestGenericWebhook_RefusesRedirect mirrors the above check for
+// the generic webhook sender used by custom REST endpoints.
+func TestSendTestGenericWebhook_RefusesRedirect(t *testing.T) {
+	var internalDialed atomic.Bool
+
+	internalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		internalDialed.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer internalServer.Close()
+
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", internalServer.URL+"/latest/meta-data/")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirectServer.Close()
+
+	err := sendTestGenericWebhook(redirectServer.URL, http.MethodPost, nil, "", "")
+	if err == nil {
+		t.Fatalf("expected error from non-2xx status, got nil")
+	}
+	if !strings.Contains(err.Error(), "302") {
+		t.Errorf("expected error to mention 302 status; got %q", err.Error())
+	}
+	if internalDialed.Load() {
+		t.Fatal("client followed redirect and dialed internal host; SSRF protection is broken")
+	}
+}
+
+// TestSendTestWebhook_Success verifies that a 200 response from a Slack or
+// Mattermost-style webhook produces no error and that the posted body
+// contains the configured channel type.
+func TestSendTestWebhook_Success(t *testing.T) {
+	var gotBody string
+	var gotContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := sendTestWebhook(server.URL, "slack"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if !strings.Contains(gotBody, "slack") {
+		t.Errorf("expected posted body to mention channel type; got %q", gotBody)
+	}
+}
+
+// TestSendTestWebhook_NonOKStatus verifies that a non-200 status is
+// surfaced in the returned error along with the response body.
+func TestSendTestWebhook_NonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "boom")
+	}))
+	defer server.Close()
+
+	err := sendTestWebhook(server.URL, "slack")
+	if err == nil {
+		t.Fatal("expected error for non-200 status, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to mention status 500; got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected error to include response body; got %q", err.Error())
+	}
+}
+
+// TestSendTestWebhook_BadURL verifies that an unparseable URL yields an
+// error from http.NewRequest rather than a panic.
+func TestSendTestWebhook_BadURL(t *testing.T) {
+	err := sendTestWebhook("http://\x00invalid", "slack")
+	if err == nil {
+		t.Fatal("expected error for malformed URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create request") {
+		t.Errorf("expected create-request error; got %q", err.Error())
+	}
+}
+
+// TestSendTestWebhook_UnreachableHost verifies that a dial failure is
+// wrapped with a descriptive error.
+func TestSendTestWebhook_UnreachableHost(t *testing.T) {
+	// Port 1 is virtually guaranteed to refuse a connection.
+	err := sendTestWebhook("http://127.0.0.1:1/", "slack")
+	if err == nil {
+		t.Fatal("expected error for unreachable host, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to send request") {
+		t.Errorf("expected send-request error; got %q", err.Error())
+	}
+}
+
+// TestSendTestGenericWebhook_DefaultMethodAndBody verifies that an empty
+// httpMethod defaults to POST and that non-GET requests carry the
+// expected JSON body and Content-Type.
+func TestSendTestGenericWebhook_DefaultMethodAndBody(t *testing.T) {
+	var gotMethod, gotContentType, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := sendTestGenericWebhook(server.URL, "", nil, "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if !strings.Contains(gotBody, "test message") {
+		t.Errorf("expected test body; got %q", gotBody)
+	}
+}
+
+// TestSendTestGenericWebhook_GetNoBody verifies that GET requests do not
+// carry a JSON body or Content-Type header.
+func TestSendTestGenericWebhook_GetNoBody(t *testing.T) {
+	var gotMethod, gotContentType string
+	var gotBodyLen int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		gotBodyLen = len(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := sendTestGenericWebhook(server.URL, http.MethodGet, nil, "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotContentType != "" {
+		t.Errorf("Content-Type = %q, want empty for GET", gotContentType)
+	}
+	if gotBodyLen != 0 {
+		t.Errorf("body length = %d, want 0 for GET", gotBodyLen)
+	}
+}
+
+// TestSendTestGenericWebhook_CustomHeaders verifies that caller-provided
+// custom headers reach the endpoint.
+func TestSendTestGenericWebhook_CustomHeaders(t *testing.T) {
+	var gotCustom string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCustom = r.Header.Get("X-Custom-Header")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	headers := map[string]string{"X-Custom-Header": "test-value"}
+	if err := sendTestGenericWebhook(server.URL, http.MethodPost, headers, "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotCustom != "test-value" {
+		t.Errorf("X-Custom-Header = %q, want 'test-value'", gotCustom)
+	}
+}
+
+// TestSendTestGenericWebhook_BasicAuth verifies that basic authentication
+// credentials are set on the outgoing request.
+func TestSendTestGenericWebhook_BasicAuth(t *testing.T) {
+	var gotUser, gotPass string
+	var gotOK bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPass, gotOK = r.BasicAuth()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	err := sendTestGenericWebhook(server.URL, http.MethodPost, nil, "basic", "alice:s3cret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gotOK {
+		t.Fatal("basic auth not set on request")
+	}
+	if gotUser != "alice" || gotPass != "s3cret" {
+		t.Errorf("basic auth = %q/%q, want alice/s3cret", gotUser, gotPass)
+	}
+}
+
+// TestSendTestGenericWebhook_BasicAuthMalformed verifies that malformed
+// basic credentials (missing colon) are silently skipped rather than
+// sending garbled authentication.
+func TestSendTestGenericWebhook_BasicAuthMalformed(t *testing.T) {
+	var gotOK bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _, gotOK = r.BasicAuth()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := sendTestGenericWebhook(server.URL, http.MethodPost, nil, "basic", "nocolon"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotOK {
+		t.Error("basic auth should not be set when credentials lack a colon")
+	}
+}
+
+// TestSendTestGenericWebhook_BearerAuth verifies that bearer tokens are
+// sent in the Authorization header.
+func TestSendTestGenericWebhook_BearerAuth(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := sendTestGenericWebhook(server.URL, http.MethodPost, nil, "bearer", "abc123"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer abc123" {
+		t.Errorf("Authorization = %q, want 'Bearer abc123'", gotAuth)
+	}
+}
+
+// TestSendTestGenericWebhook_APIKeyAuth verifies that api_key credentials
+// (name:value) set an arbitrary header.
+func TestSendTestGenericWebhook_APIKeyAuth(t *testing.T) {
+	var gotKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	err := sendTestGenericWebhook(server.URL, http.MethodPost, nil, "api_key", "X-API-Key:secret-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotKey != "secret-token" {
+		t.Errorf("X-API-Key = %q, want 'secret-token'", gotKey)
+	}
+}
+
+// TestSendTestGenericWebhook_APIKeyAuthMalformed verifies that malformed
+// api_key credentials (missing colon) are silently skipped.
+func TestSendTestGenericWebhook_APIKeyAuthMalformed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for name := range r.Header {
+			if strings.HasPrefix(strings.ToLower(name), "x-") {
+				t.Errorf("unexpected custom header %q set", name)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := sendTestGenericWebhook(server.URL, http.MethodPost, nil, "api_key", "nocolon"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestSendTestGenericWebhook_UnknownAuthType verifies that an unknown
+// auth type is silently ignored (no header added) rather than erroring.
+func TestSendTestGenericWebhook_UnknownAuthType(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := sendTestGenericWebhook(server.URL, http.MethodPost, nil, "mystery", "value"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "" {
+		t.Errorf("Authorization should be empty for unknown auth type, got %q", gotAuth)
+	}
+}
+
+// TestSendTestGenericWebhook_NonSuccessStatus verifies that any response
+// outside 2xx is surfaced as an error with the status code and body.
+func TestSendTestGenericWebhook_NonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, "bad input")
+	}))
+	defer server.Close()
+
+	err := sendTestGenericWebhook(server.URL, http.MethodPost, nil, "", "")
+	if err == nil {
+		t.Fatal("expected error for 4xx status, got nil")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("expected error to mention status 400; got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "bad input") {
+		t.Errorf("expected error to contain response body; got %q", err.Error())
+	}
+}
+
+// TestSendTestGenericWebhook_BadURL verifies that an unparseable URL
+// produces a create-request error.
+func TestSendTestGenericWebhook_BadURL(t *testing.T) {
+	err := sendTestGenericWebhook("http://\x00invalid", http.MethodPost, nil, "", "")
+	if err == nil {
+		t.Fatal("expected error for malformed URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create request") {
+		t.Errorf("expected create-request error; got %q", err.Error())
+	}
+}
+
+// TestSendTestGenericWebhook_UnreachableHost verifies dial-failure error
+// wrapping for the generic webhook sender.
+func TestSendTestGenericWebhook_UnreachableHost(t *testing.T) {
+	err := sendTestGenericWebhook("http://127.0.0.1:1/", http.MethodPost, nil, "", "")
+	if err == nil {
+		t.Fatal("expected error for unreachable host, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to send request") {
+		t.Errorf("expected send-request error; got %q", err.Error())
+	}
+}
+
+// TestSendTestGenericWebhook_PutAndPatch exercises the PUT and PATCH code
+// paths to confirm they send the JSON body like POST.
+func TestSendTestGenericWebhook_PutAndPatch(t *testing.T) {
+	cases := []string{http.MethodPut, http.MethodPatch}
+	for _, method := range cases {
+		t.Run(method, func(t *testing.T) {
+			var gotMethod, gotContentType string
+			var gotBodyLen int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotContentType = r.Header.Get("Content-Type")
+				body, _ := io.ReadAll(r.Body)
+				gotBodyLen = len(body)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			if err := sendTestGenericWebhook(server.URL, method, nil, "", ""); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotMethod != method {
+				t.Errorf("method = %q, want %q", gotMethod, method)
+			}
+			if gotContentType != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", gotContentType)
+			}
+			if gotBodyLen == 0 {
+				t.Errorf("expected non-empty body for %s", method)
+			}
+		})
+	}
+}

--- a/server/src/internal/api/webhook_test_sender_test.go
+++ b/server/src/internal/api/webhook_test_sender_test.go
@@ -151,8 +151,14 @@ func TestSendTestWebhook_BadURL(t *testing.T) {
 // TestSendTestWebhook_UnreachableHost verifies that a dial failure is
 // wrapped with a descriptive error.
 func TestSendTestWebhook_UnreachableHost(t *testing.T) {
-	// Port 1 is virtually guaranteed to refuse a connection.
-	err := sendTestWebhook("http://127.0.0.1:1/", "slack")
+	// Bind a real ephemeral port and immediately release it; the resulting
+	// URL is guaranteed to refuse connections without relying on magic
+	// low-numbered ports that may behave differently across systems.
+	closedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := closedServer.URL
+	closedServer.Close()
+
+	err := sendTestWebhook(closedURL, "slack")
 	if err == nil {
 		t.Fatal("expected error for unreachable host, got nil")
 	}
@@ -395,7 +401,14 @@ func TestSendTestGenericWebhook_BadURL(t *testing.T) {
 // TestSendTestGenericWebhook_UnreachableHost verifies dial-failure error
 // wrapping for the generic webhook sender.
 func TestSendTestGenericWebhook_UnreachableHost(t *testing.T) {
-	err := sendTestGenericWebhook("http://127.0.0.1:1/", http.MethodPost, nil, "", "")
+	// Bind a real ephemeral port and immediately release it to obtain a
+	// URL guaranteed to refuse connections, without relying on magic
+	// low-numbered ports.
+	closedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := closedServer.URL
+	closedServer.Close()
+
+	err := sendTestGenericWebhook(closedURL, http.MethodPost, nil, "", "")
 	if err == nil {
 		t.Fatal("expected error for unreachable host, got nil")
 	}

--- a/server/src/internal/auth/store.go
+++ b/server/src/internal/auth/store.go
@@ -27,6 +27,8 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 	_ "modernc.org/sqlite"
+
+	"github.com/pgedge/ai-workbench/server/internal/logging"
 )
 
 const (
@@ -1227,7 +1229,7 @@ func (s *AuthStore) ValidateSessionToken(token string) (string, error) {
 	if !user.Enabled {
 		// Log the actual reason for audit purposes, but return generic error
 		// to prevent user enumeration attacks
-		log.Printf("[AUTH] Session validation failed for user %s: account is disabled", session.Username)
+		log.Printf("[AUTH] Session validation failed for user %s: account is disabled", logging.SanitizeForLog(session.Username)) //nolint:gosec // G706: username passed through logging.SanitizeForLog
 		s.sessions.Delete(tokenHash)
 		return "", fmt.Errorf("invalid session token")
 	}

--- a/server/src/internal/chat/llm.go
+++ b/server/src/internal/chat/llm.go
@@ -226,7 +226,7 @@ func BuildSystemPrompt(base string, memories []memory.Memory) string {
 		if len(runes) > maxMemoryCharsInPrompt {
 			content = string(runes[:maxMemoryCharsInPrompt]) + "..."
 		}
-		sb.WriteString(fmt.Sprintf("- [%s/%s] %s\n", scope, category, content))
+		fmt.Fprintf(&sb, "- [%s/%s] %s\n", scope, category, content)
 	}
 	sb.WriteString("</user-stored-memories>")
 	return sb.String()
@@ -263,14 +263,14 @@ func BuildUserContext(base string, info *UserInfo) string {
 	sb.WriteString("\n\n<current-user>\n")
 	sb.WriteString("The following describes the current user. Use this to personalise responses.\n\n")
 
-	sb.WriteString(fmt.Sprintf("- Username: %s\n", sanitizeMemoryField(info.Username)))
+	fmt.Fprintf(&sb, "- Username: %s\n", sanitizeMemoryField(info.Username))
 
 	if info.DisplayName != "" {
-		sb.WriteString(fmt.Sprintf("- Display name: %s\n", sanitizeMemoryField(info.DisplayName)))
+		fmt.Fprintf(&sb, "- Display name: %s\n", sanitizeMemoryField(info.DisplayName))
 	}
 
 	if info.Notes != "" {
-		sb.WriteString(fmt.Sprintf("- Notes: %s\n", sanitizeMemoryField(info.Notes)))
+		fmt.Fprintf(&sb, "- Notes: %s\n", sanitizeMemoryField(info.Notes))
 	}
 
 	if info.IsSuperuser {
@@ -284,7 +284,7 @@ func BuildUserContext(base string, info *UserInfo) string {
 		for i, g := range info.Groups {
 			sanitized[i] = sanitizeMemoryField(g)
 		}
-		sb.WriteString(fmt.Sprintf("- Groups: %s\n", strings.Join(sanitized, ", ")))
+		fmt.Fprintf(&sb, "- Groups: %s\n", strings.Join(sanitized, ", "))
 	} else {
 		sb.WriteString("- Groups: (none)\n")
 	}
@@ -294,7 +294,7 @@ func BuildUserContext(base string, info *UserInfo) string {
 		for i, p := range info.AdminPerms {
 			sanitized[i] = sanitizeMemoryField(p)
 		}
-		sb.WriteString(fmt.Sprintf("- Admin permissions: %s\n", strings.Join(sanitized, ", ")))
+		fmt.Fprintf(&sb, "- Admin permissions: %s\n", strings.Join(sanitized, ", "))
 	} else {
 		sb.WriteString("- Admin permissions: (none)\n")
 	}

--- a/server/src/internal/compactor/compactor.go
+++ b/server/src/internal/compactor/compactor.go
@@ -305,20 +305,20 @@ func (c *Compactor) messagesEqual(m1, m2 Message) bool {
 
 // createSummary creates a summary of the compacted messages.
 func (c *Compactor) createSummary(middle, kept []Message) *Summary {
-	context := c.extractContext(middle)
+	extracted := c.extractContext(middle)
 
-	topics := make([]string, 0, len(context.Topics))
-	for topic := range context.Topics {
+	topics := make([]string, 0, len(extracted.Topics))
+	for topic := range extracted.Topics {
 		topics = append(topics, topic)
 	}
 
-	tables := make([]string, 0, len(context.Tables))
-	for table := range context.Tables {
+	tables := make([]string, 0, len(extracted.Tables))
+	for table := range extracted.Tables {
 		tables = append(tables, table)
 	}
 
-	tools := make([]string, 0, len(context.Tools))
-	for tool := range context.Tools {
+	tools := make([]string, 0, len(extracted.Tools))
+	for tool := range extracted.Tools {
 		tools = append(tools, tool)
 	}
 
@@ -335,7 +335,7 @@ func (c *Compactor) createSummary(middle, kept []Message) *Summary {
 
 // extractContext extracts context information from messages.
 func (c *Compactor) extractContext(messages []Message) ExtractedContext {
-	context := ExtractedContext{
+	extracted := ExtractedContext{
 		Topics: make(map[string]bool),
 		Tables: make(map[string]bool),
 		Tools:  make(map[string]bool),
@@ -351,7 +351,7 @@ func (c *Compactor) extractContext(messages []Message) ExtractedContext {
 				tableName := strings.ToLower(match[1])
 				// Filter out SQL keywords
 				if !c.isSQLKeyword(tableName) {
-					context.Tables[tableName] = true
+					extracted.Tables[tableName] = true
 				}
 			}
 		}
@@ -359,7 +359,7 @@ func (c *Compactor) extractContext(messages []Message) ExtractedContext {
 		// Extract tool names
 		toolNames := c.classifier.extractToolNames(msg)
 		for _, tool := range toolNames {
-			context.Tools[tool] = true
+			extracted.Tools[tool] = true
 		}
 
 		// Extract topics from user messages
@@ -372,12 +372,12 @@ func (c *Compactor) extractContext(messages []Message) ExtractedContext {
 				if len(topic) > 80 {
 					topic = topic[:80] + "..."
 				}
-				context.Topics[topic] = true
+				extracted.Topics[topic] = true
 			}
 		}
 	}
 
-	return context
+	return extracted
 }
 
 // isSQLKeyword checks if a word is a SQL keyword.

--- a/server/src/internal/compactor/compactor.go
+++ b/server/src/internal/compactor/compactor.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -311,16 +312,19 @@ func (c *Compactor) createSummary(middle, kept []Message) *Summary {
 	for topic := range extracted.Topics {
 		topics = append(topics, topic)
 	}
+	sort.Strings(topics)
 
 	tables := make([]string, 0, len(extracted.Tables))
 	for table := range extracted.Tables {
 		tables = append(tables, table)
 	}
+	sort.Strings(tables)
 
 	tools := make([]string, 0, len(extracted.Tools))
 	for tool := range extracted.Tools {
 		tools = append(tools, tool)
 	}
+	sort.Strings(tools)
 
 	droppedCount := len(middle) - len(kept)
 	description := c.buildSummaryDescription(topics, tables, tools, droppedCount)

--- a/server/src/internal/compactor/compactor_test.go
+++ b/server/src/internal/compactor/compactor_test.go
@@ -11,6 +11,7 @@ package compactor
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -362,7 +363,10 @@ func TestCompactor_ExtractContextLongTopic(t *testing.T) {
 	compactor := NewCompactor(CompactRequest{})
 
 	// A very long user message should produce a topic truncated with
-	// "..." suffix to bound prompt growth.
+	// "..." suffix to bound prompt growth. The extractor keeps the
+	// first five words of the user message and, if the resulting
+	// string exceeds 80 characters, trims it to 80 characters plus a
+	// literal "..." suffix (total length 83).
 	longWords := make([]string, 0, 20)
 	for i := 0; i < 20; i++ {
 		longWords = append(longWords, "verylongwordthatmakesatopicwaytoowide")
@@ -381,9 +385,24 @@ func TestCompactor_ExtractContextLongTopic(t *testing.T) {
 		t.Fatalf("expected one topic, got %d", len(extracted.Topics))
 	}
 	for topic := range extracted.Topics {
-		// Truncation produces a short-prefixed topic ending in "...".
 		if len(topic) == 0 {
 			t.Errorf("expected non-empty topic")
+		}
+		// The extracted topic must be strictly shorter than the
+		// original input; otherwise no truncation/slicing happened.
+		if len(topic) >= len(text) {
+			t.Errorf("expected truncated topic length < input length %d, got %d",
+				len(text), len(topic))
+		}
+		// The extractor appends "..." when the joined five-word prefix
+		// exceeds 80 characters (our input satisfies that).
+		if !strings.HasSuffix(topic, "...") {
+			t.Errorf("expected topic to end with \"...\", got %q", topic)
+		}
+		// The truncated topic is bounded at 80 characters of content
+		// plus the three-character ellipsis marker.
+		if len(topic) > 83 {
+			t.Errorf("expected topic length <= 83, got %d", len(topic))
 		}
 	}
 }

--- a/server/src/internal/compactor/compactor_test.go
+++ b/server/src/internal/compactor/compactor_test.go
@@ -322,3 +322,98 @@ func TestCompactor_SingleMessage(t *testing.T) {
 		t.Error("Expected no messages to be dropped")
 	}
 }
+
+func TestCompactor_ExtractContext(t *testing.T) {
+	compactor := NewCompactor(CompactRequest{})
+
+	messages := []Message{
+		// User messages drive topic extraction. The user messages must
+		// be longer than 20 chars and have more than 2 words to produce
+		// a topic. References to "<word> table" populate the tables
+		// map; SQL keywords like "from table" are filtered out. Tool
+		// names come from tool_use blocks.
+		createMessage("user",
+			"Please analyze the orders table and the users table for me"),
+		createMessage("user", "Also look at select from table please now"),
+		createToolMessage("assistant", "query_database", "SELECT 1"),
+		createMessage("user", "hi"), // too short, not a topic
+	}
+
+	extracted := compactor.extractContext(messages)
+
+	if !extracted.Tables["orders"] {
+		t.Errorf("expected 'orders' in Tables, got %v", extracted.Tables)
+	}
+	if !extracted.Tables["users"] {
+		t.Errorf("expected 'users' in Tables, got %v", extracted.Tables)
+	}
+	if extracted.Tables["select"] || extracted.Tables["from"] {
+		t.Errorf("SQL keywords should be filtered, got %v", extracted.Tables)
+	}
+	if !extracted.Tools["query_database"] {
+		t.Errorf("expected 'query_database' in Tools, got %v", extracted.Tools)
+	}
+	if len(extracted.Topics) == 0 {
+		t.Errorf("expected at least one topic, got %v", extracted.Topics)
+	}
+}
+
+func TestCompactor_ExtractContextLongTopic(t *testing.T) {
+	compactor := NewCompactor(CompactRequest{})
+
+	// A very long user message should produce a topic truncated with
+	// "..." suffix to bound prompt growth.
+	longWords := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		longWords = append(longWords, "verylongwordthatmakesatopicwaytoowide")
+	}
+	text := ""
+	for _, w := range longWords {
+		if text != "" {
+			text += " "
+		}
+		text += w
+	}
+	messages := []Message{createMessage("user", text)}
+
+	extracted := compactor.extractContext(messages)
+	if len(extracted.Topics) != 1 {
+		t.Fatalf("expected one topic, got %d", len(extracted.Topics))
+	}
+	for topic := range extracted.Topics {
+		// Truncation produces a short-prefixed topic ending in "...".
+		if len(topic) == 0 {
+			t.Errorf("expected non-empty topic")
+		}
+	}
+}
+
+func TestCompactor_CreateSummary(t *testing.T) {
+	compactor := NewCompactor(CompactRequest{})
+
+	middle := []Message{
+		createMessage("user",
+			"Please analyze the orders table for performance tuning"),
+		createToolMessage("assistant", "query_database", "SELECT 1"),
+	}
+	kept := []Message{middle[0]} // one dropped
+
+	summary := compactor.createSummary(middle, kept)
+
+	if summary == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	found := false
+	for _, table := range summary.Tables {
+		if table == "orders" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'orders' in summary Tables, got %v", summary.Tables)
+	}
+	if summary.Description == "" {
+		t.Errorf("expected non-empty description")
+	}
+}

--- a/server/src/internal/config/headers.go
+++ b/server/src/internal/config/headers.go
@@ -14,6 +14,8 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+
+	"github.com/pgedge/ai-workbench/server/internal/logging"
 )
 
 // parseHeadersEnvVar parses a comma-separated list of KEY=VALUE pairs.
@@ -33,7 +35,7 @@ func parseHeadersEnvVar(envVal string) (map[string]string, error) {
 		}
 		idx := strings.Index(pair, "=")
 		if idx == -1 {
-			slog.Warn("skipping malformed header entry", "entry", pair)
+			slog.Warn("skipping malformed header entry", "entry", logging.SanitizeForLog(pair)) //nolint:gosec // G706: entry passed through logging.SanitizeForLog
 			continue
 		}
 		key := strings.TrimSpace(pair[:idx])

--- a/server/src/internal/llmproxy/proxy.go
+++ b/server/src/internal/llmproxy/proxy.go
@@ -107,7 +107,7 @@ type ChatResponse struct {
 }
 
 // HandleProviders handles GET /api/v1/llm/providers
-func HandleProviders(w http.ResponseWriter, r *http.Request, config *Config) {
+func HandleProviders(w http.ResponseWriter, r *http.Request, cfg *Config) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -116,41 +116,41 @@ func HandleProviders(w http.ResponseWriter, r *http.Request, config *Config) {
 	providers := []ProviderInfo{}
 
 	// Check which providers are configured
-	if config.AnthropicAPIKey != "" {
+	if cfg.AnthropicAPIKey != "" {
 		providers = append(providers, ProviderInfo{
 			Name:      "anthropic",
 			Display:   "Anthropic Claude",
-			IsDefault: config.Provider == "anthropic",
+			IsDefault: cfg.Provider == "anthropic",
 		})
 	}
 
-	if config.OpenAIAPIKey != "" || config.OpenAIBaseURL != "" {
+	if cfg.OpenAIAPIKey != "" || cfg.OpenAIBaseURL != "" {
 		providers = append(providers, ProviderInfo{
 			Name:      "openai",
 			Display:   "OpenAI",
-			IsDefault: config.Provider == "openai",
+			IsDefault: cfg.Provider == "openai",
 		})
 	}
 
-	if config.GeminiAPIKey != "" {
+	if cfg.GeminiAPIKey != "" {
 		providers = append(providers, ProviderInfo{
 			Name:      "gemini",
 			Display:   "Google Gemini",
-			IsDefault: config.Provider == "gemini",
+			IsDefault: cfg.Provider == "gemini",
 		})
 	}
 
-	if config.OllamaURL != "" {
+	if cfg.OllamaURL != "" {
 		providers = append(providers, ProviderInfo{
 			Name:      "ollama",
 			Display:   "Ollama",
-			IsDefault: config.Provider == "ollama",
+			IsDefault: cfg.Provider == "ollama",
 		})
 	}
 
 	response := ProvidersResponse{
 		Providers:    providers,
-		DefaultModel: config.Model,
+		DefaultModel: cfg.Model,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -170,7 +170,7 @@ var validProviders = map[string]bool{
 }
 
 // HandleModels handles GET /api/v1/llm/models?provider=<provider>
-func HandleModels(w http.ResponseWriter, r *http.Request, config *Config) {
+func HandleModels(w http.ResponseWriter, r *http.Request, cfg *Config) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -192,53 +192,53 @@ func HandleModels(w http.ResponseWriter, r *http.Request, config *Config) {
 	var client chat.LLMClient
 	switch provider {
 	case "anthropic":
-		if config.AnthropicAPIKey == "" {
+		if cfg.AnthropicAPIKey == "" {
 			http.Error(w, "Anthropic API key not configured", http.StatusBadRequest)
 			return
 		}
-		headers, err := getProviderHeaders(config.LLMConfig, "anthropic")
+		headers, err := getProviderHeaders(cfg.LLMConfig, "anthropic")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to get Anthropic provider headers: %v\n", err)
 			http.Error(w, "Failed to load provider headers", http.StatusInternalServerError)
 			return
 		}
-		client = chat.NewAnthropicClient(config.AnthropicAPIKey, config.Model, config.MaxTokens, config.Temperature, false, config.AnthropicBaseURL, config.UseCompactDescriptions, headers)
+		client = chat.NewAnthropicClient(cfg.AnthropicAPIKey, cfg.Model, cfg.MaxTokens, cfg.Temperature, false, cfg.AnthropicBaseURL, cfg.UseCompactDescriptions, headers)
 	case "openai":
-		if config.OpenAIAPIKey == "" && config.OpenAIBaseURL == "" {
+		if cfg.OpenAIAPIKey == "" && cfg.OpenAIBaseURL == "" {
 			http.Error(w, "OpenAI API key not configured", http.StatusBadRequest)
 			return
 		}
-		headers, err := getProviderHeaders(config.LLMConfig, "openai")
+		headers, err := getProviderHeaders(cfg.LLMConfig, "openai")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to get OpenAI provider headers: %v\n", err)
 			http.Error(w, "Failed to load provider headers", http.StatusInternalServerError)
 			return
 		}
-		client = chat.NewOpenAIClient(config.OpenAIAPIKey, config.Model, config.MaxTokens, config.Temperature, false, config.OpenAIBaseURL, config.UseCompactDescriptions, headers)
+		client = chat.NewOpenAIClient(cfg.OpenAIAPIKey, cfg.Model, cfg.MaxTokens, cfg.Temperature, false, cfg.OpenAIBaseURL, cfg.UseCompactDescriptions, headers)
 	case "gemini":
-		if config.GeminiAPIKey == "" {
+		if cfg.GeminiAPIKey == "" {
 			http.Error(w, "Gemini API key not configured", http.StatusBadRequest)
 			return
 		}
-		headers, err := getProviderHeaders(config.LLMConfig, "gemini")
+		headers, err := getProviderHeaders(cfg.LLMConfig, "gemini")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to get Gemini provider headers: %v\n", err)
 			http.Error(w, "Failed to load provider headers", http.StatusInternalServerError)
 			return
 		}
-		client = chat.NewGeminiClient(config.GeminiAPIKey, config.Model, config.MaxTokens, config.Temperature, false, config.GeminiBaseURL, config.UseCompactDescriptions, headers)
+		client = chat.NewGeminiClient(cfg.GeminiAPIKey, cfg.Model, cfg.MaxTokens, cfg.Temperature, false, cfg.GeminiBaseURL, cfg.UseCompactDescriptions, headers)
 	case "ollama":
-		if config.OllamaURL == "" {
+		if cfg.OllamaURL == "" {
 			http.Error(w, "Ollama URL not configured", http.StatusBadRequest)
 			return
 		}
-		headers, err := getProviderHeaders(config.LLMConfig, "ollama")
+		headers, err := getProviderHeaders(cfg.LLMConfig, "ollama")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to get Ollama provider headers: %v\n", err)
 			http.Error(w, "Failed to load provider headers", http.StatusInternalServerError)
 			return
 		}
-		client = chat.NewOllamaClient(config.OllamaURL, config.Model, false, config.UseCompactDescriptions, headers)
+		client = chat.NewOllamaClient(cfg.OllamaURL, cfg.Model, false, cfg.UseCompactDescriptions, headers)
 	}
 
 	// List models
@@ -269,7 +269,7 @@ func HandleModels(w http.ResponseWriter, r *http.Request, config *Config) {
 }
 
 // HandleChat handles POST /api/v1/llm/chat
-func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
+func HandleChat(w http.ResponseWriter, r *http.Request, cfg *Config) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -316,7 +316,7 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 	// Use provided provider/model or defaults
 	provider := req.Provider
 	if provider == "" {
-		provider = config.Provider
+		provider = cfg.Provider
 	}
 
 	// Validate provider against allowlist before use
@@ -327,7 +327,7 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 
 	model := req.Model
 	if model == "" {
-		model = config.Model
+		model = cfg.Model
 	}
 
 	// Validate model name: allow only safe characters, max 256 chars
@@ -340,53 +340,53 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 	var client chat.LLMClient
 	switch provider {
 	case "anthropic":
-		if config.AnthropicAPIKey == "" {
+		if cfg.AnthropicAPIKey == "" {
 			http.Error(w, "Anthropic API key not configured", http.StatusBadRequest)
 			return
 		}
-		headers, err := getProviderHeaders(config.LLMConfig, "anthropic")
+		headers, err := getProviderHeaders(cfg.LLMConfig, "anthropic")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to get Anthropic provider headers: %v\n", err)
 			http.Error(w, "Failed to load provider headers", http.StatusInternalServerError)
 			return
 		}
-		client = chat.NewAnthropicClient(config.AnthropicAPIKey, model, config.MaxTokens, config.Temperature, req.Debug, config.AnthropicBaseURL, config.UseCompactDescriptions, headers)
+		client = chat.NewAnthropicClient(cfg.AnthropicAPIKey, model, cfg.MaxTokens, cfg.Temperature, req.Debug, cfg.AnthropicBaseURL, cfg.UseCompactDescriptions, headers)
 	case "openai":
-		if config.OpenAIAPIKey == "" && config.OpenAIBaseURL == "" {
+		if cfg.OpenAIAPIKey == "" && cfg.OpenAIBaseURL == "" {
 			http.Error(w, "OpenAI API key not configured", http.StatusBadRequest)
 			return
 		}
-		headers, err := getProviderHeaders(config.LLMConfig, "openai")
+		headers, err := getProviderHeaders(cfg.LLMConfig, "openai")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to get OpenAI provider headers: %v\n", err)
 			http.Error(w, "Failed to load provider headers", http.StatusInternalServerError)
 			return
 		}
-		client = chat.NewOpenAIClient(config.OpenAIAPIKey, model, config.MaxTokens, config.Temperature, req.Debug, config.OpenAIBaseURL, config.UseCompactDescriptions, headers)
+		client = chat.NewOpenAIClient(cfg.OpenAIAPIKey, model, cfg.MaxTokens, cfg.Temperature, req.Debug, cfg.OpenAIBaseURL, cfg.UseCompactDescriptions, headers)
 	case "gemini":
-		if config.GeminiAPIKey == "" {
+		if cfg.GeminiAPIKey == "" {
 			http.Error(w, "Gemini API key not configured", http.StatusBadRequest)
 			return
 		}
-		headers, err := getProviderHeaders(config.LLMConfig, "gemini")
+		headers, err := getProviderHeaders(cfg.LLMConfig, "gemini")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to get Gemini provider headers: %v\n", err)
 			http.Error(w, "Failed to load provider headers", http.StatusInternalServerError)
 			return
 		}
-		client = chat.NewGeminiClient(config.GeminiAPIKey, model, config.MaxTokens, config.Temperature, req.Debug, config.GeminiBaseURL, config.UseCompactDescriptions, headers)
+		client = chat.NewGeminiClient(cfg.GeminiAPIKey, model, cfg.MaxTokens, cfg.Temperature, req.Debug, cfg.GeminiBaseURL, cfg.UseCompactDescriptions, headers)
 	case "ollama":
-		if config.OllamaURL == "" {
+		if cfg.OllamaURL == "" {
 			http.Error(w, "Ollama URL not configured", http.StatusBadRequest)
 			return
 		}
-		headers, err := getProviderHeaders(config.LLMConfig, "ollama")
+		headers, err := getProviderHeaders(cfg.LLMConfig, "ollama")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to get Ollama provider headers: %v\n", err)
 			http.Error(w, "Failed to load provider headers", http.StatusInternalServerError)
 			return
 		}
-		client = chat.NewOllamaClient(config.OllamaURL, model, req.Debug, config.UseCompactDescriptions, headers)
+		client = chat.NewOllamaClient(cfg.OllamaURL, model, req.Debug, cfg.UseCompactDescriptions, headers)
 	}
 
 	// Convert proxy messages to chat messages
@@ -403,9 +403,9 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 	// The tools arrive from the web client without CompactDescription
 	// populated, so we swap the full description for the compact one
 	// before sending tools to the LLM.
-	if config.UseCompactDescriptions && len(config.CompactDescriptions) > 0 {
+	if cfg.UseCompactDescriptions && len(cfg.CompactDescriptions) > 0 {
 		for i := range req.Tools {
-			if compact, ok := config.CompactDescriptions[req.Tools[i].Name]; ok {
+			if compact, ok := cfg.CompactDescriptions[req.Tools[i].Name]; ok {
 				req.Tools[i].Description = compact
 			}
 		}
@@ -414,10 +414,10 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 	// Inject pinned memories into the system prompt when available.
 	// This ensures the LLM always has access to important stored context.
 	effectiveSystemPrompt := req.System
-	if config.MemoryStore != nil {
+	if cfg.MemoryStore != nil {
 		username := auth.GetUsernameFromContext(ctx)
 		if username != "" {
-			pinnedMemories, memErr := config.MemoryStore.GetPinned(ctx, username)
+			pinnedMemories, memErr := cfg.MemoryStore.GetPinned(ctx, username)
 			if memErr != nil {
 				fmt.Fprintf(os.Stderr, "WARNING: Failed to fetch pinned memories: %v\n", memErr)
 			} else if len(pinnedMemories) > 0 {
@@ -432,11 +432,11 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 
 	// Inject user context into the system prompt when available.
 	// This gives the LLM awareness of who it is talking to.
-	if config.AuthStore != nil {
+	if cfg.AuthStore != nil {
 		userID := auth.GetUserIDFromContext(ctx)
 		username := auth.GetUsernameFromContext(ctx)
 		if userID > 0 && username != "" {
-			userInfo := buildUserInfo(config.AuthStore, userID, username)
+			userInfo := buildUserInfo(cfg.AuthStore, userID, username)
 			if userInfo != nil {
 				base := effectiveSystemPrompt
 				if base == "" {
@@ -529,10 +529,10 @@ func isValidModelName(model string) bool {
 		return false
 	}
 	for _, c := range model {
-		if !((c >= 'a' && c <= 'z') ||
-			(c >= 'A' && c <= 'Z') ||
-			(c >= '0' && c <= '9') ||
-			c == '-' || c == '.' || c == ':' || c == '/' || c == '_') {
+		if (c < 'a' || c > 'z') &&
+			(c < 'A' || c > 'Z') &&
+			(c < '0' || c > '9') &&
+			c != '-' && c != '.' && c != ':' && c != '/' && c != '_' {
 			return false
 		}
 	}

--- a/server/src/internal/llmproxy/proxy_test.go
+++ b/server/src/internal/llmproxy/proxy_test.go
@@ -724,6 +724,7 @@ func TestIsValidModelName(t *testing.T) {
 		{"newline rejected", "bad\nmodel", false},
 		{"hash rejected", "model#1", false},
 		{"paren rejected", "model(1)", false},
+		{"non-ascii rejected", "gpt-4✅", false},
 	}
 
 	for _, tt := range tests {

--- a/server/src/internal/llmproxy/proxy_test.go
+++ b/server/src/internal/llmproxy/proxy_test.go
@@ -703,6 +703,13 @@ func TestIsValidModelName(t *testing.T) {
 	for i := range tooLong {
 		tooLong[i] = 'a'
 	}
+	// Build a 256-character string of all 'a' to exercise the inclusive
+	// upper bound (validator rejects only strings strictly longer than
+	// 256).
+	maxLen := make([]byte, 256)
+	for i := range maxLen {
+		maxLen[i] = 'a'
+	}
 
 	tests := []struct {
 		name  string
@@ -711,6 +718,7 @@ func TestIsValidModelName(t *testing.T) {
 	}{
 		{"empty", "", false},
 		{"too long", string(tooLong), false},
+		{"max length accepted", string(maxLen), true},
 		{"simple lowercase", "gpt-4", true},
 		{"simple uppercase", "GPT-4", true},
 		{"with digits", "claude-3-5-sonnet", true},
@@ -725,6 +733,7 @@ func TestIsValidModelName(t *testing.T) {
 		{"hash rejected", "model#1", false},
 		{"paren rejected", "model(1)", false},
 		{"non-ascii rejected", "gpt-4✅", false},
+		{"whitespace-only rejected", "   ", false},
 	}
 
 	for _, tt := range tests {

--- a/server/src/internal/llmproxy/proxy_test.go
+++ b/server/src/internal/llmproxy/proxy_test.go
@@ -697,6 +697,45 @@ func TestChatResponseStruct(t *testing.T) {
 	}
 }
 
+func TestIsValidModelName(t *testing.T) {
+	// Build a 257-character string of all 'a' to exceed the 256 limit.
+	tooLong := make([]byte, 257)
+	for i := range tooLong {
+		tooLong[i] = 'a'
+	}
+
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"too long", string(tooLong), false},
+		{"simple lowercase", "gpt-4", true},
+		{"simple uppercase", "GPT-4", true},
+		{"with digits", "claude-3-5-sonnet", true},
+		{"with dot", "gpt-4.1", true},
+		{"with colon", "llama3:70b", true},
+		{"with slash", "meta/llama-3", true},
+		{"with underscore", "custom_model", true},
+		{"all allowed", "abc-123.456:foo/bar_baz", true},
+		{"space rejected", "bad model", false},
+		{"tab rejected", "bad\tmodel", false},
+		{"newline rejected", "bad\nmodel", false},
+		{"hash rejected", "model#1", false},
+		{"paren rejected", "model(1)", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidModelName(tt.model); got != tt.want {
+				t.Errorf("isValidModelName(%q) = %v, want %v",
+					tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestModelsResponseStruct(t *testing.T) {
 	resp := ModelsResponse{
 		Models: []ModelInfo{

--- a/server/src/internal/logging/logging.go
+++ b/server/src/internal/logging/logging.go
@@ -13,9 +13,36 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 )
+
+// logSanitizer replaces control characters that could be used for log
+// injection (fake log entries, terminal escape sequences) with their
+// escaped visual representation. Backspace, vertical tab, form feed,
+// and DEL are included because they can forge log entries in terminal
+// output or confuse less-strict log parsers.
+var logSanitizer = strings.NewReplacer(
+	"\r", "\\r",
+	"\n", "\\n",
+	"\t", "\\t",
+	"\x00", "\\x00",
+	"\x08", "\\x08",
+	"\x0b", "\\x0b",
+	"\x0c", "\\x0c",
+	"\x1b", "\\x1b",
+	"\x7f", "\\x7f",
+)
+
+// SanitizeForLog escapes control characters in s so that user-controlled
+// values logged to a line-oriented log stream cannot forge new log
+// entries or inject terminal escape sequences. Use this on any value
+// derived from HTTP input, environment variables, or other untrusted
+// sources before embedding it in a log message.
+func SanitizeForLog(s string) string {
+	return logSanitizer.Replace(s)
+}
 
 // LogLevel represents the severity of a log message
 type LogLevel int32

--- a/server/src/internal/logging/logging_test.go
+++ b/server/src/internal/logging/logging_test.go
@@ -26,6 +26,7 @@ func TestLogLevels(t *testing.T) {
 		{LevelInfo, "INFO"},
 		{LevelWarn, "WARN"},
 		{LevelError, "ERROR"},
+		{LogLevel(42), "UNKNOWN"},
 	}
 
 	for _, tt := range tests {
@@ -237,6 +238,51 @@ func TestLogWithMultipleKeyValuePairs(t *testing.T) {
 		if entry.Fields[key] != expectedValue {
 			t.Errorf("Fields[%s] = %v, want %v", key, entry.Fields[key], expectedValue)
 		}
+	}
+}
+
+func TestSanitizeForLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"plain ascii", "hello world", "hello world"},
+		{"single CR", "foo\rbar", "foo\\rbar"},
+		{"single LF", "foo\nbar", "foo\\nbar"},
+		{"CRLF", "foo\r\nbar", "foo\\r\\nbar"},
+		{"tab", "foo\tbar", "foo\\tbar"},
+		{"null byte", "foo\x00bar", "foo\\x00bar"},
+		{"backspace", "foo\x08bar", "foo\\x08bar"},
+		{"vertical tab", "foo\x0bbar", "foo\\x0bbar"},
+		{"form feed", "foo\x0cbar", "foo\\x0cbar"},
+		{"escape byte", "foo\x1bbar", "foo\\x1bbar"},
+		{"DEL byte", "foo\x7fbar", "foo\\x7fbar"},
+		{
+			name:     "log injection attempt",
+			input:    "user\n[AUTH] fake admin login",
+			expected: "user\\n[AUTH] fake admin login",
+		},
+		{
+			name:     "terminal escape injection",
+			input:    "alert \x1b[31mRED\x1b[0m",
+			expected: "alert \\x1b[31mRED\\x1b[0m",
+		},
+		{
+			name:     "unicode preserved",
+			input:    "useré",
+			expected: "useré",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeForLog(tt.input)
+			if got != tt.expected {
+				t.Errorf("SanitizeForLog(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
 	}
 }
 

--- a/server/src/internal/mcp/http_server.go
+++ b/server/src/internal/mcp/http_server.go
@@ -534,7 +534,7 @@ func validateCORSOrigin(origin string, authEnabled bool) error {
 					"with Access-Control-Allow-Credentials: true (per the "+
 					"Fetch spec). Set cors_origin to an explicit origin "+
 					"(e.g., https://dba.example.com) or leave it empty for "+
-					"same-origin deployments.",
+					"same-origin deployments",
 				origin)
 		}
 		return nil

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -165,12 +165,12 @@ func IsValidIdentifier(s string) bool {
 	}
 	for i, c := range s {
 		if i == 0 {
-			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') {
+			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && c != '_' {
 				return false
 			}
 		} else {
-			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-				(c >= '0' && c <= '9') || c == '_') {
+			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') &&
+				(c < '0' || c > '9') && c != '_' {
 				return false
 			}
 		}

--- a/server/src/internal/search/chunking.go
+++ b/server/src/internal/search/chunking.go
@@ -169,15 +169,15 @@ func FormatChunksForOutput(chunks []ScoredChunk, queryText string) string {
 
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Search Results for: %q\n", queryText))
+	fmt.Fprintf(&sb, "Search Results for: %q\n", queryText)
 	sb.WriteString(strings.Repeat("=", 80))
 	sb.WriteString("\n\n")
 
 	totalTokens := 0
 	for i, chunk := range chunks {
-		sb.WriteString(fmt.Sprintf("--- Result %d ---\n", i+1))
-		sb.WriteString(fmt.Sprintf("Source: %s (row rank: %d)\n", chunk.SourceColumn, chunk.OriginalRank+1))
-		sb.WriteString(fmt.Sprintf("Relevance Score: %.3f\n\n", chunk.Score))
+		fmt.Fprintf(&sb, "--- Result %d ---\n", i+1)
+		fmt.Fprintf(&sb, "Source: %s (row rank: %d)\n", chunk.SourceColumn, chunk.OriginalRank+1)
+		fmt.Fprintf(&sb, "Relevance Score: %.3f\n\n", chunk.Score)
 		sb.WriteString(chunk.Text)
 		sb.WriteString("\n\n")
 
@@ -185,7 +185,7 @@ func FormatChunksForOutput(chunks []ScoredChunk, queryText string) string {
 	}
 
 	sb.WriteString(strings.Repeat("=", 80))
-	sb.WriteString(fmt.Sprintf("\nTotal Results: %d chunks (~%d tokens)\n", len(chunks), totalTokens))
+	fmt.Fprintf(&sb, "\nTotal Results: %d chunks (~%d tokens)\n", len(chunks), totalTokens)
 
 	return sb.String()
 }

--- a/server/src/internal/tools/count_rows.go
+++ b/server/src/internal/tools/count_rows.go
@@ -175,9 +175,9 @@ Use count_rows to efficiently determine data volume:
 
 			// Build response
 			var sb strings.Builder
-			sb.WriteString(fmt.Sprintf("Database: %s\n\n", database.SanitizeConnStr(connStr)))
-			sb.WriteString(fmt.Sprintf("SQL Query:\n%s\n\n", sqlQuery))
-			sb.WriteString(fmt.Sprintf("Count: %d", count))
+			fmt.Fprintf(&sb, "Database: %s\n\n", database.SanitizeConnStr(connStr))
+			fmt.Fprintf(&sb, "SQL Query:\n%s\n\n", sqlQuery)
+			fmt.Fprintf(&sb, "Count: %d", count)
 
 			return mcp.NewToolSuccess(sb.String())
 		},

--- a/server/src/internal/tools/describe_probe.go
+++ b/server/src/internal/tools/describe_probe.go
@@ -151,11 +151,11 @@ Returns TSV with:
 
 			// Format as TSV
 			var sb strings.Builder
-			sb.WriteString(fmt.Sprintf("Probe: %s\n", probeName))
+			fmt.Fprintf(&sb, "Probe: %s\n", probeName)
 			if tableDesc != "" {
-				sb.WriteString(fmt.Sprintf("Description: %s\n", tableDesc))
+				fmt.Fprintf(&sb, "Description: %s\n", tableDesc)
 			}
-			sb.WriteString(fmt.Sprintf("Columns: %d\n\n", len(columns)))
+			fmt.Fprintf(&sb, "Columns: %d\n\n", len(columns))
 
 			sb.WriteString("column_name\tdata_type\tdescription\tcolumn_type\n")
 			for _, col := range columns {
@@ -165,8 +165,8 @@ Returns TSV with:
 				}
 				// Clean up description (remove newlines)
 				desc := strings.ReplaceAll(col.Description, "\n", " ")
-				sb.WriteString(fmt.Sprintf("%s\t%s\t%s\t%s\n",
-					col.Name, col.DataType, desc, colType))
+				fmt.Fprintf(&sb, "%s\t%s\t%s\t%s\n",
+					col.Name, col.DataType, desc, colType)
 			}
 
 			return mcp.NewToolSuccess(sb.String())

--- a/server/src/internal/tools/describe_probe.go
+++ b/server/src/internal/tools/describe_probe.go
@@ -163,10 +163,11 @@ Returns TSV with:
 				if col.IsMetric {
 					colType = "metric"
 				}
-				// Clean up description (remove newlines)
-				desc := strings.ReplaceAll(col.Description, "\n", " ")
 				fmt.Fprintf(&sb, "%s\t%s\t%s\t%s\n",
-					col.Name, col.DataType, desc, colType)
+					sanitizeTSVField(col.Name),
+					sanitizeTSVField(col.DataType),
+					sanitizeTSVField(col.Description),
+					colType)
 			}
 
 			return mcp.NewToolSuccess(sb.String())

--- a/server/src/internal/tools/execute_explain.go
+++ b/server/src/internal/tools/execute_explain.go
@@ -234,8 +234,8 @@ READ ONLY transaction to prevent side effects. However, be cautious with:
 			// Format the output
 			var result strings.Builder
 			sanitizedConn := database.SanitizeConnStr(connStr)
-			result.WriteString(fmt.Sprintf("Database: %s\n\n", sanitizedConn))
-			result.WriteString(fmt.Sprintf("Query:\n%s\n\n", query))
+			fmt.Fprintf(&result, "Database: %s\n\n", sanitizedConn)
+			fmt.Fprintf(&result, "Query:\n%s\n\n", query)
 			result.WriteString("Execution Plan:\n")
 			result.WriteString(strings.Repeat("=", 80))
 			result.WriteString("\n")
@@ -346,7 +346,7 @@ func analyzeExplainOutput(explainText string) string {
 	if len(issues) > 0 {
 		analysis.WriteString("<issues>\n")
 		for _, issue := range issues {
-			analysis.WriteString(fmt.Sprintf("%s\n", issue))
+			fmt.Fprintf(&analysis, "%s\n", issue)
 		}
 		analysis.WriteString("</issues>\n\n")
 	}
@@ -354,7 +354,7 @@ func analyzeExplainOutput(explainText string) string {
 	if len(recommendations) > 0 {
 		analysis.WriteString("<recommendations>\n")
 		for i, rec := range recommendations {
-			analysis.WriteString(fmt.Sprintf("%d. %s\n", i+1, rec))
+			fmt.Fprintf(&analysis, "%d. %s\n", i+1, rec)
 		}
 		analysis.WriteString("</recommendations>\n")
 	}

--- a/server/src/internal/tools/generate_embedding.go
+++ b/server/src/internal/tools/generate_embedding.go
@@ -97,12 +97,12 @@ func GenerateEmbeddingTool(cfg *config.Config) Tool {
 			sb.WriteString("Embedding Generated Successfully\n")
 			sb.WriteString(strings.Repeat("=", 50))
 			sb.WriteString("\n\n")
-			sb.WriteString(fmt.Sprintf("Provider: %s\n", provider.ProviderName()))
-			sb.WriteString(fmt.Sprintf("Model: %s\n", provider.ModelName()))
-			sb.WriteString(fmt.Sprintf("Dimensions: %d\n", provider.Dimensions()))
-			sb.WriteString(fmt.Sprintf("Text Length: %d characters\n", len(text)))
-			sb.WriteString(fmt.Sprintf("\nText:\n%s\n\n", text))
-			sb.WriteString(fmt.Sprintf("Embedding Vector (%d dimensions):\n%s", len(vector), string(vectorJSON)))
+			fmt.Fprintf(&sb, "Provider: %s\n", provider.ProviderName())
+			fmt.Fprintf(&sb, "Model: %s\n", provider.ModelName())
+			fmt.Fprintf(&sb, "Dimensions: %d\n", provider.Dimensions())
+			fmt.Fprintf(&sb, "Text Length: %d characters\n", len(text))
+			fmt.Fprintf(&sb, "\nText:\n%s\n\n", text)
+			fmt.Fprintf(&sb, "Embedding Vector (%d dimensions):\n%s", len(vector), string(vectorJSON))
 
 			return mcp.NewToolSuccess(sb.String())
 		},

--- a/server/src/internal/tools/get_alert_history.go
+++ b/server/src/internal/tools/get_alert_history.go
@@ -343,8 +343,8 @@ func alertHistorySingleConnection(
 	if timeStart != nil {
 		timeInfo = "since " + timeStart.Format(time.RFC3339)
 	}
-	sb.WriteString(fmt.Sprintf("Alerts | Connection: %d (%s) | Status: %s | Time: %s | Limit: %d\n\n",
-		connectionID, connName, statusFilter, timeInfo, limit))
+	fmt.Fprintf(&sb, "Alerts | Connection: %d (%s) | Status: %s | Time: %s | Limit: %d\n\n",
+		connectionID, connName, statusFilter, timeInfo, limit)
 
 	// Header
 	sb.WriteString("id\ttriggered_at\tseverity\ttitle\tmetric_value\tthreshold_value\tstatus\tcleared_at\tfalse_positive\tacknowledged_by\tnotes\n")
@@ -376,7 +376,7 @@ func alertHistorySingleConnection(
 		}
 
 		// Format row
-		sb.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(&sb, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			id,
 			triggeredAt.Format(time.RFC3339),
 			severity,
@@ -387,8 +387,7 @@ func alertHistorySingleConnection(
 			formatOptionalTime(clearedAt),
 			formatOptionalBool(falsePositive),
 			formatOptionalString(acknowledgedBy),
-			formatOptionalStringEscaped(ackMessage),
-		))
+			formatOptionalStringEscaped(ackMessage))
 		rowCount++
 	}
 
@@ -403,7 +402,7 @@ func alertHistorySingleConnection(
 		return mcp.NewToolSuccess(fmt.Sprintf("No alerts found for connection %d (%s) with status='%s' in the specified time range.", connectionID, connName, statusFilter))
 	}
 
-	sb.WriteString(fmt.Sprintf("\n(%d rows)\n", rowCount))
+	fmt.Fprintf(&sb, "\n(%d rows)\n", rowCount)
 
 	return mcp.NewToolSuccess(sb.String())
 }
@@ -466,8 +465,8 @@ func alertHistoryAllConnections(
 	if timeStart != nil {
 		timeInfo = "since " + timeStart.Format(time.RFC3339)
 	}
-	sb.WriteString(fmt.Sprintf("Alerts | All accessible connections | Status: %s | Time: %s | Limit: %d\n\n",
-		statusFilter, timeInfo, limit))
+	fmt.Fprintf(&sb, "Alerts | All accessible connections | Status: %s | Time: %s | Limit: %d\n\n",
+		statusFilter, timeInfo, limit)
 
 	// Header - includes connection_id and connection_name columns
 	sb.WriteString("connection_id\tconnection_name\tid\ttriggered_at\tseverity\ttitle\tmetric_value\tthreshold_value\tstatus\tcleared_at\tfalse_positive\tacknowledged_by\tnotes\n")
@@ -500,7 +499,7 @@ func alertHistoryAllConnections(
 			return mcp.NewToolError(fmt.Sprintf("Failed to scan row: %v", err))
 		}
 
-		sb.WriteString(fmt.Sprintf("%d\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(&sb, "%d\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			connID,
 			tsv.FormatValue(connNameVal),
 			id,
@@ -513,8 +512,7 @@ func alertHistoryAllConnections(
 			formatOptionalTime(clearedAt),
 			formatOptionalBool(falsePositive),
 			formatOptionalString(acknowledgedBy),
-			formatOptionalStringEscaped(ackMessage),
-		))
+			formatOptionalStringEscaped(ackMessage))
 		rowCount++
 	}
 
@@ -529,7 +527,7 @@ func alertHistoryAllConnections(
 		return mcp.NewToolSuccess(fmt.Sprintf("No alerts found across accessible connections with status='%s' in the specified time range.", statusFilter))
 	}
 
-	sb.WriteString(fmt.Sprintf("\n(%d rows)\n", rowCount))
+	fmt.Fprintf(&sb, "\n(%d rows)\n", rowCount)
 
 	return mcp.NewToolSuccess(sb.String())
 }

--- a/server/src/internal/tools/get_alert_rules.go
+++ b/server/src/internal/tools/get_alert_rules.go
@@ -187,8 +187,8 @@ Returns TSV data with:
 			if category != nil {
 				catInfo = fmt.Sprintf("category: %s", *category)
 			}
-			sb.WriteString(fmt.Sprintf("Alert Rules | %s | %s | enabled_only: %t\n\n",
-				connInfo, catInfo, enabledOnly))
+			fmt.Fprintf(&sb, "Alert Rules | %s | %s | enabled_only: %t\n\n",
+				connInfo, catInfo, enabledOnly)
 
 			// Header
 			sb.WriteString("rule_id\tname\tcategory\tmetric_name\toperator\tthreshold\tseverity\tenabled\tdescription\n")
@@ -214,7 +214,7 @@ Returns TSV data with:
 				}
 
 				// Format row
-				sb.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%v\t%s\t%t\t%s\n",
+				fmt.Fprintf(&sb, "%d\t%s\t%s\t%s\t%s\t%v\t%s\t%t\t%s\n",
 					id,
 					tsv.FormatValue(name),
 					cat,
@@ -223,8 +223,7 @@ Returns TSV data with:
 					threshold,
 					severity,
 					enabled,
-					tsv.FormatValue(description),
-				))
+					tsv.FormatValue(description))
 				rowCount++
 			}
 
@@ -236,7 +235,7 @@ Returns TSV data with:
 				return mcp.NewToolSuccess("No alert rules found matching the specified criteria.")
 			}
 
-			sb.WriteString(fmt.Sprintf("\n(%d rules)\n", rowCount))
+			fmt.Fprintf(&sb, "\n(%d rules)\n", rowCount)
 
 			return mcp.NewToolSuccess(sb.String())
 		},

--- a/server/src/internal/tools/get_blackouts.go
+++ b/server/src/internal/tools/get_blackouts.go
@@ -273,8 +273,8 @@ func blackoutsSingleConnection(
 	if activeOnly {
 		activeLabel = "active only"
 	}
-	sb.WriteString(fmt.Sprintf("Blackouts | Connection: %d (%s) | Filter: %s | Limit: %d\n\n",
-		connectionID, connName, activeLabel, limit))
+	fmt.Fprintf(&sb, "Blackouts | Connection: %d (%s) | Filter: %s | Limit: %d\n\n",
+		connectionID, connName, activeLabel, limit)
 
 	// Header
 	sb.WriteString("id\tscope\treason\tstart_time\tend_time\tis_active\n")
@@ -296,14 +296,13 @@ func blackoutsSingleConnection(
 			return mcp.NewToolError(fmt.Sprintf("Failed to scan row: %v", err))
 		}
 
-		sb.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%t\n",
+		fmt.Fprintf(&sb, "%d\t%s\t%s\t%s\t%s\t%t\n",
 			id,
 			scope,
 			tsv.FormatValue(reason),
 			startTime.Format(time.RFC3339),
 			endTime.Format(time.RFC3339),
-			isActive,
-		))
+			isActive)
 		rowCount++
 	}
 
@@ -318,7 +317,7 @@ func blackoutsSingleConnection(
 			sb.WriteString("(no blackouts found)\n")
 		}
 	} else {
-		sb.WriteString(fmt.Sprintf("\n(%d rows)\n", rowCount))
+		fmt.Fprintf(&sb, "\n(%d rows)\n", rowCount)
 	}
 
 	// Optionally include recurring blackout schedules
@@ -385,7 +384,7 @@ func blackoutSchedulesSingleConnection(
 			return "", fmt.Errorf("failed to scan schedule row: %w", err)
 		}
 
-		sb.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\t%d\t%s\t%s\t%t\n",
+		fmt.Fprintf(&sb, "%d\t%s\t%s\t%s\t%d\t%s\t%s\t%t\n",
 			id,
 			scope,
 			tsv.FormatValue(name),
@@ -393,8 +392,7 @@ func blackoutSchedulesSingleConnection(
 			durationMinutes,
 			timezone,
 			tsv.FormatValue(reason),
-			enabled,
-		))
+			enabled)
 		schedCount++
 	}
 
@@ -405,7 +403,7 @@ func blackoutSchedulesSingleConnection(
 	if schedCount == 0 {
 		sb.WriteString("(no blackout schedules found)\n")
 	} else {
-		sb.WriteString(fmt.Sprintf("\n(%d rows)\n", schedCount))
+		fmt.Fprintf(&sb, "\n(%d rows)\n", schedCount)
 	}
 
 	return sb.String(), nil
@@ -471,8 +469,8 @@ func blackoutsAllConnections(
 	if activeOnly {
 		activeLabel = "active only"
 	}
-	sb.WriteString(fmt.Sprintf("Blackouts | All accessible connections | Filter: %s | Limit: %d\n\n",
-		activeLabel, limit))
+	fmt.Fprintf(&sb, "Blackouts | All accessible connections | Filter: %s | Limit: %d\n\n",
+		activeLabel, limit)
 
 	// Header - includes connection identification columns
 	sb.WriteString("id\tscope\tconnection_id\tconnection_name\treason\tstart_time\tend_time\tis_active\n")
@@ -505,7 +503,7 @@ func blackoutsAllConnections(
 			connNameStr = tsv.FormatValue(*connNameVal)
 		}
 
-		sb.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%s\t%s\t%t\n",
+		fmt.Fprintf(&sb, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%t\n",
 			id,
 			scope,
 			connIDStr,
@@ -513,8 +511,7 @@ func blackoutsAllConnections(
 			tsv.FormatValue(reason),
 			startTime.Format(time.RFC3339),
 			endTime.Format(time.RFC3339),
-			isActive,
-		))
+			isActive)
 		rowCount++
 	}
 
@@ -529,7 +526,7 @@ func blackoutsAllConnections(
 			sb.WriteString("(no blackouts found)\n")
 		}
 	} else {
-		sb.WriteString(fmt.Sprintf("\n(%d rows)\n", rowCount))
+		fmt.Fprintf(&sb, "\n(%d rows)\n", rowCount)
 	}
 
 	// Optionally include recurring blackout schedules
@@ -621,7 +618,7 @@ func blackoutSchedulesAllConnections(
 			connNameStr = tsv.FormatValue(*connNameVal)
 		}
 
-		sb.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%t\n",
+		fmt.Fprintf(&sb, "%d\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%t\n",
 			id,
 			scope,
 			connIDStr,
@@ -631,8 +628,7 @@ func blackoutSchedulesAllConnections(
 			durationMinutes,
 			timezone,
 			tsv.FormatValue(reason),
-			enabled,
-		))
+			enabled)
 		schedCount++
 	}
 
@@ -643,7 +639,7 @@ func blackoutSchedulesAllConnections(
 	if schedCount == 0 {
 		sb.WriteString("(no blackout schedules found)\n")
 	} else {
-		sb.WriteString(fmt.Sprintf("\n(%d rows)\n", schedCount))
+		fmt.Fprintf(&sb, "\n(%d rows)\n", schedCount)
 	}
 
 	return sb.String(), nil

--- a/server/src/internal/tools/get_metric_baselines.go
+++ b/server/src/internal/tools/get_metric_baselines.go
@@ -218,8 +218,8 @@ func baselinesSingleConnection(
 	if metricName != nil {
 		metricInfo = fmt.Sprintf("metric: %s", *metricName)
 	}
-	sb.WriteString(fmt.Sprintf("Metric Baselines | Connection: %d | %s\n\n",
-		connectionID, metricInfo))
+	fmt.Fprintf(&sb, "Metric Baselines | Connection: %d | %s\n\n",
+		connectionID, metricInfo)
 
 	// Header
 	sb.WriteString("metric_name\tperiod_type\tday_of_week\thour_of_day\tmean\tstddev\tmin\tmax\tsample_count\n")
@@ -246,7 +246,7 @@ func baselinesSingleConnection(
 		}
 
 		// Format row
-		sb.WriteString(fmt.Sprintf("%s\t%s\t%s\t%s\t%.4f\t%.4f\t%.4f\t%.4f\t%d\n",
+		fmt.Fprintf(&sb, "%s\t%s\t%s\t%s\t%.4f\t%.4f\t%.4f\t%.4f\t%d\n",
 			metricNameVal,
 			periodType,
 			formatOptionalInt(dayOfWeek),
@@ -255,8 +255,7 @@ func baselinesSingleConnection(
 			stddev,
 			minVal,
 			maxVal,
-			sampleCount,
-		))
+			sampleCount)
 		rowCount++
 	}
 
@@ -268,7 +267,7 @@ func baselinesSingleConnection(
 		return mcp.NewToolSuccess(fmt.Sprintf("No metric baselines found for connection %d. Baselines are calculated after sufficient historical data is collected.", connectionID))
 	}
 
-	sb.WriteString(fmt.Sprintf("\n(%d baselines)\n", rowCount))
+	fmt.Fprintf(&sb, "\n(%d baselines)\n", rowCount)
 
 	return mcp.NewToolSuccess(sb.String())
 }
@@ -308,7 +307,7 @@ func baselinesAllConnections(
 	if metricName != nil {
 		metricInfo = fmt.Sprintf("metric: %s", *metricName)
 	}
-	sb.WriteString(fmt.Sprintf("Metric Baselines | All accessible connections | %s\n\n", metricInfo))
+	fmt.Fprintf(&sb, "Metric Baselines | All accessible connections | %s\n\n", metricInfo)
 
 	// Header - includes connection columns
 	sb.WriteString("connection_id\tconnection_name\tmetric_name\tperiod_type\tday_of_week\thour_of_day\tmean\tstddev\tmin\tmax\tsample_count\n")
@@ -336,7 +335,7 @@ func baselinesAllConnections(
 			return mcp.NewToolError(fmt.Sprintf("Failed to scan row: %v", err))
 		}
 
-		sb.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%s\t%.4f\t%.4f\t%.4f\t%.4f\t%d\n",
+		fmt.Fprintf(&sb, "%d\t%s\t%s\t%s\t%s\t%s\t%.4f\t%.4f\t%.4f\t%.4f\t%d\n",
 			connID,
 			connNameVal,
 			metricNameVal,
@@ -347,8 +346,7 @@ func baselinesAllConnections(
 			stddev,
 			minVal,
 			maxVal,
-			sampleCount,
-		))
+			sampleCount)
 		rowCount++
 	}
 
@@ -360,7 +358,7 @@ func baselinesAllConnections(
 		return mcp.NewToolSuccess("No metric baselines found across accessible connections. Baselines are calculated after sufficient historical data is collected.")
 	}
 
-	sb.WriteString(fmt.Sprintf("\n(%d baselines)\n", rowCount))
+	fmt.Fprintf(&sb, "\n(%d baselines)\n", rowCount)
 
 	return mcp.NewToolSuccess(sb.String())
 }

--- a/server/src/internal/tools/get_schema_info.go
+++ b/server/src/internal/tools/get_schema_info.go
@@ -276,13 +276,13 @@ To avoid rate limits when calling this tool:
 				// Smart summary mode for large databases
 				sb.WriteString("Database Schema Summary:\n")
 				sb.WriteString("========================\n\n")
-				sb.WriteString(fmt.Sprintf("Found %d tables across %d schemas.\n\n",
-					totalMatched, len(schemaMap)))
+				fmt.Fprintf(&sb, "Found %d tables across %d schemas.\n\n",
+					totalMatched, len(schemaMap))
 
 				// List schemas with their tables
 				for schema, stats := range schemaMap {
-					sb.WriteString(fmt.Sprintf("Schema '%s': %d tables\n",
-						schema, len(stats.tableNames)))
+					fmt.Fprintf(&sb, "Schema '%s': %d tables\n",
+						schema, len(stats.tableNames))
 
 					// Show first few table names as preview
 					previewCount := 5
@@ -290,17 +290,17 @@ To avoid rate limits when calling this tool:
 						previewCount = len(stats.tableNames)
 					}
 					preview := stats.tableNames[:previewCount]
-					sb.WriteString(fmt.Sprintf("  Tables: %s", strings.Join(preview, ", ")))
+					fmt.Fprintf(&sb, "  Tables: %s", strings.Join(preview, ", "))
 					if len(stats.tableNames) > previewCount {
-						sb.WriteString(fmt.Sprintf(", ... (+%d more)",
-							len(stats.tableNames)-previewCount))
+						fmt.Fprintf(&sb, ", ... (+%d more)",
+							len(stats.tableNames)-previewCount)
 					}
 					sb.WriteString("\n")
 
 					// Note vector-enabled tables if any
 					if len(stats.vectorTables) > 0 {
-						sb.WriteString(fmt.Sprintf("  Vector-enabled: %s\n",
-							strings.Join(stats.vectorTables, ", ")))
+						fmt.Fprintf(&sb, "  Vector-enabled: %s\n",
+							strings.Join(stats.vectorTables, ", "))
 					}
 					sb.WriteString("\n")
 				}
@@ -309,7 +309,7 @@ To avoid rate limits when calling this tool:
 				sb.WriteString("To reduce token usage and get detailed info:\n\n")
 				sb.WriteString("1. Get details for a specific schema:\n")
 				for schema := range schemaMap {
-					sb.WriteString(fmt.Sprintf("   → get_schema_info(schema_name=%q)\n", schema))
+					fmt.Fprintf(&sb, "   → get_schema_info(schema_name=%q)\n", schema)
 				}
 				sb.WriteString("\n2. Get only vector-enabled tables:\n")
 				sb.WriteString("   → get_schema_info(vector_tables_only=true)\n\n")
@@ -421,24 +421,24 @@ To avoid rate limits when calling this tool:
 				emptyMsg.WriteString("\nNo tables found matching your criteria.\n\n")
 
 				emptyMsg.WriteString("<current_connection>\n")
-				emptyMsg.WriteString(fmt.Sprintf("Connected to: %s\n", sanitizedConn))
+				fmt.Fprintf(&emptyMsg, "Connected to: %s\n", sanitizedConn)
 				emptyMsg.WriteString("</current_connection>\n\n")
 
 				emptyMsg.WriteString("<diagnosis>\n")
 				if tableName != "" {
-					emptyMsg.WriteString(fmt.Sprintf("Table '%s.%s' not found.\n", schemaName, tableName))
+					fmt.Fprintf(&emptyMsg, "Table '%s.%s' not found.\n", schemaName, tableName)
 					emptyMsg.WriteString("Possible reasons:\n")
 					emptyMsg.WriteString("1. Table name is misspelled (PostgreSQL is case-sensitive)\n")
 					emptyMsg.WriteString("2. Table exists in a different schema\n")
 					emptyMsg.WriteString("3. You don't have permission to view this table\n")
 				} else if schemaName != "" && vectorTablesOnly {
-					emptyMsg.WriteString(fmt.Sprintf("No tables with vector columns found in schema '%s'.\n", schemaName))
+					fmt.Fprintf(&emptyMsg, "No tables with vector columns found in schema '%s'.\n", schemaName)
 					emptyMsg.WriteString("Possible reasons:\n")
 					emptyMsg.WriteString("1. Schema name is misspelled or doesn't exist\n")
 					emptyMsg.WriteString("2. Schema exists but has no tables with vector columns\n")
 					emptyMsg.WriteString("3. pgvector extension not installed or not used in this schema\n")
 				} else if schemaName != "" {
-					emptyMsg.WriteString(fmt.Sprintf("Schema '%s' not found or has no tables.\n", schemaName))
+					fmt.Fprintf(&emptyMsg, "Schema '%s' not found or has no tables.\n", schemaName)
 					emptyMsg.WriteString("Possible reasons:\n")
 					emptyMsg.WriteString("1. Schema name is misspelled (PostgreSQL is case-sensitive)\n")
 					emptyMsg.WriteString("2. Schema exists but is empty (no tables created yet)\n")
@@ -468,7 +468,7 @@ To avoid rate limits when calling this tool:
 
 				if tableName != "" {
 					emptyMsg.WriteString("3. List all tables in the schema to find the correct name:\n")
-					emptyMsg.WriteString(fmt.Sprintf("   → get_schema_info(schema_name=%q, compact=true)\n\n", schemaName))
+					fmt.Fprintf(&emptyMsg, "   → get_schema_info(schema_name=%q, compact=true)\n\n", schemaName)
 				} else if schemaName != "" {
 					emptyMsg.WriteString("3. List all available schemas:\n")
 					emptyMsg.WriteString("   → query_database(query=\"SELECT schema_name FROM information_schema.schemata ORDER BY schema_name\", limit=50)\n\n")
@@ -481,7 +481,7 @@ To avoid rate limits when calling this tool:
 					emptyMsg.WriteString("   → query_database(query=\"SELECT * FROM pg_extension WHERE extname = 'vector'\")\n\n")
 					emptyMsg.WriteString("4. Try without vector filter to see all tables:\n")
 					if schemaName != "" {
-						emptyMsg.WriteString(fmt.Sprintf("   → get_schema_info(schema_name=%q)\n\n", schemaName))
+						fmt.Fprintf(&emptyMsg, "   → get_schema_info(schema_name=%q)\n\n", schemaName)
 					} else {
 						emptyMsg.WriteString("   → get_schema_info()\n\n")
 					}

--- a/server/src/internal/tools/list_connections.go
+++ b/server/src/internal/tools/list_connections.go
@@ -195,11 +195,11 @@ CRITICAL: Never silently analyze multiple connections. Always get explicit user 
 
 			// Format as TSV
 			var sb strings.Builder
-			sb.WriteString(fmt.Sprintf("Found %d connections (%d monitored):\n\n", len(connections), monitoredCount))
+			fmt.Fprintf(&sb, "Found %d connections (%d monitored):\n\n", len(connections), monitoredCount)
 			sb.WriteString("id\tname\thost\tport\tdatabase_name\tis_monitored\tstatus\terror\n")
 			for _, conn := range connections {
-				sb.WriteString(fmt.Sprintf("%d\t%s\t%s\t%d\t%s\t%t\t%s\t%s\n",
-					conn.ID, conn.Name, conn.Host, conn.Port, conn.DatabaseName, conn.IsMonitored, conn.Status, conn.ConnectionError))
+				fmt.Fprintf(&sb, "%d\t%s\t%s\t%d\t%s\t%t\t%s\t%s\n",
+					conn.ID, conn.Name, conn.Host, conn.Port, conn.DatabaseName, conn.IsMonitored, conn.Status, conn.ConnectionError)
 			}
 
 			sb.WriteString("\nNote: Use the 'id' column value as the connection_id parameter in query_metrics and all monitored-database tools.\n")

--- a/server/src/internal/tools/list_connections.go
+++ b/server/src/internal/tools/list_connections.go
@@ -199,7 +199,14 @@ CRITICAL: Never silently analyze multiple connections. Always get explicit user 
 			sb.WriteString("id\tname\thost\tport\tdatabase_name\tis_monitored\tstatus\terror\n")
 			for _, conn := range connections {
 				fmt.Fprintf(&sb, "%d\t%s\t%s\t%d\t%s\t%t\t%s\t%s\n",
-					conn.ID, conn.Name, conn.Host, conn.Port, conn.DatabaseName, conn.IsMonitored, conn.Status, conn.ConnectionError)
+					conn.ID,
+					sanitizeTSVField(conn.Name),
+					sanitizeTSVField(conn.Host),
+					conn.Port,
+					sanitizeTSVField(conn.DatabaseName),
+					conn.IsMonitored,
+					sanitizeTSVField(conn.Status),
+					sanitizeTSVField(conn.ConnectionError))
 			}
 
 			sb.WriteString("\nNote: Use the 'id' column value as the connection_id parameter in query_metrics and all monitored-database tools.\n")

--- a/server/src/internal/tools/list_probes.go
+++ b/server/src/internal/tools/list_probes.go
@@ -119,11 +119,11 @@ Returns a TSV table with:
 
 			// Format as TSV
 			var sb strings.Builder
-			sb.WriteString(fmt.Sprintf("Found %d metrics probes:\n\n", len(probes)))
+			fmt.Fprintf(&sb, "Found %d metrics probes:\n\n", len(probes))
 			sb.WriteString("name\tdescription\trow_count\tscope\n")
 			for _, probe := range probes {
-				sb.WriteString(fmt.Sprintf("%s\t%s\t%d\t%s\n",
-					probe.Name, probe.Description, probe.RowCount, probe.Scope))
+				fmt.Fprintf(&sb, "%s\t%s\t%d\t%s\n",
+					probe.Name, probe.Description, probe.RowCount, probe.Scope)
 			}
 
 			return mcp.NewToolSuccess(sb.String())

--- a/server/src/internal/tools/list_probes.go
+++ b/server/src/internal/tools/list_probes.go
@@ -123,7 +123,10 @@ Returns a TSV table with:
 			sb.WriteString("name\tdescription\trow_count\tscope\n")
 			for _, probe := range probes {
 				fmt.Fprintf(&sb, "%s\t%s\t%d\t%s\n",
-					probe.Name, probe.Description, probe.RowCount, probe.Scope)
+					sanitizeTSVField(probe.Name),
+					sanitizeTSVField(probe.Description),
+					probe.RowCount,
+					sanitizeTSVField(probe.Scope))
 			}
 
 			return mcp.NewToolSuccess(sb.String())

--- a/server/src/internal/tools/query_database.go
+++ b/server/src/internal/tools/query_database.go
@@ -240,7 +240,7 @@ To avoid rate limits (30,000 input tokens/minute):
 			// Always show current database context (unless already shown via connection message)
 			if connectionMessage == "" {
 				sanitizedConn := database.SanitizeConnStr(connStr)
-				sb.WriteString(fmt.Sprintf("Database: %s\n\n", sanitizedConn))
+				fmt.Fprintf(&sb, "Database: %s\n\n", sanitizedConn)
 			} else {
 				sb.WriteString(connectionMessage)
 			}

--- a/server/src/internal/tools/query_metrics.go
+++ b/server/src/internal/tools/query_metrics.go
@@ -306,11 +306,11 @@ To manage response sizes:
 
 			// Build TSV output
 			var sb strings.Builder
-			sb.WriteString(fmt.Sprintf("Probe: %s | Connection: %d | Time: %s to %s | Buckets: %d | Aggregation: %s\n\n",
+			fmt.Fprintf(&sb, "Probe: %s | Connection: %d | Time: %s to %s | Buckets: %d | Aggregation: %s\n\n",
 				probeName, connectionID,
 				timeStart.Format(time.RFC3339),
 				timeEnd.Format(time.RFC3339),
-				buckets, aggregation))
+				buckets, aggregation)
 
 			// Header
 			sb.WriteString("bucket_time")
@@ -356,7 +356,7 @@ To manage response sizes:
 				return mcp.NewToolSuccess(fmt.Sprintf("No metrics data found for probe '%s' in the specified time range.", probeName))
 			}
 
-			sb.WriteString(fmt.Sprintf("\n(%d rows)\n", rowCount))
+			fmt.Fprintf(&sb, "\n(%d rows)\n", rowCount)
 
 			return mcp.NewToolSuccess(sb.String())
 		},

--- a/server/src/internal/tools/recall_memories.go
+++ b/server/src/internal/tools/recall_memories.go
@@ -157,19 +157,19 @@ func RecallMemoriesTool(memoryStore *memory.Store, cfg *config.Config) Tool {
 			sb.WriteString("Memory Recall Results\n")
 			sb.WriteString(strings.Repeat("=", 50))
 			sb.WriteString("\n")
-			sb.WriteString(fmt.Sprintf("Query: %s\n", query))
+			fmt.Fprintf(&sb, "Query: %s\n", query)
 			if category != "" {
-				sb.WriteString(fmt.Sprintf("Category Filter: %s\n", category))
+				fmt.Fprintf(&sb, "Category Filter: %s\n", category)
 			}
 			if scope != "" {
-				sb.WriteString(fmt.Sprintf("Scope Filter: %s\n", scope))
+				fmt.Fprintf(&sb, "Scope Filter: %s\n", scope)
 			}
 			if queryEmbedding != nil {
 				sb.WriteString("Search Mode: semantic similarity\n")
 			} else {
 				sb.WriteString("Search Mode: text matching\n")
 			}
-			sb.WriteString(fmt.Sprintf("Total Results: %d\n", len(final)))
+			fmt.Fprintf(&sb, "Total Results: %d\n", len(final))
 			sb.WriteString("\n")
 
 			if len(final) == 0 {
@@ -178,17 +178,17 @@ func RecallMemoriesTool(memoryStore *memory.Store, cfg *config.Config) Tool {
 			}
 
 			for i := range final {
-				sb.WriteString(fmt.Sprintf("--- Memory #%d ---\n", i+1))
-				sb.WriteString(fmt.Sprintf("  ID:       %d\n", final[i].ID))
-				sb.WriteString(fmt.Sprintf("  Scope:    %s\n", final[i].Scope))
-				sb.WriteString(fmt.Sprintf("  Category: %s\n", final[i].Category))
+				fmt.Fprintf(&sb, "--- Memory #%d ---\n", i+1)
+				fmt.Fprintf(&sb, "  ID:       %d\n", final[i].ID)
+				fmt.Fprintf(&sb, "  Scope:    %s\n", final[i].Scope)
+				fmt.Fprintf(&sb, "  Category: %s\n", final[i].Category)
 				if final[i].Pinned {
 					sb.WriteString("  Pinned:   yes\n")
 				} else {
 					sb.WriteString("  Pinned:   no\n")
 				}
-				sb.WriteString(fmt.Sprintf("  Created:  %s\n", final[i].CreatedAt.Format("2006-01-02 15:04:05 UTC")))
-				sb.WriteString(fmt.Sprintf("  Content:\n    %s\n", final[i].Content))
+				fmt.Fprintf(&sb, "  Created:  %s\n", final[i].CreatedAt.Format("2006-01-02 15:04:05 UTC"))
+				fmt.Fprintf(&sb, "  Content:\n    %s\n", final[i].Content)
 				sb.WriteString("\n")
 			}
 

--- a/server/src/internal/tools/search_knowledgebase.go
+++ b/server/src/internal/tools/search_knowledgebase.go
@@ -240,14 +240,14 @@ func listKBProducts(kbPath string) (string, error) {
 			if currentProduct != "" {
 				sb.WriteString("\n")
 			}
-			sb.WriteString(fmt.Sprintf("Product: %s\n", name))
+			fmt.Fprintf(&sb, "Product: %s\n", name)
 			currentProduct = name
 		}
 
 		if version != "" {
-			sb.WriteString(fmt.Sprintf("  - Version %s (%d chunks)\n", version, count))
+			fmt.Fprintf(&sb, "  - Version %s (%d chunks)\n", version, count)
 		} else {
-			sb.WriteString(fmt.Sprintf("  - (no version) (%d chunks)\n", count))
+			fmt.Fprintf(&sb, "  - (no version) (%d chunks)\n", count)
 		}
 		totalChunks += count
 	}
@@ -258,7 +258,7 @@ func listKBProducts(kbPath string) (string, error) {
 
 	sb.WriteString("\n")
 	sb.WriteString(strings.Repeat("=", 50))
-	sb.WriteString(fmt.Sprintf("\nTotal: %d chunks across all products\n", totalChunks))
+	fmt.Fprintf(&sb, "\nTotal: %d chunks across all products\n", totalChunks)
 
 	return sb.String(), nil
 }
@@ -311,13 +311,17 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 	}
 	defer db.Close()
 
-	// Build query
-	query := `
+	// Build query. The IN clauses are extended only with hard-coded "?"
+	// placeholder strings; the actual project name/version values flow in
+	// via the args slice and are bound as query parameters, never
+	// interpolated into SQL, so this is safe from SQL injection.
+	var queryBuilder strings.Builder
+	queryBuilder.WriteString(`
         SELECT text, title, section, project_name, project_version, file_path,
                openai_embedding, voyage_embedding, ollama_embedding
         FROM chunks
         WHERE 1=1
-    `
+    `)
 	args := []any{}
 
 	// Add project_names filter with IN clause
@@ -327,7 +331,9 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 			placeholders[i] = "?"
 			args = append(args, name)
 		}
-		query += fmt.Sprintf(" AND project_name IN (%s)", strings.Join(placeholders, ", "))
+		queryBuilder.WriteString(" AND project_name IN (")
+		queryBuilder.WriteString(strings.Join(placeholders, ", "))
+		queryBuilder.WriteString(")")
 	}
 
 	// Add project_versions filter with IN clause
@@ -337,10 +343,13 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 			placeholders[i] = "?"
 			args = append(args, version)
 		}
-		query += fmt.Sprintf(" AND project_version IN (%s)", strings.Join(placeholders, ", "))
+		queryBuilder.WriteString(" AND project_version IN (")
+		queryBuilder.WriteString(strings.Join(placeholders, ", "))
+		queryBuilder.WriteString(")")
 	}
 
-	rows, err := db.Query(query, args...)
+	query := queryBuilder.String()
+	rows, err := db.Query(query, args...) //nolint:gosec // G202: IN-clause is built from hard-coded "?" placeholders; values are bound parameters
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
@@ -424,12 +433,12 @@ func deserializeEmbedding(data []byte) []float32 {
 		return nil
 	}
 
-	embedding := make([]float32, len(data)/4)
-	for i := range embedding {
+	vec := make([]float32, len(data)/4)
+	for i := range vec {
 		bits := binary.LittleEndian.Uint32(data[i*4:])
-		embedding[i] = math.Float32frombits(bits)
+		vec[i] = math.Float32frombits(bits)
 	}
-	return embedding
+	return vec
 }
 
 func cosineSimilarity(a, b []float32) float64 {
@@ -454,35 +463,35 @@ func cosineSimilarity(a, b []float32) float64 {
 func formatKBResults(results []KBSearchResult, query string, projectNames, projectVersions []string) string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Knowledgebase Search Results: %q\n", query))
+	fmt.Fprintf(&sb, "Knowledgebase Search Results: %q\n", query)
 	if len(projectNames) > 0 {
-		sb.WriteString(fmt.Sprintf("Filter - Projects: %s", strings.Join(projectNames, ", ")))
+		fmt.Fprintf(&sb, "Filter - Projects: %s", strings.Join(projectNames, ", "))
 		if len(projectVersions) > 0 {
-			sb.WriteString(fmt.Sprintf("; Versions: %s", strings.Join(projectVersions, ", ")))
+			fmt.Fprintf(&sb, "; Versions: %s", strings.Join(projectVersions, ", "))
 		}
 		sb.WriteString("\n")
 	} else if len(projectVersions) > 0 {
-		sb.WriteString(fmt.Sprintf("Filter - Versions: %s\n", strings.Join(projectVersions, ", ")))
+		fmt.Fprintf(&sb, "Filter - Versions: %s\n", strings.Join(projectVersions, ", "))
 	}
 	sb.WriteString(strings.Repeat("=", 80))
 	sb.WriteString("\n\n")
 
-	sb.WriteString(fmt.Sprintf("Found %d relevant chunks:\n\n", len(results)))
+	fmt.Fprintf(&sb, "Found %d relevant chunks:\n\n", len(results))
 
 	for i, result := range results {
-		sb.WriteString(fmt.Sprintf("Result %d/%d\n", i+1, len(results)))
+		fmt.Fprintf(&sb, "Result %d/%d\n", i+1, len(results))
 		if result.ProjectVersion != "" {
-			sb.WriteString(fmt.Sprintf("Project: %s %s\n", result.ProjectName, result.ProjectVersion))
+			fmt.Fprintf(&sb, "Project: %s %s\n", result.ProjectName, result.ProjectVersion)
 		} else {
-			sb.WriteString(fmt.Sprintf("Project: %s\n", result.ProjectName))
+			fmt.Fprintf(&sb, "Project: %s\n", result.ProjectName)
 		}
 		if result.Title != "" {
-			sb.WriteString(fmt.Sprintf("Title: %s\n", result.Title))
+			fmt.Fprintf(&sb, "Title: %s\n", result.Title)
 		}
 		if result.Section != "" {
-			sb.WriteString(fmt.Sprintf("Section: %s\n", result.Section))
+			fmt.Fprintf(&sb, "Section: %s\n", result.Section)
 		}
-		sb.WriteString(fmt.Sprintf("Similarity: %.3f\n\n", result.Similarity))
+		fmt.Fprintf(&sb, "Similarity: %.3f\n\n", result.Similarity)
 		sb.WriteString(result.Text)
 		sb.WriteString("\n\n")
 		sb.WriteString(strings.Repeat("-", 80))
@@ -490,7 +499,7 @@ func formatKBResults(results []KBSearchResult, query string, projectNames, proje
 	}
 
 	sb.WriteString(strings.Repeat("=", 80))
-	sb.WriteString(fmt.Sprintf("\nTotal: %d results\n", len(results)))
+	fmt.Fprintf(&sb, "\nTotal: %d results\n", len(results))
 
 	return sb.String()
 }

--- a/server/src/internal/tools/search_knowledgebase_test.go
+++ b/server/src/internal/tools/search_knowledgebase_test.go
@@ -374,7 +374,7 @@ func TestSearchKB_UnfilteredReturnsAllResults(t *testing.T) {
 		t.Fatalf("searchKB: %v", err)
 	}
 	if len(results) != 3 {
-		t.Errorf("expected 3 results, got %d", len(results))
+		t.Fatalf("expected 3 results, got %d", len(results))
 	}
 	// The highest similarity result should be the one with embedding
 	// {1, 0, 0}, i.e. the PostgreSQL 17 row.
@@ -412,7 +412,7 @@ func TestSearchKB_VersionFilter(t *testing.T) {
 		t.Fatalf("searchKB: %v", err)
 	}
 	if len(results) != 1 {
-		t.Errorf("expected 1 result, got %d", len(results))
+		t.Fatalf("expected 1 result, got %d", len(results))
 	}
 	if results[0].ProjectVersion != "17" {
 		t.Errorf("expected version 17, got %s", results[0].ProjectVersion)
@@ -459,7 +459,10 @@ func TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs(t *testing.T) {
 	createSearchKBChunksSchema(t, db)
 
 	// Row with no embeddings at all - should be skipped entirely.
-	_, err = db.Exec(`INSERT INTO chunks VALUES
+	_, err = db.Exec(`INSERT INTO chunks
+        (text, title, section, project_name, project_version, file_path,
+         openai_embedding, voyage_embedding, ollama_embedding)
+        VALUES
         ('missing embedding', '', '', 'X', '1', '/x', NULL, NULL, NULL)`)
 	if err != nil {
 		t.Fatalf("insert: %v", err)
@@ -467,7 +470,10 @@ func TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs(t *testing.T) {
 
 	// Row with an invalid embedding blob (len % 4 != 0) - deserialize
 	// returns nil so the row is skipped after looking up the blob.
-	_, err = db.Exec(`INSERT INTO chunks VALUES
+	_, err = db.Exec(`INSERT INTO chunks
+        (text, title, section, project_name, project_version, file_path,
+         openai_embedding, voyage_embedding, ollama_embedding)
+        VALUES
         ('bad embedding', '', '', 'Y', '1', '/y', ?, NULL, NULL)`,
 		[]byte{1, 2, 3})
 	if err != nil {
@@ -479,14 +485,20 @@ func TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs(t *testing.T) {
 	binary.LittleEndian.PutUint32(vecBuf[0:], math.Float32bits(1))
 	binary.LittleEndian.PutUint32(vecBuf[4:], math.Float32bits(0))
 	binary.LittleEndian.PutUint32(vecBuf[8:], math.Float32bits(0))
-	_, err = db.Exec(`INSERT INTO chunks VALUES
+	_, err = db.Exec(`INSERT INTO chunks
+        (text, title, section, project_name, project_version, file_path,
+         openai_embedding, voyage_embedding, ollama_embedding)
+        VALUES
         ('voyage row', '', '', 'Z', '1', '/z', NULL, ?, NULL)`, vecBuf)
 	if err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 
 	// Row with an ollama embedding only — exercises the ollama case.
-	_, err = db.Exec(`INSERT INTO chunks VALUES
+	_, err = db.Exec(`INSERT INTO chunks
+        (text, title, section, project_name, project_version, file_path,
+         openai_embedding, voyage_embedding, ollama_embedding)
+        VALUES
         ('ollama row', '', '', 'W', '1', '/w', NULL, NULL, ?)`, vecBuf)
 	if err != nil {
 		t.Fatalf("insert: %v", err)

--- a/server/src/internal/tools/search_knowledgebase_test.go
+++ b/server/src/internal/tools/search_knowledgebase_test.go
@@ -10,9 +10,13 @@
 package tools
 
 import (
+	"database/sql"
 	"encoding/binary"
 	"math"
+	"path/filepath"
 	"testing"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestDeserializeEmbedding(t *testing.T) {
@@ -262,6 +266,267 @@ func TestKBSearchResultStruct(t *testing.T) {
 	}
 	if result.Similarity != 0.92 {
 		t.Errorf("Similarity = %f, want %f", result.Similarity, 0.92)
+	}
+}
+
+// buildSearchKBTestDB creates a temporary SQLite knowledgebase pre-
+// populated with chunk rows for searchKB tests. It returns the path to
+// the database file.
+func buildSearchKBTestDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kb.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	schema := `
+        CREATE TABLE chunks (
+            text TEXT,
+            title TEXT,
+            section TEXT,
+            project_name TEXT,
+            project_version TEXT,
+            file_path TEXT,
+            openai_embedding BLOB,
+            voyage_embedding BLOB,
+            ollama_embedding BLOB
+        );
+    `
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	// Serialize a float32 embedding to little-endian blob.
+	encode := func(vec []float32) []byte {
+		buf := make([]byte, len(vec)*4)
+		for i, v := range vec {
+			binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+		}
+		return buf
+	}
+
+	rows := []struct {
+		text, title, section, project, version, filePath string
+		openai                                           []byte
+	}{
+		{
+			text:     "PostgreSQL documentation for 17",
+			title:    "Intro",
+			section:  "Overview",
+			project:  "PostgreSQL",
+			version:  "17",
+			filePath: "/docs/pg17.md",
+			openai:   encode([]float32{1, 0, 0}),
+		},
+		{
+			text:     "pgEdge documentation",
+			title:    "Getting Started",
+			section:  "Intro",
+			project:  "pgEdge",
+			version:  "1.0",
+			filePath: "/docs/pgedge.md",
+			openai:   encode([]float32{0, 1, 0}),
+		},
+		{
+			text:     "Older PostgreSQL docs",
+			title:    "Legacy",
+			section:  "Overview",
+			project:  "PostgreSQL",
+			version:  "14",
+			filePath: "/docs/pg14.md",
+			openai:   encode([]float32{0, 0, 1}),
+		},
+	}
+
+	for _, r := range rows {
+		_, err := db.Exec(
+			`INSERT INTO chunks (text, title, section, project_name,
+                project_version, file_path, openai_embedding,
+                voyage_embedding, ollama_embedding)
+              VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
+			r.text, r.title, r.section, r.project, r.version, r.filePath,
+			r.openai,
+		)
+		if err != nil {
+			t.Fatalf("insert row: %v", err)
+		}
+	}
+	return path
+}
+
+func TestSearchKB_UnfilteredReturnsAllResults(t *testing.T) {
+	path := buildSearchKBTestDB(t)
+
+	queryEmbedding := []float32{1, 0, 0}
+	results, err := searchKB(path, queryEmbedding, nil, nil, 10, "openai")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(results))
+	}
+	// The highest similarity result should be the one with embedding
+	// {1, 0, 0}, i.e. the PostgreSQL 17 row.
+	if results[0].ProjectName != "PostgreSQL" || results[0].ProjectVersion != "17" {
+		t.Errorf("expected top result to be PostgreSQL 17, got %s %s",
+			results[0].ProjectName, results[0].ProjectVersion)
+	}
+}
+
+func TestSearchKB_ProjectNameFilter(t *testing.T) {
+	path := buildSearchKBTestDB(t)
+
+	queryEmbedding := []float32{1, 0, 0}
+	results, err := searchKB(path, queryEmbedding, []string{"pgEdge"}, nil, 10, "openai")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 pgEdge result, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.ProjectName != "pgEdge" {
+			t.Errorf("expected only pgEdge results, got %s", r.ProjectName)
+		}
+	}
+}
+
+func TestSearchKB_VersionFilter(t *testing.T) {
+	path := buildSearchKBTestDB(t)
+
+	queryEmbedding := []float32{1, 0, 0}
+	results, err := searchKB(path, queryEmbedding,
+		[]string{"PostgreSQL"}, []string{"17"}, 10, "openai")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+	if results[0].ProjectVersion != "17" {
+		t.Errorf("expected version 17, got %s", results[0].ProjectVersion)
+	}
+}
+
+func TestSearchKB_TopNLimits(t *testing.T) {
+	path := buildSearchKBTestDB(t)
+
+	queryEmbedding := []float32{1, 0, 0}
+	results, err := searchKB(path, queryEmbedding, nil, nil, 2, "openai")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results capped by topN, got %d", len(results))
+	}
+}
+
+func TestSearchKB_FallsBackWhenProviderBlobMissing(t *testing.T) {
+	path := buildSearchKBTestDB(t)
+
+	// Query with provider "voyage" but our DB only has openai blobs.
+	// The function falls back to the openai blob when voyage is empty.
+	queryEmbedding := []float32{1, 0, 0}
+	results, err := searchKB(path, queryEmbedding, nil, nil, 10, "voyage")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(results) == 0 {
+		t.Errorf("expected fallback to openai embeddings, got 0 results")
+	}
+}
+
+func TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kb.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+        CREATE TABLE chunks (
+            text TEXT,
+            title TEXT,
+            section TEXT,
+            project_name TEXT,
+            project_version TEXT,
+            file_path TEXT,
+            openai_embedding BLOB,
+            voyage_embedding BLOB,
+            ollama_embedding BLOB
+        );
+    `)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	// Row with no embeddings at all - should be skipped entirely.
+	_, err = db.Exec(`INSERT INTO chunks VALUES
+        ('missing embedding', '', '', 'X', '1', '/x', NULL, NULL, NULL)`)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Row with an invalid embedding blob (len % 4 != 0) - deserialize
+	// returns nil so the row is skipped after looking up the blob.
+	_, err = db.Exec(`INSERT INTO chunks VALUES
+        ('bad embedding', '', '', 'Y', '1', '/y', ?, NULL, NULL)`,
+		[]byte{1, 2, 3})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Row with a voyage embedding only — exercises the voyage case.
+	vecBuf := make([]byte, 12)
+	binary.LittleEndian.PutUint32(vecBuf[0:], math.Float32bits(1))
+	binary.LittleEndian.PutUint32(vecBuf[4:], math.Float32bits(0))
+	binary.LittleEndian.PutUint32(vecBuf[8:], math.Float32bits(0))
+	_, err = db.Exec(`INSERT INTO chunks VALUES
+        ('voyage row', '', '', 'Z', '1', '/z', NULL, ?, NULL)`, vecBuf)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Row with an ollama embedding only — exercises the ollama case.
+	_, err = db.Exec(`INSERT INTO chunks VALUES
+        ('ollama row', '', '', 'W', '1', '/w', NULL, NULL, ?)`, vecBuf)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	results, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "voyage")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	// The two rows with no usable embedding should be skipped. The
+	// voyage row matches directly, and the ollama row falls back from
+	// voyage to ollama.
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+
+	// Repeat with provider="ollama" so we hit the ollama branch first.
+	resultsOllama, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "ollama")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(resultsOllama) != 2 {
+		t.Errorf("expected 2 results, got %d", len(resultsOllama))
+	}
+}
+
+func TestSearchKB_OpenFailure(t *testing.T) {
+	// A path containing a null byte is invalid for SQLite and should
+	// fail to open, exercising the error branch of searchKB.
+	_, err := searchKB("/nonexistent/dir\x00/kb.sqlite", []float32{1, 0, 0},
+		nil, nil, 10, "openai")
+	if err == nil {
+		t.Errorf("expected error from invalid path, got nil")
 	}
 }
 

--- a/server/src/internal/tools/search_knowledgebase_test.go
+++ b/server/src/internal/tools/search_knowledgebase_test.go
@@ -269,20 +269,12 @@ func TestKBSearchResultStruct(t *testing.T) {
 	}
 }
 
-// buildSearchKBTestDB creates a temporary SQLite knowledgebase pre-
-// populated with chunk rows for searchKB tests. It returns the path to
-// the database file.
-func buildSearchKBTestDB(t *testing.T) string {
+// createSearchKBChunksSchema creates the `chunks` table used by searchKB
+// tests. Centralizing the DDL keeps the schema consistent across test
+// fixtures.
+func createSearchKBChunksSchema(t *testing.T, db *sql.DB) {
 	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kb.sqlite")
-	db, err := sql.Open("sqlite", path)
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
-	defer db.Close()
-
-	schema := `
+	const schema = `
         CREATE TABLE chunks (
             text TEXT,
             title TEXT,
@@ -298,6 +290,22 @@ func buildSearchKBTestDB(t *testing.T) string {
 	if _, err := db.Exec(schema); err != nil {
 		t.Fatalf("create schema: %v", err)
 	}
+}
+
+// buildSearchKBTestDB creates a temporary SQLite knowledgebase pre-
+// populated with chunk rows for searchKB tests. It returns the path to
+// the database file.
+func buildSearchKBTestDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kb.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	createSearchKBChunksSchema(t, db)
 
 	// Serialize a float32 embedding to little-endian blob.
 	encode := func(vec []float32) []byte {
@@ -448,22 +456,7 @@ func TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs(t *testing.T) {
 	}
 	defer db.Close()
 
-	_, err = db.Exec(`
-        CREATE TABLE chunks (
-            text TEXT,
-            title TEXT,
-            section TEXT,
-            project_name TEXT,
-            project_version TEXT,
-            file_path TEXT,
-            openai_embedding BLOB,
-            voyage_embedding BLOB,
-            ollama_embedding BLOB
-        );
-    `)
-	if err != nil {
-		t.Fatalf("create schema: %v", err)
-	}
+	createSearchKBChunksSchema(t, db)
 
 	// Row with no embeddings at all - should be skipped entirely.
 	_, err = db.Exec(`INSERT INTO chunks VALUES

--- a/server/src/internal/tools/similarity_search.go
+++ b/server/src/internal/tools/similarity_search.go
@@ -245,9 +245,9 @@ To avoid rate limits (30,000 input tokens/minute):
 				sanitizedConn := database.SanitizeConnStr(connStr)
 
 				var errMsg strings.Builder
-				errMsg.WriteString(fmt.Sprintf("Table '%s' not found.\n\n", tableName))
+				fmt.Fprintf(&errMsg, "Table '%s' not found.\n\n", tableName)
 				errMsg.WriteString("<current_connection>\n")
-				errMsg.WriteString(fmt.Sprintf("Connected to: %s\n", sanitizedConn))
+				fmt.Fprintf(&errMsg, "Connected to: %s\n", sanitizedConn)
 				errMsg.WriteString("</current_connection>\n\n")
 				errMsg.WriteString("<diagnosis>\n")
 				errMsg.WriteString("Possible reasons:\n")
@@ -264,7 +264,7 @@ To avoid rate limits (30,000 input tokens/minute):
 				errMsg.WriteString("3. Check current database connection:\n")
 				errMsg.WriteString("   → read_resource(uri=\"pg://system-info\")\n\n")
 				errMsg.WriteString("4. If table is in a different schema, use qualified name:\n")
-				errMsg.WriteString(fmt.Sprintf("   → similarity_search(table_name=\"schema_name.%s\", query_text=\"...\")\n", tableName))
+				fmt.Fprintf(&errMsg, "   → similarity_search(table_name=\"schema_name.%s\", query_text=\"...\")\n", tableName)
 				errMsg.WriteString("</next_steps>\n")
 
 				return mcp.NewToolError(errMsg.String())
@@ -274,7 +274,7 @@ To avoid rate limits (30,000 input tokens/minute):
 			vectorCols := discoverVectorColumns(tableInfo)
 			if len(vectorCols) == 0 {
 				var errMsg strings.Builder
-				errMsg.WriteString(fmt.Sprintf("No vector columns found in table '%s'.\n\n", tableName))
+				fmt.Fprintf(&errMsg, "No vector columns found in table '%s'.\n\n", tableName)
 				errMsg.WriteString("<diagnosis>\n")
 				errMsg.WriteString("This tool requires tables with pgvector extension columns (vector data type).\n")
 				errMsg.WriteString("Possible reasons:\n")
@@ -290,7 +290,7 @@ To avoid rate limits (30,000 input tokens/minute):
 				errMsg.WriteString("3. If no vector tables exist, install pgvector:\n")
 				errMsg.WriteString("   → Contact administrator to install: CREATE EXTENSION vector;\n\n")
 				errMsg.WriteString("4. For non-semantic queries, use query_database instead:\n")
-				errMsg.WriteString(fmt.Sprintf("   → query_database(query=\"SELECT * FROM %s WHERE ...\")\n", tableName))
+				fmt.Fprintf(&errMsg, "   → query_database(query=\"SELECT * FROM %s WHERE ...\")\n", tableName)
 				errMsg.WriteString("</next_steps>\n")
 
 				return mcp.NewToolError(errMsg.String())
@@ -300,7 +300,7 @@ To avoid rate limits (30,000 input tokens/minute):
 			textCols := discoverTextColumns(tableInfo, vectorCols)
 			if len(textCols) == 0 {
 				var errMsg strings.Builder
-				errMsg.WriteString(fmt.Sprintf("No text columns found corresponding to vector columns in table '%s'.\n\n", tableName))
+				fmt.Fprintf(&errMsg, "No text columns found corresponding to vector columns in table '%s'.\n\n", tableName)
 				errMsg.WriteString("<diagnosis>\n")
 				errMsg.WriteString("This tool needs text columns to search. Vector columns store embeddings, but the original text must be in companion text columns.\n")
 				errMsg.WriteString("Expected naming patterns:\n")
@@ -309,9 +309,9 @@ To avoid rate limits (30,000 input tokens/minute):
 				errMsg.WriteString("</diagnosis>\n\n")
 				errMsg.WriteString("<next_steps>\n")
 				errMsg.WriteString("1. Check table structure:\n")
-				errMsg.WriteString(fmt.Sprintf("   → get_schema_info(schema_name=%q)\n\n", strings.Split(tableName, ".")[0]))
+				fmt.Fprintf(&errMsg, "   → get_schema_info(schema_name=%q)\n\n", strings.Split(tableName, ".")[0])
 				errMsg.WriteString("2. List columns in this table:\n")
-				errMsg.WriteString(fmt.Sprintf("   → query_database(query=\"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '%s'\")\n\n", tableName))
+				fmt.Fprintf(&errMsg, "   → query_database(query=\"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '%s'\")\n\n", tableName)
 				errMsg.WriteString("3. This table might not be suitable for semantic search\n")
 				errMsg.WriteString("   → Try a different table with get_schema_info(vector_tables_only=true)\n")
 				errMsg.WriteString("</next_steps>\n")
@@ -333,7 +333,7 @@ To avoid rate limits (30,000 input tokens/minute):
 			queryEmbedding, err := generateQueryEmbeddingWithConfig(ctx, cfg, queryText)
 			if err != nil {
 				var errMsg strings.Builder
-				errMsg.WriteString(fmt.Sprintf("Failed to generate query embedding: %v\n\n", err))
+				fmt.Fprintf(&errMsg, "Failed to generate query embedding: %v\n\n", err)
 				errMsg.WriteString("<diagnosis>\n")
 				errMsg.WriteString("The server's embedding service encountered an error. Possible causes:\n")
 				errMsg.WriteString("1. Embedding generation is disabled in server configuration\n")
@@ -346,7 +346,7 @@ To avoid rate limits (30,000 input tokens/minute):
 				errMsg.WriteString("1. Contact server administrator to check embedding configuration\n\n")
 				errMsg.WriteString("2. Verify API keys and service availability\n\n")
 				errMsg.WriteString("3. For non-semantic queries, use query_database instead:\n")
-				errMsg.WriteString(fmt.Sprintf("   → query_database(query=\"SELECT * FROM %s WHERE text_column ILIKE '%%%s%%'\")\n", tableName, queryText))
+				fmt.Fprintf(&errMsg, "   → query_database(query=\"SELECT * FROM %s WHERE text_column ILIKE '%%%s%%'\")\n", tableName, queryText)
 				errMsg.WriteString("</next_steps>\n")
 
 				return mcp.NewToolError(errMsg.String())
@@ -366,7 +366,7 @@ To avoid rate limits (30,000 input tokens/minute):
 			)
 			if err != nil {
 				var errMsg strings.Builder
-				errMsg.WriteString(fmt.Sprintf("Vector search failed: %v\n\n", err))
+				fmt.Fprintf(&errMsg, "Vector search failed: %v\n\n", err)
 				errMsg.WriteString("<diagnosis>\n")
 				errMsg.WriteString("The database query for vector similarity failed. Possible causes:\n")
 				errMsg.WriteString("1. Vector dimension mismatch (embedding size != column size)\n")
@@ -377,7 +377,7 @@ To avoid rate limits (30,000 input tokens/minute):
 				errMsg.WriteString("</diagnosis>\n\n")
 				errMsg.WriteString("<next_steps>\n")
 				errMsg.WriteString("1. Check vector column dimensions:\n")
-				errMsg.WriteString(fmt.Sprintf("   → query_database(query=\"SELECT column_name, atttypmod FROM pg_attribute WHERE attrelid = '%s'::regclass AND atttypid = 'vector'::regtype\")\n\n", tableName))
+				fmt.Fprintf(&errMsg, "   → query_database(query=\"SELECT column_name, atttypmod FROM pg_attribute WHERE attrelid = '%s'::regclass AND atttypid = 'vector'::regtype\")\n\n", tableName)
 				errMsg.WriteString("2. Verify pgvector extension:\n")
 				errMsg.WriteString("   → query_database(query=\"SELECT * FROM pg_extension WHERE extname = 'vector'\")\n\n")
 				errMsg.WriteString("3. Try a different table:\n")
@@ -390,7 +390,7 @@ To avoid rate limits (30,000 input tokens/minute):
 
 			if len(results) == 0 {
 				var msg strings.Builder
-				msg.WriteString(fmt.Sprintf("No results found for query: %q\n\n", queryText))
+				fmt.Fprintf(&msg, "No results found for query: %q\n\n", queryText)
 				msg.WriteString("<diagnosis>\n")
 				msg.WriteString("The vector search completed but found no semantically similar content.\n")
 				msg.WriteString("Possible reasons:\n")
@@ -401,12 +401,12 @@ To avoid rate limits (30,000 input tokens/minute):
 				msg.WriteString("</diagnosis>\n\n")
 				msg.WriteString("<next_steps>\n")
 				msg.WriteString("1. Check if table has data:\n")
-				msg.WriteString(fmt.Sprintf("   → query_database(query=\"SELECT COUNT(*) FROM %s\")\n\n", tableName))
+				fmt.Fprintf(&msg, "   → query_database(query=\"SELECT COUNT(*) FROM %s\")\n\n", tableName)
 				msg.WriteString("2. Try a broader or simpler query\n\n")
 				msg.WriteString("3. Sample the table to see what content exists:\n")
-				msg.WriteString(fmt.Sprintf("   → query_database(query=\"SELECT * FROM %s\", limit=5)\n\n", tableName))
+				fmt.Fprintf(&msg, "   → query_database(query=\"SELECT * FROM %s\", limit=5)\n\n", tableName)
 				msg.WriteString("4. Increase top_n parameter to cast a wider net:\n")
-				msg.WriteString(fmt.Sprintf("   → similarity_search(table_name=%q, query_text=%q, top_n=50)\n", tableName, queryText))
+				fmt.Fprintf(&msg, "   → similarity_search(table_name=%q, query_text=%q, top_n=50)\n", tableName, queryText)
 				msg.WriteString("</next_steps>\n")
 
 				return mcp.NewToolSuccess(msg.String())
@@ -433,18 +433,18 @@ To avoid rate limits (30,000 input tokens/minute):
 				var msg strings.Builder
 				msg.WriteString("Search completed successfully, but no chunks fit within the token budget.\n\n")
 				msg.WriteString("<diagnosis>\n")
-				msg.WriteString(fmt.Sprintf("All matching chunks exceed the max_output_tokens limit of %d tokens.\n", searchCfg.MaxOutputTokens))
-				msg.WriteString(fmt.Sprintf("Found %d diverse chunks after MMR filtering, but all too large.\n", len(diverseChunks)))
+				fmt.Fprintf(&msg, "All matching chunks exceed the max_output_tokens limit of %d tokens.\n", searchCfg.MaxOutputTokens)
+				fmt.Fprintf(&msg, "Found %d diverse chunks after MMR filtering, but all too large.\n", len(diverseChunks))
 				msg.WriteString("</diagnosis>\n\n")
 				msg.WriteString("<next_steps>\n")
 				msg.WriteString("1. Increase token budget:\n")
-				msg.WriteString(fmt.Sprintf("   → similarity_search(table_name=%q, query_text=%q, max_output_tokens=2500)\n\n", tableName, queryText))
+				fmt.Fprintf(&msg, "   → similarity_search(table_name=%q, query_text=%q, max_output_tokens=2500)\n\n", tableName, queryText)
 				msg.WriteString("2. Reduce chunk size for more granular results:\n")
-				msg.WriteString(fmt.Sprintf("   → similarity_search(table_name=%q, query_text=%q, chunk_size_tokens=50)\n\n", tableName, queryText))
+				fmt.Fprintf(&msg, "   → similarity_search(table_name=%q, query_text=%q, chunk_size_tokens=50)\n\n", tableName, queryText)
 				msg.WriteString("3. Use summary format instead:\n")
-				msg.WriteString(fmt.Sprintf("   → similarity_search(table_name=%q, query_text=%q, output_format=\"summary\")\n\n", tableName, queryText))
+				fmt.Fprintf(&msg, "   → similarity_search(table_name=%q, query_text=%q, output_format=\"summary\")\n\n", tableName, queryText)
 				msg.WriteString("4. Use ids_only to see what matched:\n")
-				msg.WriteString(fmt.Sprintf("   → similarity_search(table_name=%q, query_text=%q, output_format=\"ids_only\")\n", tableName, queryText))
+				fmt.Fprintf(&msg, "   → similarity_search(table_name=%q, query_text=%q, output_format=\"ids_only\")\n", tableName, queryText)
 				msg.WriteString("</next_steps>\n")
 
 				return mcp.NewToolSuccess(msg.String())
@@ -831,9 +831,9 @@ func getDistanceOperator(metric string) string {
 	}
 }
 
-func formatEmbeddingForPostgres(embedding []float64) string {
-	parts := make([]string, len(embedding))
-	for i, val := range embedding {
+func formatEmbeddingForPostgres(vec []float64) string {
+	parts := make([]string, len(vec))
+	for i, val := range vec {
 		parts[i] = fmt.Sprintf("%f", val)
 	}
 	return "[" + strings.Join(parts, ",") + "]"
@@ -879,16 +879,16 @@ func formatSearchResults(
 ) string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Similarity Search Results: %q\n", queryText))
+	fmt.Fprintf(&sb, "Similarity Search Results: %q\n", queryText)
 	sb.WriteString(strings.Repeat("=", 80))
 	sb.WriteString("\n\n")
 
 	// Show configuration
 	sb.WriteString("Configuration:\n")
-	sb.WriteString(fmt.Sprintf("  - Vector Search: Top %d rows\n", cfg.TopN))
-	sb.WriteString(fmt.Sprintf("  - Chunking: %d tokens per chunk, %d token overlap\n", cfg.ChunkSizeTokens, cfg.OverlapTokens))
-	sb.WriteString(fmt.Sprintf("  - Diversity: λ=%.2f (%.0f%% relevance, %.0f%% diversity)\n", cfg.Lambda, cfg.Lambda*100, (1-cfg.Lambda)*100))
-	sb.WriteString(fmt.Sprintf("  - Distance Metric: %s\n", cfg.DistanceMetric))
+	fmt.Fprintf(&sb, "  - Vector Search: Top %d rows\n", cfg.TopN)
+	fmt.Fprintf(&sb, "  - Chunking: %d tokens per chunk, %d token overlap\n", cfg.ChunkSizeTokens, cfg.OverlapTokens)
+	fmt.Fprintf(&sb, "  - Diversity: λ=%.2f (%.0f%% relevance, %.0f%% diversity)\n", cfg.Lambda, cfg.Lambda*100, (1-cfg.Lambda)*100)
+	fmt.Fprintf(&sb, "  - Distance Metric: %s\n", cfg.DistanceMetric)
 
 	// Show column weights
 	if len(columnWeights) > 0 {
@@ -898,7 +898,7 @@ func formatSearchResults(
 			if w.IsTitle {
 				colType = "title"
 			}
-			sb.WriteString(fmt.Sprintf("      %s (%.1f%%) [%s]\n", w.ColumnName, w.Weight*100, colType))
+			fmt.Fprintf(&sb, "      %s (%.1f%%) [%s]\n", w.ColumnName, w.Weight*100, colType)
 		}
 	}
 	sb.WriteString("\n")
@@ -909,11 +909,11 @@ func formatSearchResults(
 		chunkTokens := search.EstimateTokens(chunk.Text)
 		totalTokens += chunkTokens
 
-		sb.WriteString(fmt.Sprintf("Result %d/%d\n", i+1, len(chunks)))
-		sb.WriteString(fmt.Sprintf("Source: %s.%s (vector search rank: #%d, chunk: %d)\n",
-			chunk.SourceTable, chunk.SourceColumn, chunk.OriginalRank+1, chunk.ChunkIndex+1))
-		sb.WriteString(fmt.Sprintf("Relevance Score: %.3f\n", chunk.Score))
-		sb.WriteString(fmt.Sprintf("Tokens: ~%d\n\n", chunkTokens))
+		fmt.Fprintf(&sb, "Result %d/%d\n", i+1, len(chunks))
+		fmt.Fprintf(&sb, "Source: %s.%s (vector search rank: #%d, chunk: %d)\n",
+			chunk.SourceTable, chunk.SourceColumn, chunk.OriginalRank+1, chunk.ChunkIndex+1)
+		fmt.Fprintf(&sb, "Relevance Score: %.3f\n", chunk.Score)
+		fmt.Fprintf(&sb, "Tokens: ~%d\n\n", chunkTokens)
 		sb.WriteString(chunk.Text)
 		sb.WriteString("\n\n")
 		sb.WriteString(strings.Repeat("-", 80))
@@ -921,7 +921,7 @@ func formatSearchResults(
 	}
 
 	sb.WriteString(strings.Repeat("=", 80))
-	sb.WriteString(fmt.Sprintf("\nTotal: %d chunks, ~%d tokens\n", len(chunks), totalTokens))
+	fmt.Fprintf(&sb, "\nTotal: %d chunks, ~%d tokens\n", len(chunks), totalTokens)
 
 	return sb.String()
 }
@@ -935,11 +935,11 @@ func formatSearchResultsSummary(
 ) string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Similarity Search Results (Summary): %q\n", queryText))
+	fmt.Fprintf(&sb, "Similarity Search Results (Summary): %q\n", queryText)
 	sb.WriteString(strings.Repeat("=", 80))
 	sb.WriteString("\n\n")
 
-	sb.WriteString(fmt.Sprintf("Found %d relevant chunks. Showing summaries:\n\n", len(chunks)))
+	fmt.Fprintf(&sb, "Found %d relevant chunks. Showing summaries:\n\n", len(chunks))
 
 	// Show compact results
 	for i, chunk := range chunks {
@@ -949,13 +949,13 @@ func formatSearchResultsSummary(
 			snippet = snippet[:100] + "..."
 		}
 
-		sb.WriteString(fmt.Sprintf("%d. Score: %.3f | Source: %s.%s (rank #%d)\n",
-			i+1, chunk.Score, chunk.SourceTable, chunk.SourceColumn, chunk.OriginalRank+1))
-		sb.WriteString(fmt.Sprintf("   %s\n\n", snippet))
+		fmt.Fprintf(&sb, "%d. Score: %.3f | Source: %s.%s (rank #%d)\n",
+			i+1, chunk.Score, chunk.SourceTable, chunk.SourceColumn, chunk.OriginalRank+1)
+		fmt.Fprintf(&sb, "   %s\n\n", snippet)
 	}
 
 	sb.WriteString(strings.Repeat("=", 80))
-	sb.WriteString(fmt.Sprintf("\nTotal: %d results shown in summary mode\n", len(chunks)))
+	fmt.Fprintf(&sb, "\nTotal: %d results shown in summary mode\n", len(chunks))
 	sb.WriteString("Use output_format='full' to see complete content\n")
 
 	return sb.String()
@@ -969,11 +969,11 @@ func formatSearchResultsIDsOnly(
 ) string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Similarity Search Results (IDs Only): %q\n", queryText))
+	fmt.Fprintf(&sb, "Similarity Search Results (IDs Only): %q\n", queryText)
 	sb.WriteString(strings.Repeat("=", 80))
 	sb.WriteString("\n\n")
 
-	sb.WriteString(fmt.Sprintf("Found %d matching rows. Row IDs and distances:\n\n", len(results)))
+	fmt.Fprintf(&sb, "Found %d matching rows. Row IDs and distances:\n\n", len(results))
 
 	// Show just IDs and distances
 	for i, result := range results {
@@ -982,12 +982,12 @@ func formatSearchResultsIDsOnly(
 			rowID = id
 		}
 
-		sb.WriteString(fmt.Sprintf("%d. ID: %v | Distance: %.4f\n", i+1, rowID, result.Distance))
+		fmt.Fprintf(&sb, "%d. ID: %v | Distance: %.4f\n", i+1, rowID, result.Distance)
 	}
 
 	sb.WriteString("\n")
 	sb.WriteString(strings.Repeat("=", 80))
-	sb.WriteString(fmt.Sprintf("\nTotal: %d results\n", len(results)))
+	fmt.Fprintf(&sb, "\nTotal: %d results\n", len(results))
 	sb.WriteString("Use output_format='summary' for snippets or 'full' for complete content\n")
 
 	return sb.String()

--- a/server/src/internal/tools/similarity_search.go
+++ b/server/src/internal/tools/similarity_search.go
@@ -264,7 +264,7 @@ To avoid rate limits (30,000 input tokens/minute):
 				errMsg.WriteString("3. Check current database connection:\n")
 				errMsg.WriteString("   → read_resource(uri=\"pg://system-info\")\n\n")
 				errMsg.WriteString("4. If table is in a different schema, use qualified name:\n")
-				fmt.Fprintf(&errMsg, "   → similarity_search(table_name=\"schema_name.%s\", query_text=\"...\")\n", tableName)
+				fmt.Fprintf(&errMsg, "   → similarity_search(table_name=%q, query_text=\"...\")\n", qualifiedTableNameHint(tableName))
 				errMsg.WriteString("</next_steps>\n")
 
 				return mcp.NewToolError(errMsg.String())
@@ -339,7 +339,8 @@ To avoid rate limits (30,000 input tokens/minute):
 				errMsg.WriteString("1. Contact server administrator to check embedding configuration\n\n")
 				errMsg.WriteString("2. Verify API keys and service availability\n\n")
 				errMsg.WriteString("3. For non-semantic queries, use query_database instead:\n")
-				fmt.Fprintf(&errMsg, "   → query_database(query=\"SELECT * FROM %s WHERE text_column ILIKE '%%%s%%'\")\n", tableName, queryText)
+				escapedQueryText := escapeSQLSingleQuotes(queryText)
+				fmt.Fprintf(&errMsg, "   → query_database(query=\"SELECT * FROM %s WHERE text_column ILIKE '%%%s%%'\")\n", tableName, escapedQueryText)
 				errMsg.WriteString("</next_steps>\n")
 
 				return mcp.NewToolError(errMsg.String())
@@ -516,6 +517,30 @@ func buildNoTextColumnsHint(tableName string) string {
 	sb.WriteString("   → Try a different table with get_schema_info(vector_tables_only=true)\n")
 	sb.WriteString("</next_steps>\n")
 	return sb.String()
+}
+
+// qualifiedTableNameHint returns a qualified "schema.table" form suitable
+// for interpolation into a "try with the correct schema" hint. If the
+// caller already passed a qualified name (contains a ".") the name is
+// returned unchanged so the hint does not produce a nonsensical triple
+// like "schema_name.public.items". Otherwise the literal placeholder
+// "schema_name." is prepended to guide the user toward providing a
+// schema.
+func qualifiedTableNameHint(tableName string) string {
+	if strings.Contains(tableName, ".") {
+		return tableName
+	}
+	return "schema_name." + tableName
+}
+
+// escapeSQLSingleQuotes doubles any single-quote characters in s so the
+// result is safe to interpolate into a PostgreSQL single-quoted string
+// literal. It is intended for building hint text that a user may copy
+// into query_database; without this escape, a query_text containing an
+// apostrophe (for example "what's new") would emit syntactically broken
+// SQL that fails to parse.
+func escapeSQLSingleQuotes(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
 }
 
 func findTableInMetadataMap(metadata map[string]database.TableInfo, tableName string) (database.TableInfo, error) {

--- a/server/src/internal/tools/similarity_search.go
+++ b/server/src/internal/tools/similarity_search.go
@@ -307,14 +307,7 @@ To avoid rate limits (30,000 input tokens/minute):
 				errMsg.WriteString("- Vector column 'content_embedding' → text column 'content'\n")
 				errMsg.WriteString("- Vector column 'title_vector' → text column 'title'\n")
 				errMsg.WriteString("</diagnosis>\n\n")
-				errMsg.WriteString("<next_steps>\n")
-				errMsg.WriteString("1. Check table structure:\n")
-				fmt.Fprintf(&errMsg, "   → get_schema_info(schema_name=%q)\n\n", strings.Split(tableName, ".")[0])
-				errMsg.WriteString("2. List columns in this table:\n")
-				fmt.Fprintf(&errMsg, "   → query_database(query=\"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '%s'\")\n\n", tableName)
-				errMsg.WriteString("3. This table might not be suitable for semantic search\n")
-				errMsg.WriteString("   → Try a different table with get_schema_info(vector_tables_only=true)\n")
-				errMsg.WriteString("</next_steps>\n")
+				errMsg.WriteString(buildNoTextColumnsHint(tableName))
 
 				return mcp.NewToolError(errMsg.String())
 			}
@@ -488,6 +481,42 @@ To avoid rate limits (30,000 input tokens/minute):
 }
 
 // Helper functions
+
+// buildNoTextColumnsHint returns the "<next_steps>" block emitted when a
+// table has vector columns but no companion text columns. The helper
+// splits the optional "schema.table" form on the first "." so the hint
+// issues well-formed information_schema queries: when the caller passes
+// a qualified name, both table_schema and table_name clauses are
+// emitted; when no schema is supplied, the query omits table_schema and
+// tells the user that search_path determines the effective schema.
+func buildNoTextColumnsHint(tableName string) string {
+	var hintSchema, hintTable string
+	if idx := strings.IndexByte(tableName, '.'); idx >= 0 {
+		hintSchema = tableName[:idx]
+		hintTable = tableName[idx+1:]
+	} else {
+		hintTable = tableName
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<next_steps>\n")
+	sb.WriteString("1. Check table structure:\n")
+	if hintSchema != "" {
+		fmt.Fprintf(&sb, "   → get_schema_info(schema_name=%q)\n\n", hintSchema)
+	} else {
+		sb.WriteString("   → get_schema_info()  (schema will be resolved via search_path; default is \"public\")\n\n")
+	}
+	sb.WriteString("2. List columns in this table:\n")
+	if hintSchema != "" {
+		fmt.Fprintf(&sb, "   → query_database(query=\"SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = '%s' AND table_name = '%s'\")\n\n", hintSchema, hintTable)
+	} else {
+		fmt.Fprintf(&sb, "   → query_database(query=\"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '%s'\")  -- add table_schema filter if the name is not unique across schemas\n\n", hintTable)
+	}
+	sb.WriteString("3. This table might not be suitable for semantic search\n")
+	sb.WriteString("   → Try a different table with get_schema_info(vector_tables_only=true)\n")
+	sb.WriteString("</next_steps>\n")
+	return sb.String()
+}
 
 func findTableInMetadataMap(metadata map[string]database.TableInfo, tableName string) (database.TableInfo, error) {
 	// Handle schema.table format

--- a/server/src/internal/tools/similarity_search_test.go
+++ b/server/src/internal/tools/similarity_search_test.go
@@ -10,10 +10,60 @@
 package tools
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pgedge/ai-workbench/server/internal/database"
 )
+
+func TestBuildNoTextColumnsHint(t *testing.T) {
+	t.Run("qualified table splits schema and table", func(t *testing.T) {
+		hint := buildNoTextColumnsHint("public.items")
+
+		if !strings.Contains(hint, `get_schema_info(schema_name="public")`) {
+			t.Errorf("expected schema hint for qualified name; got %q", hint)
+		}
+		if !strings.Contains(hint,
+			"table_schema = 'public' AND table_name = 'items'") {
+			t.Errorf("expected table_schema + table_name filters; got %q", hint)
+		}
+		if strings.Contains(hint, "table_name = 'public.items'") {
+			t.Errorf("hint must not use the full qualified name as table_name; got %q", hint)
+		}
+	})
+
+	t.Run("unqualified table omits table_schema and notes search_path", func(t *testing.T) {
+		hint := buildNoTextColumnsHint("items")
+
+		if !strings.Contains(hint, "search_path") {
+			t.Errorf("expected search_path note for unqualified name; got %q", hint)
+		}
+		if strings.Contains(hint, "get_schema_info(schema_name=\"items\")") {
+			t.Errorf("unqualified name must not be emitted as a schema; got %q", hint)
+		}
+		if strings.Contains(hint, "table_schema =") {
+			t.Errorf("expected no table_schema clause for unqualified name; got %q", hint)
+		}
+		if !strings.Contains(hint, "table_name = 'items'") {
+			t.Errorf("expected information_schema filter on table_name='items'; got %q", hint)
+		}
+	})
+
+	t.Run("multiple dots splits only on the first", func(t *testing.T) {
+		// Preserves everything after the first dot as the table name,
+		// which avoids silently dropping information from the name.
+		hint := buildNoTextColumnsHint("weird.schema.name")
+
+		if !strings.Contains(hint,
+			`get_schema_info(schema_name="weird")`) {
+			t.Errorf("expected schema 'weird'; got %q", hint)
+		}
+		if !strings.Contains(hint,
+			"table_schema = 'weird' AND table_name = 'schema.name'") {
+			t.Errorf("expected table_name 'schema.name'; got %q", hint)
+		}
+	})
+}
 
 func TestInferTextColumnName(t *testing.T) {
 	tests := []struct {

--- a/server/src/internal/tools/similarity_search_test.go
+++ b/server/src/internal/tools/similarity_search_test.go
@@ -10,6 +10,7 @@
 package tools
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -61,6 +62,190 @@ func TestBuildNoTextColumnsHint(t *testing.T) {
 		if !strings.Contains(hint,
 			"table_schema = 'weird' AND table_name = 'schema.name'") {
 			t.Errorf("expected table_name 'schema.name'; got %q", hint)
+		}
+	})
+}
+
+func TestQualifiedTableNameHint(t *testing.T) {
+	tests := []struct {
+		name      string
+		tableName string
+		want      string
+	}{
+		{
+			name:      "unqualified name gets schema_name prefix",
+			tableName: "items",
+			want:      "schema_name.items",
+		},
+		{
+			name:      "already qualified name is preserved as-is",
+			tableName: "public.items",
+			want:      "public.items",
+		},
+		{
+			name:      "qualified name with custom schema preserved",
+			tableName: "inventory.items",
+			want:      "inventory.items",
+		},
+		{
+			name:      "multi-dot name is not prefixed again",
+			tableName: "weird.schema.name",
+			want:      "weird.schema.name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := qualifiedTableNameHint(tt.tableName)
+			if got != tt.want {
+				t.Errorf("qualifiedTableNameHint(%q) = %q, want %q",
+					tt.tableName, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQualifiedTableNameHint_RenderedInHint renders the helper into the
+// exact fmt.Fprintf hint string used by the "table not found" recovery
+// block and asserts that qualified names never collapse into a nonsense
+// "schema_name.schema.table" triple, while unqualified names receive the
+// "schema_name." placeholder prefix.
+func TestQualifiedTableNameHint_RenderedInHint(t *testing.T) {
+	render := func(tableName string) string {
+		return fmt.Sprintf(
+			"   → similarity_search(table_name=%q, query_text=\"...\")\n",
+			qualifiedTableNameHint(tableName),
+		)
+	}
+
+	t.Run("qualified name is not double-prefixed", func(t *testing.T) {
+		hint := render("public.items")
+
+		if strings.Contains(hint, "schema_name.public.items") {
+			t.Errorf("qualified name must not be prefixed with schema_name.; got %q", hint)
+		}
+		if strings.Contains(hint, "schema_name.schema.table") {
+			t.Errorf("hint must not contain the schema_name.schema.table nonsense form; got %q", hint)
+		}
+		if !strings.Contains(hint, `table_name="public.items"`) {
+			t.Errorf("expected qualified name to appear as-is inside table_name=; got %q", hint)
+		}
+	})
+
+	t.Run("unqualified name receives schema_name placeholder", func(t *testing.T) {
+		hint := render("items")
+
+		if !strings.Contains(hint, `table_name="schema_name.items"`) {
+			t.Errorf("expected schema_name.items placeholder for unqualified name; got %q", hint)
+		}
+		if strings.Contains(hint, "schema_name.schema_name.items") {
+			t.Errorf("unqualified name must not be double-prefixed; got %q", hint)
+		}
+	})
+
+	t.Run("multi-dot qualified name is preserved", func(t *testing.T) {
+		hint := render("weird.schema.name")
+
+		if strings.Contains(hint, "schema_name.weird.schema.name") {
+			t.Errorf("multi-dot name must not be prefixed; got %q", hint)
+		}
+		if !strings.Contains(hint, `table_name="weird.schema.name"`) {
+			t.Errorf("expected multi-dot name preserved inside table_name=; got %q", hint)
+		}
+	})
+}
+
+func TestEscapeSQLSingleQuotes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty string is unchanged",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "string without quotes is unchanged",
+			in:   "hello world",
+			want: "hello world",
+		},
+		{
+			name: "single apostrophe is doubled",
+			in:   "what's new",
+			want: "what''s new",
+		},
+		{
+			name: "multiple apostrophes are each doubled",
+			in:   "it's a user's guide",
+			want: "it''s a user''s guide",
+		},
+		{
+			name: "only apostrophes",
+			in:   "'''",
+			want: "''''''",
+		},
+		{
+			name: "double quotes are not touched",
+			in:   `he said "hi"`,
+			want: `he said "hi"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := escapeSQLSingleQuotes(tt.in)
+			if got != tt.want {
+				t.Errorf("escapeSQLSingleQuotes(%q) = %q, want %q",
+					tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEscapeSQLSingleQuotes_RenderedInILikeHint renders the helper into
+// the exact fmt.Fprintf hint string used by the embedding-failure
+// recovery block and asserts that apostrophes in the user-supplied query
+// text are doubled so the emitted SQL parses cleanly.
+func TestEscapeSQLSingleQuotes_RenderedInILikeHint(t *testing.T) {
+	render := func(tableName, queryText string) string {
+		escapedQueryText := escapeSQLSingleQuotes(queryText)
+		return fmt.Sprintf(
+			"   → query_database(query=\"SELECT * FROM %s WHERE text_column ILIKE '%%%s%%'\")\n",
+			tableName, escapedQueryText,
+		)
+	}
+
+	t.Run("apostrophe in query_text is escaped", func(t *testing.T) {
+		hint := render("public.items", "what's new")
+
+		if !strings.Contains(hint, "ILIKE '%what''s new%'") {
+			t.Errorf("expected doubled-quote escape inside ILIKE literal; got %q", hint)
+		}
+
+		// Count total apostrophes in the emitted line. The only
+		// unescaped singletons must come from the enclosing
+		// ILIKE '...' delimiters (two of them). Every apostrophe
+		// introduced by queryText must appear as a doubled pair.
+		if strings.Contains(hint, "ILIKE '%what's new%'") {
+			t.Errorf("hint must not contain an unescaped apostrophe from query_text; got %q", hint)
+		}
+	})
+
+	t.Run("multiple apostrophes are each escaped", func(t *testing.T) {
+		hint := render("public.items", "it's a user's guide")
+
+		if !strings.Contains(hint, "ILIKE '%it''s a user''s guide%'") {
+			t.Errorf("expected both apostrophes doubled; got %q", hint)
+		}
+	})
+
+	t.Run("query text without quotes is unchanged in hint", func(t *testing.T) {
+		hint := render("public.items", "hello world")
+
+		if !strings.Contains(hint, "ILIKE '%hello world%'") {
+			t.Errorf("expected unmodified interpolation for quote-free text; got %q", hint)
 		}
 	})
 }

--- a/server/src/internal/tools/store_memory.go
+++ b/server/src/internal/tools/store_memory.go
@@ -156,21 +156,21 @@ func StoreMemoryTool(memoryStore *memory.Store, cfg *config.Config, rbacChecker 
 			sb.WriteString("Memory Stored Successfully\n")
 			sb.WriteString(strings.Repeat("=", 50))
 			sb.WriteString("\n\n")
-			sb.WriteString(fmt.Sprintf("ID:       %d\n", mem.ID))
-			sb.WriteString(fmt.Sprintf("Scope:    %s\n", mem.Scope))
-			sb.WriteString(fmt.Sprintf("Category: %s\n", mem.Category))
+			fmt.Fprintf(&sb, "ID:       %d\n", mem.ID)
+			fmt.Fprintf(&sb, "Scope:    %s\n", mem.Scope)
+			fmt.Fprintf(&sb, "Category: %s\n", mem.Category)
 			if mem.Pinned {
 				sb.WriteString("Pinned:   yes\n")
 			} else {
 				sb.WriteString("Pinned:   no\n")
 			}
 			if embeddingVec != nil {
-				sb.WriteString(fmt.Sprintf("Embedding: generated (%d dimensions, model: %s)\n", len(embeddingVec), modelName))
+				fmt.Fprintf(&sb, "Embedding: generated (%d dimensions, model: %s)\n", len(embeddingVec), modelName)
 			} else {
 				sb.WriteString("Embedding: none (embedding generation unavailable)\n")
 			}
-			sb.WriteString(fmt.Sprintf("Created:  %s\n", mem.CreatedAt.Format("2006-01-02 15:04:05 UTC")))
-			sb.WriteString(fmt.Sprintf("\nContent:\n  %s\n", mem.Content))
+			fmt.Fprintf(&sb, "Created:  %s\n", mem.CreatedAt.Format("2006-01-02 15:04:05 UTC"))
+			fmt.Fprintf(&sb, "\nContent:\n  %s\n", mem.Content)
 
 			return mcp.NewToolSuccess(sb.String())
 		},

--- a/server/src/internal/tools/util.go
+++ b/server/src/internal/tools/util.go
@@ -1,0 +1,34 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import "strings"
+
+// sanitizeTSVField replaces characters that break tab-separated output
+// (tabs, newlines, carriage returns) with single spaces. This variant is
+// intended for human- and LLM-readable TSV output emitted by tools such
+// as list_probes and list_connections. It deliberately does not escape
+// with backslash sequences because the output is not round-tripped
+// through a TSV parser; keeping the text readable matters more than
+// losslessly preserving the original separator characters.
+//
+// Numeric fields do not require this helper; only untrusted string
+// fields that may contain tabs or newlines should be wrapped.
+func sanitizeTSVField(s string) string {
+	if s == "" {
+		return s
+	}
+	replacer := strings.NewReplacer(
+		"\t", " ",
+		"\n", " ",
+		"\r", " ",
+	)
+	return replacer.Replace(s)
+}

--- a/server/src/internal/tools/util_test.go
+++ b/server/src/internal/tools/util_test.go
@@ -1,0 +1,42 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import "testing"
+
+func TestSanitizeTSVField(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"plain text unchanged", "hello world", "hello world"},
+		{"tab replaced with space", "a\tb", "a b"},
+		{"newline replaced with space", "a\nb", "a b"},
+		{"carriage return replaced with space", "a\rb", "a b"},
+		{"crlf replaced with two spaces", "a\r\nb", "a  b"},
+		{"mixed separators", "a\tb\nc\rd", "a b c d"},
+		{"multiple tabs", "x\t\ty", "x  y"},
+		{"unicode preserved", "café ✓", "café ✓"},
+		{"no backslash escaping", "foo\tbar", "foo bar"},
+		{"leading and trailing separators", "\tmiddle\n", " middle "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeTSVField(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeTSVField(%q) = %q, want %q",
+					tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #66.

- Migrates `.golangci.yml` for collector, alerter, and server from
  golangci-lint v1 to v2; updates the three CI workflows to install
  `golangci-lint/v2@latest`. `make test-all` works again on
  developer machines that have golangci-lint v2 installed.
- Fixes the 26 pre-existing findings the v2 linter surfaced, including
  the security-relevant ones (G202 SQL concat, G707 SMTP
  injection, G706 log injection).
- Hardens the webhook test path against SSRF-via-redirect by installing
  `CheckRedirect: http.ErrUseLastResponse` on the two test-sender
  `http.Client` instances.
- Adds tests bringing `sendTestWebhook`, `sendTestGenericWebhook`,
  `handleGroupMCPPrivileges`, `grantGroupPermission`,
  `handleGroupPermissions`, `revokeGroupPermission`, and
  `SanitizeForLog` to ≥ 90% line coverage.

## What changed

### Real fixes

- `server/src/internal/tools/search_knowledgebase.go`: SQL query built
  through `strings.Builder` with only `?` placeholders varying; user
  values bound as parameters.
- `server/src/internal/api/email_test_sender.go`: new
  `sanitizeSMTPHeader` helper strips CR/LF from envelope (MAIL FROM,
  RCPT TO) and header writes (From, To).
- `server/src/internal/logging/logging.go`: new `SanitizeForLog`
  helper escapes CR, LF, HT, NUL, BS, VT, FF, ESC, DEL; applied at
  every user-tainted log site across api/auth/config packages.
- `server/src/internal/api/webhook_test_sender.go`:
  `CheckRedirect: http.ErrUseLastResponse` on both `http.Client`
  instances closes SSRF-via-Location-header against cloud metadata.
- Staticcheck QF1012 (`WriteString(Sprintf)` → `Fprintf`) and QF1001
  (De Morgan's law) refactors across the three Go sub-projects.
- gocritic `importShadow` resolved via local rename in
  `compactor.go`, `llmproxy/proxy.go`, `search_knowledgebase.go`,
  and `similarity_search.go`.

### Suppressions

Every `//nolint:gosec` added in this PR cites the concrete upstream
invariant that makes the finding safe (admin-only provider URLs,
`hostValidator.ValidateHost` pre-dial, integer-typed log arguments,
allowlisted scope names) and notes on the dial-path sites that DNS
rebinding between validation and dial remains an admin-scope residual
risk.

### Security review

This PR was reviewed by the security-auditor sub-agent before push.
Verdict: approve with fixes; all must-fix items (SSRF redirect
bypass, incomplete log sanitization at
`rbac_group_privilege_handlers.go:63,221`, broader sanitizer
character set, DNS-rebind nolint wording) have been applied.

## Test plan

- [x] `cd collector && make test-all` — lint 0 issues, all tests pass
- [x] `cd alerter && make test-all` — lint 0 issues, all tests pass
- [x] `cd server && make test-all` — lint 0 issues, all tests pass
- [x] `gofmt -l` clean across all touched Go files
- [x] Coverage ≥ 90% on every unit touched by security fixes
  (`SanitizeForLog` 100%, `sendTestWebhook` 94.1%,
  `sendTestGenericWebhook` 97.1%, `handleGroupMCPPrivileges` 96.2%,
  `grantGroupPermission` 90.9%)
- [ ] CI green on this PR
- [ ] Review from CodeRabbit

Note: one client Vitest test (`ServerDialog.test.tsx > SSL settings >
includes SSL settings in save data`) times out under full-suite load
and passes in isolation. This is a pre-existing environmental flake
on main, not introduced by this PR; verified by running against
`main` with changes stashed.

https://claude.ai/code/session_01Cz44YgSu4tLGdr4HyEpeQR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Hardened SMTP and webhook handling to prevent header injection and unsafe redirects; logs now sanitize user-tainted values.

* **Testing**
  * Added and expanded unit/integration tests across email, webhooks, RBAC, knowledgebase search, compactor, tools, and TSV/helpers.

* **Infrastructure**
  * CI lint install and linter configurations migrated to golangci-lint v2.

* **Improvements**
  * Centralized log-sanitization utility and safer TSV/output field handling; many string-building paths streamlined for efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->