### PR TITLE
Fix dismissed auto-detected clusters reappearing in topology (#36)

### DIFF
--- a/.claude/plans/2026-04-23-issue-36-dismissed-clusters-topology-fix.md
+++ b/.claude/plans/2026-04-23-issue-36-dismissed-clusters-topology-fix.md
@@ -1,0 +1,991 @@
+# Issue #36: Dismissed Clusters Topology Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent dismissed (soft-deleted) auto-detected clusters from
+reappearing in the topology view, and allow users to DELETE
+auto-detected clusters via the API.
+
+**Architecture:** Add a `dismissedKeys` filter (mirroring the existing
+`claimedKeys` pattern) to `buildTopologyHierarchy` and
+`buildAutoDetectedClusters`. Extend the API handler at
+`/api/v1/clusters/{id}` to accept DELETE for `server-*` and
+`cluster-spock-*` paths by resolving the auto_cluster_key and
+soft-deleting via a new `DeleteAutoDetectedCluster` datastore method.
+Update the OpenAPI specification to reflect the new DELETE operation.
+
+**Tech Stack:** Go 1.24, pgx v5, net/http, PostgreSQL
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `server/src/internal/database/topology_autodetect.go` | Modify | Add `getDismissedAutoClusterKeys()`; update `buildAutoDetectedClusters()` signature to accept and filter dismissed keys |
+| `server/src/internal/database/topology_queries.go` | Modify | Wire dismissed keys into `GetClusterTopology()`; update `buildTopologyHierarchy()` signature and filtering |
+| `server/src/internal/database/cluster_queries.go` | Modify | Add `DeleteAutoDetectedCluster()` and `deriveClusterNameFromKey()` |
+| `server/src/internal/api/cluster_handlers.go` | Modify | Add DELETE case for auto-detected cluster paths; add `deleteAutoDetectedCluster()` handler |
+| `server/src/internal/api/openapi.go` | Modify | Add DELETE operation to `/api/v1/clusters/{id}` for auto-detected cluster IDs |
+| `server/src/internal/database/cluster_dismiss_integration_test.go` | Modify | Add topology-filtering and delete-by-key integration tests |
+| `server/src/internal/api/cluster_handlers_test.go` | Modify | Add tests for DELETE on auto-detected cluster paths |
+| `docs/admin-guide/api/reference.md` | Modify | Update endpoint summary table |
+
+---
+
+### Task 1: Add `getDismissedAutoClusterKeys` and unit test
+
+**Files:**
+
+- Modify: `server/src/internal/database/topology_autodetect.go:176`
+  (insert after `getClaimedAutoClusterKeys`)
+- Modify:
+  `server/src/internal/database/cluster_dismiss_integration_test.go`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `cluster_dismiss_integration_test.go` after the existing
+`containsClusterID` helper:
+
+```go
+// TestGetDismissedAutoClusterKeys verifies that getDismissedAutoClusterKeys
+// returns only the auto_cluster_keys of dismissed clusters.
+func TestGetDismissedAutoClusterKeys(t *testing.T) {
+    ds, pool, cleanup := newClusterDismissTestDatastore(t)
+    defer cleanup()
+
+    ctx := context.Background()
+    groupID := insertClusterDismissTestGroup(t, pool)
+
+    // Insert two auto-detected clusters: one active, one dismissed.
+    _, err := pool.Exec(ctx, `
+        INSERT INTO clusters (name, auto_cluster_key, group_id, dismissed)
+        VALUES ('active-cluster', 'spock:active', $1, FALSE),
+               ('dismissed-cluster', 'spock:dismissed', $1, TRUE)
+    `, groupID)
+    if err != nil {
+        t.Fatalf("failed to seed clusters: %v", err)
+    }
+
+    // Also insert a manual cluster (no auto_cluster_key) that is
+    // irrelevant to the dismissed key set.
+    _, err = pool.Exec(ctx, `
+        INSERT INTO clusters (name, group_id, dismissed)
+        VALUES ('manual-cluster', $1, FALSE)
+    `, groupID)
+    if err != nil {
+        t.Fatalf("failed to seed manual cluster: %v", err)
+    }
+
+    dismissed, err := ds.getDismissedAutoClusterKeys(ctx)
+    if err != nil {
+        t.Fatalf("getDismissedAutoClusterKeys failed: %v", err)
+    }
+
+    if len(dismissed) != 1 {
+        t.Fatalf("expected 1 dismissed key, got %d: %v", len(dismissed), dismissed)
+    }
+    if !dismissed["spock:dismissed"] {
+        t.Fatalf("expected spock:dismissed in set, got %v", dismissed)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/database/ \
+    -run TestGetDismissedAutoClusterKeys -v -count=1
+```
+
+Expected: compilation error — `getDismissedAutoClusterKeys` is undefined.
+
+- [ ] **Step 3: Implement `getDismissedAutoClusterKeys`**
+
+Insert the following function in `topology_autodetect.go` immediately
+after `getClaimedAutoClusterKeys` (after line 176):
+
+```go
+// getDismissedAutoClusterKeys returns auto_cluster_keys for clusters
+// that have been dismissed (soft-deleted). The topology builder uses
+// this set to suppress clusters the user has hidden.
+func (d *Datastore) getDismissedAutoClusterKeys(ctx context.Context) (map[string]bool, error) {
+    query := `
+        SELECT auto_cluster_key
+        FROM clusters
+        WHERE auto_cluster_key IS NOT NULL
+          AND dismissed = TRUE
+    `
+
+    rows, err := d.pool.Query(ctx, query)
+    if err != nil {
+        return nil, fmt.Errorf("failed to query dismissed cluster keys: %w", err)
+    }
+    defer rows.Close()
+
+    dismissed := make(map[string]bool)
+    for rows.Next() {
+        var key string
+        if err := rows.Scan(&key); err != nil {
+            return nil, fmt.Errorf("failed to scan dismissed key: %w", err)
+        }
+        dismissed[key] = true
+    }
+
+    if err := rows.Err(); err != nil {
+        return nil, fmt.Errorf("error iterating dismissed keys: %w", err)
+    }
+
+    return dismissed, nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/database/ \
+    -run TestGetDismissedAutoClusterKeys -v -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run gofmt**
+
+```bash
+gofmt -w /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/topology_autodetect.go
+gofmt -w /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/cluster_dismiss_integration_test.go
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36 && \
+git add server/src/internal/database/topology_autodetect.go \
+        server/src/internal/database/cluster_dismiss_integration_test.go && \
+git commit -m "Add getDismissedAutoClusterKeys query and test
+
+Query the clusters table for auto_cluster_key values that have been
+soft-deleted (dismissed = TRUE). This set will be used by the topology
+builder to suppress dismissed clusters from the UI. Issue #36.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire dismissed keys into topology building
+
+**Files:**
+
+- Modify: `server/src/internal/database/topology_queries.go:157-273`
+  (`GetClusterTopology`, `buildTopologyHierarchy`)
+- Modify: `server/src/internal/database/topology_autodetect.go:181-337`
+  (`buildAutoDetectedClusters`)
+- Modify:
+  `server/src/internal/database/cluster_dismiss_integration_test.go`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `cluster_dismiss_integration_test.go`:
+
+```go
+// TestDismissedClusterExcludedFromBuildTopologyHierarchy verifies that
+// buildTopologyHierarchy omits clusters whose auto_cluster_key appears
+// in the dismissedKeys set.
+func TestDismissedClusterExcludedFromBuildTopologyHierarchy(t *testing.T) {
+    ds, pool, cleanup := newClusterDismissTestDatastore(t)
+    defer cleanup()
+
+    ctx := context.Background()
+    groupID := insertClusterDismissTestGroup(t, pool)
+
+    // Create an auto-detected cluster and then dismiss it.
+    created, err := ds.UpsertAutoDetectedCluster(
+        ctx, "binary:999", "doomed-cluster", nil, &groupID,
+    )
+    if err != nil {
+        t.Fatalf("UpsertAutoDetectedCluster failed: %v", err)
+    }
+    if err := ds.DeleteCluster(ctx, created.ID); err != nil {
+        t.Fatalf("DeleteCluster failed: %v", err)
+    }
+
+    // The dismissed key must be returned by getDismissedAutoClusterKeys.
+    dismissedKeys, err := ds.getDismissedAutoClusterKeys(ctx)
+    if err != nil {
+        t.Fatalf("getDismissedAutoClusterKeys failed: %v", err)
+    }
+    if !dismissedKeys["binary:999"] {
+        t.Fatalf("expected binary:999 in dismissed set")
+    }
+
+    // Build a minimal topology; the dismissed key must be absent from
+    // the resulting clusters list.
+    defaultGroup := &defaultGroupInfo{ID: groupID, Name: "Servers/Clusters"}
+    groups := ds.buildTopologyHierarchy(
+        nil,                              // no connections
+        make(map[string]clusterOverride), // no overrides
+        make(map[string]bool),            // no claimed keys
+        dismissedKeys,                    // dismissed keys
+        defaultGroup,
+    )
+    for _, g := range groups {
+        for _, c := range g.Clusters {
+            if c.AutoClusterKey == "binary:999" {
+                t.Fatalf("dismissed cluster binary:999 appeared in topology")
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/database/ \
+    -run TestDismissedClusterExcludedFromBuildTopologyHierarchy -v -count=1
+```
+
+Expected: compilation error — `buildTopologyHierarchy` does not accept
+a `dismissedKeys` parameter.
+
+- [ ] **Step 3: Update `buildTopologyHierarchy` signature and add filtering**
+
+In `topology_queries.go`, change the function signature at line 455
+from:
+
+```go
+func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clusterOverrides map[string]clusterOverride, claimedKeys map[string]bool, defaultGroup *defaultGroupInfo) []TopologyGroup {
+```
+
+to:
+
+```go
+func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clusterOverrides map[string]clusterOverride, claimedKeys map[string]bool, dismissedKeys map[string]bool, defaultGroup *defaultGroupInfo) []TopologyGroup {
+```
+
+Then add `dismissedKeys` checks next to every existing `claimedKeys`
+check. There are four locations:
+
+**Spock clusters (line 545):** Change:
+```go
+if cluster.AutoClusterKey != "" && claimedKeys[cluster.AutoClusterKey] {
+```
+to:
+```go
+if cluster.AutoClusterKey != "" && (claimedKeys[cluster.AutoClusterKey] || dismissedKeys[cluster.AutoClusterKey]) {
+```
+
+**Binary clusters (line 569):** Change:
+```go
+if claimedKeys[autoKey] {
+```
+to:
+```go
+if claimedKeys[autoKey] || dismissedKeys[autoKey] {
+```
+
+**Logical clusters (line 601):** Change:
+```go
+if cluster.AutoClusterKey != "" && claimedKeys[cluster.AutoClusterKey] {
+```
+to:
+```go
+if cluster.AutoClusterKey != "" && (claimedKeys[cluster.AutoClusterKey] || dismissedKeys[cluster.AutoClusterKey]) {
+```
+
+**Standalone servers (line 625):** Change:
+```go
+if claimedKeys[autoKey] {
+```
+to:
+```go
+if claimedKeys[autoKey] || dismissedKeys[autoKey] {
+```
+
+- [ ] **Step 4: Update the call site in `GetClusterTopology`**
+
+In `topology_queries.go`, after Step 4 (line 197, after
+`getClaimedAutoClusterKeys`), add:
+
+```go
+// Step 4b: Get dismissed auto-detected cluster keys so they are
+// excluded from the topology. Issue #36.
+dismissedKeys, err := d.getDismissedAutoClusterKeys(ctx)
+if err != nil {
+    return nil, fmt.Errorf("failed to get dismissed cluster keys: %w", err)
+}
+```
+
+Then update the call to `buildTopologyHierarchy` at line 226 from:
+
+```go
+defaultGroups := d.buildTopologyHierarchy(unclaimedConnections, clusterOverrides, claimedKeys, defaultGroup)
+```
+
+to:
+
+```go
+defaultGroups := d.buildTopologyHierarchy(unclaimedConnections, clusterOverrides, claimedKeys, dismissedKeys, defaultGroup)
+```
+
+- [ ] **Step 5: Update `buildAutoDetectedClusters` to filter dismissed keys**
+
+In `topology_autodetect.go`, change the signature at line 181 from:
+
+```go
+func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, clusterOverrides map[string]clusterOverride) map[string]TopologyCluster {
+```
+
+to:
+
+```go
+func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, clusterOverrides map[string]clusterOverride, dismissedKeys map[string]bool) map[string]TopologyCluster {
+```
+
+Add dismissed-key checks for each cluster type:
+
+**Spock clusters (after line 262):** Change:
+```go
+for _, cluster := range spockClusters {
+    if cluster.AutoClusterKey != "" {
+        result[cluster.AutoClusterKey] = cluster
+    }
+}
+```
+to:
+```go
+for _, cluster := range spockClusters {
+    if cluster.AutoClusterKey != "" && !dismissedKeys[cluster.AutoClusterKey] {
+        result[cluster.AutoClusterKey] = cluster
+    }
+}
+```
+
+**Binary clusters (after line 282):** Add before building the
+TopologyCluster (immediately after the `autoKey :=` line):
+```go
+if dismissedKeys[autoKey] {
+    continue
+}
+```
+
+**Logical clusters (after line 303):** Change:
+```go
+for _, cluster := range logicalClusters {
+    if cluster.AutoClusterKey != "" {
+        result[cluster.AutoClusterKey] = cluster
+    }
+}
+```
+to:
+```go
+for _, cluster := range logicalClusters {
+    if cluster.AutoClusterKey != "" && !dismissedKeys[cluster.AutoClusterKey] {
+        result[cluster.AutoClusterKey] = cluster
+    }
+}
+```
+
+**Standalone servers (after line 318):** Add after the `autoKey :=`
+line:
+```go
+if dismissedKeys[autoKey] {
+    continue
+}
+```
+
+- [ ] **Step 6: Update the call site for `buildAutoDetectedClusters`**
+
+In `topology_queries.go` at line 190, change:
+
+```go
+autoDetectedClusters := d.buildAutoDetectedClusters(allConnections, clusterOverrides)
+```
+
+to:
+
+```go
+autoDetectedClusters := d.buildAutoDetectedClusters(allConnections, clusterOverrides, dismissedKeys)
+```
+
+Note: `dismissedKeys` must be queried before this line. Move the new
+Step 4b code (from Step 4 above) to before Step 3, i.e., between the
+`clusterOverrides` block (line 186) and the
+`buildAutoDetectedClusters` call (line 190).
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/database/ \
+    -run TestDismissedClusterExcluded -v -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run full database package tests**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/database/ -v -count=1
+```
+
+Expected: all tests pass (existing tests must not break).
+
+- [ ] **Step 9: Run gofmt**
+
+```bash
+gofmt -w /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/topology_queries.go
+gofmt -w /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/topology_autodetect.go
+gofmt -w /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/cluster_dismiss_integration_test.go
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36 && \
+git add server/src/internal/database/topology_queries.go \
+        server/src/internal/database/topology_autodetect.go \
+        server/src/internal/database/cluster_dismiss_integration_test.go && \
+git commit -m "Filter dismissed clusters from topology building
+
+Wire getDismissedAutoClusterKeys into GetClusterTopology,
+buildTopologyHierarchy, and buildAutoDetectedClusters so that clusters
+a user has dismissed no longer reappear in the ClusterNavigator. The
+dismissedKeys set mirrors the existing claimedKeys pattern. Issue #36.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add `DeleteAutoDetectedCluster` datastore method and tests
+
+**Files:**
+
+- Modify: `server/src/internal/database/cluster_queries.go`
+- Modify:
+  `server/src/internal/database/cluster_dismiss_integration_test.go`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add to `cluster_dismiss_integration_test.go`:
+
+```go
+// TestDeleteAutoDetectedCluster_ExistingRow verifies that
+// DeleteAutoDetectedCluster soft-deletes an existing cluster by its
+// auto_cluster_key and detaches connections.
+func TestDeleteAutoDetectedCluster_ExistingRow(t *testing.T) {
+    ds, pool, cleanup := newClusterDismissTestDatastore(t)
+    defer cleanup()
+
+    ctx := context.Background()
+    groupID := insertClusterDismissTestGroup(t, pool)
+
+    // Create cluster and attach a connection.
+    cluster, err := ds.UpsertAutoDetectedCluster(
+        ctx, "binary:100", "test-cluster", nil, &groupID,
+    )
+    if err != nil {
+        t.Fatalf("UpsertAutoDetectedCluster failed: %v", err)
+    }
+    _, err = pool.Exec(ctx, `
+        INSERT INTO connections (name, cluster_id, membership_source)
+        VALUES ('conn-1', $1, 'auto')
+    `, cluster.ID)
+    if err != nil {
+        t.Fatalf("failed to insert connection: %v", err)
+    }
+
+    // Soft-delete by auto_cluster_key.
+    if err := ds.DeleteAutoDetectedCluster(ctx, "binary:100"); err != nil {
+        t.Fatalf("DeleteAutoDetectedCluster failed: %v", err)
+    }
+
+    // Cluster must be dismissed.
+    var dismissed bool
+    err = pool.QueryRow(ctx,
+        `SELECT dismissed FROM clusters WHERE id = $1`, cluster.ID,
+    ).Scan(&dismissed)
+    if err != nil {
+        t.Fatalf("failed to read dismissed flag: %v", err)
+    }
+    if !dismissed {
+        t.Fatal("cluster was not dismissed")
+    }
+
+    // Connection must be detached.
+    var clusterID *int
+    err = pool.QueryRow(ctx,
+        `SELECT cluster_id FROM connections WHERE name = 'conn-1'`,
+    ).Scan(&clusterID)
+    if err != nil {
+        t.Fatalf("failed to read connection cluster_id: %v", err)
+    }
+    if clusterID != nil {
+        t.Fatalf("connection still attached to cluster %d", *clusterID)
+    }
+}
+
+// TestDeleteAutoDetectedCluster_NoRow verifies that
+// DeleteAutoDetectedCluster creates a dismissed record when no cluster
+// row exists for the given auto_cluster_key.
+func TestDeleteAutoDetectedCluster_NoRow(t *testing.T) {
+    ds, pool, cleanup := newClusterDismissTestDatastore(t)
+    defer cleanup()
+
+    ctx := context.Background()
+    _ = insertClusterDismissTestGroup(t, pool)
+
+    // Delete a cluster that has no database row yet.
+    if err := ds.DeleteAutoDetectedCluster(ctx, "spock:phantom"); err != nil {
+        t.Fatalf("DeleteAutoDetectedCluster (no row) failed: %v", err)
+    }
+
+    // A dismissed row must have been created.
+    var dismissed bool
+    var name string
+    err := pool.QueryRow(ctx, `
+        SELECT name, dismissed FROM clusters
+        WHERE auto_cluster_key = 'spock:phantom'
+    `).Scan(&name, &dismissed)
+    if err != nil {
+        t.Fatalf("failed to read newly created cluster: %v", err)
+    }
+    if !dismissed {
+        t.Fatal("newly created cluster is not dismissed")
+    }
+    if name != "phantom Spock" {
+        t.Fatalf("derived name = %q, want %q", name, "phantom Spock")
+    }
+}
+
+// TestDeriveClusterNameFromKey verifies the key-to-name mapping.
+func TestDeriveClusterNameFromKey(t *testing.T) {
+    tests := []struct {
+        key  string
+        want string
+    }{
+        {"spock:pg17", "pg17 Spock"},
+        {"binary:42", "binary-42"},
+        {"standalone:7", "standalone-7"},
+        {"logical:99", "logical-99"},
+        {"unknown", "unknown"},
+        {"custom:xyz", "custom:xyz"},
+    }
+    for _, tt := range tests {
+        got := deriveClusterNameFromKey(tt.key)
+        if got != tt.want {
+            t.Errorf("deriveClusterNameFromKey(%q) = %q, want %q",
+                tt.key, got, tt.want)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/database/ \
+    -run "TestDeleteAutoDetectedCluster|TestDeriveClusterNameFromKey" \
+    -v -count=1
+```
+
+Expected: compilation error — `DeleteAutoDetectedCluster` and
+`deriveClusterNameFromKey` are undefined.
+
+- [ ] **Step 3: Implement `deriveClusterNameFromKey`**
+
+Add at the end of `cluster_queries.go`:
+
+```go
+// deriveClusterNameFromKey produces a human-readable name from an
+// auto_cluster_key. The result is used when creating a dismissed
+// placeholder row for a cluster that has no existing database record.
+func deriveClusterNameFromKey(autoKey string) string {
+    parts := strings.SplitN(autoKey, ":", 2)
+    if len(parts) != 2 {
+        return autoKey
+    }
+    prefix, suffix := parts[0], parts[1]
+    switch prefix {
+    case "spock":
+        return suffix + " Spock"
+    case "binary":
+        return "binary-" + suffix
+    case "standalone":
+        return "standalone-" + suffix
+    case "logical":
+        return "logical-" + suffix
+    default:
+        return autoKey
+    }
+}
+```
+
+- [ ] **Step 4: Implement `DeleteAutoDetectedCluster`**
+
+Add in `cluster_queries.go` after `DeleteCluster`:
+
+```go
+// DeleteAutoDetectedCluster soft-deletes an auto-detected cluster by
+// its auto_cluster_key. If no database record exists for the key, a
+// dismissed placeholder is created so the topology builder skips the
+// cluster on subsequent refreshes.
+func (d *Datastore) DeleteAutoDetectedCluster(ctx context.Context, autoKey string) error {
+    d.mu.Lock()
+    defer d.mu.Unlock()
+
+    // Try to find an existing cluster with this auto_cluster_key.
+    var clusterID int
+    err := d.pool.QueryRow(ctx,
+        `SELECT id FROM clusters WHERE auto_cluster_key = $1`,
+        autoKey,
+    ).Scan(&clusterID)
+
+    if err != nil {
+        // No existing record — create one in dismissed state.
+        name := deriveClusterNameFromKey(autoKey)
+        _, insertErr := d.pool.Exec(ctx, `
+            INSERT INTO clusters (name, auto_cluster_key, dismissed)
+            VALUES ($1, $2, TRUE)
+        `, name, autoKey)
+        if insertErr != nil {
+            return fmt.Errorf("failed to create dismissed cluster record: %w", insertErr)
+        }
+        return nil
+    }
+
+    // Existing record found — soft-delete it.
+    _, err = d.pool.Exec(ctx,
+        `UPDATE clusters SET dismissed = TRUE, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+        clusterID,
+    )
+    if err != nil {
+        return fmt.Errorf("failed to dismiss cluster: %w", err)
+    }
+
+    // Detach connections.
+    _, err = d.pool.Exec(ctx,
+        `UPDATE connections SET cluster_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE cluster_id = $1`,
+        clusterID,
+    )
+    if err != nil {
+        return fmt.Errorf("failed to detach connections from dismissed cluster: %w", err)
+    }
+
+    return nil
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/database/ \
+    -run "TestDeleteAutoDetectedCluster|TestDeriveClusterNameFromKey" \
+    -v -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run gofmt**
+
+```bash
+gofmt -w /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/cluster_queries.go
+gofmt -w /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/cluster_dismiss_integration_test.go
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36 && \
+git add server/src/internal/database/cluster_queries.go \
+        server/src/internal/database/cluster_dismiss_integration_test.go && \
+git commit -m "Add DeleteAutoDetectedCluster datastore method
+
+Soft-delete auto-detected clusters by auto_cluster_key. When no DB
+row exists for the key, create a dismissed placeholder so the topology
+builder suppresses the cluster on subsequent refreshes. Issue #36.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Add DELETE handler for auto-detected clusters
+
+**Files:**
+
+- Modify: `server/src/internal/api/cluster_handlers.go:346-355`
+- Modify: `server/src/internal/api/cluster_handlers_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cluster_handlers_test.go`. Follow the existing test patterns
+in that file (use `httptest.NewRecorder`, mock datastore, etc.).
+First, find the existing test setup in the file to understand the
+mock pattern, then add:
+
+```go
+func TestDeleteAutoDetectedCluster_Success(t *testing.T) {
+    // This test verifies that DELETE /api/v1/clusters/server-42
+    // calls DeleteAutoDetectedCluster with the correct auto_cluster_key.
+    // Follow the existing mock pattern in this file.
+}
+```
+
+The exact test shape depends on the mock infrastructure already in the
+file. The test must:
+
+1. Send `DELETE /api/v1/clusters/server-42` with admin auth.
+2. Assert the response is 204 No Content.
+3. Assert `DeleteAutoDetectedCluster` was called with
+   `"standalone:42"`.
+
+Also test the Spock path:
+
+1. Send `DELETE /api/v1/clusters/cluster-spock-pg17` with admin auth.
+2. Assert 204 No Content.
+3. Assert `DeleteAutoDetectedCluster` was called with `"spock:pg17"`.
+
+And a forbidden test:
+
+1. Send `DELETE /api/v1/clusters/server-42` without admin auth.
+2. Assert 403 Forbidden.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/api/ \
+    -run TestDeleteAutoDetectedCluster -v -count=1
+```
+
+Expected: failure (handler not implemented).
+
+- [ ] **Step 3: Add DELETE case to `handleClusterSubpath`**
+
+In `cluster_handlers.go` at line 347-355, change:
+
+```go
+if strings.HasPrefix(parts[0], "server-") || strings.HasPrefix(parts[0], "cluster-spock-") {
+    switch r.Method {
+    case http.MethodPut:
+        h.updateAutoDetectedCluster(w, r, parts[0])
+    default:
+        w.Header().Set("Allow", "PUT")
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+    }
+    return
+}
+```
+
+to:
+
+```go
+if strings.HasPrefix(parts[0], "server-") || strings.HasPrefix(parts[0], "cluster-spock-") {
+    switch r.Method {
+    case http.MethodPut:
+        h.updateAutoDetectedCluster(w, r, parts[0])
+    case http.MethodDelete:
+        h.deleteAutoDetectedCluster(w, r, parts[0])
+    default:
+        w.Header().Set("Allow", "PUT, DELETE")
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+    }
+    return
+}
+```
+
+- [ ] **Step 4: Add `deleteAutoDetectedCluster` handler**
+
+Add after `updateAutoDetectedCluster` in `cluster_handlers.go`:
+
+```go
+// deleteAutoDetectedCluster handles DELETE requests for auto-detected
+// clusters. It resolves the auto_cluster_key from the topology ID and
+// soft-deletes the cluster.
+func (h *ClusterHandler) deleteAutoDetectedCluster(w http.ResponseWriter, r *http.Request, clusterID string) {
+    if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+        RespondError(w, http.StatusForbidden,
+            "Permission denied: you do not have permission to delete auto-detected clusters")
+        return
+    }
+
+    autoKey := computeAutoClusterKey(clusterID)
+    if autoKey == "" {
+        RespondError(w, http.StatusBadRequest, "Invalid auto-detected cluster ID")
+        return
+    }
+
+    ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+    defer cancel()
+
+    if err := h.datastore.DeleteAutoDetectedCluster(ctx, autoKey); err != nil {
+        log.Printf("[ERROR] Failed to delete auto-detected cluster %s: %v",
+            logging.SanitizeForLog(clusterID), err)
+        RespondError(w, http.StatusInternalServerError,
+            "Failed to delete auto-detected cluster")
+        return
+    }
+
+    w.WriteHeader(http.StatusNoContent)
+}
+```
+
+- [ ] **Step 5: Add `DeleteAutoDetectedCluster` to the datastore interface**
+
+Check if there is a `DatastoreInterface` or similar interface that the
+mock uses. If so, add the method signature:
+
+```go
+DeleteAutoDetectedCluster(ctx context.Context, autoKey string) error
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/api/ \
+    -run TestDeleteAutoDetectedCluster -v -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run gofmt**
+
+```bash
+gofmt -w /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/api/cluster_handlers.go
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36 && \
+git add server/src/internal/api/cluster_handlers.go \
+        server/src/internal/api/cluster_handlers_test.go && \
+git commit -m "Add DELETE handler for auto-detected clusters
+
+Support DELETE on /api/v1/clusters/server-{id} and
+/api/v1/clusters/cluster-spock-{prefix} paths. The handler resolves
+the auto_cluster_key and delegates to DeleteAutoDetectedCluster.
+Requires manage_connections permission. Issue #36.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update OpenAPI specification
+
+**Files:**
+
+- Modify: `server/src/internal/api/openapi.go`
+- Modify: `docs/admin-guide/api/reference.md`
+
+- [ ] **Step 1: Add DELETE operation to the clusters path in `openapi.go`**
+
+Find the `/api/v1/clusters/{id}` path entry in `BuildOpenAPISpec()`
+and add a DELETE operation entry. Follow the pattern of the existing
+DELETE operation for database-backed clusters, but note that this
+DELETE also applies to `server-*` and `cluster-spock-*` ID formats.
+
+- [ ] **Step 2: Regenerate the static OpenAPI file**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server && \
+  make openapi
+```
+
+- [ ] **Step 3: Run the OpenAPI tests**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src && \
+  go test ./internal/api/ -run OpenAPI -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Update endpoint summary table in `reference.md`**
+
+Add or update the DELETE entry for `/api/v1/clusters/{id}` to note
+that auto-detected cluster IDs (`server-*`, `cluster-spock-*`) are
+now accepted.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36 && \
+git add server/src/internal/api/openapi.go \
+        docs/admin-guide/api/openapi.json \
+        docs/admin-guide/api/reference.md && \
+git commit -m "Update OpenAPI spec for auto-detected cluster DELETE
+
+Document that DELETE /api/v1/clusters/{id} now accepts auto-detected
+cluster IDs (server-*, cluster-spock-*). Issue #36.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full test suite and coverage verification
+
+**Files:** All modified files.
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36 && \
+  make test-all
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run coverage for the server package**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server && \
+  make coverage && \
+  go tool cover -func=coverage.out | grep -E \
+    "(getDismissed|DeleteAutoDetected|deriveCluster|buildTopologyHierarchy|buildAutoDetected)"
+```
+
+Verify all new functions meet the 90% line coverage floor.
+
+- [ ] **Step 3: Run gofmt on all modified files**
+
+```bash
+gofmt -l /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/topology_autodetect.go \
+         /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/topology_queries.go \
+         /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/database/cluster_queries.go \
+         /workspaces/ai-dba-workbench/.worktrees/fix-issue-36/server/src/internal/api/cluster_handlers.go
+```
+
+Expected: no output (all files already formatted).
+
+- [ ] **Step 4: Fix any failures and re-run**
+
+If tests fail or coverage is below 90%, fix the issues and re-run.
+
+- [ ] **Step 5: Final commit (if any fixes were needed)**
+
+```bash
+cd /workspaces/ai-dba-workbench/.worktrees/fix-issue-36 && \
+git add -A && \
+git commit -m "Fix test and coverage issues from review
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```

--- a/.claude/plans/2026-04-23-token-dialog-copy-fix.md
+++ b/.claude/plans/2026-04-23-token-dialog-copy-fix.md
@@ -1,0 +1,304 @@
+# Token Dialog Copy Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the broken copy-to-clipboard button on the
+token-created dialog (issue #71).
+
+**Architecture:** Add an optional `container` parameter to the
+`copyToClipboard` utility so the execCommand fallback textarea
+is appended inside the MUI Dialog's focus trap instead of
+`document.body`. Pass a ref from the dialog's `<DialogContent>`
+as the container.
+
+**Tech Stack:** React, TypeScript, MUI, Vitest
+
+---
+
+## Task 1: Add container parameter to clipboard utility — tests
+
+**Files:**
+
+- Modify: `client/src/utils/__tests__/clipboard.test.ts`
+
+- [ ] **Step 1: Write failing tests for the container parameter**
+
+Add a new `describe` block inside the existing
+`'when the Clipboard API is unavailable'` section. These tests
+verify the textarea is appended to and cleaned up from a custom
+container element rather than `document.body`.
+
+```typescript
+describe('with a custom container', () => {
+    let container: HTMLDivElement;
+    let containerAppendSpy: ReturnType<typeof vi.fn>;
+    let containerRemoveSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        containerAppendSpy = vi.spyOn(
+            container, 'appendChild'
+        ) as unknown as ReturnType<typeof vi.fn>;
+        containerRemoveSpy = vi.spyOn(
+            container, 'removeChild'
+        ) as unknown as ReturnType<typeof vi.fn>;
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('appends the textarea to the container instead of body',
+        async () => {
+            await copyToClipboard('container text', container);
+
+            expect(containerAppendSpy).toHaveBeenCalledTimes(1);
+            expect(containerRemoveSpy).toHaveBeenCalledTimes(1);
+
+            const textarea = containerAppendSpy.mock
+                .calls[0][0] as HTMLTextAreaElement;
+            expect(textarea.tagName).toBe('TEXTAREA');
+            expect(textarea.value).toBe('container text');
+
+            // document.body should NOT have been touched.
+            expect(appendChildSpy).not.toHaveBeenCalled();
+            expect(removeChildSpy).not.toHaveBeenCalled();
+
+            expect(execCommandMock).toHaveBeenCalledWith('copy');
+        }
+    );
+
+    it('cleans up the textarea from the container on failure',
+        async () => {
+            execCommandMock.mockImplementation(() => {
+                throw new Error('boom');
+            });
+
+            await expect(
+                copyToClipboard('cleanup', container)
+            ).rejects.toThrow('boom');
+
+            expect(containerRemoveSpy).toHaveBeenCalledTimes(1);
+        }
+    );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run src/utils/__tests__/clipboard.test.ts`
+
+Expected: FAIL — `copyToClipboard` does not accept a second
+argument yet, so the textarea still appends to `document.body`
+and the `containerAppendSpy` assertion fails.
+
+---
+
+## Task 2: Add container parameter to clipboard utility — implementation
+
+**Files:**
+
+- Modify: `client/src/utils/clipboard.ts:22-52`
+
+- [ ] **Step 1: Update the function signature and fallback path**
+
+Replace the existing `copyToClipboard` function body (lines
+22–52) with the version that accepts an optional `container`
+parameter:
+
+```typescript
+export async function copyToClipboard(
+    text: string,
+    container?: HTMLElement
+): Promise<void> {
+    // Prefer the modern Clipboard API when available.
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    // Fallback: create a temporary textarea, select its content, and
+    // invoke the deprecated execCommand('copy').
+    // When a container is supplied (e.g. inside a dialog portal) the
+    // textarea is appended there so it remains within any active focus
+    // trap; otherwise it falls back to document.body.
+    const target = container ?? document.body;
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+
+    // Keep the element invisible and out of the layout flow.
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '-9999px';
+    textarea.style.opacity = '0';
+
+    target.appendChild(textarea);
+    try {
+        textarea.select();
+        const ok = document.execCommand('copy');
+        if (!ok) {
+            throw new Error(
+                'Clipboard API unavailable and execCommand("copy") failed.'
+            );
+        }
+    } finally {
+        target.removeChild(textarea);
+    }
+}
+```
+
+Also update the JSDoc `@param` block above the function to
+document the new parameter:
+
+```typescript
+/**
+ * Copy text to the clipboard.
+ *
+ * Tries the modern Clipboard API first (requires a secure context). When
+ * that is unavailable (plain HTTP), falls back to the legacy
+ * `document.execCommand('copy')` approach with a temporary textarea.
+ *
+ * @param text - The string to place on the clipboard.
+ * @param container - Optional DOM element to append the temporary textarea
+ *                    to. Useful when calling from within a focus-trapped
+ *                    dialog; defaults to `document.body`.
+ * @returns A promise that resolves on success.
+ * @throws On failure so callers can report the error to the user.
+ */
+```
+
+- [ ] **Step 2: Run clipboard tests to verify they pass**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run src/utils/__tests__/clipboard.test.ts`
+
+Expected: All tests PASS, including the new container tests from
+Task 1.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/utils/clipboard.ts \
+       client/src/utils/__tests__/clipboard.test.ts
+git commit -m "fix: add container parameter to copyToClipboard for dialog focus traps (#71)"
+```
+
+---
+
+## Task 3: Pass dialog ref from AdminTokenScopes — tests
+
+**Files:**
+
+- Modify: `client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx`
+
+No new tests are needed for the `AdminTokenScopes` component.
+The existing tests mock `navigator.clipboard.writeText` so they
+exercise the modern Clipboard API path, which is unchanged. The
+ref wiring is an internal implementation detail verified by the
+clipboard utility tests (Task 1) and by manual testing. The
+existing tests already confirm the copy button calls
+`copyToClipboard` and renders the correct feedback.
+
+- [ ] **Step 1: Run the existing AdminTokenScopes tests**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx`
+
+Expected: All existing tests PASS (nothing has changed in this
+file yet).
+
+---
+
+## Task 4: Pass dialog ref from AdminTokenScopes — implementation
+
+**Files:**
+
+- Modify: `client/src/components/AdminPanel/AdminTokenScopes.tsx:199-203,511-516,1027`
+
+- [ ] **Step 1: Add a ref for the dialog content area**
+
+After line 203 (`const copyResetTimerRef = ...`), add:
+
+```typescript
+const createdDialogContentRef = useRef<HTMLDivElement>(null);
+```
+
+- [ ] **Step 2: Pass the ref as the container argument**
+
+In `handleCopyToken` (line 516), change:
+
+```typescript
+await copyToClipboard(createdToken);
+```
+
+to:
+
+```typescript
+await copyToClipboard(
+    createdToken,
+    createdDialogContentRef.current ?? undefined
+);
+```
+
+Note: `useRef.current` is `null` when the dialog is not mounted;
+we convert to `undefined` so the utility falls back to
+`document.body`. This is defensive only — the ref will always
+be populated when the dialog is open.
+
+- [ ] **Step 3: Attach the ref to DialogContent**
+
+On line 1027, change:
+
+```tsx
+<DialogContent>
+```
+
+to:
+
+```tsx
+<DialogContent ref={createdDialogContentRef}>
+```
+
+- [ ] **Step 4: Run the AdminTokenScopes tests**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run the full client test suite**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx vitest run`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/AdminPanel/AdminTokenScopes.tsx
+git commit -m "fix: wire dialog content ref to copyToClipboard container (#71)"
+```
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Run make test-all from the repository root**
+
+Run: `cd /workspaces/ai-dba-workbench && make test-all`
+
+Expected: All sub-project test suites pass.
+
+- [ ] **Step 2: Run client coverage check**
+
+Run: `cd /workspaces/ai-dba-workbench/client && make coverage`
+
+Expected: `clipboard.ts` and `AdminTokenScopes.tsx` both meet
+the 90% line coverage floor.
+
+- [ ] **Step 3: Run linter**
+
+Run: `cd /workspaces/ai-dba-workbench/client && npx eslint src/utils/clipboard.ts src/components/AdminPanel/AdminTokenScopes.tsx`
+
+Expected: No errors or warnings.

--- a/.claude/specs/2026-04-23-issue-36-dismissed-clusters-topology-fix-design.md
+++ b/.claude/specs/2026-04-23-issue-36-dismissed-clusters-topology-fix-design.md
@@ -1,0 +1,442 @@
+# Design Spec: Fix Dismissed Clusters Reappearing in Topology
+
+This specification describes the fix for GitHub issue #36: "Deleted
+auto-detected clusters reappear in the cluster selection dropdown."
+
+## Summary
+
+Auto-detected clusters that users dismiss reappear in the ClusterNavigator
+topology view because `buildTopologyHierarchy()` reconstructs clusters
+from live metrics without checking the `dismissed` flag. This fix adds
+a dismissed-key filter to the topology building process and extends the
+API to support DELETE on auto-detected cluster paths.
+
+## Problem
+
+The AI DBA Workbench has two paths for displaying clusters:
+
+1. **Server creation dialog dropdown** (`GET /api/v1/clusters/list`) uses
+   `ListClustersForAutocomplete()` with `WHERE dismissed = FALSE`. This
+   correctly filters dismissed clusters.
+
+2. **Cluster Navigator / topology view** (`GET /api/v1/clusters`) uses
+   `GetClusterTopology()` which calls `buildTopologyHierarchy()`. This
+   function builds clusters from raw connection metrics data (system
+   identifiers, Spock node info, replication topology), not from the
+   clusters table. It does NOT check the `dismissed` flag.
+
+When a user deletes an auto-detected cluster:
+
+- `DeleteCluster()` soft-deletes it by setting `dismissed = TRUE`.
+- Connections are detached (`cluster_id = NULL`).
+- But `buildTopologyHierarchy()` re-detects the cluster from live metrics
+  on the next topology refresh.
+- The cluster reappears in the ClusterNavigator because the topology
+  builder does not know about dismissed clusters.
+
+Additionally, the API handler at `cluster_handlers.go:347-355` returns
+"Method not allowed" for DELETE on auto-detected cluster IDs
+(`server-*`, `cluster-spock-*`). Only PUT is supported. This means
+users cannot delete auto-detected clusters through the ClusterNavigator
+UI unless the cluster has been synced to the database.
+
+## Solution Overview
+
+The fix combines two approaches:
+
+### Part A: Filter dismissed clusters from topology building
+
+This prevents dismissed clusters from appearing in the topology view by
+checking the `dismissed` flag during the auto-detection process.
+
+### Part C: Support DELETE for auto-detected clusters
+
+This allows users to dismiss auto-detected clusters directly from the
+ClusterNavigator UI without requiring the cluster to exist in the
+database first.
+
+## Detailed Design
+
+### Part A: Filter Dismissed Clusters from Topology Building
+
+#### New Function: getDismissedAutoClusterKeys
+
+Add a new function in `topology_autodetect.go` that returns the set of
+auto_cluster_keys that have been dismissed:
+
+```go
+// getDismissedAutoClusterKeys returns auto_cluster_keys for clusters
+// that have been dismissed (soft-deleted). These keys are used to filter
+// auto-detected clusters from the topology view.
+func (d *Datastore) getDismissedAutoClusterKeys(ctx context.Context) (map[string]bool, error) {
+    query := `
+        SELECT auto_cluster_key
+        FROM clusters
+        WHERE auto_cluster_key IS NOT NULL
+          AND dismissed = TRUE
+    `
+
+    rows, err := d.pool.Query(ctx, query)
+    if err != nil {
+        return nil, fmt.Errorf("failed to query dismissed cluster keys: %w", err)
+    }
+    defer rows.Close()
+
+    dismissed := make(map[string]bool)
+    for rows.Next() {
+        var key string
+        if err := rows.Scan(&key); err != nil {
+            return nil, fmt.Errorf("failed to scan dismissed key: %w", err)
+        }
+        dismissed[key] = true
+    }
+
+    if err := rows.Err(); err != nil {
+        return nil, fmt.Errorf("error iterating dismissed keys: %w", err)
+    }
+
+    return dismissed, nil
+}
+```
+
+#### Modify GetClusterTopology
+
+Update `GetClusterTopology()` in `topology_queries.go` to query dismissed
+keys early and pass them to `buildTopologyHierarchy()`:
+
+```go
+// After Step 4 (getClaimedAutoClusterKeys), add:
+
+// Step 4b: Get dismissed auto-detected cluster keys
+dismissedKeys, err := d.getDismissedAutoClusterKeys(ctx)
+if err != nil {
+    return nil, fmt.Errorf("failed to get dismissed cluster keys: %w", err)
+}
+```
+
+#### Modify buildTopologyHierarchy Signature
+
+Update `buildTopologyHierarchy()` to accept the dismissed keys set and
+filter clusters whose `AutoClusterKey` matches a dismissed key:
+
+```go
+func (d *Datastore) buildTopologyHierarchy(
+    connections []connectionWithRole,
+    clusterOverrides map[string]clusterOverride,
+    claimedKeys map[string]bool,
+    dismissedKeys map[string]bool,  // NEW PARAMETER
+    defaultGroup *defaultGroupInfo,
+) []TopologyGroup
+```
+
+The filtering logic mirrors the existing `claimedKeys` pattern. In each
+place where the code checks `claimedKeys[autoKey]`, also check
+`dismissedKeys[autoKey]`:
+
+- Spock clusters (around line 545)
+- Binary replication clusters (around line 569)
+- Logical replication clusters (around line 601)
+- Standalone servers (around line 625)
+
+#### Modify buildAutoDetectedClusters
+
+Update `buildAutoDetectedClusters()` in `topology_autodetect.go` to also
+skip dismissed keys. This ensures dismissed clusters do not appear in
+manual group topology either.
+
+### Part C: Support DELETE for Auto-Detected Clusters
+
+#### Modify handleClusterSubpath
+
+Extend the handling for `server-*` and `cluster-spock-*` paths in
+`cluster_handlers.go` to support DELETE in addition to PUT:
+
+```go
+// Check if it's an auto-detected cluster ID (server-{id} or cluster-spock-{prefix})
+if strings.HasPrefix(parts[0], "server-") || strings.HasPrefix(parts[0], "cluster-spock-") {
+    switch r.Method {
+    case http.MethodPut:
+        h.updateAutoDetectedCluster(w, r, parts[0])
+    case http.MethodDelete:
+        h.deleteAutoDetectedCluster(w, r, parts[0])
+    default:
+        w.Header().Set("Allow", "PUT, DELETE")
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+    }
+    return
+}
+```
+
+#### New Handler: deleteAutoDetectedCluster
+
+Add a new handler function that resolves the auto_cluster_key from the
+topology ID and performs the soft-delete:
+
+```go
+// deleteAutoDetectedCluster handles DELETE requests for auto-detected clusters.
+// It resolves the auto_cluster_key from the topology ID, ensures a database
+// record exists, then soft-deletes it.
+func (h *ClusterHandler) deleteAutoDetectedCluster(w http.ResponseWriter, r *http.Request, clusterID string) {
+    // Check user permissions - requires manage_connections permission
+    if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+        RespondError(w, http.StatusForbidden,
+            "Permission denied: you do not have permission to delete auto-detected clusters")
+        return
+    }
+
+    // Compute auto_cluster_key from cluster ID
+    autoKey := computeAutoClusterKey(clusterID)
+    if autoKey == "" {
+        RespondError(w, http.StatusBadRequest, "Invalid auto-detected cluster ID")
+        return
+    }
+
+    ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+    defer cancel()
+
+    // Delete (soft-delete) the cluster by auto_cluster_key
+    err := h.datastore.DeleteAutoDetectedCluster(ctx, autoKey)
+    if err != nil {
+        log.Printf("[ERROR] Failed to delete auto-detected cluster %s: %v",
+            logging.SanitizeForLog(clusterID), err)
+        RespondError(w, http.StatusInternalServerError,
+            "Failed to delete auto-detected cluster")
+        return
+    }
+
+    w.WriteHeader(http.StatusNoContent)
+}
+```
+
+#### New Datastore Method: DeleteAutoDetectedCluster
+
+Add a new method in `cluster_queries.go` that handles soft-delete by
+auto_cluster_key, creating the record first if necessary:
+
+```go
+// DeleteAutoDetectedCluster soft-deletes an auto-detected cluster by its
+// auto_cluster_key. If no database record exists for the key, one is created
+// first (with dismissed = TRUE) so the dismissed state persists across
+// topology rebuilds.
+func (d *Datastore) DeleteAutoDetectedCluster(ctx context.Context, autoKey string) error {
+    d.mu.Lock()
+    defer d.mu.Unlock()
+
+    // First, try to find an existing cluster with this auto_cluster_key
+    var clusterID int
+    err := d.pool.QueryRow(ctx,
+        `SELECT id FROM clusters WHERE auto_cluster_key = $1`,
+        autoKey,
+    ).Scan(&clusterID)
+
+    if err != nil {
+        // No existing record - create one in dismissed state
+        // The name is derived from the auto_cluster_key prefix
+        name := deriveClusterNameFromKey(autoKey)
+        err = d.pool.QueryRow(ctx, `
+            INSERT INTO clusters (name, auto_cluster_key, dismissed)
+            VALUES ($1, $2, TRUE)
+            RETURNING id
+        `, name, autoKey).Scan(&clusterID)
+        if err != nil {
+            return fmt.Errorf("failed to create dismissed cluster record: %w", err)
+        }
+        return nil // Already dismissed upon creation
+    }
+
+    // Existing record found - soft-delete it
+    _, err = d.pool.Exec(ctx,
+        `UPDATE clusters SET dismissed = TRUE, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+        clusterID,
+    )
+    if err != nil {
+        return fmt.Errorf("failed to dismiss cluster: %w", err)
+    }
+
+    // Detach connections
+    _, err = d.pool.Exec(ctx,
+        `UPDATE connections SET cluster_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE cluster_id = $1`,
+        clusterID,
+    )
+    if err != nil {
+        return fmt.Errorf("failed to detach connections from dismissed cluster: %w", err)
+    }
+
+    return nil
+}
+
+// deriveClusterNameFromKey extracts a reasonable name from an auto_cluster_key.
+// For example, "spock:pg17" becomes "pg17 Spock", "binary:42" becomes "binary-42".
+func deriveClusterNameFromKey(autoKey string) string {
+    parts := strings.SplitN(autoKey, ":", 2)
+    if len(parts) != 2 {
+        return autoKey
+    }
+    prefix, suffix := parts[0], parts[1]
+    switch prefix {
+    case "spock":
+        return suffix + " Spock"
+    case "binary":
+        return "binary-" + suffix
+    case "standalone":
+        return "standalone-" + suffix
+    case "logical":
+        return "logical-" + suffix
+    default:
+        return autoKey
+    }
+}
+```
+
+## Files Changed
+
+### Server Changes
+
+| File | Change |
+|------|--------|
+| `server/src/internal/database/topology_autodetect.go` | Add `getDismissedAutoClusterKeys()` function; update `buildAutoDetectedClusters()` to filter dismissed keys |
+| `server/src/internal/database/topology_queries.go` | Update `GetClusterTopology()` to query dismissed keys; update `buildTopologyHierarchy()` signature and filtering logic |
+| `server/src/internal/database/cluster_queries.go` | Add `DeleteAutoDetectedCluster()` and `deriveClusterNameFromKey()` functions |
+| `server/src/internal/api/cluster_handlers.go` | Add DELETE support for auto-detected cluster paths; add `deleteAutoDetectedCluster()` handler |
+
+### Test Changes
+
+| File | Change |
+|------|--------|
+| `server/src/internal/database/cluster_dismiss_integration_test.go` | Add tests for topology filtering of dismissed clusters |
+| `server/src/internal/api/cluster_handlers_test.go` | Add tests for DELETE on auto-detected clusters |
+
+## Architecture Notes
+
+### Pattern Consistency
+
+The dismissed filter joins the existing `claimedKeys` filter pattern.
+Both are `map[string]bool` sets that cause `buildTopologyHierarchy` to
+skip matching auto_cluster_keys. This keeps the change minimal and
+consistent with existing patterns.
+
+### RBAC and Error Handling
+
+The DELETE handler for auto-detected clusters follows the same RBAC and
+error handling patterns as the existing `deleteCluster` handler for
+database-backed clusters. It requires the `manage_connections` permission
+and returns appropriate HTTP status codes.
+
+### Soft-Delete Semantics
+
+The fix preserves the existing soft-delete semantics:
+
+- Auto-detected clusters are never hard-deleted.
+- The `dismissed` flag prevents re-detection.
+- Users can restore dismissed clusters through the rename (PUT) endpoint,
+  which clears the dismissed flag via `UpsertClusterByAutoKey`.
+
+### Query Flow
+
+The topology query flow after this change:
+
+1. `GetClusterTopology()` is called.
+2. Query all connections with roles.
+3. Get cluster name overrides (non-dismissed only).
+4. Build auto-detected clusters map.
+5. Get claimed keys (clusters moved to non-default groups).
+6. **NEW:** Get dismissed keys.
+7. Build manual groups topology.
+8. Build default group topology, filtering out claimed AND dismissed keys.
+9. Merge persisted members.
+10. Populate relationships.
+11. Apply visibility filter.
+12. Return topology.
+
+## Testing Strategy
+
+### Unit Tests
+
+- Verify `getDismissedAutoClusterKeys` returns the correct set of keys.
+- Verify `deriveClusterNameFromKey` handles all key prefixes correctly.
+- Verify `computeAutoClusterKey` handles all cluster ID formats.
+
+### Integration Tests
+
+New integration tests in `cluster_dismiss_integration_test.go`:
+
+1. **TestDismissedClusterExcludedFromTopology**: Create a cluster, dismiss
+   it, verify it does not appear in `GetClusterTopology` results.
+
+2. **TestDismissedClusterStaysHiddenAfterRefresh**: Create a cluster,
+   dismiss it, call `RefreshClusterAssignments`, verify the cluster
+   remains hidden.
+
+3. **TestDeleteAutoDetectedClusterAPI**: Call DELETE on a `server-*`
+   path, verify the cluster is dismissed.
+
+4. **TestDeleteAutoDetectedClusterCreatesRecord**: Call DELETE on a
+   cluster that has no database record, verify a dismissed record is
+   created.
+
+### Existing Tests
+
+The existing `TestUpsertAutoDetectedCluster_PreservesDismissed` test
+continues to pass. This test verifies that `UpsertAutoDetectedCluster`
+does not clear the dismissed flag when rediscovering a cluster.
+
+### Coverage Requirements
+
+All new and modified code must reach at least 90% line coverage:
+
+- `getDismissedAutoClusterKeys()` - query execution paths
+- `DeleteAutoDetectedCluster()` - both create and update paths
+- `deleteAutoDetectedCluster()` - HTTP handler paths
+- `buildTopologyHierarchy()` - dismissed key filtering branches
+
+Run coverage verification:
+
+```bash
+cd server && make coverage
+go tool cover -func=coverage.out | grep -E "(getDismissed|DeleteAuto|buildTopology)"
+```
+
+## Out of Scope
+
+The following items are explicitly excluded from this change:
+
+- **UI changes**: The client already calls the correct endpoints. This
+  fix enables the DELETE operation server-side.
+
+- **Restore dismissed clusters UI**: Users can restore dismissed clusters
+  by renaming them (PUT). A dedicated "restore" UI is out of scope.
+
+- **Hard-delete option**: All auto-detected clusters use soft-delete.
+  A hard-delete option would require additional consideration around
+  data retention and audit trails.
+
+- **Batch dismiss**: Dismissing multiple clusters at once is out of scope.
+
+## Risks and Mitigations
+
+### Risk: Performance impact of additional query
+
+The new `getDismissedAutoClusterKeys()` query runs on every topology
+request. However, the query is simple (single-table scan with two
+conditions) and the clusters table is small. The risk is minimal.
+
+**Mitigation**: The query uses indexed columns (`auto_cluster_key`,
+`dismissed`) and returns only keys, not full rows.
+
+### Risk: Stale dismissed state
+
+If the dismissed flag is set but the cluster row is later modified
+through a bug or direct database access, the cluster could reappear.
+
+**Mitigation**: The `dismissed` flag is only cleared through explicit
+user action (PUT on the cluster). The `UpsertAutoDetectedCluster`
+function explicitly preserves the dismissed flag.
+
+### Risk: Orphaned dismissed records
+
+Dismissed clusters remain in the database indefinitely. Over time, this
+could accumulate unused rows.
+
+**Mitigation**: The number of dismissed clusters is expected to be small
+(user-initiated deletes only). A periodic cleanup job could be added in
+a future release if needed.

--- a/.claude/specs/2026-04-23-token-dialog-copy-fix-design.md
+++ b/.claude/specs/2026-04-23-token-dialog-copy-fix-design.md
@@ -1,0 +1,97 @@
+# Fix Clipboard Copy in Token Dialog
+
+## Problem
+
+Issue #71: the copy button on the token-created dialog does not
+copy the token value to the clipboard.
+
+The `copyToClipboard` utility appends a temporary textarea to
+`document.body` when the modern Clipboard API is unavailable
+(non-secure HTTP contexts). MUI `<Dialog>` enforces a focus trap
+that prevents focus from leaving the dialog portal. The textarea's
+`select()` call fails because focus cannot move outside the
+dialog, so `execCommand('copy')` returns `false` and throws.
+
+## Solution
+
+Add an optional `container` parameter to `copyToClipboard`. When
+provided, the temporary textarea is appended to the container
+element instead of `document.body`. This keeps the textarea inside
+the dialog's focus trap, allowing `select()` and
+`execCommand('copy')` to succeed.
+
+The modern Clipboard API path (secure contexts) is unaffected.
+
+## File Changes
+
+### `client/src/utils/clipboard.ts`
+
+Add an optional second parameter `container?: HTMLElement` to
+`copyToClipboard`. In the fallback path, append the textarea to
+`container ?? document.body` instead of `document.body`.
+
+```typescript
+export async function copyToClipboard(
+    text: string,
+    container?: HTMLElement
+): Promise<void> {
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    const target = container ?? document.body;
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '-9999px';
+    textarea.style.opacity = '0';
+
+    target.appendChild(textarea);
+    try {
+        textarea.select();
+        const ok = document.execCommand('copy');
+        if (!ok) {
+            throw new Error(
+                'Clipboard API unavailable and '
+                + 'execCommand("copy") failed.'
+            );
+        }
+    } finally {
+        target.removeChild(textarea);
+    }
+}
+```
+
+### `client/src/components/AdminPanel/AdminTokenScopes.tsx`
+
+Add a `useRef<HTMLDivElement>(null)` ref for the dialog content
+area. Attach the ref to the `<DialogContent>` element of the
+token-created dialog. Pass `ref.current` as the second argument
+to `copyToClipboard` in `handleCopyToken`. Update the
+`useCallback` dependency array to include the ref if needed.
+
+### `client/src/utils/__tests__/clipboard.test.ts`
+
+Add test cases for the `container` parameter:
+
+- When a container is provided, the textarea is appended to and
+  removed from that container instead of `document.body`.
+- When `execCommand` fails with a container, the textarea is
+  still cleaned up from the container.
+
+### `client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx`
+
+Verify that the copy button works correctly in the dialog
+context. Existing tests that mock `navigator.clipboard.writeText`
+remain valid since the modern path is unchanged. Add or adjust
+tests for the fallback path if coverage requires it.
+
+## Scope
+
+Four files touched. The change is backward-compatible; the new
+parameter is optional and defaults to `document.body`. No changes
+to focus trap behavior or accessibility. All existing callers of
+`copyToClipboard` (e.g., `CopyCodeButton`) continue to work
+without modification.

--- a/docs/admin-guide/api/openapi.json
+++ b/docs/admin-guide/api/openapi.json
@@ -2967,7 +2967,7 @@
       },
       "delete": {
         "summary": "Delete a cluster",
-        "description": "Deletes a manually created cluster",
+        "description": "Deletes a cluster. For manually created clusters, the record is removed. For auto-detected clusters (server-{id} or cluster-spock-{prefix}), the cluster is soft-deleted by setting dismissed=true so it does not reappear in topology.",
         "operationId": "deleteCluster",
         "tags": [
           "Clusters"
@@ -2976,7 +2976,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Cluster ID",
+            "description": "Cluster ID (numeric, server-{id}, or cluster-spock-{prefix})",
             "required": true,
             "schema": {
               "type": "string"

--- a/docs/admin-guide/api/openapi.json
+++ b/docs/admin-guide/api/openapi.json
@@ -2967,7 +2967,7 @@
       },
       "delete": {
         "summary": "Delete a cluster",
-        "description": "Deletes a cluster. For manually created clusters, the record is removed. For auto-detected clusters (server-{id} or cluster-spock-{prefix}), the cluster is soft-deleted by setting dismissed=true so it does not reappear in topology.",
+        "description": "Deletes a cluster. Manually created clusters are hard-deleted. Auto-detected clusters are soft-deleted by setting dismissed=true so they do not reappear in topology. This applies to persisted auto-detected clusters addressed by numeric ID and to transient auto-detected IDs (server-{id} or cluster-spock-{prefix}).",
         "operationId": "deleteCluster",
         "tags": [
           "Clusters"
@@ -2976,7 +2976,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Cluster ID (numeric, server-{id}, or cluster-spock-{prefix})",
+            "description": "Cluster ID. Accepts a numeric cluster ID, server-{id}, or cluster-spock-{prefix}.",
             "required": true,
             "schema": {
               "type": "string"

--- a/docs/admin-guide/api/reference.md
+++ b/docs/admin-guide/api/reference.md
@@ -105,7 +105,7 @@ The API provides endpoints in the following categories.
 | GET | `/api/v1/clusters/list` | List all clusters as a flat list. |
 | GET | `/api/v1/clusters/{id}` | Get a cluster by ID. |
 | PUT | `/api/v1/clusters/{id}` | Update a cluster. |
-| DELETE | `/api/v1/clusters/{id}` | Delete a cluster (soft-deletes auto-detected clusters). |
+| DELETE | `/api/v1/clusters/{id}` | Delete a cluster; accepts numeric, server-{id}, or cluster-spock-{prefix} IDs. |
 | GET | `/api/v1/clusters/{id}/servers` | List servers in a cluster. |
 | POST | `/api/v1/clusters/{id}/servers` | Add a server to a cluster. |
 | DELETE | `/api/v1/clusters/{id}/servers/{connectionId}` | Remove a server from a cluster. |

--- a/docs/admin-guide/api/reference.md
+++ b/docs/admin-guide/api/reference.md
@@ -105,7 +105,7 @@ The API provides endpoints in the following categories.
 | GET | `/api/v1/clusters/list` | List all clusters as a flat list. |
 | GET | `/api/v1/clusters/{id}` | Get a cluster by ID. |
 | PUT | `/api/v1/clusters/{id}` | Update a cluster. |
-| DELETE | `/api/v1/clusters/{id}` | Delete a cluster. |
+| DELETE | `/api/v1/clusters/{id}` | Delete a cluster (soft-deletes auto-detected clusters). |
 | GET | `/api/v1/clusters/{id}/servers` | List servers in a cluster. |
 | POST | `/api/v1/clusters/{id}/servers` | Add a server to a cluster. |
 | DELETE | `/api/v1/clusters/{id}/servers/{connectionId}` | Remove a server from a cluster. |

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -348,8 +348,10 @@ func (h *ClusterHandler) handleClusterSubpath(w http.ResponseWriter, r *http.Req
 		switch r.Method {
 		case http.MethodPut:
 			h.updateAutoDetectedCluster(w, r, parts[0])
+		case http.MethodDelete:
+			h.deleteAutoDetectedCluster(w, r, parts[0])
 		default:
-			w.Header().Set("Allow", "PUT")
+			w.Header().Set("Allow", "PUT, DELETE")
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
 		return
@@ -890,6 +892,36 @@ func (h *ClusterHandler) updateAutoDetectedCluster(w http.ResponseWriter, r *htt
 	}
 
 	RespondJSON(w, http.StatusOK, cluster)
+}
+
+// deleteAutoDetectedCluster handles DELETE requests for auto-detected
+// clusters. It resolves the auto_cluster_key from the topology ID and
+// soft-deletes the cluster.
+func (h *ClusterHandler) deleteAutoDetectedCluster(w http.ResponseWriter, r *http.Request, clusterID string) {
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: you do not have permission to delete auto-detected clusters")
+		return
+	}
+
+	autoKey := computeAutoClusterKey(clusterID)
+	if autoKey == "" {
+		RespondError(w, http.StatusBadRequest, "Invalid auto-detected cluster ID")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	if err := h.datastore.DeleteAutoDetectedCluster(ctx, autoKey); err != nil {
+		log.Printf("[ERROR] Failed to delete auto-detected cluster %s: %v",
+			logging.SanitizeForLog(clusterID), err)
+		RespondError(w, http.StatusInternalServerError,
+			"Failed to delete auto-detected cluster")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // computeAutoClusterKey computes the auto_cluster_key from a cluster ID

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -914,8 +914,7 @@ func (h *ClusterHandler) deleteAutoDetectedCluster(w http.ResponseWriter, r *htt
 	defer cancel()
 
 	if err := h.datastore.DeleteAutoDetectedCluster(ctx, autoKey); err != nil {
-		log.Printf("[ERROR] Failed to delete auto-detected cluster %s: %v",
-			logging.SanitizeForLog(clusterID), err)
+		log.Printf("[ERROR] Failed to delete auto-detected cluster %s: %v", logging.SanitizeForLog(clusterID), err) //nolint:gosec // G706: clusterID passed through logging.SanitizeForLog
 		RespondError(w, http.StatusInternalServerError,
 			"Failed to delete auto-detected cluster")
 		return

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -904,23 +904,43 @@ func (h *ClusterHandler) deleteAutoDetectedCluster(w http.ResponseWriter, r *htt
 		return
 	}
 
-	autoKey := computeAutoClusterKey(clusterID)
-	if autoKey == "" {
-		RespondError(w, http.StatusBadRequest, "Invalid auto-detected cluster ID")
-		return
-	}
-
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	if err := h.datastore.DeleteAutoDetectedCluster(ctx, autoKey); err != nil {
-		log.Printf("[ERROR] Failed to delete auto-detected cluster %s: %v", logging.SanitizeForLog(clusterID), err) //nolint:gosec // G706: clusterID passed through logging.SanitizeForLog
-		RespondError(w, http.StatusInternalServerError,
-			"Failed to delete auto-detected cluster")
+	// For Spock clusters, the key is unambiguous
+	if strings.HasPrefix(clusterID, "cluster-spock-") {
+		prefix := strings.TrimPrefix(clusterID, "cluster-spock-")
+		autoKey := "spock:" + prefix
+		if err := h.datastore.DeleteAutoDetectedCluster(ctx, autoKey); err != nil {
+			log.Printf("[ERROR] Failed to delete auto-detected cluster %s: %v", logging.SanitizeForLog(clusterID), err) //nolint:gosec // G706: clusterID passed through logging.SanitizeForLog
+			RespondError(w, http.StatusInternalServerError, "Failed to delete auto-detected cluster")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	// For server-{id}, multiple auto_cluster_key prefixes share the same ID.
+	// The topology builder may have created a binary, standalone, or logical
+	// cluster depending on the connection's replication role. Since we cannot
+	// know which type it was from the ID alone, we dismiss all candidate keys.
+	if strings.HasPrefix(clusterID, "server-") {
+		idStr := strings.TrimPrefix(clusterID, "server-")
+		candidates := []string{
+			"binary:" + idStr,
+			"standalone:" + idStr,
+			"logical:" + idStr,
+		}
+		if err := h.datastore.DismissAutoDetectedClusterKeys(ctx, candidates); err != nil {
+			log.Printf("[ERROR] Failed to delete auto-detected cluster %s: %v", logging.SanitizeForLog(clusterID), err) //nolint:gosec // G706: clusterID passed through logging.SanitizeForLog
+			RespondError(w, http.StatusInternalServerError, "Failed to delete auto-detected cluster")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	RespondError(w, http.StatusBadRequest, "Invalid auto-detected cluster ID")
 }
 
 // computeAutoClusterKey computes the auto_cluster_key from a cluster ID

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -1652,3 +1652,412 @@ func TestFilterTopologyServers_IsExpandableReflectsVisibleChildren(t *testing.T)
 		t.Errorf("Expected single visible child ID=3, got %+v", got[1].Children)
 	}
 }
+
+// =============================================================================
+// DELETE /api/v1/clusters/{auto-detected-id} tests
+//
+// Coverage for issue #36: users can dismiss auto-detected clusters via
+// DELETE /api/v1/clusters/server-{id} or DELETE /api/v1/clusters/cluster-spock-{prefix}.
+// The handler resolves the auto_cluster_key and soft-deletes the cluster.
+// =============================================================================
+
+// TestClusterHandler_HandleClusterSubpath_AutoDetectedCluster_MethodNotAllowed
+// confirms that unsupported methods (like PATCH) return 405 with the correct
+// Allow header listing PUT and DELETE.
+func TestClusterHandler_HandleClusterSubpath_AutoDetectedCluster_MethodNotAllowed(t *testing.T) {
+	handler := NewClusterHandler(nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/clusters/server-42", nil)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterSubpath(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+	}
+
+	allowed := rec.Header().Get("Allow")
+	if allowed != "PUT, DELETE" {
+		t.Errorf("Expected Allow header 'PUT, DELETE', got %q", allowed)
+	}
+}
+
+// TestClusterHandler_HandleClusterSubpath_AutoDetectedCluster_SpockMethodNotAllowed
+// confirms Spock cluster IDs also return the correct Allow header for unsupported methods.
+func TestClusterHandler_HandleClusterSubpath_AutoDetectedCluster_SpockMethodNotAllowed(t *testing.T) {
+	handler := NewClusterHandler(nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/clusters/cluster-spock-pg17", nil)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterSubpath(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+	}
+
+	allowed := rec.Header().Get("Allow")
+	if allowed != "PUT, DELETE" {
+		t.Errorf("Expected Allow header 'PUT, DELETE', got %q", allowed)
+	}
+}
+
+// TestClusterHandler_DeleteAutoDetectedCluster_PermissionDenied confirms that
+// DELETE auto-detected cluster requires manage_connections permission and
+// returns 403 for users without it.
+func TestClusterHandler_DeleteAutoDetectedCluster_PermissionDenied(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	// Create an unprivileged user.
+	if err := store.CreateUser("noperm", "Password1", "", "", ""); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	userID, err := store.GetUserID("noperm")
+	if err != nil {
+		t.Fatalf("Failed to get user id: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/clusters/server-42", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterSubpath(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("Expected status %d, got %d. Body: %s",
+			http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+
+	var response ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if response.Error != "Permission denied: you do not have permission to delete auto-detected clusters" {
+		t.Errorf("Expected permission denied error, got %q", response.Error)
+	}
+}
+
+// TestClusterHandler_DeleteAutoDetectedCluster_SpockPermissionDenied confirms
+// that Spock cluster IDs also require manage_connections permission.
+func TestClusterHandler_DeleteAutoDetectedCluster_SpockPermissionDenied(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	// Create an unprivileged user.
+	if err := store.CreateUser("noperm2", "Password1", "", "", ""); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	userID, err := store.GetUserID("noperm2")
+	if err != nil {
+		t.Fatalf("Failed to get user id: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/clusters/cluster-spock-pg17", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterSubpath(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("Expected status %d, got %d. Body: %s",
+			http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+}
+
+// deleteAutoClusterTestSchema extends the cluster dismiss test schema used
+// in cluster_dismiss_integration_test.go for the handler-level integration
+// tests that require the clusters table.
+const deleteAutoClusterTestSchema = `
+DROP TABLE IF EXISTS connections CASCADE;
+DROP TABLE IF EXISTS clusters CASCADE;
+DROP TABLE IF EXISTS cluster_groups CASCADE;
+
+CREATE TABLE cluster_groups (
+    id SERIAL PRIMARY KEY,
+    owner_username VARCHAR(255),
+    owner_token VARCHAR(255),
+    is_shared BOOLEAN NOT NULL DEFAULT TRUE,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    auto_group_key VARCHAR(255) UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT cluster_groups_name_unique UNIQUE (name)
+);
+CREATE UNIQUE INDEX idx_cluster_groups_is_default
+    ON cluster_groups (is_default) WHERE is_default = TRUE;
+
+CREATE TABLE clusters (
+    id SERIAL PRIMARY KEY,
+    group_id INTEGER REFERENCES cluster_groups(id) ON DELETE CASCADE,
+    auto_cluster_key VARCHAR(255) UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    replication_type VARCHAR(50),
+    dismissed BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT clusters_group_name_unique UNIQUE (group_id, name)
+);
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    cluster_id INTEGER REFERENCES clusters(id) ON DELETE SET NULL,
+    membership_source VARCHAR(16) NOT NULL DEFAULT 'auto',
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+// newDeleteAutoClusterTestDatastore returns a *database.Datastore wired to
+// the Postgres instance named by TEST_AI_WORKBENCH_SERVER with the schema
+// needed for delete auto-detected cluster tests. The test is skipped if
+// the env var is missing or the connection cannot be established.
+func newDeleteAutoClusterTestDatastore(t *testing.T) (*database.Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping delete auto cluster integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, deleteAutoClusterTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create test schema: %v", err)
+	}
+
+	ds := database.NewTestDatastore(pool)
+
+	cleanup := func() {
+		_, _ = pool.Exec(context.Background(),
+			"DROP TABLE IF EXISTS connections, clusters, cluster_groups CASCADE")
+		pool.Close()
+	}
+
+	return ds, pool, cleanup
+}
+
+// insertDeleteAutoClusterTestGroup inserts a default cluster_groups row and
+// returns its id.
+func insertDeleteAutoClusterTestGroup(t *testing.T, pool *pgxpool.Pool) int {
+	t.Helper()
+	var id int
+	err := pool.QueryRow(context.Background(), `
+        INSERT INTO cluster_groups (name, description, is_shared, is_default)
+        VALUES ('Servers/Clusters', 'default', TRUE, TRUE)
+        RETURNING id
+    `).Scan(&id)
+	if err != nil {
+		t.Fatalf("Failed to insert default cluster group: %v", err)
+	}
+	return id
+}
+
+// TestClusterHandler_DeleteAutoDetectedCluster_Integration_Standalone exercises
+// the full DELETE flow for a standalone server (server-{id} format). The
+// handler should resolve the auto_cluster_key and soft-delete the cluster.
+func TestClusterHandler_DeleteAutoDetectedCluster_Integration_Standalone(t *testing.T) {
+	ds, pool, cleanupDS := newDeleteAutoClusterTestDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(ds, store, checker)
+
+	ctx := context.Background()
+	groupID := insertDeleteAutoClusterTestGroup(t, pool)
+
+	// Create a standalone server cluster via direct SQL to simulate
+	// auto-detection having found it previously.
+	_, err := pool.Exec(ctx, `
+        INSERT INTO clusters (name, auto_cluster_key, group_id, dismissed)
+        VALUES ('standalone-42', 'standalone:42', $1, FALSE)
+    `, groupID)
+	if err != nil {
+		t.Fatalf("Failed to seed standalone cluster: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/clusters/server-42", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterSubpath(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Expected status %d, got %d. Body: %s",
+			http.StatusNoContent, rec.Code, rec.Body.String())
+	}
+
+	// Verify the cluster was soft-deleted.
+	var dismissed bool
+	err = pool.QueryRow(ctx,
+		`SELECT dismissed FROM clusters WHERE auto_cluster_key = 'standalone:42'`,
+	).Scan(&dismissed)
+	if err != nil {
+		t.Fatalf("Failed to read dismissed flag: %v", err)
+	}
+	if !dismissed {
+		t.Fatal("Cluster was not dismissed after DELETE request")
+	}
+}
+
+// TestClusterHandler_DeleteAutoDetectedCluster_Integration_Spock exercises
+// the full DELETE flow for a Spock cluster (cluster-spock-{prefix} format).
+func TestClusterHandler_DeleteAutoDetectedCluster_Integration_Spock(t *testing.T) {
+	ds, pool, cleanupDS := newDeleteAutoClusterTestDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(ds, store, checker)
+
+	ctx := context.Background()
+	groupID := insertDeleteAutoClusterTestGroup(t, pool)
+
+	// Create a Spock cluster via direct SQL.
+	_, err := pool.Exec(ctx, `
+        INSERT INTO clusters (name, auto_cluster_key, group_id, dismissed)
+        VALUES ('pg17 Spock', 'spock:pg17', $1, FALSE)
+    `, groupID)
+	if err != nil {
+		t.Fatalf("Failed to seed Spock cluster: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/clusters/cluster-spock-pg17", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterSubpath(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Expected status %d, got %d. Body: %s",
+			http.StatusNoContent, rec.Code, rec.Body.String())
+	}
+
+	// Verify the cluster was soft-deleted.
+	var dismissed bool
+	err = pool.QueryRow(ctx,
+		`SELECT dismissed FROM clusters WHERE auto_cluster_key = 'spock:pg17'`,
+	).Scan(&dismissed)
+	if err != nil {
+		t.Fatalf("Failed to read dismissed flag: %v", err)
+	}
+	if !dismissed {
+		t.Fatal("Spock cluster was not dismissed after DELETE request")
+	}
+}
+
+// TestClusterHandler_DeleteAutoDetectedCluster_Integration_NoExistingRow verifies
+// that DELETE still succeeds when the cluster row does not exist (it creates
+// a dismissed placeholder row, matching DeleteAutoDetectedCluster behavior).
+func TestClusterHandler_DeleteAutoDetectedCluster_Integration_NoExistingRow(t *testing.T) {
+	ds, pool, cleanupDS := newDeleteAutoClusterTestDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(ds, store, checker)
+
+	// Ensure the default group exists for the upsert to succeed.
+	_ = insertDeleteAutoClusterTestGroup(t, pool)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/clusters/cluster-spock-nonexistent", nil)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterSubpath(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Expected status %d, got %d. Body: %s",
+			http.StatusNoContent, rec.Code, rec.Body.String())
+	}
+
+	// Verify a dismissed placeholder row was created.
+	var dismissed bool
+	var name string
+	err := pool.QueryRow(context.Background(), `
+        SELECT name, dismissed FROM clusters
+        WHERE auto_cluster_key = 'spock:nonexistent'
+    `).Scan(&name, &dismissed)
+	if err != nil {
+		t.Fatalf("Failed to read newly created cluster: %v", err)
+	}
+	if !dismissed {
+		t.Fatal("Placeholder cluster is not dismissed")
+	}
+	if name != "nonexistent Spock" {
+		t.Fatalf("Derived name = %q, want %q", name, "nonexistent Spock")
+	}
+}
+
+// TestClusterHandler_DeleteAutoDetectedCluster_WithPermission verifies that a
+// user with manage_connections permission can successfully delete an
+// auto-detected cluster.
+func TestClusterHandler_DeleteAutoDetectedCluster_WithPermission(t *testing.T) {
+	ds, pool, cleanupDS := newDeleteAutoClusterTestDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+
+	userID := setupUserWithPermission(t, store, "delete_tester", auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(ds, store, checker)
+
+	ctx := context.Background()
+	groupID := insertDeleteAutoClusterTestGroup(t, pool)
+
+	_, err := pool.Exec(ctx, `
+        INSERT INTO clusters (name, auto_cluster_key, group_id, dismissed)
+        VALUES ('test-cluster', 'standalone:99', $1, FALSE)
+    `, groupID)
+	if err != nil {
+		t.Fatalf("Failed to seed cluster: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/clusters/server-99", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterSubpath(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Expected status %d, got %d. Body: %s",
+			http.StatusNoContent, rec.Code, rec.Body.String())
+	}
+
+	// Verify the cluster was soft-deleted.
+	var dismissed bool
+	err = pool.QueryRow(ctx,
+		`SELECT dismissed FROM clusters WHERE auto_cluster_key = 'standalone:99'`,
+	).Scan(&dismissed)
+	if err != nil {
+		t.Fatalf("Failed to read dismissed flag: %v", err)
+	}
+	if !dismissed {
+		t.Fatal("Cluster was not dismissed")
+	}
+}

--- a/server/src/internal/api/openapi.go
+++ b/server/src/internal/api/openapi.go
@@ -1540,11 +1540,11 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Delete: &OpenAPIOperation{
 				Summary:     "Delete a cluster",
-				Description: "Deletes a manually created cluster",
+				Description: "Deletes a cluster. For manually created clusters, the record is removed. For auto-detected clusters (server-{id} or cluster-spock-{prefix}), the cluster is soft-deleted by setting dismissed=true so it does not reappear in topology.",
 				OperationID: "deleteCluster",
 				Tags:        []string{"Clusters"},
 				Security:    bearerAuth,
-				Parameters:  []OpenAPIParameter{pathParamString("id", "Cluster ID")},
+				Parameters:  []OpenAPIParameter{pathParamString("id", "Cluster ID (numeric, server-{id}, or cluster-spock-{prefix})")},
 				Responses: map[string]OpenAPIResponse{
 					"204": {Description: "Cluster deleted"},
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),

--- a/server/src/internal/api/openapi.go
+++ b/server/src/internal/api/openapi.go
@@ -1540,11 +1540,11 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Delete: &OpenAPIOperation{
 				Summary:     "Delete a cluster",
-				Description: "Deletes a cluster. For manually created clusters, the record is removed. For auto-detected clusters (server-{id} or cluster-spock-{prefix}), the cluster is soft-deleted by setting dismissed=true so it does not reappear in topology.",
+				Description: "Deletes a cluster. Manually created clusters are hard-deleted. Auto-detected clusters are soft-deleted by setting dismissed=true so they do not reappear in topology. This applies to persisted auto-detected clusters addressed by numeric ID and to transient auto-detected IDs (server-{id} or cluster-spock-{prefix}).",
 				OperationID: "deleteCluster",
 				Tags:        []string{"Clusters"},
 				Security:    bearerAuth,
-				Parameters:  []OpenAPIParameter{pathParamString("id", "Cluster ID (numeric, server-{id}, or cluster-spock-{prefix})")},
+				Parameters:  []OpenAPIParameter{pathParamString("id", "Cluster ID. Accepts a numeric cluster ID, server-{id}, or cluster-spock-{prefix}.")},
 				Responses: map[string]OpenAPIResponse{
 					"204": {Description: "Cluster deleted"},
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),

--- a/server/src/internal/database/cluster_dismiss_integration_test.go
+++ b/server/src/internal/database/cluster_dismiss_integration_test.go
@@ -271,3 +271,45 @@ func TestGetDismissedAutoClusterKeys(t *testing.T) {
 		t.Fatalf("expected spock:dismissed in set, got %v", dismissed)
 	}
 }
+
+func TestDismissedClusterExcludedFromBuildTopologyHierarchy(t *testing.T) {
+	ds, pool, cleanup := newClusterDismissTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	groupID := insertClusterDismissTestGroup(t, pool)
+
+	created, err := ds.UpsertAutoDetectedCluster(
+		ctx, "binary:999", "doomed-cluster", nil, &groupID,
+	)
+	if err != nil {
+		t.Fatalf("UpsertAutoDetectedCluster failed: %v", err)
+	}
+	if err := ds.DeleteCluster(ctx, created.ID); err != nil {
+		t.Fatalf("DeleteCluster failed: %v", err)
+	}
+
+	dismissedKeys, err := ds.getDismissedAutoClusterKeys(ctx)
+	if err != nil {
+		t.Fatalf("getDismissedAutoClusterKeys failed: %v", err)
+	}
+	if !dismissedKeys["binary:999"] {
+		t.Fatalf("expected binary:999 in dismissed set")
+	}
+
+	defaultGroup := &defaultGroupInfo{ID: groupID, Name: "Servers/Clusters"}
+	groups := ds.buildTopologyHierarchy(
+		nil,
+		make(map[string]clusterOverride),
+		make(map[string]bool),
+		dismissedKeys,
+		defaultGroup,
+	)
+	for _, g := range groups {
+		for _, c := range g.Clusters {
+			if c.AutoClusterKey == "binary:999" {
+				t.Fatalf("dismissed cluster binary:999 appeared in topology")
+			}
+		}
+	}
+}

--- a/server/src/internal/database/cluster_dismiss_integration_test.go
+++ b/server/src/internal/database/cluster_dismiss_integration_test.go
@@ -313,3 +313,100 @@ func TestDismissedClusterExcludedFromBuildTopologyHierarchy(t *testing.T) {
 		}
 	}
 }
+
+func TestDeleteAutoDetectedCluster_ExistingRow(t *testing.T) {
+	ds, pool, cleanup := newClusterDismissTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	groupID := insertClusterDismissTestGroup(t, pool)
+
+	cluster, err := ds.UpsertAutoDetectedCluster(
+		ctx, "binary:100", "test-cluster", nil, &groupID,
+	)
+	if err != nil {
+		t.Fatalf("UpsertAutoDetectedCluster failed: %v", err)
+	}
+	_, err = pool.Exec(ctx, `
+        INSERT INTO connections (name, cluster_id, membership_source)
+        VALUES ('conn-1', $1, 'auto')
+    `, cluster.ID)
+	if err != nil {
+		t.Fatalf("failed to insert connection: %v", err)
+	}
+
+	if err := ds.DeleteAutoDetectedCluster(ctx, "binary:100"); err != nil {
+		t.Fatalf("DeleteAutoDetectedCluster failed: %v", err)
+	}
+
+	var dismissed bool
+	err = pool.QueryRow(ctx,
+		`SELECT dismissed FROM clusters WHERE id = $1`, cluster.ID,
+	).Scan(&dismissed)
+	if err != nil {
+		t.Fatalf("failed to read dismissed flag: %v", err)
+	}
+	if !dismissed {
+		t.Fatal("cluster was not dismissed")
+	}
+
+	var clusterID *int
+	err = pool.QueryRow(ctx,
+		`SELECT cluster_id FROM connections WHERE name = 'conn-1'`,
+	).Scan(&clusterID)
+	if err != nil {
+		t.Fatalf("failed to read connection cluster_id: %v", err)
+	}
+	if clusterID != nil {
+		t.Fatalf("connection still attached to cluster %d", *clusterID)
+	}
+}
+
+func TestDeleteAutoDetectedCluster_NoRow(t *testing.T) {
+	ds, pool, cleanup := newClusterDismissTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_ = insertClusterDismissTestGroup(t, pool)
+
+	if err := ds.DeleteAutoDetectedCluster(ctx, "spock:phantom"); err != nil {
+		t.Fatalf("DeleteAutoDetectedCluster (no row) failed: %v", err)
+	}
+
+	var dismissed bool
+	var name string
+	err := pool.QueryRow(ctx, `
+        SELECT name, dismissed FROM clusters
+        WHERE auto_cluster_key = 'spock:phantom'
+    `).Scan(&name, &dismissed)
+	if err != nil {
+		t.Fatalf("failed to read newly created cluster: %v", err)
+	}
+	if !dismissed {
+		t.Fatal("newly created cluster is not dismissed")
+	}
+	if name != "phantom Spock" {
+		t.Fatalf("derived name = %q, want %q", name, "phantom Spock")
+	}
+}
+
+func TestDeriveClusterNameFromKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"spock:pg17", "pg17 Spock"},
+		{"binary:42", "binary-42"},
+		{"standalone:7", "standalone-7"},
+		{"logical:99", "logical-99"},
+		{"unknown", "unknown"},
+		{"custom:xyz", "custom:xyz"},
+	}
+	for _, tt := range tests {
+		got := deriveClusterNameFromKey(tt.key)
+		if got != tt.want {
+			t.Errorf("deriveClusterNameFromKey(%q) = %q, want %q",
+				tt.key, got, tt.want)
+		}
+	}
+}

--- a/server/src/internal/database/cluster_dismiss_integration_test.go
+++ b/server/src/internal/database/cluster_dismiss_integration_test.go
@@ -279,8 +279,9 @@ func TestDismissedClusterExcludedFromBuildTopologyHierarchy(t *testing.T) {
 	ctx := context.Background()
 	groupID := insertClusterDismissTestGroup(t, pool)
 
+	// Create and then dismiss a cluster
 	created, err := ds.UpsertAutoDetectedCluster(
-		ctx, "binary:999", "doomed-cluster", nil, &groupID,
+		ctx, "standalone:999", "doomed-cluster", nil, &groupID,
 	)
 	if err != nil {
 		t.Fatalf("UpsertAutoDetectedCluster failed: %v", err)
@@ -293,22 +294,61 @@ func TestDismissedClusterExcludedFromBuildTopologyHierarchy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getDismissedAutoClusterKeys failed: %v", err)
 	}
-	if !dismissedKeys["binary:999"] {
-		t.Fatalf("expected binary:999 in dismissed set")
+	if !dismissedKeys["standalone:999"] {
+		t.Fatalf("expected standalone:999 in dismissed set")
+	}
+
+	// Seed a connection that would produce a standalone cluster with ID 999.
+	// The buildTopologyHierarchy function creates a standalone cluster for
+	// connections that are not Spock nodes, not binary primaries with children,
+	// and have no cluster_id set.
+	conn := connectionWithRole{
+		ID:               999,
+		Name:             "test-server",
+		Host:             "localhost",
+		Port:             5432,
+		PrimaryRole:      "standalone",
+		HasSpock:         false,
+		MembershipSource: "auto",
+		Status:           "online",
 	}
 
 	defaultGroup := &defaultGroupInfo{ID: groupID, Name: "Servers/Clusters"}
-	groups := ds.buildTopologyHierarchy(
-		nil,
+
+	// First verify that without the dismissed filter, the connection would
+	// produce a standalone cluster.
+	groupsWithoutFilter := ds.buildTopologyHierarchy(
+		[]connectionWithRole{conn},
+		make(map[string]clusterOverride),
+		make(map[string]bool),
+		make(map[string]bool), // empty dismissed set
+		defaultGroup,
+	)
+	foundWithoutFilter := false
+	for _, g := range groupsWithoutFilter {
+		for _, c := range g.Clusters {
+			if c.AutoClusterKey == "standalone:999" {
+				foundWithoutFilter = true
+				break
+			}
+		}
+	}
+	if !foundWithoutFilter {
+		t.Fatalf("expected standalone:999 cluster without dismissed filter")
+	}
+
+	// Now verify that WITH the dismissed filter, the cluster is excluded.
+	groupsWithFilter := ds.buildTopologyHierarchy(
+		[]connectionWithRole{conn},
 		make(map[string]clusterOverride),
 		make(map[string]bool),
 		dismissedKeys,
 		defaultGroup,
 	)
-	for _, g := range groups {
+	for _, g := range groupsWithFilter {
 		for _, c := range g.Clusters {
-			if c.AutoClusterKey == "binary:999" {
-				t.Fatalf("dismissed cluster binary:999 appeared in topology")
+			if c.AutoClusterKey == "standalone:999" {
+				t.Fatalf("dismissed cluster standalone:999 appeared in topology")
 			}
 		}
 	}
@@ -408,5 +448,161 @@ func TestDeriveClusterNameFromKey(t *testing.T) {
 			t.Errorf("deriveClusterNameFromKey(%q) = %q, want %q",
 				tt.key, got, tt.want)
 		}
+	}
+}
+
+// TestDismissAutoDetectedClusterKeys_ExistingRow verifies that
+// DismissAutoDetectedClusterKeys correctly dismisses clusters that
+// already exist in the database and detaches their connections.
+func TestDismissAutoDetectedClusterKeys_ExistingRow(t *testing.T) {
+	ds, pool, cleanup := newClusterDismissTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	groupID := insertClusterDismissTestGroup(t, pool)
+
+	// Create a cluster with a connection
+	cluster, err := ds.UpsertAutoDetectedCluster(
+		ctx, "binary:200", "test-cluster", nil, &groupID,
+	)
+	if err != nil {
+		t.Fatalf("UpsertAutoDetectedCluster failed: %v", err)
+	}
+	_, err = pool.Exec(ctx, `
+        INSERT INTO connections (name, cluster_id, membership_source)
+        VALUES ('conn-1', $1, 'auto')
+    `, cluster.ID)
+	if err != nil {
+		t.Fatalf("failed to insert connection: %v", err)
+	}
+
+	// Dismiss with multiple candidate keys (only one matches)
+	candidates := []string{"binary:200", "standalone:200", "logical:200"}
+	if err := ds.DismissAutoDetectedClusterKeys(ctx, candidates); err != nil {
+		t.Fatalf("DismissAutoDetectedClusterKeys failed: %v", err)
+	}
+
+	// Verify the matching cluster was dismissed
+	var dismissed bool
+	err = pool.QueryRow(ctx,
+		`SELECT dismissed FROM clusters WHERE id = $1`, cluster.ID,
+	).Scan(&dismissed)
+	if err != nil {
+		t.Fatalf("failed to read dismissed flag: %v", err)
+	}
+	if !dismissed {
+		t.Fatal("cluster was not dismissed")
+	}
+
+	// Verify the connection was detached
+	var clusterID *int
+	err = pool.QueryRow(ctx,
+		`SELECT cluster_id FROM connections WHERE name = 'conn-1'`,
+	).Scan(&clusterID)
+	if err != nil {
+		t.Fatalf("failed to read connection cluster_id: %v", err)
+	}
+	if clusterID != nil {
+		t.Fatalf("connection still attached to cluster %d", *clusterID)
+	}
+
+	// Verify placeholders were created for the other candidate keys
+	var count int
+	err = pool.QueryRow(ctx, `
+        SELECT COUNT(*) FROM clusters
+        WHERE auto_cluster_key IN ('standalone:200', 'logical:200')
+        AND dismissed = TRUE
+    `).Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count placeholder clusters: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 dismissed placeholders, got %d", count)
+	}
+}
+
+// TestDismissAutoDetectedClusterKeys_NoExistingRows verifies that
+// DismissAutoDetectedClusterKeys creates dismissed placeholders for
+// all candidate keys when none of them exist in the database.
+func TestDismissAutoDetectedClusterKeys_NoExistingRows(t *testing.T) {
+	ds, pool, cleanup := newClusterDismissTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_ = insertClusterDismissTestGroup(t, pool)
+
+	candidates := []string{"binary:300", "standalone:300", "logical:300"}
+	if err := ds.DismissAutoDetectedClusterKeys(ctx, candidates); err != nil {
+		t.Fatalf("DismissAutoDetectedClusterKeys failed: %v", err)
+	}
+
+	// Verify all placeholders were created as dismissed
+	var count int
+	err := pool.QueryRow(ctx, `
+        SELECT COUNT(*) FROM clusters
+        WHERE auto_cluster_key IN ('binary:300', 'standalone:300', 'logical:300')
+        AND dismissed = TRUE
+    `).Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count placeholder clusters: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 dismissed placeholders, got %d", count)
+	}
+}
+
+// TestDismissAutoDetectedClusterKeys_EmptyList verifies that
+// DismissAutoDetectedClusterKeys handles an empty candidate list gracefully.
+func TestDismissAutoDetectedClusterKeys_EmptyList(t *testing.T) {
+	ds, _, cleanup := newClusterDismissTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	if err := ds.DismissAutoDetectedClusterKeys(ctx, []string{}); err != nil {
+		t.Fatalf("DismissAutoDetectedClusterKeys with empty list failed: %v", err)
+	}
+}
+
+// TestDismissAutoDetectedClusterKeys_Idempotent verifies that calling
+// DismissAutoDetectedClusterKeys multiple times with the same keys is
+// safe and leaves the clusters dismissed.
+func TestDismissAutoDetectedClusterKeys_Idempotent(t *testing.T) {
+	ds, pool, cleanup := newClusterDismissTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	groupID := insertClusterDismissTestGroup(t, pool)
+
+	// Create a cluster
+	cluster, err := ds.UpsertAutoDetectedCluster(
+		ctx, "standalone:400", "test-cluster", nil, &groupID,
+	)
+	if err != nil {
+		t.Fatalf("UpsertAutoDetectedCluster failed: %v", err)
+	}
+
+	candidates := []string{"binary:400", "standalone:400", "logical:400"}
+
+	// First dismiss
+	if err := ds.DismissAutoDetectedClusterKeys(ctx, candidates); err != nil {
+		t.Fatalf("first DismissAutoDetectedClusterKeys failed: %v", err)
+	}
+
+	// Second dismiss (should be idempotent)
+	if err := ds.DismissAutoDetectedClusterKeys(ctx, candidates); err != nil {
+		t.Fatalf("second DismissAutoDetectedClusterKeys failed: %v", err)
+	}
+
+	// Verify the cluster is still dismissed
+	var dismissed bool
+	err = pool.QueryRow(ctx,
+		`SELECT dismissed FROM clusters WHERE id = $1`, cluster.ID,
+	).Scan(&dismissed)
+	if err != nil {
+		t.Fatalf("failed to read dismissed flag: %v", err)
+	}
+	if !dismissed {
+		t.Fatal("cluster should still be dismissed after idempotent call")
 	}
 }

--- a/server/src/internal/database/cluster_dismiss_integration_test.go
+++ b/server/src/internal/database/cluster_dismiss_integration_test.go
@@ -234,3 +234,40 @@ func containsClusterID(summaries []ClusterSummary, id int) bool {
 	}
 	return false
 }
+
+func TestGetDismissedAutoClusterKeys(t *testing.T) {
+	ds, pool, cleanup := newClusterDismissTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	groupID := insertClusterDismissTestGroup(t, pool)
+
+	_, err := pool.Exec(ctx, `
+        INSERT INTO clusters (name, auto_cluster_key, group_id, dismissed)
+        VALUES ('active-cluster', 'spock:active', $1, FALSE),
+               ('dismissed-cluster', 'spock:dismissed', $1, TRUE)
+    `, groupID)
+	if err != nil {
+		t.Fatalf("failed to seed clusters: %v", err)
+	}
+
+	_, err = pool.Exec(ctx, `
+        INSERT INTO clusters (name, group_id, dismissed)
+        VALUES ('manual-cluster', $1, FALSE)
+    `, groupID)
+	if err != nil {
+		t.Fatalf("failed to seed manual cluster: %v", err)
+	}
+
+	dismissed, err := ds.getDismissedAutoClusterKeys(ctx)
+	if err != nil {
+		t.Fatalf("getDismissedAutoClusterKeys failed: %v", err)
+	}
+
+	if len(dismissed) != 1 {
+		t.Fatalf("expected 1 dismissed key, got %d: %v", len(dismissed), dismissed)
+	}
+	if !dismissed["spock:dismissed"] {
+		t.Fatalf("expected spock:dismissed in set, got %v", dismissed)
+	}
+}

--- a/server/src/internal/database/cluster_queries.go
+++ b/server/src/internal/database/cluster_queries.go
@@ -439,6 +439,74 @@ func (d *Datastore) DeleteCluster(ctx context.Context, id int) error {
 	return nil
 }
 
+// deriveClusterNameFromKey produces a human-readable name from an
+// auto_cluster_key. The result is used when creating a dismissed
+// placeholder row for a cluster that has no existing database record.
+func deriveClusterNameFromKey(autoKey string) string {
+	parts := strings.SplitN(autoKey, ":", 2)
+	if len(parts) != 2 {
+		return autoKey
+	}
+	prefix, suffix := parts[0], parts[1]
+	switch prefix {
+	case "spock":
+		return suffix + " Spock"
+	case "binary":
+		return "binary-" + suffix
+	case "standalone":
+		return "standalone-" + suffix
+	case "logical":
+		return "logical-" + suffix
+	default:
+		return autoKey
+	}
+}
+
+// DeleteAutoDetectedCluster soft-deletes an auto-detected cluster by
+// its auto_cluster_key. If no database record exists for the key, a
+// dismissed placeholder is created so the topology builder skips the
+// cluster on subsequent refreshes.
+func (d *Datastore) DeleteAutoDetectedCluster(ctx context.Context, autoKey string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var clusterID int
+	err := d.pool.QueryRow(ctx,
+		`SELECT id FROM clusters WHERE auto_cluster_key = $1`,
+		autoKey,
+	).Scan(&clusterID)
+
+	if err != nil {
+		name := deriveClusterNameFromKey(autoKey)
+		_, insertErr := d.pool.Exec(ctx, `
+            INSERT INTO clusters (name, auto_cluster_key, dismissed)
+            VALUES ($1, $2, TRUE)
+        `, name, autoKey)
+		if insertErr != nil {
+			return fmt.Errorf("failed to create dismissed cluster record: %w", insertErr)
+		}
+		return nil
+	}
+
+	_, err = d.pool.Exec(ctx,
+		`UPDATE clusters SET dismissed = TRUE, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+		clusterID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to dismiss cluster: %w", err)
+	}
+
+	_, err = d.pool.Exec(ctx,
+		`UPDATE connections SET cluster_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE cluster_id = $1`,
+		clusterID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to detach connections from dismissed cluster: %w", err)
+	}
+
+	return nil
+}
+
 // GetClusterOverrides returns a map of auto_cluster_key -> clusterOverride
 // for all clusters that have an auto_cluster_key set. This is used to
 // apply custom names and descriptions to auto-detected clusters in the

--- a/server/src/internal/database/cluster_queries.go
+++ b/server/src/internal/database/cluster_queries.go
@@ -465,30 +465,42 @@ func deriveClusterNameFromKey(autoKey string) string {
 // DeleteAutoDetectedCluster soft-deletes an auto-detected cluster by
 // its auto_cluster_key. If no database record exists for the key, a
 // dismissed placeholder is created so the topology builder skips the
-// cluster on subsequent refreshes.
+// cluster on subsequent refreshes. All operations run in a transaction
+// to prevent partial state if connection detach fails after dismiss.
 func (d *Datastore) DeleteAutoDetectedCluster(ctx context.Context, autoKey string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin cluster dismiss transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // Rollback is no-op if already committed
+
 	var clusterID int
-	err := d.pool.QueryRow(ctx,
+	err = tx.QueryRow(ctx,
 		`SELECT id FROM clusters WHERE auto_cluster_key = $1`,
 		autoKey,
 	).Scan(&clusterID)
 
 	if err != nil {
+		// No existing record — create a dismissed placeholder
 		name := deriveClusterNameFromKey(autoKey)
-		_, insertErr := d.pool.Exec(ctx, `
+		_, insertErr := tx.Exec(ctx, `
             INSERT INTO clusters (name, auto_cluster_key, dismissed)
             VALUES ($1, $2, TRUE)
         `, name, autoKey)
 		if insertErr != nil {
 			return fmt.Errorf("failed to create dismissed cluster record: %w", insertErr)
 		}
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("failed to commit cluster dismiss transaction: %w", err)
+		}
 		return nil
 	}
 
-	_, err = d.pool.Exec(ctx,
+	// Existing record — dismiss it and detach connections
+	_, err = tx.Exec(ctx,
 		`UPDATE clusters SET dismissed = TRUE, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
 		clusterID,
 	)
@@ -496,7 +508,7 @@ func (d *Datastore) DeleteAutoDetectedCluster(ctx context.Context, autoKey strin
 		return fmt.Errorf("failed to dismiss cluster: %w", err)
 	}
 
-	_, err = d.pool.Exec(ctx,
+	_, err = tx.Exec(ctx,
 		`UPDATE connections SET cluster_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE cluster_id = $1`,
 		clusterID,
 	)
@@ -504,6 +516,70 @@ func (d *Datastore) DeleteAutoDetectedCluster(ctx context.Context, autoKey strin
 		return fmt.Errorf("failed to detach connections from dismissed cluster: %w", err)
 	}
 
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit cluster dismiss transaction: %w", err)
+	}
+	return nil
+}
+
+// DismissAutoDetectedClusterKeys soft-deletes clusters matching any of
+// the provided auto_cluster_keys. For keys with existing database records,
+// it sets dismissed=TRUE and detaches connections. For keys without records,
+// it creates dismissed placeholder rows so the topology builder skips them.
+// All operations run in a single transaction for atomicity.
+func (d *Datastore) DismissAutoDetectedClusterKeys(ctx context.Context, autoKeys []string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin dismiss transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // Rollback is no-op if already committed
+
+	for _, autoKey := range autoKeys {
+		var clusterID int
+		err := tx.QueryRow(ctx,
+			`SELECT id FROM clusters WHERE auto_cluster_key = $1`,
+			autoKey,
+		).Scan(&clusterID)
+
+		if err != nil {
+			// No existing record — create a dismissed placeholder so the
+			// topology builder skips this key on subsequent refreshes.
+			name := deriveClusterNameFromKey(autoKey)
+			_, insertErr := tx.Exec(ctx, `
+                INSERT INTO clusters (name, auto_cluster_key, dismissed)
+                VALUES ($1, $2, TRUE)
+                ON CONFLICT (auto_cluster_key) DO UPDATE SET dismissed = TRUE, updated_at = CURRENT_TIMESTAMP
+            `, name, autoKey)
+			if insertErr != nil {
+				return fmt.Errorf("failed to create dismissed placeholder for %s: %w", autoKey, insertErr)
+			}
+			continue
+		}
+
+		// Existing record — dismiss it and detach connections
+		_, err = tx.Exec(ctx,
+			`UPDATE clusters SET dismissed = TRUE, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+			clusterID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to dismiss cluster %d: %w", clusterID, err)
+		}
+
+		_, err = tx.Exec(ctx,
+			`UPDATE connections SET cluster_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE cluster_id = $1`,
+			clusterID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to detach connections from cluster %d: %w", clusterID, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit dismiss transaction: %w", err)
+	}
 	return nil
 }
 

--- a/server/src/internal/database/config_queries.go
+++ b/server/src/internal/database/config_queries.go
@@ -507,7 +507,12 @@ func (d *Datastore) resolveConnectionHierarchy(ctx context.Context, connectionID
 		return nil, nil, nil, nil, fmt.Errorf("failed to get connections with roles: %w", err)
 	}
 
-	autoClusters := d.buildAutoDetectedClusters(connections, clusterOverrides)
+	dismissedKeys, err := d.getDismissedAutoClusterKeys(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to get dismissed cluster keys: %w", err)
+	}
+
+	autoClusters := d.buildAutoDetectedClusters(connections, clusterOverrides, dismissedKeys)
 
 	// Find which auto-detected cluster contains this connection
 	var foundKey string

--- a/server/src/internal/database/topology_autodetect.go
+++ b/server/src/internal/database/topology_autodetect.go
@@ -175,6 +175,39 @@ func (d *Datastore) getClaimedAutoClusterKeys(ctx context.Context, defaultGroupI
 	return claimed, nil
 }
 
+// getDismissedAutoClusterKeys returns auto_cluster_keys for clusters
+// that have been dismissed (soft-deleted). The topology builder uses
+// this set to suppress clusters the user has hidden.
+func (d *Datastore) getDismissedAutoClusterKeys(ctx context.Context) (map[string]bool, error) {
+	query := `
+        SELECT auto_cluster_key
+        FROM clusters
+        WHERE auto_cluster_key IS NOT NULL
+          AND dismissed = TRUE
+    `
+
+	rows, err := d.pool.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query dismissed cluster keys: %w", err)
+	}
+	defer rows.Close()
+
+	dismissed := make(map[string]bool)
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("failed to scan dismissed key: %w", err)
+		}
+		dismissed[key] = true
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating dismissed keys: %w", err)
+	}
+
+	return dismissed, nil
+}
+
 // buildAutoDetectedClusters builds a map of auto_cluster_key -> TopologyCluster
 // This is used to get server information for auto-detected clusters that have been
 // moved to manual groups

--- a/server/src/internal/database/topology_autodetect.go
+++ b/server/src/internal/database/topology_autodetect.go
@@ -210,8 +210,9 @@ func (d *Datastore) getDismissedAutoClusterKeys(ctx context.Context) (map[string
 
 // buildAutoDetectedClusters builds a map of auto_cluster_key -> TopologyCluster
 // This is used to get server information for auto-detected clusters that have been
-// moved to manual groups
-func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, clusterOverrides map[string]clusterOverride) map[string]TopologyCluster {
+// moved to manual groups. The dismissedKeys set contains auto_cluster_keys for
+// clusters that have been soft-deleted; these are excluded from the result.
+func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, clusterOverrides map[string]clusterOverride, dismissedKeys map[string]bool) map[string]TopologyCluster {
 	result := make(map[string]TopologyCluster)
 
 	// Create maps for lookups
@@ -293,7 +294,7 @@ func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, 
 
 	spockClusters := d.groupSpockNodesByClusters(spockNodes, childrenMap, connByID, assignedConnections, clusterOverrides)
 	for _, cluster := range spockClusters {
-		if cluster.AutoClusterKey != "" {
+		if cluster.AutoClusterKey != "" && !dismissedKeys[cluster.AutoClusterKey] {
 			result[cluster.AutoClusterKey] = cluster
 		}
 	}
@@ -310,9 +311,12 @@ func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, 
 			continue
 		}
 		if !conn.HasSpock && (conn.PrimaryRole == "binary_primary" && len(childrenMap[conn.ID]) > 0) {
+			autoKey := fmt.Sprintf("binary:%d", conn.ID)
+			if dismissedKeys[autoKey] {
+				continue
+			}
 			// Auto binary cluster: exclude manually pinned children.
 			server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections, false)
-			autoKey := fmt.Sprintf("binary:%d", conn.ID)
 			clusterName := conn.Name
 			clusterDescription := ""
 			if override, ok := clusterOverrides[autoKey]; ok {
@@ -334,7 +338,7 @@ func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, 
 	// Process logical replication clusters
 	logicalClusters := d.groupLogicalReplicationByPublisher(connections, connByID, connByHostPort, connByNamePort, assignedConnections, clusterOverrides)
 	for _, cluster := range logicalClusters {
-		if cluster.AutoClusterKey != "" {
+		if cluster.AutoClusterKey != "" && !dismissedKeys[cluster.AutoClusterKey] {
 			result[cluster.AutoClusterKey] = cluster
 		}
 	}
@@ -345,10 +349,13 @@ func (d *Datastore) buildAutoDetectedClusters(connections []connectionWithRole, 
 		if assignedConnections[conn.ID] {
 			continue
 		}
+		autoKey := fmt.Sprintf("standalone:%d", conn.ID)
+		if dismissedKeys[autoKey] {
+			continue
+		}
 		// Build server info. Standalone is an auto-detected entry, so
 		// manually pinned children must not be pulled into it.
 		server := d.buildServerWithChildren(conn, childrenMap, connByID, assignedConnections, false)
-		autoKey := fmt.Sprintf("standalone:%d", conn.ID)
 		clusterName := conn.Name
 		clusterDescription := ""
 		if override, ok := clusterOverrides[autoKey]; ok {

--- a/server/src/internal/database/topology_manual_membership_test.go
+++ b/server/src/internal/database/topology_manual_membership_test.go
@@ -74,10 +74,11 @@ func TestTopologyExcludesManualMembersFromAutoClusters(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
 	// buildAutoDetectedClusters must not produce a Spock cluster for the
 	// "pg17-" prefix when every candidate is pinned to a manual cluster.
-	autoClusters := ds.buildAutoDetectedClusters(manualSpockConns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(manualSpockConns, overrides, dismissed)
 	if cluster, ok := autoClusters["spock:pg17"]; ok {
 		t.Fatalf("manual Spock members were regrouped into auto cluster %q with %d servers (issue #74)",
 			cluster.AutoClusterKey, len(cluster.Servers))
@@ -98,7 +99,7 @@ func TestTopologyExcludesManualMembersFromAutoClusters(t *testing.T) {
 	// "spock_ha" should be returned.
 	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
 	claimed := map[string]bool{}
-	groups := ds.buildTopologyHierarchy(manualSpockConns, overrides, claimed, defaultGroup)
+	groups := ds.buildTopologyHierarchy(manualSpockConns, overrides, claimed, dismissed, defaultGroup)
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 topology group, got %d", len(groups))
 	}
@@ -157,15 +158,16 @@ func TestTopologyExcludesManualBinaryPrimaryFromAutoClusters(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	if cluster, ok := autoClusters["binary:201"]; ok {
 		t.Fatalf("manual binary primary regrouped into auto cluster %q with %d servers (issue #74)",
 			cluster.AutoClusterKey, len(cluster.Servers))
 	}
 
 	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
-	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, dismissed, defaultGroup)
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 topology group, got %d", len(groups))
 	}
@@ -213,15 +215,16 @@ func TestTopologyExcludesManualLogicalPublisherFromAutoClusters(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	if cluster, ok := autoClusters["logical:301"]; ok {
 		t.Fatalf("manual logical publisher regrouped into auto cluster %q with %d servers (issue #74)",
 			cluster.AutoClusterKey, len(cluster.Servers))
 	}
 
 	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
-	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, dismissed, defaultGroup)
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 topology group, got %d", len(groups))
 	}
@@ -280,7 +283,8 @@ func TestTopologyIncludesAutoMembersInAutoClusters(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	dismissed := map[string]bool{}
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	cluster, ok := autoClusters["spock:pg17"]
 	if !ok {
 		t.Fatalf("expected auto Spock cluster %q for three auto Spock nodes; got keys %v",
@@ -332,12 +336,13 @@ func TestTopologyExcludesManualChildrenFromAutoBinaryCluster(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
 	// buildAutoDetectedClusters must produce the auto binary cluster for
 	// the primary (it still has the standby linked via childrenMap), but
 	// the Children list of that primary must not contain the manually
 	// pinned standby.
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	cluster, ok := autoClusters["binary:401"]
 	if !ok {
 		t.Fatalf("expected auto binary cluster %q for auto primary; got keys %v",
@@ -365,7 +370,7 @@ func TestTopologyExcludesManualChildrenFromAutoBinaryCluster(t *testing.T) {
 	// buildTopologyHierarchy must likewise keep the manual standby out of
 	// the auto binary cluster tree in the default group.
 	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
-	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, dismissed, defaultGroup)
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 topology group, got %d", len(groups))
 	}
@@ -446,8 +451,9 @@ func TestTopologyExcludesManualSubscriberFromAutoLogicalCluster(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	cluster, ok := autoClusters["logical:501"]
 	if !ok {
 		t.Fatalf("expected auto logical cluster %q for auto publisher; got keys %v",
@@ -473,7 +479,7 @@ func TestTopologyExcludesManualSubscriberFromAutoLogicalCluster(t *testing.T) {
 	}
 
 	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
-	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, dismissed, defaultGroup)
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 topology group, got %d", len(groups))
 	}
@@ -555,10 +561,11 @@ func TestTopologyAutoPrimaryWithManualStandby(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
 	// buildAutoDetectedClusters should form a binary cluster with the
 	// auto primary and auto standby, but NOT include the manual standby.
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	cluster, ok := autoClusters["binary:501"]
 	if !ok {
 		t.Fatalf("expected auto binary cluster binary:501; got keys %v",
@@ -590,7 +597,7 @@ func TestTopologyAutoPrimaryWithManualStandby(t *testing.T) {
 
 	// buildTopologyHierarchy should produce the same result.
 	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
-	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, dismissed, defaultGroup)
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 topology group, got %d", len(groups))
 	}
@@ -651,10 +658,11 @@ func TestTopologyManualPrimaryWithAutoStandby(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
 	// buildAutoDetectedClusters: no binary cluster should form because
 	// the primary is manual.
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	if cluster, ok := autoClusters["binary:601"]; ok {
 		t.Fatalf("manual primary regrouped into auto binary cluster %q with %d servers",
 			cluster.AutoClusterKey, len(cluster.Servers))
@@ -664,7 +672,7 @@ func TestTopologyManualPrimaryWithAutoStandby(t *testing.T) {
 	// skipped from both binary-cluster and standalone processing. The
 	// auto standby should appear as a standalone server.
 	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
-	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, defaultGroup)
+	groups := ds.buildTopologyHierarchy(conns, overrides, map[string]bool{}, dismissed, defaultGroup)
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 topology group, got %d", len(groups))
 	}
@@ -726,9 +734,10 @@ func TestTopologyAutoPublisherWithManualSubscriber(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
 	// No logical cluster should form because the subscriber is manual.
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	if cluster, ok := autoClusters["logical:701"]; ok {
 		t.Fatalf("auto publisher + manual subscriber formed logical cluster %q with %d servers",
 			cluster.AutoClusterKey, len(cluster.Servers))
@@ -777,9 +786,10 @@ func TestTopologyManualPublisherWithAutoSubscriber(t *testing.T) {
 	}
 
 	overrides := map[string]clusterOverride{}
+	dismissed := map[string]bool{}
 
 	// No logical cluster should form because the publisher is manual.
-	autoClusters := ds.buildAutoDetectedClusters(conns, overrides)
+	autoClusters := ds.buildAutoDetectedClusters(conns, overrides, dismissed)
 	if cluster, ok := autoClusters["logical:801"]; ok {
 		t.Fatalf("manual publisher + auto subscriber formed logical cluster %q with %d servers",
 			cluster.AutoClusterKey, len(cluster.Servers))

--- a/server/src/internal/database/topology_queries.go
+++ b/server/src/internal/database/topology_queries.go
@@ -185,9 +185,16 @@ func (d *Datastore) GetClusterTopology(ctx context.Context, visibleConnectionIDs
 		clusterOverrides = make(map[string]clusterOverride)
 	}
 
+	// Step 2b: Get dismissed auto-detected cluster keys so they are
+	// excluded from the topology. Issue #36.
+	dismissedKeys, err := d.getDismissedAutoClusterKeys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dismissed cluster keys: %w", err)
+	}
+
 	// Step 3: Build auto-detected topology from ALL connections
 	// This creates a map of auto_cluster_key -> TopologyCluster with servers
-	autoDetectedClusters := d.buildAutoDetectedClusters(allConnections, clusterOverrides)
+	autoDetectedClusters := d.buildAutoDetectedClusters(allConnections, clusterOverrides, dismissedKeys)
 
 	// Step 4: Get clusters that have been moved to non-default groups
 	// These have auto_cluster_key set AND group_id pointing to a non-default group
@@ -223,7 +230,7 @@ func (d *Datastore) GetClusterTopology(ctx context.Context, visibleConnectionIDs
 	}
 
 	// Build topology hierarchy for the default group, excluding claimed auto_cluster_keys
-	defaultGroups := d.buildTopologyHierarchy(unclaimedConnections, clusterOverrides, claimedKeys, defaultGroup)
+	defaultGroups := d.buildTopologyHierarchy(unclaimedConnections, clusterOverrides, claimedKeys, dismissedKeys, defaultGroup)
 
 	// Step 6b: Add manual clusters (no auto_cluster_key) from the
 	// default group. These clusters were created by users and are not
@@ -436,8 +443,14 @@ func (d *Datastore) RefreshClusterAssignments(ctx context.Context) error {
 		clusterOverrides = make(map[string]clusterOverride)
 	}
 
+	// Get dismissed auto-detected cluster keys (issue #36)
+	dismissedKeys, err := d.getDismissedAutoClusterKeys(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get dismissed cluster keys: %w", err)
+	}
+
 	// Build auto-detected clusters
-	autoDetectedClusters := d.buildAutoDetectedClusters(allConnections, clusterOverrides)
+	autoDetectedClusters := d.buildAutoDetectedClusters(allConnections, clusterOverrides, dismissedKeys)
 
 	// Sync assignments and get mapping of auto_cluster_key -> db cluster ID
 	clusterIDMap := d.syncAutoDetectedClusterAssignments(ctx, autoDetectedClusters, defaultGroup.ID)
@@ -451,8 +464,10 @@ func (d *Datastore) RefreshClusterAssignments(ctx context.Context) error {
 // buildTopologyHierarchy builds the topology hierarchy from connections.
 // The claimedKeys parameter contains auto_cluster_keys that have been moved to
 // manual groups - these clusters will be excluded from the default group.
+// The dismissedKeys parameter contains auto_cluster_keys for clusters that have
+// been soft-deleted - these are also excluded from the default group (issue #36).
 // The defaultGroup parameter provides the database-backed default group info.
-func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clusterOverrides map[string]clusterOverride, claimedKeys map[string]bool, defaultGroup *defaultGroupInfo) []TopologyGroup {
+func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clusterOverrides map[string]clusterOverride, claimedKeys map[string]bool, dismissedKeys map[string]bool, defaultGroup *defaultGroupInfo) []TopologyGroup {
 	// Create maps for lookups
 	connByID := make(map[int]*connectionWithRole)
 	connByHostPort := make(map[string]*connectionWithRole)
@@ -538,11 +553,11 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 	// pg18-spock1, pg18-spock2 -> another cluster
 	spockClusters := d.groupSpockNodesByClusters(spockNodes, childrenMap, connByID, assignedConnections, clusterOverrides)
 
-	// Build clusters list, filtering out claimed clusters
+	// Build clusters list, filtering out claimed and dismissed clusters
 	var clusters []TopologyCluster
 	for _, cluster := range spockClusters {
-		// Skip clusters that have been moved to manual groups
-		if cluster.AutoClusterKey != "" && claimedKeys[cluster.AutoClusterKey] {
+		// Skip clusters that have been moved to manual groups or dismissed
+		if cluster.AutoClusterKey != "" && (claimedKeys[cluster.AutoClusterKey] || dismissedKeys[cluster.AutoClusterKey]) {
 			continue
 		}
 		clusters = append(clusters, cluster)
@@ -562,11 +577,11 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 		}
 		// Check if this is a primary with standbys (and not a Spock node)
 		if !conn.HasSpock && (conn.PrimaryRole == "binary_primary" && len(childrenMap[conn.ID]) > 0) {
-			// Compute auto_cluster_key first to check if claimed
+			// Compute auto_cluster_key first to check if claimed or dismissed
 			autoKey := fmt.Sprintf("binary:%d", conn.ID)
 
-			// Skip if this cluster has been moved to a manual group
-			if claimedKeys[autoKey] {
+			// Skip if this cluster has been moved to a manual group or dismissed
+			if claimedKeys[autoKey] || dismissedKeys[autoKey] {
 				continue
 			}
 
@@ -596,9 +611,9 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 	// 2.5. Group logical replication publishers with their subscribers
 	// Match subscribers to publishers based on publisher_host:publisher_port
 	logicalClusters := d.groupLogicalReplicationByPublisher(connections, connByID, connByHostPort, connByNamePort, assignedConnections, clusterOverrides)
-	// Filter out claimed logical clusters
+	// Filter out claimed or dismissed logical clusters
 	for _, cluster := range logicalClusters {
-		if cluster.AutoClusterKey != "" && claimedKeys[cluster.AutoClusterKey] {
+		if cluster.AutoClusterKey != "" && (claimedKeys[cluster.AutoClusterKey] || dismissedKeys[cluster.AutoClusterKey]) {
 			continue
 		}
 		clusters = append(clusters, cluster)
@@ -621,8 +636,8 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 		// Compute auto_cluster_key for standalone servers
 		autoKey := fmt.Sprintf("standalone:%d", conn.ID)
 
-		// Skip if this standalone has been moved to a manual group
-		if claimedKeys[autoKey] {
+		// Skip if this standalone has been moved to a manual group or dismissed
+		if claimedKeys[autoKey] || dismissedKeys[autoKey] {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Fixes #36. Auto-detected clusters that users dismiss were reappearing in the ClusterNavigator topology view because `buildTopologyHierarchy()` reconstructed clusters from live connection metrics without checking the `dismissed` flag.

- Add `getDismissedAutoClusterKeys()` to query dismissed cluster keys from the database.
- Wire a `dismissedKeys` filter into `buildTopologyHierarchy()` and `buildAutoDetectedClusters()`, mirroring the existing `claimedKeys` pattern.
- Add `DeleteAutoDetectedCluster()` datastore method that soft-deletes by `auto_cluster_key`, creating a dismissed placeholder if no database record exists.
- Add DELETE handler for auto-detected cluster paths (`server-{id}`, `cluster-spock-{prefix}`) in the API layer. Previously only PUT was supported.
- Update OpenAPI specification to reflect the expanded DELETE endpoint.

## Test plan

- [ ] Verify unit tests pass: `cd server/src && go test ./internal/api/ -run "TestClusterHandler_DeleteAutoDetected|TestClusterHandler_HandleClusterSubpath_AutoDetected|TestComputeAutoClusterKey|TestDeriveClusterName" -v`
- [ ] Verify database tests pass: `cd server/src && go test ./internal/database/ -run "TestDismissed|TestDeleteAutoDetected|TestDeriveCluster" -v`
- [ ] Verify topology integration tests pass with `TEST_AI_WORKBENCH_SERVER` set
- [ ] Verify `make test-all` passes for all Go sub-projects (collector, server, alerter)
- [ ] Verify golangci-lint reports 0 issues for server
- [ ] Manually verify: create a server connection, observe auto-detected cluster in topology, delete it, verify it does not reappear on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now supports deleting/dismissing auto-detected clusters so dismissed clusters no longer reappear in topology.

* **Bug Fixes**
  * Token dialog copy behavior fixed for non-secure contexts so clipboard fallback works inside dialogs.

* **Documentation**
  * API docs updated to clarify deletion semantics (manual = hard-delete, auto-detected = soft-dismiss) and accepted ID formats.

* **Tests**
  * Added unit and integration tests covering dismissal, topology filtering, and DELETE behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->