### PR TITLE
Enforce token connection scope on session-based MCP access

### DIFF
--- a/server/src/internal/resources/context_aware_registry.go
+++ b/server/src/internal/resources/context_aware_registry.go
@@ -315,6 +315,20 @@ func (r *ContextAwareRegistry) getClient(ctx context.Context) (*database.Client,
 		}
 
 		if session != nil {
+			// Verify the token still has access to this connection.
+			// The session may have been established before token scope
+			// was restricted; enforce the scope at use-time.
+			if r.rbacChecker != nil {
+				canAccess, _ := r.rbacChecker.CanAccessConnection(ctx, session.ConnectionID)
+				if !canAccess {
+					// Clear the stale session so subsequent calls get
+					// a clean "no connection selected" error.
+					//nolint:errcheck // Best effort cleanup; we return the access denied error regardless
+					r.authStore.ClearConnectionSession(tokenHash)
+					return nil, fmt.Errorf("access denied: the selected connection is no longer accessible with this token's scope. Please select a permitted connection")
+				}
+			}
+
 			// Get connection info from datastore
 			conn, password, err := r.datastore.GetConnectionWithPassword(ctx, session.ConnectionID)
 			if err != nil {

--- a/server/src/internal/resources/context_aware_registry_test.go
+++ b/server/src/internal/resources/context_aware_registry_test.go
@@ -279,3 +279,408 @@ func TestContextAwareRegistry_DefaultNilConfig(t *testing.T) {
 		t.Errorf("expected at least 1 resource with default config, got %d", len(resources))
 	}
 }
+
+// TestGetClient_TokenScopeEnforcement tests that getClient enforces token connection
+// scope at use-time. This is a regression test for issue #94 where a session
+// established before token scope restriction would bypass RBAC checks.
+func TestGetClient_TokenScopeEnforcement(t *testing.T) {
+	// Create a temporary auth store
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create a test user and token
+	if err := authStore.CreateUser("testuser", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("testuser")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	// Create a token for the user
+	_, token, err := authStore.CreateToken("testuser", "test-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session (simulating a previously selected connection)
+	if err := authStore.SetConnectionSession(tokenHash, 42, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	t.Run("registry creation with nil authStore creates valid rbacChecker", func(t *testing.T) {
+		clientManager := database.NewClientManager(nil)
+		defer clientManager.CloseAll()
+
+		cfg := &conf.Config{}
+
+		// Create registry with nil authStore - should not panic
+		registry := NewContextAwareRegistry(clientManager, cfg, nil, nil)
+		if registry == nil {
+			t.Fatal("Expected non-nil registry")
+		}
+		if registry.rbacChecker == nil {
+			t.Fatal("Expected non-nil rbacChecker even with nil authStore")
+		}
+
+		// With nil authStore, superuser check should return true
+		ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, "any-token")
+		if !registry.rbacChecker.IsSuperuser(ctx) {
+			t.Error("Expected IsSuperuser to return true with nil authStore")
+		}
+	})
+
+	t.Run("non-superuser context is properly identified", func(t *testing.T) {
+		// Build context for the non-superuser token
+		ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+		ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+		ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+		ctx = context.WithValue(ctx, auth.UsernameContextKey, "testuser")
+
+		// Create RBAC checker with the auth store
+		rbacChecker := auth.NewRBACChecker(authStore)
+
+		// Verify superuser check works correctly
+		if rbacChecker.IsSuperuser(ctx) {
+			t.Error("Expected IsSuperuser to return false for non-superuser context")
+		}
+	})
+
+	t.Run("RBAC denies access to unowned unshared connection", func(t *testing.T) {
+		// Build context for the non-superuser token
+		ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+		ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+		ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+		ctx = context.WithValue(ctx, auth.UsernameContextKey, "testuser")
+
+		// Create RBAC checker that will deny access to connection 42
+		rbacChecker := auth.NewRBACChecker(authStore)
+		// Configure sharing lookup to return unshared connection owned by someone else
+		rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+			if connectionID == 42 {
+				// Connection is not shared and owned by a different user
+				return false, "otheruser", nil
+			}
+			return false, "", nil
+		})
+
+		// Verify RBAC denies access to connection 42
+		canAccess, _ := rbacChecker.CanAccessConnection(ctx, 42)
+		if canAccess {
+			t.Error("Expected CanAccessConnection to return false for unowned unshared connection")
+		}
+	})
+}
+
+// TestGetClient_SessionClearedOnRBACDenial verifies that when RBAC denies
+// access to a session's connection, the session is cleared so subsequent
+// calls get a clean "no connection selected" error.
+func TestGetClient_SessionClearedOnRBACDenial(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create user and token
+	if err := authStore.CreateUser("alice", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	_, token, err := authStore.CreateToken("alice", "alice-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session
+	if err := authStore.SetConnectionSession(tokenHash, 99, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Verify session exists before the test
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil {
+		t.Fatal("Expected session to exist before test")
+	}
+	if session.ConnectionID != 99 {
+		t.Errorf("Expected ConnectionID 99, got %d", session.ConnectionID)
+	}
+
+	// Clear the session (simulating what getClient does on RBAC denial)
+	if err := authStore.ClearConnectionSession(tokenHash); err != nil {
+		t.Fatalf("ClearConnectionSession: %v", err)
+	}
+
+	// Verify session is cleared
+	session, err = authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession after clear: %v", err)
+	}
+	if session != nil {
+		t.Error("Expected session to be nil after clearing")
+	}
+}
+
+// TestGetClient_RBACDenialClearsSession exercises the full getClient()
+// code path. This test verifies that when a session exists but RBAC denies
+// access to the connection, the session is cleared and an appropriate error
+// is returned.
+//
+// This is a regression test for issue #94 where sessions established before
+// token scope restriction would bypass RBAC checks at use-time.
+func TestGetClient_RBACDenialClearsSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create user and token
+	if err := authStore.CreateUser("alice", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("alice")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("alice", "alice-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session for connection 42
+	if err := authStore.SetConnectionSession(tokenHash, 42, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Verify session exists
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil || session.ConnectionID != 42 {
+		t.Fatal("Expected session with ConnectionID 42")
+	}
+
+	// Create registry with both authStore AND datastore (non-nil)
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &conf.Config{}
+	datastore := database.NewTestDatastore(nil)
+
+	registry := NewContextAwareRegistry(clientManager, cfg, authStore, datastore)
+
+	// Configure the RBAC checker to deny access to connection 42
+	registry.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 42 {
+			return false, "otheruser", nil // Not shared, owned by someone else
+		}
+		return false, "", nil
+	})
+
+	// Build context for non-superuser token
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "alice")
+
+	// Call getClient - should return access denied error
+	_, err = registry.getClient(ctx)
+	if err == nil {
+		t.Fatal("Expected error for RBAC-denied connection")
+	}
+	if err.Error() != "access denied: the selected connection is no longer accessible with this token's scope. Please select a permitted connection" {
+		t.Errorf("Expected access denied error, got: %v", err)
+	}
+
+	// Verify the session was cleared by getClient
+	session, err = authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession after denial: %v", err)
+	}
+	if session != nil {
+		t.Error("Expected session to be nil after RBAC denial cleared it")
+	}
+}
+
+// TestGetClient_RBACAllowsAccessProceedsToDatastore exercises the
+// getClient() code path when RBAC allows access.
+func TestGetClient_RBACAllowsAccessProceedsToDatastore(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create user and token
+	if err := authStore.CreateUser("bob", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("bob", "bob-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session for connection 99
+	if err := authStore.SetConnectionSession(tokenHash, 99, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Create registry with both authStore AND datastore
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &conf.Config{}
+	datastore := database.NewTestDatastore(nil)
+
+	registry := NewContextAwareRegistry(clientManager, cfg, authStore, datastore)
+
+	// Configure the RBAC checker to allow access to connection 99
+	registry.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 99 {
+			return true, "bob", nil // Shared connection
+		}
+		return false, "", nil
+	})
+
+	// Build context for non-superuser token
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "bob")
+
+	// Call getClient. RBAC allows access, so the code proceeds
+	// to GetConnectionWithPassword which panics with a nil pool.
+	var panicValue any
+	func() {
+		defer func() {
+			panicValue = recover()
+		}()
+		_, _ = registry.getClient(ctx)
+	}()
+
+	// If we got a panic, it means RBAC passed and code proceeded to datastore
+	if panicValue != nil {
+		// Panic occurred - verify session still exists (RBAC didn't clear it)
+		session, err := authStore.GetConnectionSession(tokenHash)
+		if err != nil {
+			t.Fatalf("GetConnectionSession: %v", err)
+		}
+		if session == nil {
+			t.Error("Expected session to still exist after RBAC allowed access")
+		}
+		return // Test passed - RBAC was allowed, code reached datastore
+	}
+
+	// Session should still exist (RBAC allowed, only datastore failed)
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil {
+		t.Error("Expected session to still exist after RBAC allowed access")
+	}
+}
+
+// TestGetClient_SuperuserBypassesRBAC verifies that superuser context
+// bypasses RBAC checks even when a sharing lookup would deny access.
+func TestGetClient_SuperuserBypassesRBAC(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create superuser and token
+	if err := authStore.CreateUser("admin", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := authStore.SetUserSuperuser("admin", true); err != nil {
+		t.Fatalf("SetUserSuperuser: %v", err)
+	}
+	userID, err := authStore.GetUserID("admin")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("admin", "admin-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session
+	if err := authStore.SetConnectionSession(tokenHash, 88, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Create registry
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &conf.Config{}
+	datastore := database.NewTestDatastore(nil)
+
+	registry := NewContextAwareRegistry(clientManager, cfg, authStore, datastore)
+
+	// Configure RBAC checker to deny access if it were checked
+	registry.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		return false, "otheruser", nil // Would deny non-superusers
+	})
+
+	// Build context with superuser flag
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, true) // Superuser!
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "admin")
+
+	// Call getClient. The superuser bypasses RBAC, so the code proceeds
+	// to GetConnectionWithPassword which panics with a nil pool.
+	var panicValue any
+	func() {
+		defer func() {
+			panicValue = recover()
+		}()
+		_, _ = registry.getClient(ctx)
+	}()
+
+	// If we got a panic, it means RBAC passed and code proceeded to datastore
+	if panicValue != nil {
+		// Panic occurred - verify session still exists (RBAC didn't clear it)
+		session, err := authStore.GetConnectionSession(tokenHash)
+		if err != nil {
+			t.Fatalf("GetConnectionSession: %v", err)
+		}
+		if session == nil {
+			t.Error("Expected session to still exist for superuser (RBAC was bypassed)")
+		}
+		return // Test passed - RBAC was bypassed, code reached datastore
+	}
+
+	// Session should still exist (not cleared by RBAC denial)
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil {
+		t.Error("Expected session to still exist for superuser")
+	}
+}

--- a/server/src/internal/tools/context_aware_provider.go
+++ b/server/src/internal/tools/context_aware_provider.go
@@ -442,8 +442,13 @@ func (p *ContextAwareProvider) Execute(ctx context.Context, name string, args ma
 				if tokenHash != "" {
 					session, err := p.authStore.GetConnectionSession(tokenHash)
 					if err == nil && session != nil {
-						// Inject the session's connection ID as the default
-						args["connection_id"] = float64(session.ConnectionID)
+						// Verify token still has access before injecting
+						if p.rbacChecker == nil {
+							args["connection_id"] = float64(session.ConnectionID)
+						} else if canAccess, _ := p.rbacChecker.CanAccessConnection(ctx, session.ConnectionID); canAccess {
+							args["connection_id"] = float64(session.ConnectionID)
+						}
+						// If access denied, don't inject - let tool report "connection_id required"
 					}
 				}
 			}
@@ -518,6 +523,20 @@ func (p *ContextAwareProvider) getClient(ctx context.Context) (*database.Client,
 		}
 
 		if session != nil {
+			// Verify the token still has access to this connection.
+			// The session may have been established before token scope
+			// was restricted; enforce the scope at use-time.
+			if p.rbacChecker != nil {
+				canAccess, _ := p.rbacChecker.CanAccessConnection(ctx, session.ConnectionID)
+				if !canAccess {
+					// Clear the stale session so subsequent calls get
+					// a clean "no connection selected" error.
+					//nolint:errcheck // Best effort cleanup; we return the access denied error regardless
+					p.authStore.ClearConnectionSession(tokenHash)
+					return nil, fmt.Errorf("access denied: the selected connection is no longer accessible with this token's scope. Please select a permitted connection")
+				}
+			}
+
 			// Get connection info from datastore
 			conn, password, err := p.datastore.GetConnectionWithPassword(ctx, session.ConnectionID)
 			if err != nil {

--- a/server/src/internal/tools/context_aware_provider_test.go
+++ b/server/src/internal/tools/context_aware_provider_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/config"
 	"github.com/pgedge/ai-workbench/server/internal/database"
+	"github.com/pgedge/ai-workbench/server/internal/mcp"
 	"github.com/pgedge/ai-workbench/server/internal/resources"
 )
 
@@ -257,5 +258,957 @@ func TestContextAwareProvider_RegisterTools_WithContext(t *testing.T) {
 	tools := provider.List()
 	if len(tools) == 0 {
 		t.Error("Expected tools to be registered")
+	}
+}
+
+// TestGetClient_TokenScopeEnforcement tests that getClient enforces token connection
+// scope at use-time. This is a regression test for issue #94 where a session
+// established before token scope restriction would bypass RBAC checks.
+func TestGetClient_TokenScopeEnforcement(t *testing.T) {
+	// Create a temporary auth store
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create a test user and token
+	if err := authStore.CreateUser("testuser", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("testuser")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	// Create a token for the user
+	_, token, err := authStore.CreateToken("testuser", "test-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session (simulating a previously selected connection)
+	if err := authStore.SetConnectionSession(tokenHash, 42, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	t.Run("provider creation with nil authStore creates valid rbacChecker", func(t *testing.T) {
+		// This test verifies that NewContextAwareProvider handles nil authStore
+		// correctly by creating an rbacChecker that grants full access
+		clientManager := database.NewClientManager(nil)
+		defer clientManager.CloseAll()
+
+		cfg := &config.Config{}
+		resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+
+		// Create provider with nil authStore - should not panic
+		provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, nil, nil, nil)
+		if provider == nil {
+			t.Fatal("Expected non-nil provider")
+		}
+		if provider.rbacChecker == nil {
+			t.Fatal("Expected non-nil rbacChecker even with nil authStore")
+		}
+
+		// With nil authStore, superuser check should return true
+		ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, "any-token")
+		if !provider.rbacChecker.IsSuperuser(ctx) {
+			t.Error("Expected IsSuperuser to return true with nil authStore")
+		}
+	})
+
+	t.Run("non-superuser context is properly identified", func(t *testing.T) {
+		// Build context for the non-superuser token
+		ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+		ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+		ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+		ctx = context.WithValue(ctx, auth.UsernameContextKey, "testuser")
+
+		// Create RBAC checker with the auth store
+		rbacChecker := auth.NewRBACChecker(authStore)
+
+		// Verify superuser check works correctly
+		if rbacChecker.IsSuperuser(ctx) {
+			t.Error("Expected IsSuperuser to return false for non-superuser context")
+		}
+	})
+
+	t.Run("RBAC denies access to unowned unshared connection", func(t *testing.T) {
+		// Build context for the non-superuser token
+		ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+		ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+		ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+		ctx = context.WithValue(ctx, auth.UsernameContextKey, "testuser")
+
+		// Create RBAC checker that will deny access to connection 42
+		rbacChecker := auth.NewRBACChecker(authStore)
+		// Configure sharing lookup to return unshared connection owned by someone else
+		rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+			if connectionID == 42 {
+				// Connection is not shared and owned by a different user
+				return false, "otheruser", nil
+			}
+			return false, "", nil
+		})
+
+		// Verify RBAC denies access to connection 42
+		canAccess, _ := rbacChecker.CanAccessConnection(ctx, 42)
+		if canAccess {
+			t.Error("Expected CanAccessConnection to return false for unowned unshared connection")
+		}
+	})
+}
+
+// TestGetClient_SessionClearedOnRBACDenial verifies that when RBAC denies
+// access to a session's connection, the session is cleared so subsequent
+// calls get a clean "no connection selected" error.
+func TestGetClient_SessionClearedOnRBACDenial(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create user and token
+	if err := authStore.CreateUser("alice", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	_, token, err := authStore.CreateToken("alice", "alice-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session
+	if err := authStore.SetConnectionSession(tokenHash, 99, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Verify session exists before the test
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil {
+		t.Fatal("Expected session to exist before test")
+	}
+	if session.ConnectionID != 99 {
+		t.Errorf("Expected ConnectionID 99, got %d", session.ConnectionID)
+	}
+
+	// The actual session clearing happens inside getClient when:
+	// 1. authStore != nil && datastore != nil
+	// 2. session != nil
+	// 3. rbacChecker != nil
+	// 4. rbacChecker.CanAccessConnection returns false
+	//
+	// We can verify that ClearConnectionSession works correctly when called.
+
+	// Clear the session (simulating what getClient does on RBAC denial)
+	if err := authStore.ClearConnectionSession(tokenHash); err != nil {
+		t.Fatalf("ClearConnectionSession: %v", err)
+	}
+
+	// Verify session is cleared
+	session, err = authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession after clear: %v", err)
+	}
+	if session != nil {
+		t.Error("Expected session to be nil after clearing")
+	}
+}
+
+// TestGetClient_NilRBACCheckerInSession verifies that the nil check for
+// rbacChecker in getClient prevents panics when rbacChecker is nil.
+// Note: In normal operation, NewContextAwareProvider always creates an
+// rbacChecker, but this test ensures defensive coding is in place.
+func TestGetClient_NilRBACCheckerInSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create user and token
+	if err := authStore.CreateUser("bob", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	_, token, err := authStore.CreateToken("bob", "bob-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session
+	if err := authStore.SetConnectionSession(tokenHash, 50, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Create a provider using the constructor which ensures rbacChecker is not nil
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+
+	// Create provider with the authStore but no datastore
+	// The constructor will create a valid rbacChecker
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, nil)
+
+	// Verify provider has a non-nil rbacChecker
+	if provider.rbacChecker == nil {
+		t.Fatal("Expected non-nil rbacChecker from constructor")
+	}
+
+	// The getClient code path with session != nil and rbacChecker != nil
+	// is now properly guarded. Without a datastore, we won't reach the
+	// RBAC check in getClient, but we can verify the provider was created correctly.
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+
+	// Execute should not panic due to nil rbacChecker
+	response, _ := provider.Execute(ctx, "read_resource", map[string]any{
+		"uri": "test://resource",
+	})
+
+	// Should get a response (may be an error about resource not found)
+	if len(response.Content) == 0 {
+		t.Fatal("Expected non-empty response content")
+	}
+}
+
+// TestExecute_GetClient_RBACDenialClearsSession exercises the full getClient()
+// code path through Execute(). This test verifies that when a session exists
+// but RBAC denies access to the connection, the session is cleared and an
+// appropriate error is returned.
+//
+// This is a regression test for issue #94 where sessions established before
+// token scope restriction would bypass RBAC checks at use-time.
+func TestExecute_GetClient_RBACDenialClearsSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Register query_database as a public privilege so the MCP tool RBAC check
+	// passes and we can reach the getClient() code path that we're testing
+	if _, err := authStore.RegisterMCPPrivilege("query_database", auth.MCPPrivilegeTypeTool, "Query database", true); err != nil {
+		t.Fatalf("RegisterMCPPrivilege: %v", err)
+	}
+
+	// Create user and token
+	if err := authStore.CreateUser("alice", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("alice")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("alice", "alice-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session for connection 42
+	if err := authStore.SetConnectionSession(tokenHash, 42, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Verify session exists
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil || session.ConnectionID != 42 {
+		t.Fatal("Expected session with ConnectionID 42")
+	}
+
+	// Create provider with both authStore AND datastore (non-nil)
+	// Using NewTestDatastore(nil) creates a datastore with nil pool, but that's
+	// OK because the RBAC denial path returns BEFORE any datastore methods are called
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+	datastore := database.NewTestDatastore(nil)
+
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, datastore)
+
+	// Configure the RBAC checker to deny access to connection 42
+	// The connection is not shared and owned by a different user
+	provider.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 42 {
+			return false, "otheruser", nil // Not shared, owned by someone else
+		}
+		return false, "", nil
+	})
+
+	// Build context for non-superuser token
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "alice")
+
+	// Execute a database-dependent tool (query_database requires getClient)
+	response, _ := provider.Execute(ctx, "query_database", map[string]any{
+		"query": "SELECT 1",
+	})
+
+	// Should get an error response about access denied (connection-level RBAC)
+	if !response.IsError {
+		t.Error("Expected error response for RBAC-denied connection")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("Expected non-empty response content")
+	}
+	errorMsg := response.Content[0].Text
+	if !strings.Contains(errorMsg, "access denied") {
+		t.Errorf("Expected 'access denied' error, got: %s", errorMsg)
+	}
+
+	// Verify the session was cleared by getClient
+	session, err = authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession after denial: %v", err)
+	}
+	if session != nil {
+		t.Error("Expected session to be nil after RBAC denial cleared it")
+	}
+}
+
+// TestExecute_GetClient_RBACAllowsAccessProceedsToDatastore exercises the
+// getClient() code path when RBAC allows access. The test verifies that after
+// passing the RBAC check, the code attempts to fetch connection info from
+// the datastore (which will panic with nil pool, but proves the RBAC path was
+// exercised).
+func TestExecute_GetClient_RBACAllowsAccessProceedsToDatastore(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Register query_database as a public privilege so the MCP tool RBAC check
+	// passes and we can reach the getClient() code path
+	if _, err := authStore.RegisterMCPPrivilege("query_database", auth.MCPPrivilegeTypeTool, "Query database", true); err != nil {
+		t.Fatalf("RegisterMCPPrivilege: %v", err)
+	}
+
+	// Create user and token
+	if err := authStore.CreateUser("bob", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("bob", "bob-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session for connection 99
+	if err := authStore.SetConnectionSession(tokenHash, 99, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Create provider with both authStore AND datastore
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+	datastore := database.NewTestDatastore(nil)
+
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, datastore)
+
+	// Configure the RBAC checker to allow access to connection 99
+	// The connection is shared, so any user can access it
+	provider.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 99 {
+			return true, "bob", nil // Shared connection
+		}
+		return false, "", nil
+	})
+
+	// Build context for non-superuser token
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "bob")
+
+	// Execute a database-dependent tool. RBAC allows access, so the code proceeds
+	// to GetConnectionWithPassword which panics with a nil pool. We catch the panic
+	// to verify that RBAC was passed (no access denied error).
+	var response mcp.ToolResponse
+	var panicValue any
+	func() {
+		defer func() {
+			panicValue = recover()
+		}()
+		response, _ = provider.Execute(ctx, "query_database", map[string]any{
+			"query": "SELECT 1",
+		})
+	}()
+
+	// If we got a panic, it means RBAC passed and code proceeded to datastore
+	// (which has nil pool and panics). This is the expected path.
+	if panicValue != nil {
+		// Panic occurred - verify session still exists (RBAC didn't clear it)
+		session, err := authStore.GetConnectionSession(tokenHash)
+		if err != nil {
+			t.Fatalf("GetConnectionSession: %v", err)
+		}
+		if session == nil {
+			t.Error("Expected session to still exist after RBAC allowed access")
+		}
+		return // Test passed - RBAC was allowed, code reached datastore
+	}
+
+	// If we got a response without panic, check that it's not access denied
+	if len(response.Content) > 0 {
+		errorMsg := response.Content[0].Text
+		if strings.Contains(errorMsg, "access denied") {
+			t.Errorf("Expected RBAC to allow access, but got access denied: %s", errorMsg)
+		}
+	}
+
+	// The session should still exist (RBAC allowed, only datastore failed)
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil {
+		t.Error("Expected session to still exist after RBAC allowed access")
+	}
+}
+
+// TestExecute_GetClient_NoSession exercises the getClient() code path when
+// authStore and datastore are both non-nil but no session exists. This
+// should return a helpful "no connection selected" error.
+func TestExecute_GetClient_NoSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Register query_database as a public privilege so the MCP tool RBAC check
+	// passes and we can reach the getClient() code path
+	if _, err := authStore.RegisterMCPPrivilege("query_database", auth.MCPPrivilegeTypeTool, "Query database", true); err != nil {
+		t.Fatalf("RegisterMCPPrivilege: %v", err)
+	}
+
+	// Create user and token but don't set a connection session
+	if err := authStore.CreateUser("carol", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("carol")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("carol", "carol-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Create provider with both authStore AND datastore
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+	datastore := database.NewTestDatastore(nil)
+
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, datastore)
+
+	// Build context
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "carol")
+
+	// Execute a database-dependent tool without having a session
+	response, _ := provider.Execute(ctx, "query_database", map[string]any{
+		"query": "SELECT 1",
+	})
+
+	// Should get an error response about no connection selected
+	if !response.IsError {
+		t.Error("Expected error response for no session")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("Expected non-empty response content")
+	}
+	errorMsg := response.Content[0].Text
+	if !strings.Contains(errorMsg, "no database connection selected") {
+		t.Errorf("Expected 'no database connection selected' error, got: %s", errorMsg)
+	}
+}
+
+// TestExecute_GetClient_SessionWithDatabaseOverride exercises the getClient()
+// code path when a session has a database name override. The RBAC check should
+// pass, and the code should attempt to use the database override.
+func TestExecute_GetClient_SessionWithDatabaseOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Register query_database as a public privilege so the MCP tool RBAC check
+	// passes and we can reach the getClient() code path
+	if _, err := authStore.RegisterMCPPrivilege("query_database", auth.MCPPrivilegeTypeTool, "Query database", true); err != nil {
+		t.Fatalf("RegisterMCPPrivilege: %v", err)
+	}
+
+	// Create user and token
+	if err := authStore.CreateUser("dave", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("dave")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("dave", "dave-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session with database override
+	dbName := "myapp_db"
+	if err := authStore.SetConnectionSession(tokenHash, 77, &dbName); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Verify session has the database override
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil || session.ConnectionID != 77 {
+		t.Fatal("Expected session with ConnectionID 77")
+	}
+	if session.DatabaseName == nil || *session.DatabaseName != "myapp_db" {
+		t.Fatal("Expected session with DatabaseName 'myapp_db'")
+	}
+
+	// Create provider with both authStore AND datastore
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+	datastore := database.NewTestDatastore(nil)
+
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, datastore)
+
+	// Configure the RBAC checker to allow access (shared connection)
+	provider.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 77 {
+			return true, "dave", nil
+		}
+		return false, "", nil
+	})
+
+	// Build context
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "dave")
+
+	// Execute a database-dependent tool. RBAC allows access, so the code proceeds
+	// to GetConnectionWithPassword which panics with a nil pool.
+	var response mcp.ToolResponse
+	var panicValue any
+	func() {
+		defer func() {
+			panicValue = recover()
+		}()
+		response, _ = provider.Execute(ctx, "query_database", map[string]any{
+			"query": "SELECT current_database()",
+		})
+	}()
+
+	// If we got a panic, it means RBAC passed and code proceeded to datastore
+	if panicValue != nil {
+		// Panic occurred - verify session still exists (RBAC didn't clear it)
+		session, err := authStore.GetConnectionSession(tokenHash)
+		if err != nil {
+			t.Fatalf("GetConnectionSession: %v", err)
+		}
+		if session == nil {
+			t.Error("Expected session to still exist after RBAC allowed access")
+		}
+		return // Test passed - RBAC was allowed, code reached datastore
+	}
+
+	// If we got a response without panic, check that it's not access denied
+	if len(response.Content) > 0 {
+		errorMsg := response.Content[0].Text
+		if strings.Contains(errorMsg, "access denied") {
+			t.Errorf("Expected RBAC to allow access, but got access denied: %s", errorMsg)
+		}
+	}
+
+	// Session should still exist
+	session, err = authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil {
+		t.Error("Expected session to still exist")
+	}
+}
+
+// TestExecute_GetClient_SuperuserBypassesRBAC verifies that superuser context
+// bypasses RBAC checks even when a sharing lookup would deny access.
+func TestExecute_GetClient_SuperuserBypassesRBAC(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create superuser and token
+	if err := authStore.CreateUser("admin", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := authStore.SetUserSuperuser("admin", true); err != nil {
+		t.Fatalf("SetUserSuperuser: %v", err)
+	}
+	userID, err := authStore.GetUserID("admin")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("admin", "admin-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session
+	if err := authStore.SetConnectionSession(tokenHash, 88, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	// Create provider
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+	datastore := database.NewTestDatastore(nil)
+
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, datastore)
+
+	// Configure RBAC checker to deny access if it were checked
+	// (for non-superusers, this would deny access)
+	provider.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		return false, "otheruser", nil // Would deny non-superusers
+	})
+
+	// Build context with superuser flag
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, true) // Superuser!
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "admin")
+
+	// Execute a database-dependent tool. The superuser bypasses RBAC, so the code
+	// proceeds to GetConnectionWithPassword which panics with a nil pool. We catch
+	// the panic to verify that RBAC was bypassed (no access denied error).
+	var response mcp.ToolResponse
+	var panicValue any
+	func() {
+		defer func() {
+			panicValue = recover()
+		}()
+		response, _ = provider.Execute(ctx, "query_database", map[string]any{
+			"query": "SELECT 1",
+		})
+	}()
+
+	// If we got a panic, it means RBAC passed and code proceeded to datastore
+	// (which has nil pool and panics). This is the expected path for superuser.
+	if panicValue != nil {
+		// Panic occurred - verify session still exists (RBAC didn't clear it)
+		session, err := authStore.GetConnectionSession(tokenHash)
+		if err != nil {
+			t.Fatalf("GetConnectionSession: %v", err)
+		}
+		if session == nil {
+			t.Error("Expected session to still exist for superuser (RBAC was bypassed)")
+		}
+		return // Test passed - RBAC was bypassed, code reached datastore
+	}
+
+	// If we got a response without panic, check that it's not access denied
+	if len(response.Content) > 0 {
+		errorMsg := response.Content[0].Text
+		if strings.Contains(errorMsg, "access denied") {
+			t.Errorf("Superuser should bypass RBAC, but got access denied: %s", errorMsg)
+		}
+	}
+
+	// Session should still exist (not cleared by RBAC denial)
+	session, err := authStore.GetConnectionSession(tokenHash)
+	if err != nil {
+		t.Fatalf("GetConnectionSession: %v", err)
+	}
+	if session == nil {
+		t.Error("Expected session to still exist for superuser")
+	}
+}
+
+// TestExecute_QueryMetrics_RBACChecksConnectionIDInjection verifies that the
+// query_metrics tool's connection_id injection respects RBAC. When RBAC denies
+// access to the session's connection, the connection_id should NOT be injected.
+//
+// This is a regression test for VULN-002 in issue #94 where the query_metrics
+// tool would inject a connection_id from an expired/restricted session scope.
+func TestExecute_QueryMetrics_RBACChecksConnectionIDInjection(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Register query_metrics as a public privilege so RBAC check passes
+	if _, err := authStore.RegisterMCPPrivilege("query_metrics", auth.MCPPrivilegeTypeTool, "Query metrics", true); err != nil {
+		t.Fatalf("RegisterMCPPrivilege: %v", err)
+	}
+
+	// Create user and token
+	if err := authStore.CreateUser("alice", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("alice")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("alice", "alice-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session for connection 42
+	if err := authStore.SetConnectionSession(tokenHash, 42, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+
+	// Create provider with nil datastore - query_metrics will return error
+	// but we can observe whether connection_id was injected by checking args
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, nil)
+
+	// Configure the RBAC checker to deny access to connection 42
+	provider.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 42 {
+			return false, "otheruser", nil // Not shared, owned by someone else
+		}
+		return false, "", nil
+	})
+
+	// Build context for non-superuser token
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "alice")
+
+	// Execute query_metrics without connection_id. Since RBAC denies access to
+	// connection 42, the session's connection_id should NOT be injected.
+	// The tool should report that connection_id is required (datastore is nil,
+	// so it will fail regardless, but we want to verify the injection path).
+	response, _ := provider.Execute(ctx, "query_metrics", map[string]any{
+		"probe_name":  "pg_stat_activity",
+		"time_bucket": "1 hour",
+	})
+
+	// The response should indicate an error (no datastore configured)
+	// but the important thing is that connection_id was NOT injected
+	// from a session that RBAC should have denied.
+	if !response.IsError {
+		t.Log("Response was not an error, which is unexpected without datastore")
+	}
+
+	// The error message should NOT be "access denied" (that's the getClient path).
+	// Since query_metrics is a stateless tool, it doesn't call getClient.
+	// Without connection_id injection (due to RBAC denial), the tool should
+	// either succeed with filtering by token's connection grants, or fail
+	// because datastore is nil.
+	if len(response.Content) > 0 {
+		errorMsg := response.Content[0].Text
+		// Verify we didn't get an access denied error from getClient path
+		// (query_metrics doesn't use getClient)
+		if strings.Contains(errorMsg, "the selected connection is no longer accessible") {
+			t.Error("query_metrics should not trigger getClient access denied error")
+		}
+	}
+}
+
+// TestExecute_QueryMetrics_RBACAllowsConnectionIDInjection verifies that when
+// RBAC allows access to the session's connection, the connection_id IS injected.
+func TestExecute_QueryMetrics_RBACAllowsConnectionIDInjection(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Register query_metrics as a public privilege
+	if _, err := authStore.RegisterMCPPrivilege("query_metrics", auth.MCPPrivilegeTypeTool, "Query metrics", true); err != nil {
+		t.Fatalf("RegisterMCPPrivilege: %v", err)
+	}
+
+	// Create user and token
+	if err := authStore.CreateUser("bob", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("bob", "bob-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session for connection 99
+	if err := authStore.SetConnectionSession(tokenHash, 99, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+
+	// Create provider with nil datastore
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, nil)
+
+	// Configure the RBAC checker to ALLOW access to connection 99
+	provider.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		if connectionID == 99 {
+			return true, "bob", nil // Shared connection - allow access
+		}
+		return false, "", nil
+	})
+
+	// Build context for non-superuser token
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "bob")
+
+	// Execute query_metrics without connection_id. Since RBAC allows access,
+	// the session's connection_id (99) should be injected.
+	response, _ := provider.Execute(ctx, "query_metrics", map[string]any{
+		"probe_name":  "pg_stat_activity",
+		"time_bucket": "1 hour",
+	})
+
+	// The tool will fail because datastore is nil, but the injection should
+	// have happened. We verify by checking the error is about datastore, not
+	// about missing connection_id.
+	if len(response.Content) > 0 {
+		errorMsg := response.Content[0].Text
+		// The error should be about datastore, not about connection_id
+		if strings.Contains(errorMsg, "connection_id is required") {
+			t.Error("Expected connection_id to be injected when RBAC allows access")
+		}
+	}
+}
+
+// TestExecute_QueryMetrics_SuperuserAlwaysInjectsConnectionID verifies that
+// when the user is a superuser, connection_id is always injected from the session.
+func TestExecute_QueryMetrics_SuperuserAlwaysInjectsConnectionID(t *testing.T) {
+	tmpDir := t.TempDir()
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer authStore.Close()
+
+	// Create superuser and token
+	if err := authStore.CreateUser("admin", "Password1", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := authStore.SetUserSuperuser("admin", true); err != nil {
+		t.Fatalf("SetUserSuperuser: %v", err)
+	}
+	userID, err := authStore.GetUserID("admin")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+	_, token, err := authStore.CreateToken("admin", "admin-token", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	tokenHash := token.TokenHash
+
+	// Set up a connection session for connection 50
+	if err := authStore.SetConnectionSession(tokenHash, 50, nil); err != nil {
+		t.Fatalf("SetConnectionSession: %v", err)
+	}
+
+	clientManager := database.NewClientManager(nil)
+	defer clientManager.CloseAll()
+
+	cfg := &config.Config{}
+	resourceReg := resources.NewContextAwareRegistry(clientManager, cfg, nil, nil)
+
+	// Create provider
+	provider := NewContextAwareProvider(clientManager, resourceReg, nil, cfg, authStore, nil, nil)
+
+	// Configure RBAC to deny access (but superuser bypasses this)
+	provider.rbacChecker.SetConnectionSharingLookup(func(_ context.Context, connectionID int) (bool, string, error) {
+		return false, "otheruser", nil // Would deny non-superusers
+	})
+
+	// Build context with superuser flag
+	ctx := context.WithValue(context.Background(), auth.TokenHashContextKey, tokenHash)
+	ctx = context.WithValue(ctx, auth.IsSuperuserContextKey, true) // Superuser!
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, auth.UsernameContextKey, "admin")
+
+	// Execute query_metrics without connection_id. Superuser bypasses RBAC,
+	// so connection_id should be injected.
+	response, _ := provider.Execute(ctx, "query_metrics", map[string]any{
+		"probe_name":  "pg_stat_activity",
+		"time_bucket": "1 hour",
+	})
+
+	// The tool will fail because datastore is nil, but check that error
+	// is not about missing connection_id (which would mean injection failed)
+	if len(response.Content) > 0 {
+		errorMsg := response.Content[0].Text
+		if strings.Contains(errorMsg, "connection_id is required") {
+			t.Error("Expected connection_id to be injected for superuser")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #94.

- When a token is scoped to specific connections, the server now enforces the scope restriction at use-time in session-based code paths.
- Previously, `getClient()` in both the tools and resources modules retrieved the session connection without verifying the token's scope, allowing access to any connection available to the owner's group.
- Adds RBAC verification in three code paths: `ContextAwareProvider.getClient()`, `ContextAwareRegistry.getClient()`, and the `query_metrics` connection_id injection logic.
- Stale sessions are automatically cleared when scope denial occurs, so subsequent calls receive a clean "no connection selected" error.

## Test plan

- [ ] Verify that a token scoped to connection A cannot use a session pointing to connection B via MCP tool calls.
- [ ] Verify that a token scoped to connection A cannot access resources for connection B via the resources module.
- [ ] Verify that `query_metrics` does not inject an out-of-scope connection_id from a stale session.
- [ ] Verify that superuser tokens bypass the scope check (existing behavior preserved).
- [ ] Verify that unscoped tokens (no connection scope defined) continue to work without restriction.
- [ ] Run `make test-all` — all server and alerter tests pass; linter reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added role-based access control (RBAC) verification when users access connections, ensuring proper authorization before tool execution.
  * Connection sessions are now automatically cleared when access is denied, with users prompted to select a permitted connection.
  * Superusers continue to bypass RBAC checks as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->