### PR TITLE
Fix clipboard copy in token dialog (#71)

### DIFF
--- a/.claude/plans/2026-04-23-token-dialog-copy-fix.md
+++ b/.claude/plans/2026-04-23-token-dialog-copy-fix.md
@@ -1,0 +1,304 @@
+# Token Dialog Copy Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the broken copy-to-clipboard button on the
+token-created dialog (issue #71).
+
+**Architecture:** Add an optional `container` parameter to the
+`copyToClipboard` utility so the execCommand fallback textarea
+is appended inside the MUI Dialog's focus trap instead of
+`document.body`. Pass a ref from the dialog's `<DialogContent>`
+as the container.
+
+**Tech Stack:** React, TypeScript, MUI, Vitest
+
+---
+
+## Task 1: Add container parameter to clipboard utility — tests
+
+**Files:**
+
+- Modify: `client/src/utils/__tests__/clipboard.test.ts`
+
+- [ ] **Step 1: Write failing tests for the container parameter**
+
+Add a new `describe` block inside the existing
+`'when the Clipboard API is unavailable'` section. These tests
+verify the textarea is appended to and cleaned up from a custom
+container element rather than `document.body`.
+
+```typescript
+describe('with a custom container', () => {
+    let container: HTMLDivElement;
+    let containerAppendSpy: ReturnType<typeof vi.fn>;
+    let containerRemoveSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        containerAppendSpy = vi.spyOn(
+            container, 'appendChild'
+        ) as unknown as ReturnType<typeof vi.fn>;
+        containerRemoveSpy = vi.spyOn(
+            container, 'removeChild'
+        ) as unknown as ReturnType<typeof vi.fn>;
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('appends the textarea to the container instead of body',
+        async () => {
+            await copyToClipboard('container text', container);
+
+            expect(containerAppendSpy).toHaveBeenCalledTimes(1);
+            expect(containerRemoveSpy).toHaveBeenCalledTimes(1);
+
+            const textarea = containerAppendSpy.mock
+                .calls[0][0] as HTMLTextAreaElement;
+            expect(textarea.tagName).toBe('TEXTAREA');
+            expect(textarea.value).toBe('container text');
+
+            // document.body should NOT have been touched.
+            expect(appendChildSpy).not.toHaveBeenCalled();
+            expect(removeChildSpy).not.toHaveBeenCalled();
+
+            expect(execCommandMock).toHaveBeenCalledWith('copy');
+        }
+    );
+
+    it('cleans up the textarea from the container on failure',
+        async () => {
+            execCommandMock.mockImplementation(() => {
+                throw new Error('boom');
+            });
+
+            await expect(
+                copyToClipboard('cleanup', container)
+            ).rejects.toThrow('boom');
+
+            expect(containerRemoveSpy).toHaveBeenCalledTimes(1);
+        }
+    );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run src/utils/__tests__/clipboard.test.ts`
+
+Expected: FAIL — `copyToClipboard` does not accept a second
+argument yet, so the textarea still appends to `document.body`
+and the `containerAppendSpy` assertion fails.
+
+---
+
+## Task 2: Add container parameter to clipboard utility — implementation
+
+**Files:**
+
+- Modify: `client/src/utils/clipboard.ts:22-52`
+
+- [ ] **Step 1: Update the function signature and fallback path**
+
+Replace the existing `copyToClipboard` function body (lines
+22–52) with the version that accepts an optional `container`
+parameter:
+
+```typescript
+export async function copyToClipboard(
+    text: string,
+    container?: HTMLElement
+): Promise<void> {
+    // Prefer the modern Clipboard API when available.
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    // Fallback: create a temporary textarea, select its content, and
+    // invoke the deprecated execCommand('copy').
+    // When a container is supplied (e.g. inside a dialog portal) the
+    // textarea is appended there so it remains within any active focus
+    // trap; otherwise it falls back to document.body.
+    const target = container ?? document.body;
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+
+    // Keep the element invisible and out of the layout flow.
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '-9999px';
+    textarea.style.opacity = '0';
+
+    target.appendChild(textarea);
+    try {
+        textarea.select();
+        const ok = document.execCommand('copy');
+        if (!ok) {
+            throw new Error(
+                'Clipboard API unavailable and execCommand("copy") failed.'
+            );
+        }
+    } finally {
+        target.removeChild(textarea);
+    }
+}
+```
+
+Also update the JSDoc `@param` block above the function to
+document the new parameter:
+
+```typescript
+/**
+ * Copy text to the clipboard.
+ *
+ * Tries the modern Clipboard API first (requires a secure context). When
+ * that is unavailable (plain HTTP), falls back to the legacy
+ * `document.execCommand('copy')` approach with a temporary textarea.
+ *
+ * @param text - The string to place on the clipboard.
+ * @param container - Optional DOM element to append the temporary textarea
+ *                    to. Useful when calling from within a focus-trapped
+ *                    dialog; defaults to `document.body`.
+ * @returns A promise that resolves on success.
+ * @throws On failure so callers can report the error to the user.
+ */
+```
+
+- [ ] **Step 2: Run clipboard tests to verify they pass**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run src/utils/__tests__/clipboard.test.ts`
+
+Expected: All tests PASS, including the new container tests from
+Task 1.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/utils/clipboard.ts \
+       client/src/utils/__tests__/clipboard.test.ts
+git commit -m "fix: add container parameter to copyToClipboard for dialog focus traps (#71)"
+```
+
+---
+
+## Task 3: Pass dialog ref from AdminTokenScopes — tests
+
+**Files:**
+
+- Modify: `client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx`
+
+No new tests are needed for the `AdminTokenScopes` component.
+The existing tests mock `navigator.clipboard.writeText` so they
+exercise the modern Clipboard API path, which is unchanged. The
+ref wiring is an internal implementation detail verified by the
+clipboard utility tests (Task 1) and by manual testing. The
+existing tests already confirm the copy button calls
+`copyToClipboard` and renders the correct feedback.
+
+- [ ] **Step 1: Run the existing AdminTokenScopes tests**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx`
+
+Expected: All existing tests PASS (nothing has changed in this
+file yet).
+
+---
+
+## Task 4: Pass dialog ref from AdminTokenScopes — implementation
+
+**Files:**
+
+- Modify: `client/src/components/AdminPanel/AdminTokenScopes.tsx:199-203,511-516,1027`
+
+- [ ] **Step 1: Add a ref for the dialog content area**
+
+After line 203 (`const copyResetTimerRef = ...`), add:
+
+```typescript
+const createdDialogContentRef = useRef<HTMLDivElement>(null);
+```
+
+- [ ] **Step 2: Pass the ref as the container argument**
+
+In `handleCopyToken` (line 516), change:
+
+```typescript
+await copyToClipboard(createdToken);
+```
+
+to:
+
+```typescript
+await copyToClipboard(
+    createdToken,
+    createdDialogContentRef.current ?? undefined
+);
+```
+
+Note: `useRef.current` is `null` when the dialog is not mounted;
+we convert to `undefined` so the utility falls back to
+`document.body`. This is defensive only — the ref will always
+be populated when the dialog is open.
+
+- [ ] **Step 3: Attach the ref to DialogContent**
+
+On line 1027, change:
+
+```tsx
+<DialogContent>
+```
+
+to:
+
+```tsx
+<DialogContent ref={createdDialogContentRef}>
+```
+
+- [ ] **Step 4: Run the AdminTokenScopes tests**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run the full client test suite**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/AdminPanel/AdminTokenScopes.tsx
+git commit -m "fix: wire dialog content ref to copyToClipboard container (#71)"
+```
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Run make test-all from the repository root**
+
+Run: `cd /workspaces/ai-dba-workbench && make test-all`
+
+Expected: All sub-project test suites pass.
+
+- [ ] **Step 2: Run client coverage check**
+
+Run: `cd /workspaces/ai-dba-workbench/client && make coverage`
+
+Expected: `clipboard.ts` and `AdminTokenScopes.tsx` both meet
+the 90% line coverage floor.
+
+- [ ] **Step 3: Run linter**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx eslint src/utils/clipboard.ts src/components/AdminPanel/AdminTokenScopes.tsx`
+
+Expected: No errors or warnings.

--- a/.claude/specs/2026-04-23-token-dialog-copy-fix-design.md
+++ b/.claude/specs/2026-04-23-token-dialog-copy-fix-design.md
@@ -1,0 +1,97 @@
+# Fix Clipboard Copy in Token Dialog
+
+## Problem
+
+Issue #71: the copy button on the token-created dialog does not
+copy the token value to the clipboard.
+
+The `copyToClipboard` utility appends a temporary textarea to
+`document.body` when the modern Clipboard API is unavailable
+(non-secure HTTP contexts). MUI `<Dialog>` enforces a focus trap
+that prevents focus from leaving the dialog portal. The textarea's
+`select()` call fails because focus cannot move outside the
+dialog, so `execCommand('copy')` returns `false` and throws.
+
+## Solution
+
+Add an optional `container` parameter to `copyToClipboard`. When
+provided, the temporary textarea is appended to the container
+element instead of `document.body`. This keeps the textarea inside
+the dialog's focus trap, allowing `select()` and
+`execCommand('copy')` to succeed.
+
+The modern Clipboard API path (secure contexts) is unaffected.
+
+## File Changes
+
+### `client/src/utils/clipboard.ts`
+
+Add an optional second parameter `container?: HTMLElement` to
+`copyToClipboard`. In the fallback path, append the textarea to
+`container ?? document.body` instead of `document.body`.
+
+```typescript
+export async function copyToClipboard(
+    text: string,
+    container?: HTMLElement
+): Promise<void> {
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    const target = container ?? document.body;
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '-9999px';
+    textarea.style.opacity = '0';
+
+    target.appendChild(textarea);
+    try {
+        textarea.select();
+        const ok = document.execCommand('copy');
+        if (!ok) {
+            throw new Error(
+                'Clipboard API unavailable and '
+                + 'execCommand("copy") failed.'
+            );
+        }
+    } finally {
+        target.removeChild(textarea);
+    }
+}
+```
+
+### `client/src/components/AdminPanel/AdminTokenScopes.tsx`
+
+Add a `useRef<HTMLDivElement>(null)` ref for the dialog content
+area. Attach the ref to the `<DialogContent>` element of the
+token-created dialog. Pass `ref.current` as the second argument
+to `copyToClipboard` in `handleCopyToken`. Update the
+`useCallback` dependency array to include the ref if needed.
+
+### `client/src/utils/__tests__/clipboard.test.ts`
+
+Add test cases for the `container` parameter:
+
+- When a container is provided, the textarea is appended to and
+  removed from that container instead of `document.body`.
+- When `execCommand` fails with a container, the textarea is
+  still cleaned up from the container.
+
+### `client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx`
+
+Verify that the copy button works correctly in the dialog
+context. Existing tests that mock `navigator.clipboard.writeText`
+remain valid since the modern path is unchanged. Add or adjust
+tests for the fallback path if coverage requires it.
+
+## Scope
+
+Four files touched. The change is backward-compatible; the new
+parameter is optional and defaults to `document.body`. No changes
+to focus trap behavior or accessibility. All existing callers of
+`copyToClipboard` (e.g., `CopyCodeButton`) continue to work
+without modification.

--- a/client/src/components/AdminPanel/AdminTokenScopes.tsx
+++ b/client/src/components/AdminPanel/AdminTokenScopes.tsx
@@ -201,6 +201,7 @@ const AdminTokenScopes: React.FC = () => {
     const [createdDialogOpen, setCreatedDialogOpen] = useState(false);
     const [tokenCopied, setTokenCopied] = useState(false);
     const copyResetTimerRef = useRef<number | null>(null);
+    const createdDialogContentRef = useRef<HTMLDivElement>(null);
 
     // Create dialog - owner privilege filtering
     const [ownerConnections, setOwnerConnections] = useState<Connection[]>([]);
@@ -513,7 +514,10 @@ const AdminTokenScopes: React.FC = () => {
             return;
         }
         try {
-            await copyToClipboard(createdToken);
+            await copyToClipboard(
+                createdToken,
+                createdDialogContentRef.current ?? undefined
+            );
             setError(null);
             setTokenCopied(true);
             if (copyResetTimerRef.current !== null) {
@@ -1024,7 +1028,7 @@ curl -s -X POST -H "Authorization: Bearer <token>" \\
                 fullWidth
             >
                 <DialogTitle sx={dialogTitleSx}>Token created</DialogTitle>
-                <DialogContent>
+                <DialogContent ref={createdDialogContentRef}>
                     <Alert severity="warning" sx={{ mb: 2, borderRadius: 1 }}>
                         Save this token securely. It will not be shown again.
                     </Alert>

--- a/client/src/utils/__tests__/clipboard.test.ts
+++ b/client/src/utils/__tests__/clipboard.test.ts
@@ -137,6 +137,66 @@ describe('copyToClipboard', () => {
             // The finally block must still remove the element.
             expect(removeChildSpy).toHaveBeenCalledTimes(1);
         });
+
+        describe('with a custom container', () => {
+            let container: HTMLDivElement;
+            let containerAppendSpy: ReturnType<typeof vi.fn>;
+            let containerRemoveSpy: ReturnType<typeof vi.fn>;
+
+            beforeEach(() => {
+                container = document.createElement('div');
+                document.body.appendChild(container);
+                containerAppendSpy = vi.spyOn(
+                    container, 'appendChild'
+                ) as unknown as ReturnType<typeof vi.fn>;
+                containerRemoveSpy = vi.spyOn(
+                    container, 'removeChild'
+                ) as unknown as ReturnType<typeof vi.fn>;
+
+                // Reset the document.body spies after creating the container
+                // so they only capture calls made by copyToClipboard.
+                appendChildSpy.mockClear();
+                removeChildSpy.mockClear();
+            });
+
+            afterEach(() => {
+                document.body.removeChild(container);
+            });
+
+            it('appends the textarea to the container instead of body',
+                async () => {
+                    await copyToClipboard('container text', container);
+
+                    expect(containerAppendSpy).toHaveBeenCalledTimes(1);
+                    expect(containerRemoveSpy).toHaveBeenCalledTimes(1);
+
+                    const textarea = containerAppendSpy.mock
+                        .calls[0][0] as HTMLTextAreaElement;
+                    expect(textarea.tagName).toBe('TEXTAREA');
+                    expect(textarea.value).toBe('container text');
+
+                    // document.body should NOT have been touched.
+                    expect(appendChildSpy).not.toHaveBeenCalled();
+                    expect(removeChildSpy).not.toHaveBeenCalled();
+
+                    expect(execCommandMock).toHaveBeenCalledWith('copy');
+                }
+            );
+
+            it('cleans up the textarea from the container on failure',
+                async () => {
+                    execCommandMock.mockImplementation(() => {
+                        throw new Error('boom');
+                    });
+
+                    await expect(
+                        copyToClipboard('cleanup', container)
+                    ).rejects.toThrow('boom');
+
+                    expect(containerRemoveSpy).toHaveBeenCalledTimes(1);
+                }
+            );
+        });
     });
 
     // -- Clipboard API present but writeText missing (edge case) ------------

--- a/client/src/utils/clipboard.ts
+++ b/client/src/utils/clipboard.ts
@@ -16,10 +16,16 @@
  * `document.execCommand('copy')` approach with a temporary textarea.
  *
  * @param text - The string to place on the clipboard.
+ * @param container - Optional DOM element to append the temporary textarea
+ *                    to. Useful when calling from within a focus-trapped
+ *                    dialog; defaults to `document.body`.
  * @returns A promise that resolves on success.
  * @throws On failure so callers can report the error to the user.
  */
-export async function copyToClipboard(text: string): Promise<void> {
+export async function copyToClipboard(
+    text: string,
+    container?: HTMLElement
+): Promise<void> {
     // Prefer the modern Clipboard API when available.
     if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(text);
@@ -28,6 +34,10 @@ export async function copyToClipboard(text: string): Promise<void> {
 
     // Fallback: create a temporary textarea, select its content, and
     // invoke the deprecated execCommand('copy').
+    // When a container is supplied (e.g. inside a dialog portal) the
+    // textarea is appended there so it remains within any active focus
+    // trap; otherwise it falls back to document.body.
+    const target = container ?? document.body;
     const textarea = document.createElement('textarea');
     textarea.value = text;
 
@@ -37,7 +47,7 @@ export async function copyToClipboard(text: string): Promise<void> {
     textarea.style.top = '-9999px';
     textarea.style.opacity = '0';
 
-    document.body.appendChild(textarea);
+    target.appendChild(textarea);
     try {
         textarea.select();
         const ok = document.execCommand('copy');
@@ -47,6 +57,6 @@ export async function copyToClipboard(text: string): Promise<void> {
             );
         }
     } finally {
-        document.body.removeChild(textarea);
+        target.removeChild(textarea);
     }
 }


### PR DESCRIPTION
## Summary

- Adds an optional `container` parameter to `copyToClipboard()` so the `execCommand('copy')` fallback appends its temporary textarea inside a provided DOM element instead of `document.body`.
- Wires the token-created dialog's `<DialogContent>` as the container via a ref, keeping the textarea inside MUI's focus trap.

## Root Cause

The copy button failed on non-HTTPS contexts where `navigator.clipboard` is unavailable. The `execCommand('copy')` fallback created a textarea on `document.body`, but MUI Dialog's focus trap prevented `textarea.select()` from working outside the dialog portal.

## Changes

| File | Change |
|------|--------|
| `client/src/utils/clipboard.ts` | Add optional `container?: HTMLElement` param; use `container ?? document.body` in fallback path |
| `client/src/utils/__tests__/clipboard.test.ts` | Add 2 tests for container parameter (append + cleanup) |
| `client/src/components/AdminPanel/AdminTokenScopes.tsx` | Add `createdDialogContentRef`, pass to `copyToClipboard`, attach to `<DialogContent>` |

## Test plan

- [x] clipboard.ts: 9 tests pass (100% coverage)
- [x] AdminTokenScopes.tsx: 6 tests pass
- [x] All sub-project test suites pass (server, collector, alerter, client)
- [x] ESLint passes with no errors or warnings
- [ ] Manual test: create a token over HTTP, verify copy button works

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the copy-to-clipboard button on the token-created dialog to reliably copy newly generated tokens in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->