### PR TITLE
Fix walkthrough scripts for macOS bash 3.2 and LLM reconfiguration

### DIFF
--- a/examples/walkthrough/guide.sh
+++ b/examples/walkthrough/guide.sh
@@ -246,10 +246,37 @@ if docker ps --filter "name=wt-" --format "{{.Names}}" 2>/dev/null | grep -q "wt
         chmod 600 "$SCRIPT_DIR/secret/llm-api-key"
       fi
 
+      for f in ai-dba.secret pg-password llm-api-key; do
+        if [[ ! -f "$SCRIPT_DIR/secret/$f" ]]; then
+          error "Missing secret file: secret/$f"
+          error "Tear down and start fresh (option 1) to regenerate."
+          exit 1
+        fi
+      done
+
       info "Restarting server..."
-      (cd "$SCRIPT_DIR" && docker compose restart server 2>/dev/null) || true
+      if ! docker restart wt-server; then
+        error "Failed to restart server container."
+        exit 1
+      fi
+
+      local elapsed=0
+      while [[ $elapsed -lt 30 ]]; do
+        if docker exec wt-server bash -c 'echo > /dev/tcp/localhost/8080' 2>/dev/null; then
+          break
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+      done
+
+      if [[ $elapsed -ge 30 ]]; then
+        error "Server did not become healthy after restart."
+        warn "Check logs with: docker compose logs server"
+        exit 1
+      fi
+
       echo ""
-      info "LLM configuration updated. The server is restarting."
+      info "LLM configuration updated. Server is healthy."
 
       if [[ -n "$SELECTED_LLM_PROVIDER" ]]; then
         info "Provider: $SELECTED_LLM_PROVIDER ($SELECTED_LLM_MODEL)"

--- a/examples/walkthrough/guide.sh
+++ b/examples/walkthrough/guide.sh
@@ -260,7 +260,7 @@ if docker ps --filter "name=wt-" --format "{{.Names}}" 2>/dev/null | grep -q "wt
         exit 1
       fi
 
-      local elapsed=0
+      elapsed=0
       while [[ $elapsed -lt 30 ]]; do
         if docker exec wt-server bash -c 'echo > /dev/tcp/localhost/8080' 2>/dev/null; then
           break

--- a/examples/walkthrough/seed/rebase-timestamps.sh
+++ b/examples/walkthrough/seed/rebase-timestamps.sh
@@ -268,7 +268,7 @@ BEGIN
 
         -- 3. Determine the date range of shifted data and create
         --    weekly partitions (Monday boundaries, matching the
-        --    collector's EnsurePartition logic).
+        --    the collector EnsurePartition logic).
         EXECUTE 'SELECT date_trunc(''week'', MIN(collected_at))::date, '
              || '(date_trunc(''week'', MAX(collected_at)) + interval ''7 days'')::date '
              || 'FROM _rebase_tmp'


### PR DESCRIPTION
## Summary

Two fixes for the walkthrough scripts discovered during production
launch testing on macOS:

- **rebase-timestamps.sh**: Remove apostrophe in a SQL comment
  (`collector's`) that triggers a known bash 3.2.57 parser bug.
  macOS ships this ancient bash version, and unmatched single quotes
  inside heredocs nested in `$()` cause a spurious parse error at
  startup.

- **guide.sh**: Fix the "Change LLM configuration" menu option
  (option 4) which left the server container dead after restart.
  `docker compose restart` re-parses the compose file, and without
  the port env vars (only set during initial setup), compose detects
  config drift and may recreate containers — causing port conflicts
  and corrupted bind mounts. Replaced with `docker restart wt-server`
  which operates on the container directly. Also added secret file
  validation and a post-restart health check.

## Changes

- `examples/walkthrough/seed/rebase-timestamps.sh`: one-word change
  in a SQL comment to remove an unmatched apostrophe
- `examples/walkthrough/guide.sh`: replace `docker compose restart`
  with `docker restart`, add secret file checks, add health check
  with timeout after restart

## Test plan

- [x] `bash -n rebase-timestamps.sh` passes on macOS bash 3.2.57
- [x] Full walkthrough runs clean on macOS via `curl | bash`
- [x] Timestamp rebase completes without parse errors
- [x] LLM reconfiguration (option 4) restarts server and reports health
- [x] Full tear-down and fresh restart works end to end
- [x] ShellCheck passes