### PR TITLE
Fix wildcard resolution in MCP and admin scope intersection (#96)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,16 @@ project adheres to
 
 ### Fixed
 
+- Fix MCP and admin scope privileges granted through a
+  wildcard group grant (`"*"`) being silently dropped
+  during token scope intersection; the intersection
+  logic now recognises wildcard grants and preserves
+  the scoped privileges. The fix also introduces an
+  explicit `AccessLevelNone` constant to replace raw
+  empty strings for "no access" semantics, improving
+  code clarity and reducing error-prone comparisons.
+  (#96)
+
 - Fix the ClusterNavigator group-editing flow
   round-tripping string group ids (`"group-{x}"`)
   through numeric parses; the string id now travels

--- a/docs/superpowers/plans/2026-04-22-decompose-oversized-go-files.md
+++ b/docs/superpowers/plans/2026-04-22-decompose-oversized-go-files.md
@@ -1,0 +1,798 @@
+# Decompose Oversized Go Files — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split three oversized Go files into domain-focused files,
+extract duplicated scan helpers, and refactor metric queries into a
+data-driven registry — all without changing external behavior.
+
+**Architecture:** Each file is decomposed within its existing Go
+package so no import paths change. Functions are moved wholesale;
+new scan-helper functions and a metric registry replace duplicated
+code. Every task ends with `make test-all` green.
+
+**Tech Stack:** Go 1.24, pgx/v5, PostgreSQL
+
+**Spec:** `docs/superpowers/specs/2026-04-22-decompose-oversized-go-files-design.md`
+
+---
+
+## Phase 1: Collector `base.go` (886 lines → 5 files)
+
+### Task 1: Extract `hash.go` from `collector/src/probes/base.go`
+
+The simplest extraction: three pure functions with no database
+dependencies.
+
+**Files:**
+- Create: `collector/src/probes/hash.go`
+- Modify: `collector/src/probes/base.go` (remove lines 745-886)
+
+- [ ] **Step 1: Create `hash.go`**
+
+Create `collector/src/probes/hash.go` containing the copyright
+header, `package probes`, the necessary imports (`crypto/sha256`,
+`encoding/hex`, `encoding/json`, `fmt`, `math`, `sort`), and
+three functions cut from `base.go`:
+
+- `ComputeMetricsHash` (base.go lines 748-788)
+- `normalizeValue` (base.go lines 794-876)
+- `getSortedKeys` (base.go lines 879-886)
+
+- [ ] **Step 2: Remove the moved code from `base.go`**
+
+Delete lines 745-886 from `base.go` (the `ComputeMetricsHash`,
+`normalizeValue`, and `getSortedKeys` functions). Also remove
+any imports that are no longer used in `base.go` (`crypto/sha256`,
+`encoding/hex`, `encoding/json`, `math`, `sort`).
+
+- [ ] **Step 3: Verify compilation and tests**
+
+```bash
+cd collector/src && go build ./... && go test ./probes/ -v -count=1
+```
+
+All existing `base_test.go` tests (`TestNormalizeValue*`,
+`TestComputeMetricsHash*`) must pass because the functions are
+still in the same package.
+
+- [ ] **Step 4: Run gofmt**
+
+```bash
+gofmt -w collector/src/probes/hash.go collector/src/probes/base.go
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add collector/src/probes/hash.go collector/src/probes/base.go
+git commit -m "refactor(collector): extract hash.go from base.go
+
+Move ComputeMetricsHash, normalizeValue, and getSortedKeys into
+their own file for change-detection hashing.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Extract `partition.go` from `collector/src/probes/base.go`
+
+Partition management: weekly bounds, partition creation, GC, and
+helpers.
+
+**Files:**
+- Create: `collector/src/probes/partition.go`
+- Modify: `collector/src/probes/base.go` (remove lines 138-415)
+
+- [ ] **Step 1: Create `partition.go`**
+
+Create `collector/src/probes/partition.go` containing the copyright
+header, `package probes`, the necessary imports (`context`, `fmt`,
+`strings`, `time`, `pgx/v5`, `pgx/v5/pgconn`, `pgx/v5/pgxpool`,
+`logger`), and these items cut from `base.go`:
+
+- `weeklyPartitionBounds` (lines 143-157)
+- `partitionBoundLayout` constant (line 162)
+- `EnsurePartition` (lines 165-214)
+- `DropExpiredPartitions` (lines 223-275)
+- `partitionCandidate` struct (lines 280-283)
+- `loadProtectedPartitions` (lines 291-336)
+- `loadPartitionCandidates` (lines 343-377)
+- `parsePartitionEnd` (lines 385-415)
+
+Include the comment block above each function.
+
+- [ ] **Step 2: Remove the moved code from `base.go`**
+
+Delete lines 138-415 from `base.go`. Remove any imports no longer
+needed (`errors`, `strings`, `pgx/v5/pgconn`). Keep the imports
+still used by remaining code.
+
+- [ ] **Step 3: Verify compilation and tests**
+
+```bash
+cd collector/src && go build ./... && go test ./probes/ -v -count=1
+```
+
+Existing `base_test.go` partition tests (`TestWeeklyPartitionBounds*`,
+`TestPartitionBoundLayout*`, `TestParsePartitionEnd`) must still pass.
+
+- [ ] **Step 4: Run gofmt**
+
+```bash
+gofmt -w collector/src/probes/partition.go collector/src/probes/base.go
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add collector/src/probes/partition.go collector/src/probes/base.go
+git commit -m "refactor(collector): extract partition.go from base.go
+
+Move partition management (weekly bounds, creation, GC) into a
+dedicated file.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Extract `storage.go` and `config_loader.go`
+
+Split the remaining non-interface code into storage and config files.
+
+**Files:**
+- Create: `collector/src/probes/storage.go`
+- Create: `collector/src/probes/config_loader.go`
+- Modify: `collector/src/probes/base.go` (remove lines 417-743)
+
+- [ ] **Step 1: Create `storage.go`**
+
+Create `collector/src/probes/storage.go` with the copyright header,
+`package probes`, necessary imports (`context`, `fmt`,
+`pgx/v5`, `pgx/v5/pgxpool`, `logger`), and:
+
+- `StoreMetricsWithCopy` (base.go lines 419-491)
+
+- [ ] **Step 2: Create `config_loader.go`**
+
+Create `collector/src/probes/config_loader.go` with the copyright
+header, `package probes`, necessary imports (`context`, `errors`,
+`fmt`, `strings`, `time`, `pgx/v5`, `pgx/v5/pgxpool`, `logger`),
+and:
+
+- `LoadProbeConfigs` (base.go lines 495-530)
+- `EnsureProbeConfig` (base.go lines 536-647)
+- `getDefaultInterval` (base.go lines 650-689)
+- `GetLastCollectionTime` (base.go lines 693-719)
+- `CheckExtensionExists` (base.go lines 723-743)
+
+- [ ] **Step 3: Remove the moved code from `base.go`**
+
+Delete lines 417-743 from `base.go` (everything from
+`StoreMetricsWithCopy` through `CheckExtensionExists`). The
+remaining `base.go` should contain only: the package declaration,
+imports, `WrapQuery`, `featureCache`, `cachedCheck`, `ProbeConfig`,
+`MetricsProbe`, `ExtensionProbe`, `BaseMetricsProbe`, and its
+methods.
+
+- [ ] **Step 4: Verify compilation and tests**
+
+```bash
+cd collector/src && go build ./... && go test ./probes/ -v -count=1
+```
+
+- [ ] **Step 5: Run gofmt and verify line counts**
+
+```bash
+gofmt -w collector/src/probes/storage.go collector/src/probes/config_loader.go collector/src/probes/base.go
+wc -l collector/src/probes/base.go collector/src/probes/partition.go collector/src/probes/storage.go collector/src/probes/config_loader.go collector/src/probes/hash.go
+```
+
+Every file should be well under 1,000 lines.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add collector/src/probes/storage.go collector/src/probes/config_loader.go collector/src/probes/base.go
+git commit -m "refactor(collector): extract storage.go and config_loader.go
+
+Move StoreMetricsWithCopy into storage.go and config resolution
+functions (LoadProbeConfigs, EnsureProbeConfig, etc.) into
+config_loader.go. base.go now contains only interface definitions.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Run full test suite for Phase 1
+
+- [ ] **Step 1: Run make test-all**
+
+```bash
+cd /workspaces/ai-dba-workbench && make test-all
+```
+
+All tests across all sub-projects must pass. Fix any issues before
+proceeding to Phase 2.
+
+- [ ] **Step 2: Commit any fixes if needed**
+
+---
+
+## Phase 2: Alerter `queries.go` (2,557 lines → 5 files + registry)
+
+### Task 5: Extract `alert_queries.go` with `scanAlert` helper
+
+Move alert lifecycle functions and extract the duplicated 21-field
+scan pattern.
+
+**Files:**
+- Create: `alerter/src/internal/database/alert_queries.go`
+- Modify: `alerter/src/internal/database/queries.go`
+
+- [ ] **Step 1: Create `alert_queries.go`**
+
+Create `alerter/src/internal/database/alert_queries.go` with the
+copyright header, `package database`, necessary imports, and these
+functions moved from `queries.go`:
+
+- `GetActiveThresholdAlert` (line 1073)
+- `GetActiveAnomalyAlert` (line 1103)
+- `GetRecentlyClearedAlert` (line 1131)
+- `GetReevaluationSuppressedAlert` (line 1152)
+- `GetFalsePositiveSuppressedAlert` (line 1177)
+- `UpdateAlertValues` (line 1202)
+- `CreateAlert` (line 1215)
+- `GetActiveAlerts` (line 1232)
+- `GetAlert` (line 1271)
+- `ClearAlert` (line 1295)
+- `ReactivateAlert` (line 1314)
+- `GetAlertsByCluster` (line 2442)
+- `GetAlertsByConnection` (line 2488)
+- `UpdateAlertReevaluation` (line 2528)
+
+Also add a `scanAlert` helper function at the top of the file.
+Identify the exact 21-field scan pattern from the existing code
+(in `GetActiveThresholdAlert`, `GetActiveAnomalyAlert`,
+`GetActiveAlerts`, `GetAlert`, `GetAlertsByCluster`,
+`GetAlertsByConnection`) and replace each inline `Scan(...)` call
+with `scanAlert(row, &alert)`.
+
+The `scanAlert` helper should accept a `pgx.Row` interface and
+an `*Alert` pointer, scanning all 21 fields.
+
+- [ ] **Step 2: Remove the moved functions from `queries.go`**
+
+Delete the moved functions from `queries.go`. Update imports in
+both files.
+
+- [ ] **Step 3: Verify compilation and tests**
+
+```bash
+cd alerter/src && go build ./... && go test ./internal/database/ -v -count=1
+```
+
+- [ ] **Step 4: Run gofmt**
+
+```bash
+gofmt -w alerter/src/internal/database/alert_queries.go alerter/src/internal/database/queries.go
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add alerter/src/internal/database/alert_queries.go alerter/src/internal/database/queries.go
+git commit -m "refactor(alerter): extract alert_queries.go with scanAlert helper
+
+Move 14 alert lifecycle functions into alert_queries.go. Extract
+the duplicated 21-field alert scan pattern into scanAlert().
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Extract `anomaly_queries.go` with scan helper
+
+Move anomaly, baseline, and embedding functions.
+
+**Files:**
+- Create: `alerter/src/internal/database/anomaly_queries.go`
+- Modify: `alerter/src/internal/database/queries.go`
+
+- [ ] **Step 1: Create `anomaly_queries.go`**
+
+Create `alerter/src/internal/database/anomaly_queries.go` with the
+copyright header, `package database`, necessary imports, and these
+functions moved from `queries.go`:
+
+- `CreateAnomalyCandidate` (line 1557)
+- `GetUnprocessedAnomalyCandidates` (line 1569)
+- `UpdateAnomalyCandidate` (line 1606)
+- `StoreAnomalyEmbedding` (line 2144)
+- `FindSimilarAnomalies` (line 2175)
+- `GetAnomalyCandidateByID` (line 2222)
+- `GetMetricBaselines` (line 1479)
+- `UpsertMetricBaseline` (line 1513)
+- `GetAcknowledgedAnomalyAlerts` (line 2310)
+- `GetAcknowledgmentHistoryForMetric` (line 2359)
+- `float32SliceToVectorString` (line 2539)
+
+Also add a `scanAcknowledgedAnomalyAlert` helper for the 15-field
+scan pattern shared by `GetAcknowledgedAnomalyAlerts` and
+`GetAcknowledgmentHistoryForMetric`.
+
+- [ ] **Step 2: Remove the moved functions from `queries.go`**
+
+- [ ] **Step 3: Verify compilation and tests**
+
+```bash
+cd alerter/src && go build ./... && go test ./internal/database/ -v -count=1
+```
+
+- [ ] **Step 4: Run gofmt and commit**
+
+```bash
+gofmt -w alerter/src/internal/database/anomaly_queries.go alerter/src/internal/database/queries.go
+git add alerter/src/internal/database/anomaly_queries.go alerter/src/internal/database/queries.go
+git commit -m "refactor(alerter): extract anomaly_queries.go
+
+Move anomaly candidate, embedding, baseline, and acknowledgment
+functions. Extract scanAcknowledgedAnomalyAlert helper.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Build metric registry and extract `metric_queries.go`
+
+This is the most significant behavioral refactor: replacing the two
+massive switch statements with a data-driven metric registry.
+
+**Files:**
+- Create: `alerter/src/internal/database/metric_registry.go`
+- Create: `alerter/src/internal/database/metric_queries.go`
+- Modify: `alerter/src/internal/database/queries.go`
+
+- [ ] **Step 1: Create `metric_registry.go`**
+
+Create `alerter/src/internal/database/metric_registry.go` with the
+copyright header, `package database`, and the registry types and
+data.
+
+Read the exact SQL from each case in `GetLatestMetricValues`
+(lines 295-1057) and `GetHistoricalMetricValues` (lines 1626-2132)
+to populate the registry. Each entry maps a metric name to its
+latest SQL, historical SQL, and scan type.
+
+Define the `scanType` enum, `metricQueryConfig` struct, and the
+`metricRegistry` map containing every metric.
+
+- [ ] **Step 2: Create `metric_queries.go`**
+
+Create `alerter/src/internal/database/metric_queries.go` with the
+copyright header, `package database`, necessary imports, and these
+functions:
+
+- `queryMetricValues` (line 220)
+- `queryMetricValuesWithDB` (line 243)
+- `queryMetricValuesWithDBAndObject` (line 268)
+- `GetLatestMetricValues` — rewritten to use the registry
+- `GetLatestMetricValue` (line 1061)
+- `GetHistoricalMetricValues` — rewritten to use the registry
+
+The rewritten `GetLatestMetricValues` should look up the metric in
+the registry and dispatch to the appropriate query helper based on
+`scanType`. Similarly for `GetHistoricalMetricValues`, which should
+use `queryHistoricalMetricValues`, `queryHistoricalMetricValuesWithDB`,
+etc. — either reuse the existing helpers or write new ones for the
+historical query pattern.
+
+- [ ] **Step 3: Remove old metric functions from `queries.go`**
+
+Delete `GetLatestMetricValues`, `GetLatestMetricValue`,
+`GetHistoricalMetricValues`, `queryMetricValues`,
+`queryMetricValuesWithDB`, `queryMetricValuesWithDBAndObject`,
+and the `MetricValue` type definition (if present in queries.go
+rather than types.go).
+
+- [ ] **Step 4: Verify compilation and tests**
+
+```bash
+cd alerter/src && go build ./... && go test ./... -v -count=1
+```
+
+This is the critical step. The integration tests for metric
+queries validate that every metric name returns correct data.
+
+- [ ] **Step 5: Run gofmt and commit**
+
+```bash
+gofmt -w alerter/src/internal/database/metric_registry.go alerter/src/internal/database/metric_queries.go alerter/src/internal/database/queries.go
+git add alerter/src/internal/database/metric_registry.go alerter/src/internal/database/metric_queries.go alerter/src/internal/database/queries.go
+git commit -m "refactor(alerter): replace metric switch statements with registry
+
+Introduce metricRegistry map that maps metric names to SQL queries
+and scan types. GetLatestMetricValues and GetHistoricalMetricValues
+now perform simple registry lookups instead of 27-case and 14-case
+switch statements.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Verify alerter line counts and run full suite
+
+- [ ] **Step 1: Check line counts**
+
+```bash
+wc -l alerter/src/internal/database/*.go | grep -v _test | sort -n
+```
+
+Every file must be under ~1,000 lines. `queries.go` should be
+the remainder (connection monitoring, settings, blackouts, probe
+availability, cluster peers).
+
+- [ ] **Step 2: Run make test-all**
+
+```bash
+cd /workspaces/ai-dba-workbench && make test-all
+```
+
+- [ ] **Step 3: Commit any fixes if needed**
+
+---
+
+## Phase 3: Server `datastore.go` (5,668 lines → 7 files)
+
+### Task 9: Extract `connection_queries.go`
+
+**Files:**
+- Create: `server/src/internal/database/connection_queries.go`
+- Modify: `server/src/internal/database/datastore.go`
+
+- [ ] **Step 1: Create `connection_queries.go`**
+
+Create `server/src/internal/database/connection_queries.go` with
+the copyright header, `package database`, necessary imports, and
+these functions cut from `datastore.go`:
+
+- `MonitoredConnection.MarshalJSON` (line 76)
+- `NewDatastore` (line 212)
+- `Close` (line 268)
+- `GetAllConnections` (line 275)
+- `GetConnectionSharingInfo` (line 310)
+- `GetConnection` (line 323)
+- `GetConnectionWithPassword` (line 352)
+- `UpdateConnectionName` (line 374)
+- `CreateConnection` (line 423)
+- `DeleteConnection` (line 473)
+- `UpdateConnectionFull` (line 512)
+- `BuildConnectionString` (line 631)
+- `ListDatabases` (line 687)
+- `GetPool` (line 740)
+
+Also extract `scanConnectionListItem` and `scanFullConnection`
+helper functions from the duplicated scan patterns.
+
+- [ ] **Step 2: Remove the moved functions from `datastore.go`**
+
+- [ ] **Step 3: Verify compilation and tests**
+
+```bash
+cd server/src && go build ./... && go test ./internal/database/ -v -count=1
+```
+
+- [ ] **Step 4: Run gofmt and commit**
+
+```bash
+gofmt -w server/src/internal/database/connection_queries.go server/src/internal/database/datastore.go
+git add server/src/internal/database/connection_queries.go server/src/internal/database/datastore.go
+git commit -m "refactor(server): extract connection_queries.go
+
+Move connection CRUD, NewDatastore, Close, and GetPool into
+connection_queries.go. Extract scanConnectionListItem and
+scanFullConnection helpers.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Extract `cluster_queries.go`
+
+**Files:**
+- Create: `server/src/internal/database/cluster_queries.go`
+- Modify: `server/src/internal/database/datastore.go`
+
+- [ ] **Step 1: Create `cluster_queries.go`**
+
+Move all cluster/group CRUD functions (lines 798-1410):
+
+- `GetClusterGroups`, `GetClusterGroup`, `CreateClusterGroup`,
+  `CreateClusterGroupWithOwner`, `UpdateClusterGroup`,
+  `DeleteClusterGroup`, `GetClustersInGroup`, `GetCluster`,
+  `CreateCluster`, `UpdateCluster`, `UpdateClusterPartial`,
+  `DeleteCluster`, `GetClusterOverrides`,
+  `getClusterOverridesInternal`, `UpsertClusterByAutoKey`,
+  `UpsertAutoDetectedCluster`, `GetGroupOverrides`,
+  `getGroupOverridesInternal`, `getDefaultGroupInternal`,
+  `GetDefaultGroupID`, `UpsertGroupByAutoKey`
+
+- [ ] **Step 2: Remove moved code, verify, gofmt, commit**
+
+```bash
+cd server/src && go build ./... && go test ./internal/database/ -v -count=1
+gofmt -w server/src/internal/database/cluster_queries.go server/src/internal/database/datastore.go
+git add server/src/internal/database/cluster_queries.go server/src/internal/database/datastore.go
+git commit -m "refactor(server): extract cluster_queries.go
+
+Move cluster/group CRUD and auto-detection upsert functions.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Extract `topology_queries.go`
+
+The largest extraction. Contains 50+ tightly coupled topology
+functions.
+
+**Files:**
+- Create: `server/src/internal/database/topology_queries.go`
+- Modify: `server/src/internal/database/datastore.go`
+
+- [ ] **Step 1: Create `topology_queries.go`**
+
+Move all topology-related functions: hierarchy builders, auto-
+detection, replication extractors, persisted member handlers,
+Spock/logical grouping, pruning, and relationship population.
+
+This includes all functions from approximately lines 1412-4064
+that are topology-related (see the function list in the spec).
+
+Key functions: `GetServersInCluster`, `GetClusterHierarchy`,
+`AssignConnectionToCluster`, `GetClusterTopology`,
+`RefreshClusterAssignments`, plus all internal helpers
+(`buildAutoDetectedClusters`, `buildTopologyHierarchy`,
+`groupSpockNodesByClusters`, etc.).
+
+- [ ] **Step 2: Check line count of topology_queries.go**
+
+```bash
+wc -l server/src/internal/database/topology_queries.go
+```
+
+If over 1,000 lines, split into `topology_queries.go` (public API
++ hierarchy builders) and `topology_autodetect.go` (auto-detection,
+replication extractors, Spock/logical grouping, persisted members).
+
+- [ ] **Step 3: Remove moved code, verify, gofmt, commit**
+
+```bash
+cd server/src && go build ./... && go test ./internal/database/ -v -count=1
+gofmt -w server/src/internal/database/topology_queries.go server/src/internal/database/datastore.go
+git add server/src/internal/database/topology_queries.go server/src/internal/database/datastore.go
+git commit -m "refactor(server): extract topology_queries.go
+
+Move topology building, auto-detection, replication inference,
+and all related helpers.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Extract `alert_queries.go`
+
+**Files:**
+- Create: `server/src/internal/database/alert_queries.go`
+- Modify: `server/src/internal/database/datastore.go`
+
+- [ ] **Step 1: Create `alert_queries.go`**
+
+Move alert management functions (lines 4144-4483):
+
+- `GetAlerts` (line 4144)
+- `GetAlertCounts` (line 4308)
+- `GetAlertConnectionID` (line 4387)
+- `SaveAlertAnalysis` (line 4401)
+- `AcknowledgeAlert` (line 4423)
+- `UnacknowledgeAlert` (line 4483)
+
+Include the `Alert`, `AlertListFilter`, `AlertListResult`, and
+`AlertCountsResult` types if they are defined in this section
+(otherwise they stay in `datastore.go` with other types).
+
+- [ ] **Step 2: Remove moved code, verify, gofmt, commit**
+
+```bash
+cd server/src && go build ./... && go test ./internal/database/ -v -count=1
+gofmt -w server/src/internal/database/alert_queries.go server/src/internal/database/datastore.go
+git add server/src/internal/database/alert_queries.go server/src/internal/database/datastore.go
+git commit -m "refactor(server): extract alert_queries.go
+
+Move alert retrieval, acknowledgment, and analysis functions.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Extract `estate_queries.go`
+
+**Files:**
+- Create: `server/src/internal/database/estate_queries.go`
+- Modify: `server/src/internal/database/datastore.go`
+
+- [ ] **Step 1: Create `estate_queries.go`**
+
+Move estate snapshot functions (lines 4527-5064+):
+
+- `GetEstateSnapshot`, `gatherEstateServerData`,
+  `flattenTopologyServers`, `gatherEstateAlertData`,
+  `gatherEstateBlackoutData`, `gatherEstateRecentEvents`,
+  `GetServerSnapshot`, `GetClusterSnapshot`, `GetGroupSnapshot`,
+  `GetConnectionsSnapshot`, `buildScopedSnapshot`,
+  `getConnectionIDsForCluster`, `getConnectionIDsForGroup`,
+  `GetConnectionIDsForCluster`, `GetConnectionIDsForGroup`,
+  `gatherScopedServerData`, `gatherScopedAlertData`,
+  `gatherScopedRecentEvents`, `GetConnectionContext`
+
+- [ ] **Step 2: Remove moved code, verify, gofmt, commit**
+
+```bash
+cd server/src && go build ./... && go test ./internal/database/ -v -count=1
+gofmt -w server/src/internal/database/estate_queries.go server/src/internal/database/datastore.go
+git add server/src/internal/database/estate_queries.go server/src/internal/database/datastore.go
+git commit -m "refactor(server): extract estate_queries.go
+
+Move estate snapshot, server/cluster/group snapshots, scoped
+snapshot builder, and connection context.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Extract `relationship_queries.go`
+
+**Files:**
+- Create: `server/src/internal/database/relationship_queries.go`
+- Modify: `server/src/internal/database/datastore.go`
+
+- [ ] **Step 1: Create `relationship_queries.go`**
+
+Move node relationship and cluster membership functions
+(lines 5293-5668):
+
+- `CreateManualCluster`, `GetConnectionClusterInfo`,
+  `ListClustersForAutocomplete`, `ResetMembershipSource`,
+  `GetClusterRelationships`, `SetNodeRelationships`,
+  `SyncAutoDetectedRelationships`, `RemoveNodeRelationship`,
+  `ClearNodeRelationships`, `AddServerToCluster`,
+  `RemoveServerFromCluster`, `IsConnectionInCluster`
+
+- [ ] **Step 2: Remove moved code, verify, gofmt, commit**
+
+```bash
+cd server/src && go build ./... && go test ./internal/database/ -v -count=1
+gofmt -w server/src/internal/database/relationship_queries.go server/src/internal/database/datastore.go
+git add server/src/internal/database/relationship_queries.go server/src/internal/database/datastore.go
+git commit -m "refactor(server): extract relationship_queries.go
+
+Move cluster relationship CRUD and cluster membership functions.
+
+Part of #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: Clean up remaining `datastore.go` and verify
+
+The remaining `datastore.go` should contain only type definitions,
+struct declarations, constants, and error variables.
+
+**Files:**
+- Modify: `server/src/internal/database/datastore.go`
+
+- [ ] **Step 1: Verify line counts**
+
+```bash
+wc -l server/src/internal/database/*.go | grep -v _test | sort -n
+```
+
+Every file must be under ~1,000 lines. If `topology_queries.go`
+exceeds the limit, split it now (see Task 11 Step 2).
+
+- [ ] **Step 2: Clean up imports in remaining `datastore.go`**
+
+Remove any unused imports from `datastore.go`. Ensure the file
+compiles cleanly.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+cd /workspaces/ai-dba-workbench && make test-all
+```
+
+- [ ] **Step 4: Run gofmt on all modified files**
+
+```bash
+gofmt -w server/src/internal/database/datastore.go
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add server/src/internal/database/datastore.go
+git commit -m "refactor(server): clean up datastore.go types-only remainder
+
+datastore.go now contains only type definitions and struct
+declarations. All query functions live in domain-specific files.
+
+Closes #75.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 4: Final Verification
+
+### Task 16: Full project verification
+
+- [ ] **Step 1: Run make test-all**
+
+```bash
+cd /workspaces/ai-dba-workbench && make test-all
+```
+
+- [ ] **Step 2: Verify no file exceeds ~1,000 lines**
+
+```bash
+wc -l collector/src/probes/base.go collector/src/probes/partition.go collector/src/probes/storage.go collector/src/probes/config_loader.go collector/src/probes/hash.go
+wc -l alerter/src/internal/database/queries.go alerter/src/internal/database/alert_queries.go alerter/src/internal/database/anomaly_queries.go alerter/src/internal/database/metric_queries.go alerter/src/internal/database/metric_registry.go
+wc -l server/src/internal/database/datastore.go server/src/internal/database/connection_queries.go server/src/internal/database/cluster_queries.go server/src/internal/database/topology_queries.go server/src/internal/database/alert_queries.go server/src/internal/database/estate_queries.go server/src/internal/database/relationship_queries.go
+```
+
+- [ ] **Step 3: Verify gofmt**
+
+```bash
+gofmt -l collector/src/probes/*.go alerter/src/internal/database/*.go server/src/internal/database/*.go
+```
+
+Output should be empty (all files already formatted).

--- a/docs/superpowers/specs/2026-04-22-decompose-oversized-go-files-design.md
+++ b/docs/superpowers/specs/2026-04-22-decompose-oversized-go-files-design.md
@@ -1,0 +1,173 @@
+# Decompose Oversized Go Files — Design Spec
+
+Issue: #75
+
+## Problem
+
+Three Go source files have grown too large for maintainability:
+
+- `server/src/internal/database/datastore.go` — 5,668 lines
+- `alerter/src/internal/database/queries.go` — 2,557 lines
+- `collector/src/probes/base.go` — 886 lines
+
+Each file mixes multiple domains. Duplicated scan patterns and
+repetitive switch statements inflate line counts further.
+
+## Acceptance Criteria
+
+- No single Go source file exceeds ~1,000 lines.
+- Duplicated scan patterns extracted into helper functions.
+- Metric query switch statements refactored into a data-driven
+  approach (metric registry).
+- All tests pass after decomposition.
+- No behavioral changes; pure refactoring.
+
+## Design
+
+### 1. Server `datastore.go` → 7 Files
+
+All files remain in the `database` package. Methods keep their
+`*Datastore` receiver. No import changes for callers.
+
+| New File | Domain | Contents |
+|---|---|---|
+| `connection_queries.go` | Connection CRUD | `NewDatastore`, `Close`, `GetPool`, `GetAllConnections`, `GetConnection`, `GetConnectionWithPassword`, `GetConnectionSharingInfo`, `CreateConnection`, `UpdateConnectionFull`, `UpdateConnectionName`, `DeleteConnection`, `BuildConnectionString`, `ListDatabases`, `MonitoredConnection.MarshalJSON`, scan helpers |
+| `cluster_queries.go` | Cluster/group CRUD | `GetClusterGroups`, `GetClusterGroup`, `CreateClusterGroup*`, `UpdateClusterGroup`, `DeleteClusterGroup`, `GetClustersInGroup`, `GetCluster`, `CreateCluster`, `UpdateCluster`, `UpdateClusterPartial`, `DeleteCluster`, `GetClusterOverrides`, `GetDefaultGroupID`, `Upsert*ByAutoKey`, group overrides, internal helpers |
+| `topology_queries.go` | Topology building | `GetClusterTopology`, `RefreshClusterAssignments`, all auto-detection helpers, replication extractors, persisted member handlers, hierarchy builders, Spock/logical grouping, pruning, relationship population |
+| `alert_queries.go` | Alert management | `GetAlerts`, `GetAlertCounts`, `GetAlertConnectionID`, `SaveAlertAnalysis`, `AcknowledgeAlert`, `UnacknowledgeAlert` |
+| `estate_queries.go` | Estate snapshots | `GetEstateSnapshot`, `GetServerSnapshot`, `GetClusterSnapshot`, `GetGroupSnapshot`, `GetConnectionsSnapshot`, `GetConnectionContext`, scoped helpers, flatten helpers |
+| `relationship_queries.go` | Node relationships | `GetClusterRelationships`, `SetNodeRelationships`, `SyncAutoDetectedRelationships`, `RemoveNodeRelationship`, `ClearNodeRelationships`, `AddServerToCluster`, `RemoveServerFromCluster`, `IsConnectionInCluster`, `CreateManualCluster`, `GetConnectionClusterInfo`, `ListClustersForAutocomplete`, `ResetMembershipSource` |
+| `datastore.go` (remaining) | Types and structs | All type definitions, struct declarations, error variables, constants. Keeps file as the canonical "what's in this package" overview. |
+
+#### Scan Helper Extraction
+
+Extract these duplicated scan patterns into helper functions in
+`connection_queries.go`:
+
+- `scanConnectionListItem(scanner) error` — 11 fields, used 8 times.
+- `scanFullConnection(scanner) error` — 18 fields, used 3 times.
+
+The `scanner` parameter accepts `pgx.Row` (implements `Scan()`).
+
+### 2. Alerter `queries.go` → 5 Files + Metric Registry
+
+All files remain in the `database` package with `*Datastore` receiver.
+
+| New File | Domain | Contents |
+|---|---|---|
+| `alert_queries.go` | Alert lifecycle | `GetActiveThresholdAlert`, `GetActiveAnomalyAlert`, `GetRecentlyClearedAlert`, `GetReevaluationSuppressedAlert`, `GetFalsePositiveSuppressedAlert`, `UpdateAlertValues`, `CreateAlert`, `GetActiveAlerts`, `GetAlert`, `ClearAlert`, `ReactivateAlert`, `GetAlertsByCluster`, `GetAlertsByConnection`, `UpdateAlertReevaluation`, scan helpers |
+| `metric_queries.go` | Metric retrieval | `GetLatestMetricValues`, `GetLatestMetricValue`, `GetHistoricalMetricValues`, `queryMetricValues`, `queryMetricValuesWithDB`, `queryMetricValuesWithDBAndObject` |
+| `metric_registry.go` | Metric config | `metricQueryConfig` struct, `scanType` enum, `metricRegistry` map |
+| `anomaly_queries.go` | Anomaly/baseline | `CreateAnomalyCandidate`, `GetUnprocessedAnomalyCandidates`, `UpdateAnomalyCandidate`, `StoreAnomalyEmbedding`, `FindSimilarAnomalies`, `GetAnomalyCandidateByID`, `GetMetricBaselines`, `UpsertMetricBaseline`, `GetAcknowledgedAnomalyAlerts`, `GetAcknowledgmentHistoryForMetric`, `float32SliceToVectorString` |
+| `queries.go` (remaining) | Connection/settings | `GetMonitoredConnectionErrors`, `GetActiveConnectionAlert`, `CreateConnectionAlert`, `UpdateConnectionAlertDescription`, `GetAlerterSettings`, `GetEnabledAlertRules`, `GetEffectiveThreshold`, `IsBlackoutActive`, `DeleteOldAlerts`, `DeleteOldAnomalyCandidates`, `GetProbeAvailability`, `GetEnabledBlackoutSchedules`, `CreateBlackout`, `GetActiveConnections`, `GetProbeStalenessByConnection`, `GetAlertRuleByName`, `GetClusterPeers` |
+
+#### Scan Helper Extraction
+
+- `scanAlert(scanner, *Alert) error` — 21 fields, used in 6 functions.
+- `scanAcknowledgedAnomalyAlert(scanner, *AcknowledgedAnomalyAlert) error` — 15 fields, used in 2 functions.
+
+#### Metric Registry Refactor
+
+Replace the two massive switch statements with a data-driven
+registry:
+
+```go
+type scanType int
+
+const (
+    scanBasic        scanType = iota // (connection_id, value, collected_at)
+    scanWithDB                       // (connection_id, db_name, value, collected_at)
+    scanWithDBObject                 // (connection_id, db_name, object_name, value, collected_at)
+)
+
+type metricQueryConfig struct {
+    latestSQL     string
+    historicalSQL string
+    scan          scanType
+}
+
+var metricRegistry = map[string]metricQueryConfig{
+    "pg_settings.max_connections": {
+        latestSQL:     `SELECT ... ORDER BY collected_at DESC LIMIT 1`,
+        historicalSQL: `SELECT ... WHERE collected_at >= NOW() - $1::interval`,
+        scan:          scanBasic,
+    },
+    // ... one entry per metric
+}
+```
+
+`GetLatestMetricValues` becomes:
+
+```go
+func (d *Datastore) GetLatestMetricValues(ctx context.Context, metricName string) ([]MetricValue, error) {
+    cfg, ok := metricRegistry[metricName]
+    if !ok {
+        return nil, fmt.Errorf("unknown metric: %s", metricName)
+    }
+    switch cfg.scan {
+    case scanBasic:
+        return d.queryMetricValues(ctx, cfg.latestSQL)
+    case scanWithDB:
+        return d.queryMetricValuesWithDB(ctx, cfg.latestSQL)
+    case scanWithDBObject:
+        return d.queryMetricValuesWithDBAndObject(ctx, cfg.latestSQL)
+    }
+    return nil, fmt.Errorf("unknown scan type for metric: %s", metricName)
+}
+```
+
+`GetHistoricalMetricValues` follows the same pattern using
+`cfg.historicalSQL` and returning `[]HistoricalMetricValue`.
+
+### 3. Collector `base.go` → 5 Files
+
+All files remain in the `probes` package.
+
+| New File | Domain | Contents |
+|---|---|---|
+| `base.go` (remaining) | Core interfaces | Package imports, `WrapQuery`, `featureCache`, `cachedCheck`, `ProbeConfig`, `MetricsProbe`, `ExtensionProbe`, `BaseMetricsProbe` + methods |
+| `partition.go` | Partition mgmt | `weeklyPartitionBounds`, `partitionBoundLayout`, `EnsurePartition`, `DropExpiredPartitions`, `partitionCandidate`, `loadProtectedPartitions`, `loadPartitionCandidates`, `parsePartitionEnd` |
+| `storage.go` | Metric storage | `StoreMetricsWithCopy` |
+| `config_loader.go` | Config resolution | `LoadProbeConfigs`, `EnsureProbeConfig`, `getDefaultInterval`, `GetLastCollectionTime`, `CheckExtensionExists` |
+| `hash.go` | Change detection | `ComputeMetricsHash`, `normalizeValue`, `getSortedKeys` |
+
+## Test Strategy
+
+This is a pure refactoring; no behavioral changes occur. Existing
+tests remain in their current files and continue to pass. No new
+tests are required for the file decomposition itself.
+
+New tests are required only for the newly extracted helper functions:
+
+- `scanAlert` and `scanAcknowledgedAnomalyAlert` — unit tests with
+  mock scanners to verify field mapping.
+- Metric registry — unit tests to verify every registered metric
+  name resolves to a valid config and that both `GetLatestMetricValues`
+  and `GetHistoricalMetricValues` return correct results for each
+  registry entry.
+- `scanConnectionListItem` and `scanFullConnection` — unit tests
+  with mock scanners.
+
+## Implementation Order
+
+1. **Collector `base.go`** — smallest file, fewest dependencies,
+   lowest risk. Validates the approach.
+2. **Alerter `queries.go`** — medium complexity. Metric registry
+   is the most significant behavioral refactor.
+3. **Server `datastore.go`** — largest file, most functions. Pure
+   mechanical decomposition after patterns are proven.
+
+Each sub-project is verified independently with `make test-all`
+before proceeding to the next.
+
+## Risks
+
+- **Topology file exceeds 1,000 lines.** The topology domain has
+  50+ tightly coupled functions. If the file exceeds the limit after
+  extraction, split further into `topology_autodetect.go` and
+  `topology_helpers.go`.
+- **Merge conflicts.** This is a large refactoring across many files.
+  Work in a dedicated branch and merge promptly.
+- **Metric registry correctness.** Each SQL query must be preserved
+  exactly. The existing integration tests validate this, but careful
+  review is needed during the registry migration.

--- a/server/src/internal/auth/access.go
+++ b/server/src/internal/auth/access.go
@@ -170,7 +170,7 @@ func (rc *RBACChecker) CanAccessConnection(ctx context.Context, connectionID int
 	isRestricted, err := rc.authStore.IsConnectionAssignedToAnyGroup(connectionID)
 	if err != nil {
 		// On error, deny access for safety
-		return false, ""
+		return false, AccessLevelNone
 	}
 
 	// If not restricted by group assignment, check sharing status
@@ -180,13 +180,13 @@ func (rc *RBACChecker) CanAccessConnection(ctx context.Context, connectionID int
 			isShared, ownerUsername, lookupErr := rc.connSharingLookupFn(ctx, connectionID)
 			if lookupErr != nil {
 				// On error, deny access for safety
-				return false, ""
+				return false, AccessLevelNone
 			}
 			if !isShared {
 				// Not shared: only the owner gets access
 				username := GetUsernameFromContext(ctx)
 				if ownerUsername == "" || username != ownerUsername {
-					return false, ""
+					return false, AccessLevelNone
 				}
 			}
 		}
@@ -197,13 +197,13 @@ func (rc *RBACChecker) CanAccessConnection(ctx context.Context, connectionID int
 	userID := GetUserIDFromContext(ctx)
 	if userID == 0 {
 		// Defensive check - all tokens now have owners
-		return false, ""
+		return false, AccessLevelNone
 	}
 
 	// Get user's connection privileges through group membership
 	privileges, err := rc.authStore.GetUserConnectionPrivileges(userID)
 	if err != nil {
-		return false, ""
+		return false, AccessLevelNone
 	}
 
 	// Check if user has access to this connection (specific or via "all
@@ -211,7 +211,7 @@ func (rc *RBACChecker) CanAccessConnection(ctx context.Context, connectionID int
 	// are present.
 	accessLevel, hasAccess := resolveConnectionAccess(privileges, connectionID)
 	if !hasAccess {
-		return false, ""
+		return false, AccessLevelNone
 	}
 
 	// Check token scoping (if applicable)
@@ -220,10 +220,10 @@ func (rc *RBACChecker) CanAccessConnection(ctx context.Context, connectionID int
 		// Token-based access - check if token is scoped to this connection
 		inScope, scopeAccessLevel, err := rc.authStore.IsConnectionInTokenScope(tokenID, connectionID)
 		if err != nil {
-			return false, ""
+			return false, AccessLevelNone
 		}
 		if !inScope {
-			return false, ""
+			return false, AccessLevelNone
 		}
 		// Apply minimum access level: token scope can restrict but not elevate
 		accessLevel = applyTokenCeiling(scopeAccessLevel, accessLevel)
@@ -241,7 +241,7 @@ func resolveConnectionAccess(privs map[int]string, connID int) (string, bool) {
 	specificLevel, hasSpecific := privs[connID]
 	wildcardLevel, hasWildcard := privs[ConnectionIDAll]
 	if !hasSpecific && !hasWildcard {
-		return "", false
+		return AccessLevelNone, false
 	}
 
 	// If only one side is present, use it directly.
@@ -333,7 +333,7 @@ func (rc *RBACChecker) GetEffectivePrivileges(ctx context.Context) *EffectivePri
 			if len(scope.Connections) > 0 {
 				// Check for wildcard connection (connection_id = 0)
 				hasWildcard := false
-				wildcardLevel := ""
+				wildcardLevel := AccessLevelNone
 				for _, sc := range scope.Connections {
 					if sc.ConnectionID == ConnectionIDAll {
 						hasWildcard = true
@@ -394,7 +394,8 @@ func (rc *RBACChecker) GetEffectivePrivileges(ctx context.Context) *EffectivePri
 					for _, privID := range scope.MCPPrivileges {
 						priv, err := rc.authStore.GetMCPPrivilegeByID(privID)
 						if err == nil && priv != nil {
-							if result.MCPPrivileges[priv.Identifier] {
+							// Check if user has this privilege (specific or via wildcard "*")
+							if result.MCPPrivileges[priv.Identifier] || result.MCPPrivileges["*"] {
 								scopedMCPPrivs[priv.Identifier] = true
 							}
 						}
@@ -418,7 +419,8 @@ func (rc *RBACChecker) GetEffectivePrivileges(ctx context.Context) *EffectivePri
 				if !hasWildcard {
 					scopedAdminPerms := make(map[string]bool)
 					for _, perm := range scope.AdminPermissions {
-						if result.AdminPermissions[perm] {
+						// Check if user has this permission (specific or via wildcard "*")
+						if result.AdminPermissions[perm] || result.AdminPermissions[AdminPermissionWildcard] {
 							scopedAdminPerms[perm] = true
 						}
 					}

--- a/server/src/internal/auth/access_test.go
+++ b/server/src/internal/auth/access_test.go
@@ -2130,7 +2130,7 @@ func TestResolveConnectionAccessSpecificOnlyNoWildcard(t *testing.T) {
 	}
 
 	// Connection 2 should have no access
-	level, hasAccess = resolveConnectionAccess(privs, 2)
+	_, hasAccess = resolveConnectionAccess(privs, 2)
 	if hasAccess {
 		t.Error("Expected no access for ungrant connection")
 	}

--- a/server/src/internal/auth/access_test.go
+++ b/server/src/internal/auth/access_test.go
@@ -1562,3 +1562,866 @@ func TestGetEffectivePrivilegesScopedTokenWildcardUserReadOnly(t *testing.T) {
 			level)
 	}
 }
+
+// =============================================================================
+// GetEffectivePrivileges MCP/Admin Wildcard Scope Tests (Issue #96)
+//
+// Issue #96: GetEffectivePrivileges ignored user wildcard grants ("*") when
+// intersecting with a scoped token. If a user's ONLY MCP or admin access came
+// through a wildcard group grant, a token scoped to specific privileges would
+// silently drop those privileges. These tests pin the corrected behavior.
+// =============================================================================
+
+func TestGetEffectivePrivilegesScopedTokenWithUserMCPWildcard(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// User has access to all MCP privileges via the wildcard "*" group grant.
+	// Prior to the fix, a scoped token that named specific MCP privileges
+	// would be intersected against the MCPPrivileges map and the scoped
+	// entries would be dropped because only "*" was present.
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+
+	// Register MCP privileges and grant wildcard access
+	store.RegisterMCPPrivilege("tool_alpha", MCPPrivilegeTypeTool, "Tool Alpha", false)
+	store.RegisterMCPPrivilege("tool_beta", MCPPrivilegeTypeTool, "Tool Beta", false)
+	store.GrantMCPPrivilegeByName(groupID, "*") // Wildcard grant ONLY
+
+	// Token scoped to tool_alpha only
+	_, storedToken, _ := store.CreateToken("testuser", "Scoped token", nil)
+	store.SetTokenMCPScopeByNames(storedToken.ID, []string{"tool_alpha"})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	privs := checker.GetEffectivePrivileges(ctx)
+
+	// Should have tool_alpha (in token scope and user has wildcard access)
+	if len(privs.MCPPrivileges) != 1 {
+		t.Fatalf("Expected exactly 1 MCP privilege, got %d: %+v",
+			len(privs.MCPPrivileges), privs.MCPPrivileges)
+	}
+	if !privs.MCPPrivileges["tool_alpha"] {
+		t.Fatalf("Expected tool_alpha in privileges, got %+v",
+			privs.MCPPrivileges)
+	}
+	// Wildcard "*" must not survive a non-wildcard token scope
+	if privs.MCPPrivileges["*"] {
+		t.Error("Expected '*' to be removed by non-wildcard scope")
+	}
+	// tool_beta should NOT be present (not in token scope)
+	if privs.MCPPrivileges["tool_beta"] {
+		t.Error("Expected tool_beta to be excluded (not in token scope)")
+	}
+}
+
+func TestGetEffectivePrivilegesScopedTokenWithUserAdminWildcard(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// User has access to all admin permissions via the wildcard "*" group grant.
+	// Prior to the fix, a scoped token that named specific admin permissions
+	// would be intersected against the AdminPermissions map and the scoped
+	// entries would be dropped because only "*" was present.
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+
+	// Grant wildcard admin access ONLY (no specific permissions)
+	store.GrantAdminPermission(groupID, AdminPermissionWildcard)
+
+	// Token scoped to manage_users only
+	_, storedToken, _ := store.CreateToken("testuser", "Scoped token", nil)
+	store.SetTokenAdminScope(storedToken.ID, []string{PermManageUsers})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	privs := checker.GetEffectivePrivileges(ctx)
+
+	// Should have manage_users (in token scope and user has wildcard access)
+	if len(privs.AdminPermissions) != 1 {
+		t.Fatalf("Expected exactly 1 admin permission, got %d: %+v",
+			len(privs.AdminPermissions), privs.AdminPermissions)
+	}
+	if !privs.AdminPermissions[PermManageUsers] {
+		t.Fatalf("Expected %s in permissions, got %+v",
+			PermManageUsers, privs.AdminPermissions)
+	}
+	// Wildcard "*" must not survive a non-wildcard token scope
+	if privs.AdminPermissions[AdminPermissionWildcard] {
+		t.Error("Expected '*' to be removed by non-wildcard scope")
+	}
+	// manage_connections should NOT be present (not in token scope)
+	if privs.AdminPermissions[PermManageConnections] {
+		t.Error("Expected manage_connections to be excluded (not in token scope)")
+	}
+}
+
+func TestGetEffectivePrivilegesMCPWildcardUserMultipleScopedPrivileges(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// User has wildcard MCP access only. Token scopes to multiple privileges.
+	// All scoped privileges should resolve successfully.
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+
+	// Register several MCP privileges
+	store.RegisterMCPPrivilege("tool_a", MCPPrivilegeTypeTool, "Tool A", false)
+	store.RegisterMCPPrivilege("tool_b", MCPPrivilegeTypeTool, "Tool B", false)
+	store.RegisterMCPPrivilege("tool_c", MCPPrivilegeTypeTool, "Tool C", false)
+	store.GrantMCPPrivilegeByName(groupID, "*") // Wildcard grant ONLY
+
+	// Token scoped to tool_a and tool_b
+	_, storedToken, _ := store.CreateToken("testuser", "Scoped token", nil)
+	store.SetTokenMCPScopeByNames(storedToken.ID, []string{"tool_a", "tool_b"})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	privs := checker.GetEffectivePrivileges(ctx)
+
+	// Should have both tool_a and tool_b
+	if len(privs.MCPPrivileges) != 2 {
+		t.Fatalf("Expected exactly 2 MCP privileges, got %d: %+v",
+			len(privs.MCPPrivileges), privs.MCPPrivileges)
+	}
+	if !privs.MCPPrivileges["tool_a"] {
+		t.Error("Expected tool_a in privileges")
+	}
+	if !privs.MCPPrivileges["tool_b"] {
+		t.Error("Expected tool_b in privileges")
+	}
+	// tool_c should NOT be present (not in token scope)
+	if privs.MCPPrivileges["tool_c"] {
+		t.Error("Expected tool_c to be excluded (not in token scope)")
+	}
+}
+
+func TestGetEffectivePrivilegesAdminWildcardUserMultipleScopedPermissions(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// User has wildcard admin access only. Token scopes to multiple permissions.
+	// All scoped permissions should resolve successfully.
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+
+	// Grant wildcard admin access ONLY
+	store.GrantAdminPermission(groupID, AdminPermissionWildcard)
+
+	// Token scoped to manage_users and manage_connections
+	_, storedToken, _ := store.CreateToken("testuser", "Scoped token", nil)
+	store.SetTokenAdminScope(storedToken.ID, []string{PermManageUsers, PermManageConnections})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	privs := checker.GetEffectivePrivileges(ctx)
+
+	// Should have both manage_users and manage_connections
+	if len(privs.AdminPermissions) != 2 {
+		t.Fatalf("Expected exactly 2 admin permissions, got %d: %+v",
+			len(privs.AdminPermissions), privs.AdminPermissions)
+	}
+	if !privs.AdminPermissions[PermManageUsers] {
+		t.Error("Expected manage_users in permissions")
+	}
+	if !privs.AdminPermissions[PermManageConnections] {
+		t.Error("Expected manage_connections in permissions")
+	}
+	// manage_groups should NOT be present (not in token scope)
+	if privs.AdminPermissions[PermManageGroups] {
+		t.Error("Expected manage_groups to be excluded (not in token scope)")
+	}
+}
+
+// =============================================================================
+// AccessLevelNone Constant Tests (Issue #96)
+// =============================================================================
+
+func TestAccessLevelNoneConstant(t *testing.T) {
+	// Verify AccessLevelNone equals empty string for backward compatibility
+	if AccessLevelNone != "" {
+		t.Errorf("Expected AccessLevelNone to equal empty string, got %q", AccessLevelNone)
+	}
+
+	// Verify AccessLevelNone is distinct from Read and ReadWrite
+	if AccessLevelNone == AccessLevelRead {
+		t.Error("AccessLevelNone should not equal AccessLevelRead")
+	}
+	if AccessLevelNone == AccessLevelReadWrite {
+		t.Error("AccessLevelNone should not equal AccessLevelReadWrite")
+	}
+}
+
+func TestCanAccessConnectionReturnsAccessLevelNone(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Create user without any group membership
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+
+	// Create restricted connection (assigned to another group)
+	otherGroupID, _ := store.CreateGroup("other-group", "Other group")
+	store.GrantConnectionPrivilege(otherGroupID, 1, AccessLevelReadWrite)
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+
+	// User should be denied with AccessLevelNone
+	canAccess, level := checker.CanAccessConnection(ctx, 1)
+	if canAccess {
+		t.Error("Expected access to be denied")
+	}
+	if level != AccessLevelNone {
+		t.Errorf("Expected AccessLevelNone when denied, got %q", level)
+	}
+}
+
+func TestResolveConnectionAccessReturnsAccessLevelNone(t *testing.T) {
+	// Test that resolveConnectionAccess returns AccessLevelNone when no access
+	privs := make(map[int]string)
+
+	level, hasAccess := resolveConnectionAccess(privs, 1)
+	if hasAccess {
+		t.Error("Expected no access for empty privs map")
+	}
+	if level != AccessLevelNone {
+		t.Errorf("Expected AccessLevelNone, got %q", level)
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - CanAccessConnection
+// =============================================================================
+
+func TestCanAccessConnection_EmptyOwnerUsername(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Connection 10 is not shared and has empty owner username
+	// This should deny access because we cannot determine ownership
+	checker.SetConnectionSharingLookup(mockSharingLookup(map[int]struct {
+		isShared      bool
+		ownerUsername string
+	}{
+		10: {isShared: false, ownerUsername: ""},
+	}))
+
+	// User tries to access connection with empty owner
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, int64(1))
+	ctx = context.WithValue(ctx, UsernameContextKey, "alice")
+
+	canAccess, level := checker.CanAccessConnection(ctx, 10)
+	if canAccess {
+		t.Error("Expected access to be denied when owner is empty string")
+	}
+	if level != AccessLevelNone {
+		t.Errorf("Expected AccessLevelNone, got %q", level)
+	}
+}
+
+func TestCanAccessConnection_SharingLookupError(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Set up a sharing lookup function that returns an error
+	checker.SetConnectionSharingLookup(func(_ context.Context, _ int) (bool, string, error) {
+		return false, "", fmt.Errorf("database connection failed")
+	})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, int64(1))
+	ctx = context.WithValue(ctx, UsernameContextKey, "alice")
+
+	// Should deny access when sharing lookup returns error
+	canAccess, level := checker.CanAccessConnection(ctx, 99)
+	if canAccess {
+		t.Error("Expected access to be denied when sharing lookup returns error")
+	}
+	if level != AccessLevelNone {
+		t.Errorf("Expected AccessLevelNone, got %q", level)
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - HasAdminPermission with Token Scoping
+// =============================================================================
+
+func TestHasAdminPermissionTokenScopeDenied(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Create user with both manage_users and manage_connections
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("admin-group", "Admin group")
+	store.AddUserToGroup(groupID, userID)
+	store.GrantAdminPermission(groupID, PermManageUsers)
+	store.GrantAdminPermission(groupID, PermManageConnections)
+
+	// Create token scoped to ONLY manage_connections (not manage_users)
+	_, storedToken, _ := store.CreateToken("testuser", "Scoped admin token", nil)
+	store.SetTokenAdminScope(storedToken.ID, []string{PermManageConnections})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	// User has manage_users via group but token scope excludes it
+	// This should return false because token scope restricts access
+	if checker.HasAdminPermission(ctx, PermManageUsers) {
+		t.Error("Expected manage_users to be denied due to token scope restriction")
+	}
+
+	// manage_connections should still work (in token scope)
+	if !checker.HasAdminPermission(ctx, PermManageConnections) {
+		t.Error("Expected manage_connections to be allowed (in token scope)")
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - CanAccessMCPItem with Token Scoping
+// =============================================================================
+
+func TestCanAccessMCPItemTokenScopeDenied(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Create user with privileges
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+
+	// Grant multiple MCP privileges
+	store.RegisterMCPPrivilege("tool_x", MCPPrivilegeTypeTool, "Tool X", false)
+	store.RegisterMCPPrivilege("tool_y", MCPPrivilegeTypeTool, "Tool Y", false)
+	store.GrantMCPPrivilegeByName(groupID, "tool_x")
+	store.GrantMCPPrivilegeByName(groupID, "tool_y")
+
+	// Create token scoped to ONLY tool_x
+	_, storedToken, _ := store.CreateToken("testuser", "Scoped MCP token", nil)
+	store.SetTokenMCPScopeByNames(storedToken.ID, []string{"tool_x"})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	// tool_x should be accessible (in scope)
+	if !checker.CanAccessMCPItem(ctx, "tool_x") {
+		t.Error("Expected tool_x to be accessible (in token scope)")
+	}
+
+	// tool_y should be denied (user has it but token scope excludes it)
+	if checker.CanAccessMCPItem(ctx, "tool_y") {
+		t.Error("Expected tool_y to be denied due to token scope restriction")
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - GetEffectivePrivileges MCP Scope with Invalid IDs
+// =============================================================================
+
+func TestGetEffectivePrivilegesMCPScopeWithNonexistentPrivilegeID(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Create user with MCP privileges
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+
+	// Register and grant MCP privileges
+	store.RegisterMCPPrivilege("tool_valid", MCPPrivilegeTypeTool, "Valid Tool", false)
+	store.GrantMCPPrivilegeByName(groupID, "tool_valid")
+
+	// Create token with a valid MCP scope entry
+	_, storedToken, _ := store.CreateToken("testuser", "Scoped token", nil)
+	store.SetTokenMCPScopeByNames(storedToken.ID, []string{"tool_valid"})
+
+	// Now manually insert an invalid privilege ID into token_mcp_scope
+	// This exercises the GetMCPPrivilegeByID error/nil path in GetEffectivePrivileges
+	store.db.Exec(
+		"INSERT INTO token_mcp_scope (token_id, privilege_identifier_id) VALUES (?, ?)",
+		storedToken.ID, 99999, // Non-existent privilege ID
+	)
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	privs := checker.GetEffectivePrivileges(ctx)
+
+	// Should still return the valid tool_valid privilege
+	if !privs.MCPPrivileges["tool_valid"] {
+		t.Error("Expected tool_valid in effective privileges")
+	}
+	// The invalid ID 99999 should be silently skipped (GetMCPPrivilegeByID returns nil)
+	// Total privileges should be 1 (only tool_valid)
+	if len(privs.MCPPrivileges) != 1 {
+		t.Errorf("Expected 1 MCP privilege, got %d: %+v",
+			len(privs.MCPPrivileges), privs.MCPPrivileges)
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - CanAccessConnection Token Scope Error Paths
+// =============================================================================
+
+func TestCanAccessConnectionTokenScopeNotInScope(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Create user with connection privileges
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+
+	// Grant access to connections 1 and 2 via group
+	store.GrantConnectionPrivilege(groupID, 1, AccessLevelReadWrite)
+	store.GrantConnectionPrivilege(groupID, 2, AccessLevelReadWrite)
+
+	// Create token scoped to ONLY connection 1
+	_, storedToken, _ := store.CreateToken("testuser", "Scoped token", nil)
+	store.SetTokenConnectionScope(storedToken.ID, []ScopedConnection{
+		{ConnectionID: 1, AccessLevel: AccessLevelReadWrite},
+	})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	// Connection 1 should be accessible (in token scope)
+	canAccess, level := checker.CanAccessConnection(ctx, 1)
+	if !canAccess {
+		t.Error("Expected connection 1 to be accessible (in token scope)")
+	}
+	if level != AccessLevelReadWrite {
+		t.Errorf("Expected read_write for connection 1, got %q", level)
+	}
+
+	// Connection 2 should be DENIED (user has group access but token scope excludes it)
+	canAccess, level = checker.CanAccessConnection(ctx, 2)
+	if canAccess {
+		t.Error("Expected connection 2 to be denied due to token scope restriction")
+	}
+	if level != AccessLevelNone {
+		t.Errorf("Expected AccessLevelNone for denied connection, got %q", level)
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - GetEffectivePrivileges Connection Wildcard Scope
+// =============================================================================
+
+func TestGetEffectivePrivilegesConnectionWildcardReadCeiling(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// User has read_write to multiple connections
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+	store.GrantConnectionPrivilege(groupID, 1, AccessLevelReadWrite)
+	store.GrantConnectionPrivilege(groupID, 2, AccessLevelReadWrite)
+
+	// Token with wildcard connection scope at read level
+	// This should cap all connections to read access
+	_, storedToken, _ := store.CreateToken("testuser", "Wildcard read token", nil)
+	store.SetTokenConnectionScope(storedToken.ID, []ScopedConnection{
+		{ConnectionID: ConnectionIDAll, AccessLevel: AccessLevelRead},
+	})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	privs := checker.GetEffectivePrivileges(ctx)
+
+	// Both connections should be capped to read
+	if privs.ConnectionPrivileges[1] != AccessLevelRead {
+		t.Errorf("Expected read for connection 1 (wildcard ceiling), got %q",
+			privs.ConnectionPrivileges[1])
+	}
+	if privs.ConnectionPrivileges[2] != AccessLevelRead {
+		t.Errorf("Expected read for connection 2 (wildcard ceiling), got %q",
+			privs.ConnectionPrivileges[2])
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - resolveConnectionAccess edge cases
+// =============================================================================
+
+func TestResolveConnectionAccessWildcardReadWriteElevates(t *testing.T) {
+	// Test that when both specific and wildcard are present,
+	// and wildcard is ReadWrite, the result is ReadWrite
+	privs := map[int]string{
+		1:               AccessLevelRead,      // Specific grant is read
+		ConnectionIDAll: AccessLevelReadWrite, // Wildcard is read_write
+	}
+
+	level, hasAccess := resolveConnectionAccess(privs, 1)
+	if !hasAccess {
+		t.Error("Expected access to be granted")
+	}
+	// Wildcard read_write should elevate the result
+	if level != AccessLevelReadWrite {
+		t.Errorf("Expected read_write (wildcard elevates), got %q", level)
+	}
+}
+
+func TestResolveConnectionAccessSpecificOnlyNoWildcard(t *testing.T) {
+	// Test when only specific grant exists (no wildcard)
+	privs := map[int]string{
+		1: AccessLevelRead,
+	}
+
+	level, hasAccess := resolveConnectionAccess(privs, 1)
+	if !hasAccess {
+		t.Error("Expected access to be granted")
+	}
+	if level != AccessLevelRead {
+		t.Errorf("Expected read (specific grant), got %q", level)
+	}
+
+	// Connection 2 should have no access
+	level, hasAccess = resolveConnectionAccess(privs, 2)
+	if hasAccess {
+		t.Error("Expected no access for ungrant connection")
+	}
+}
+
+func TestResolveConnectionAccessWildcardOnlyNoSpecific(t *testing.T) {
+	// Test when only wildcard grant exists (no specific)
+	privs := map[int]string{
+		ConnectionIDAll: AccessLevelRead,
+	}
+
+	level, hasAccess := resolveConnectionAccess(privs, 999)
+	if !hasAccess {
+		t.Error("Expected access via wildcard")
+	}
+	if level != AccessLevelRead {
+		t.Errorf("Expected read (wildcard grant), got %q", level)
+	}
+}
+
+func TestResolveConnectionAccessBothPresentWildcardRead(t *testing.T) {
+	// Test when both specific and wildcard are present,
+	// and wildcard is Read (not ReadWrite)
+	privs := map[int]string{
+		1:               AccessLevelReadWrite, // Specific is read_write
+		ConnectionIDAll: AccessLevelRead,      // Wildcard is read
+	}
+
+	level, hasAccess := resolveConnectionAccess(privs, 1)
+	if !hasAccess {
+		t.Error("Expected access to be granted")
+	}
+	// Should use specific level (wildcard is not ReadWrite)
+	if level != AccessLevelReadWrite {
+		t.Errorf("Expected read_write (specific grant), got %q", level)
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - CanAccessConnection with restricted connection, no userID
+// =============================================================================
+
+func TestCanAccessConnectionRestrictedNoUserID(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Create a group and assign connection 1 to it (makes it restricted)
+	groupID, _ := store.CreateGroup("some-group", "Group with connection access")
+	store.GrantConnectionPrivilege(groupID, 1, AccessLevelReadWrite)
+
+	// Context without user ID but connection is restricted (assigned to group)
+	// This exercises the userID == 0 check in the restricted path
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	// Deliberately NOT setting UserIDContextKey
+
+	canAccess, level := checker.CanAccessConnection(ctx, 1)
+	if canAccess {
+		t.Error("Expected access to be denied when userID is 0 and connection is restricted")
+	}
+	if level != AccessLevelNone {
+		t.Errorf("Expected AccessLevelNone, got %q", level)
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - CanAccessMCPItem without userID for non-public tool
+// =============================================================================
+
+func TestCanAccessMCPItemNoUserIDForNonPublicTool(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Register a non-public tool
+	store.RegisterMCPPrivilege("private_tool", MCPPrivilegeTypeTool, "Private Tool", false)
+
+	// Grant it to a group (so it's restricted)
+	groupID, _ := store.CreateGroup("tool-group", "Group with tool access")
+	store.GrantMCPPrivilegeByName(groupID, "private_tool")
+
+	// Context without user ID
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	// Deliberately NOT setting UserIDContextKey
+
+	// The tool is registered and not public, so it should hit userID == 0 check
+	if checker.CanAccessMCPItem(ctx, "private_tool") {
+		t.Error("Expected denial when userID is 0 for non-public registered tool")
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - HasAdminPermission token scope returns false
+// =============================================================================
+
+func TestHasAdminPermissionTokenScopeReturnsFalse(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Create user with admin permissions
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("admin-group", "Admin group")
+	store.AddUserToGroup(groupID, userID)
+
+	// Grant wildcard admin permission to user via group
+	store.GrantAdminPermission(groupID, AdminPermissionWildcard)
+
+	// Create token with scope to only manage_connections
+	_, storedToken, _ := store.CreateToken("testuser", "Limited admin token", nil)
+	store.SetTokenAdminScope(storedToken.ID, []string{PermManageConnections})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	// User has wildcard admin via group, but token scope restricts to manage_connections
+	// manage_users should be denied
+	if checker.HasAdminPermission(ctx, PermManageUsers) {
+		t.Error("Expected manage_users to be denied (not in token admin scope)")
+	}
+
+	// manage_connections should be allowed
+	if !checker.HasAdminPermission(ctx, PermManageConnections) {
+		t.Error("Expected manage_connections to be allowed (in token admin scope)")
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - GetEffectivePrivileges admin scope filtering
+// =============================================================================
+
+func TestGetEffectivePrivilegesAdminScopeFiltering(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	// Create user with admin permissions
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("admin-group", "Admin group")
+	store.AddUserToGroup(groupID, userID)
+
+	// Grant multiple admin permissions
+	store.GrantAdminPermission(groupID, PermManageUsers)
+	store.GrantAdminPermission(groupID, PermManageConnections)
+	store.GrantAdminPermission(groupID, PermManageGroups)
+
+	// Create token with scope to only manage_users
+	_, storedToken, _ := store.CreateToken("testuser", "Limited admin token", nil)
+	store.SetTokenAdminScope(storedToken.ID, []string{PermManageUsers})
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, storedToken.ID)
+
+	privs := checker.GetEffectivePrivileges(ctx)
+
+	// Should only have manage_users (the only one in token scope)
+	if len(privs.AdminPermissions) != 1 {
+		t.Errorf("Expected 1 admin permission after scope filtering, got %d: %+v",
+			len(privs.AdminPermissions), privs.AdminPermissions)
+	}
+	if !privs.AdminPermissions[PermManageUsers] {
+		t.Error("Expected manage_users in scoped admin permissions")
+	}
+	if privs.AdminPermissions[PermManageConnections] {
+		t.Error("Expected manage_connections to be filtered out by token scope")
+	}
+	if privs.AdminPermissions[PermManageGroups] {
+		t.Error("Expected manage_groups to be filtered out by token scope")
+	}
+}
+
+// =============================================================================
+// Coverage Gap Tests - Database Error Paths (using closed DB)
+// =============================================================================
+
+func TestCanAccessMCPItemDatabaseError(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+
+	checker := NewRBACChecker(store)
+
+	// Register a non-public privilege before closing
+	store.RegisterMCPPrivilege("test_tool", MCPPrivilegeTypeTool, "Test Tool", false)
+
+	// Create user and give them access
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+	store.GrantMCPPrivilegeByName(groupID, "test_tool")
+
+	// Close the database to trigger errors
+	cleanup()
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+
+	// Should return false due to database error in IsPrivilegePublic
+	if checker.CanAccessMCPItem(ctx, "test_tool") {
+		t.Error("Expected false when database is closed")
+	}
+}
+
+func TestHasAdminPermissionDatabaseError(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+
+	checker := NewRBACChecker(store)
+
+	// Create user and give them admin permission
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("admin-group", "Admin")
+	store.AddUserToGroup(groupID, userID)
+	store.GrantAdminPermission(groupID, PermManageUsers)
+
+	// Close the database to trigger errors
+	cleanup()
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+
+	// Should return false due to database error in GetUserAdminPermissions
+	if checker.HasAdminPermission(ctx, PermManageUsers) {
+		t.Error("Expected false when database is closed")
+	}
+}
+
+func TestCanAccessConnectionDatabaseError(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+
+	checker := NewRBACChecker(store)
+
+	// Create user and give them connection access
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+	store.GrantConnectionPrivilege(groupID, 1, AccessLevelReadWrite)
+
+	// Close the database to trigger errors
+	cleanup()
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+
+	// Should return false due to database error in IsConnectionAssignedToAnyGroup
+	canAccess, level := checker.CanAccessConnection(ctx, 1)
+	if canAccess {
+		t.Error("Expected false when database is closed")
+	}
+	if level != AccessLevelNone {
+		t.Errorf("Expected AccessLevelNone, got %q", level)
+	}
+}
+
+func TestHasAdminPermissionTokenScopeDatabaseError(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+
+	checker := NewRBACChecker(store)
+
+	// Create user with admin permission and token
+	store.CreateUser("testuser", "Password1", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("admin-group", "Admin")
+	store.AddUserToGroup(groupID, userID)
+	store.GrantAdminPermission(groupID, PermManageUsers)
+
+	// Create token with admin scope
+	_, storedToken, _ := store.CreateToken("testuser", "Admin token", nil)
+	store.SetTokenAdminScope(storedToken.ID, []string{PermManageUsers})
+
+	// Store the token ID before closing
+	tokenID := storedToken.ID
+
+	// Close the database to trigger errors
+	cleanup()
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+	ctx = context.WithValue(ctx, TokenIDContextKey, tokenID)
+
+	// Should return false due to database error in GetUserAdminPermissions
+	// (the first DB call in the function after nil and superuser checks)
+	if checker.HasAdminPermission(ctx, PermManageUsers) {
+		t.Error("Expected false when database is closed")
+	}
+}

--- a/server/src/internal/auth/token_scope.go
+++ b/server/src/internal/auth/token_scope.go
@@ -243,7 +243,7 @@ func (s *AuthStore) IsConnectionInTokenScope(tokenID int64, connectionID int) (b
 
 	// No scope means unrestricted
 	if count == 0 {
-		return true, "", nil
+		return true, AccessLevelNone, nil
 	}
 
 	// Check for specific connection
@@ -265,7 +265,7 @@ func (s *AuthStore) IsConnectionInTokenScope(tokenID int64, connectionID int) (b
 		tokenID, ConnectionIDAll,
 	).Scan(&accessLevel)
 	if err == sql.ErrNoRows {
-		return false, "", nil
+		return false, AccessLevelNone, nil
 	}
 	if err != nil {
 		return false, "", fmt.Errorf("failed to check wildcard connection in scope: %w", err)

--- a/server/src/internal/auth/types.go
+++ b/server/src/internal/auth/types.go
@@ -94,6 +94,7 @@ const ConnectionIDAll = 0
 
 // ConnectionAccessLevel constants
 const (
+	AccessLevelNone      = "" // No access or unrestricted scope
 	AccessLevelRead      = "read"
 	AccessLevelReadWrite = "read_write"
 )


### PR DESCRIPTION
## Summary

- Fix `GetEffectivePrivileges` silently dropping MCP privileges and admin
  permissions when the user's access comes solely through a wildcard group
  grant (`"*"`); the intersection logic now checks for wildcard grants,
  aligning with the patterns already used by `CanAccessMCPItem` and
  `HasAdminPermission`.
- Introduce an explicit `AccessLevelNone` constant to replace raw empty
  strings for "no access" semantics across all RBAC return paths, making
  the code more self-documenting and less error-prone.
- Add comprehensive tests covering wildcard resolution in all three scope
  types, raising coverage above 90% for all modified functions.

Closes #96

## Test plan

- [x] All existing auth package tests pass (65+ tests)
- [x] New tests verify MCP wildcard user → scoped token resolves privileges
- [x] New tests verify admin wildcard user → scoped token resolves permissions
- [x] New tests verify `AccessLevelNone` constant backward compatibility
- [x] Coverage above 90% for all modified functions:
  - `CanAccessMCPItem`: 92.6%
  - `CanAccessConnection`: 94.3%
  - `resolveConnectionAccess`: 100%
  - `GetEffectivePrivileges`: 97.1%
  - `HasAdminPermission`: 94.7%
- [x] Full server test suite passes (`go test ./...`)
- [x] `go vet` clean, `gofmt` applied
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve wildcard group/admin grants when intersecting with token scopes; token-scoped connection access now consistently reports "no access" on denials/errors.

* **Tests**
  * Added extensive RBAC regression tests covering wildcard grant handling, token-scope interactions, denial/error paths, and connection-access edge cases.

* **Chores**
  * Added planning and design documentation describing a phased refactor to decompose oversized source files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->