### PR TITLE
Fix locale-dependent date assertions in client tests

### DIFF
--- a/client/src/components/AdminPanel/__tests__/AdminMemories.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminMemories.test.tsx
@@ -348,8 +348,24 @@ describe('AdminMemories', () => {
 
         renderWithTheme(<AdminMemories />);
 
+        // AdminMemories formats dates with `toLocaleString(undefined, {...})`
+        // so the rendered string depends on the runner's locale. CI (en-US)
+        // shows "Jan 15, 2024, 10:30 AM" while en-GB shows
+        // "15 Jan 2024, 10:30". Compute the expected display string using
+        // the same ISO input and the same Intl options the component uses,
+        // rather than hard-coding a locale-specific pattern.
+        const expected = new Date(
+            MOCK_MEMORIES[0].created_at,
+        ).toLocaleString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+
         await waitFor(() => {
-            expect(screen.getByText(/Jan 15, 2024/)).toBeInTheDocument();
+            expect(screen.getByText(expected)).toBeInTheDocument();
         });
     });
 

--- a/client/src/components/ChatPanel/__tests__/ChatMessage.test.tsx
+++ b/client/src/components/ChatPanel/__tests__/ChatMessage.test.tsx
@@ -14,6 +14,24 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import ChatMessage, { ChatMessageData } from '../ChatMessage';
 import { renderWithTheme } from '../../../test/renderWithTheme';
 
+// ChatMessage's formatTimestamp helper calls `Date.toLocaleString(undefined,
+// {...})` so the rendered string depends on the test runner's locale. CI runs
+// on an en-US image and emits "Jan 15, 2024, 10:30 AM"; a contributor on a
+// machine set to en-GB (or any day-first locale) sees "15 Jan 2024, 10:30".
+// To keep the assertions locale-independent, compute the expected display
+// string here with the same ISO input and the same Intl options the
+// component uses, rather than hard-coding a locale-specific pattern.
+const TIMESTAMP_ISO = '2024-01-15T10:30:00Z';
+
+const expectedFormattedTimestamp = (iso: string): string =>
+    new Date(iso).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+
 // Mock toolDisplayNames
 vi.mock('../../../utils/toolDisplayNames', () => ({
     getToolDisplayName: (name: string) => name,
@@ -56,11 +74,13 @@ describe('ChatMessage', () => {
             const message: ChatMessageData = {
                 role: 'user',
                 content: 'Hello',
-                timestamp: '2024-01-15T10:30:00Z',
+                timestamp: TIMESTAMP_ISO,
             };
             renderWithTheme(<ChatMessage message={message} mode="dark" />);
 
-            expect(screen.getByText(/jan.*15.*2024/i)).toBeInTheDocument();
+            expect(
+                screen.getByText(expectedFormattedTimestamp(TIMESTAMP_ISO)),
+            ).toBeInTheDocument();
         });
     });
 
@@ -106,11 +126,13 @@ describe('ChatMessage', () => {
             const message: ChatMessageData = {
                 role: 'assistant',
                 content: 'Response',
-                timestamp: '2024-01-15T10:30:00Z',
+                timestamp: TIMESTAMP_ISO,
             };
             renderWithTheme(<ChatMessage message={message} mode="dark" />);
 
-            expect(screen.getByText(/jan.*15.*2024/i)).toBeInTheDocument();
+            expect(
+                screen.getByText(expectedFormattedTimestamp(TIMESTAMP_ISO)),
+            ).toBeInTheDocument();
         });
     });
 
@@ -131,11 +153,13 @@ describe('ChatMessage', () => {
             const message: ChatMessageData = {
                 role: 'system',
                 content: 'System message',
-                timestamp: '2024-01-15T10:30:00Z',
+                timestamp: TIMESTAMP_ISO,
             };
             renderWithTheme(<ChatMessage message={message} mode="dark" />);
 
-            expect(screen.queryByText(/jan.*15.*2024/i)).not.toBeInTheDocument();
+            // Year is the most stable anchor across locales for a rendered
+            // timestamp from this ISO input.
+            expect(screen.queryByText(/2024/)).not.toBeInTheDocument();
         });
     });
 
@@ -156,11 +180,13 @@ describe('ChatMessage', () => {
                 role: 'assistant',
                 content: 'Error message',
                 isError: true,
-                timestamp: '2024-01-15T10:30:00Z',
+                timestamp: TIMESTAMP_ISO,
             };
             renderWithTheme(<ChatMessage message={message} mode="dark" />);
 
-            expect(screen.getByText(/jan.*15.*2024/i)).toBeInTheDocument();
+            expect(
+                screen.getByText(expectedFormattedTimestamp(TIMESTAMP_ISO)),
+            ).toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
## Summary

- `ChatMessage.test.tsx` (3 assertions) and `AdminMemories.test.tsx` (1 assertion) matched against locale-specific date patterns (`/jan.*15.*2024/i`, `/Jan 15, 2024/`). They passed in CI only because the GitHub Ubuntu runner defaults to en-US (month-first). On any machine set to a day-first locale — en-GB and most of EU — the components render `15 Jan 2024, 10:30` and the assertions failed. A latent flake waiting for a runner image bump or a non-US contributor to expose.
- Both components render timestamps with `toLocaleString(undefined, {...})`, which is the correct UX (respect the user's locale). Rather than pin the components to en-US (a UX regression), the tests now compute the expected display string from the same ISO input using the same `Intl` options the components use.

## Test plan

- [x] `npx vitest run` on the two touched files under default macOS locale — 37/37 passed (component rendered `15 Jan 2024, 10:30`).
- [x] Same under `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8` (CI-like) — 37/37 passed (component rendered `Jan 15, 2024, 10:30 AM`).
- [x] Same under `LANG=en_GB.UTF-8 LC_ALL=en_GB.UTF-8` — 37/37 passed.
- [x] `cd client && make test-all` — 1614/1614 tests passed, 0 ESLint errors.
- [x] `cd client && make coverage` — touched files above the 90% floor (`ChatMessage.tsx` 91.02%, `AdminMemories.tsx` 98.9%).
- [ ] CI (running now).

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for date and timestamp formatting across different locales to ensure consistent behavior regardless of user location settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->