### PR TITLE
Fix dashboard graph overflow when chat panel is open

### DIFF
--- a/client/src/components/Dashboard/EstateDashboard/HealthOverviewSection.tsx
+++ b/client/src/components/Dashboard/EstateDashboard/HealthOverviewSection.tsx
@@ -35,10 +35,10 @@ interface AlertCounts {
 
 const RINGS_CONTAINER_SX = {
     display: 'grid',
-    gridTemplateColumns: 'repeat(2, 1fr)',
+    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
     gap: 2,
     '@media (max-width: 600px)': {
-        gridTemplateColumns: '1fr',
+        gridTemplateColumns: 'minmax(0, 1fr)',
     },
 };
 

--- a/client/src/components/Dashboard/styles.ts
+++ b/client/src/components/Dashboard/styles.ts
@@ -58,11 +58,11 @@ export const KPI_GRID_SX: SxProps<Theme> = {
 /** Metric chart container */
 export const CHART_SECTION_SX: SxProps<Theme> = {
     display: 'grid',
-    gridTemplateColumns: 'repeat(2, 1fr)',
+    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
     gap: 2,
     mb: 2,
     '@media (max-width: 900px)': {
-        gridTemplateColumns: '1fr',
+        gridTemplateColumns: 'minmax(0, 1fr)',
     },
 };
 


### PR DESCRIPTION
## Summary

- Replace `1fr` with `minmax(0, 1fr)` in `CHART_SECTION_SX` grid template so chart containers respect their track width instead of overflowing to fit intrinsic content size.
- Apply the same fix to `RINGS_CONTAINER_SX` in the estate dashboard's health overview section.
- Covers all 18 charts across 5 dashboard sections (System Resources, Postgres Overview, WAL/Replication, Database Performance, Cluster Comparative Metrics) plus 2 estate donut charts.

Fixes #138

## Test plan

- [ ] Open a server dashboard with the Ask Ellie chat panel open; confirm all charts (CPU, Memory, Disk, Load Average, Network I/O) fit within their grid cells without clipping.
- [ ] Scroll down to Postgres Overview charts (Connections, Transactions, Block I/O, Tuples) and confirm no overflow.
- [ ] Check WAL/Replication section charts.
- [ ] Select a database and confirm Performance section charts resize correctly.
- [ ] Select a cluster and confirm Comparative Metrics bar charts fit.
- [ ] Select the estate view and confirm donut charts fit.
- [ ] Resize the chat panel wider/narrower and confirm charts reflow smoothly.
- [ ] Close the chat panel and confirm charts expand to fill the full width.
- [ ] Narrow the browser below 900px and confirm charts stack to a single column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved grid layout responsiveness for dashboard charts and health overview sections to better adapt to various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->