### PR TITLE
Extract shared CRUD pattern from admin notification channels (#80)

### DIFF
--- a/client/src/components/AdminPanel/AdminEmailChannels.tsx
+++ b/client/src/components/AdminPanel/AdminEmailChannels.tsx
@@ -115,6 +115,8 @@ const AdminEmailChannels: React.FC = () => {
     // --- Dialog open handlers ---
 
     const handleOpenCreate = () => {
+        editingChannelIdRef.current = null;
+        setRecipientsLoading(false);
         crud.openCreate();
         setForm(DEFAULT_EMAIL_FORM);
         setRecipients([]);
@@ -122,6 +124,7 @@ const AdminEmailChannels: React.FC = () => {
     };
 
     const handleOpenEdit = (e: React.MouseEvent, channel: EmailChannel) => {
+        editingChannelIdRef.current = channel.id;
         crud.openEdit(e, channel);
         setForm({
             name: channel.name,
@@ -141,6 +144,8 @@ const AdminEmailChannels: React.FC = () => {
 
     const handleCloseDialog = () => {
         if (crud.saving || recipientSaving) { return; }
+        editingChannelIdRef.current = null;
+        setRecipientsLoading(false);
         crud.closeDialog();
         setRecipients([]);
         setPendingRecipients([]);

--- a/client/src/components/AdminPanel/AdminEmailChannels.tsx
+++ b/client/src/components/AdminPanel/AdminEmailChannels.tsx
@@ -8,7 +8,7 @@
  *-------------------------------------------------------------------------
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Chip } from '@mui/material';
 import DeleteConfirmationDialog from '../DeleteConfirmationDialog';
 import { apiGet, apiPost, apiPut, apiDelete } from '../../utils/apiClient';
@@ -61,6 +61,15 @@ const AdminEmailChannels: React.FC = () => {
         Array<{ email: string; name: string }>
     >([]);
 
+    // Ref to track the currently-editing channel ID for staleness checks.
+    // This avoids race conditions when the user quickly switches channels.
+    const editingChannelIdRef = useRef<number | null>(null);
+
+    // Keep ref in sync with crud.editingChannel
+    useEffect(() => {
+        editingChannelIdRef.current = crud.editingChannel?.id ?? null;
+    }, [crud.editingChannel]);
+
     // --- Fetch recipients ---
 
     const fetchRecipients = useCallback(async (channelId: number) => {
@@ -69,6 +78,8 @@ const AdminEmailChannels: React.FC = () => {
             const data = await apiGet<Record<string, unknown>>(
                 `/api/v1/notification-channels/${channelId}/recipients`
             );
+            // Guard against stale responses: only update if still editing same channel
+            if (editingChannelIdRef.current !== channelId) { return; }
             const raw = (data.recipients || data || []) as Record<string, unknown>[];
             const mapped: EmailRecipient[] = raw.map(
                 (r: Record<string, unknown>) => ({
@@ -80,13 +91,18 @@ const AdminEmailChannels: React.FC = () => {
             );
             setRecipients(mapped);
         } catch (err: unknown) {
+            // Only show error if still editing the same channel
+            if (editingChannelIdRef.current !== channelId) { return; }
             if (err instanceof Error) {
                 crud.setDialogError(err.message);
             } else {
                 crud.setDialogError('Failed to load recipients');
             }
         } finally {
-            setRecipientsLoading(false);
+            // Only clear loading if still editing the same channel
+            if (editingChannelIdRef.current === channelId) {
+                setRecipientsLoading(false);
+            }
         }
     }, [crud]);
 
@@ -215,26 +231,50 @@ const AdminEmailChannels: React.FC = () => {
                     body
                 );
 
-                // Add any pending recipients to the newly created channel
-                if (pendingRecipients.length > 0) {
+                // Capture pending recipients before closing dialog
+                const recipientsToAdd = [...pendingRecipients];
+                const channelName = form.name.trim();
+
+                // Close dialog immediately to prevent duplicate creation attempts
+                crud.closeDialog();
+                setRecipients([]);
+                setPendingRecipients([]);
+                crud.setSaving(false);
+                crud.setSuccess(`Channel "${channelName}" created successfully.`);
+                crud.fetchChannels();
+
+                // Add pending recipients as best-effort follow-up
+                if (recipientsToAdd.length > 0) {
                     const newChannelId = createData.id ||
                         (createData.channel as Record<string, unknown>)?.id;
                     if (newChannelId) {
-                        for (const pending of pendingRecipients) {
-                            await apiPost(
-                                `/api/v1/notification-channels/${newChannelId}/recipients`,
-                                {
-                                    email_address: pending.email,
-                                    display_name: pending.name,
-                                    enabled: true,
-                                }
+                        const failedRecipients: string[] = [];
+                        for (const pending of recipientsToAdd) {
+                            try {
+                                await apiPost(
+                                    `/api/v1/notification-channels/${newChannelId}/recipients`,
+                                    {
+                                        email_address: pending.email,
+                                        display_name: pending.name,
+                                        enabled: true,
+                                    }
+                                );
+                            } catch {
+                                failedRecipients.push(pending.email);
+                            }
+                        }
+                        // Update success message if some recipients failed
+                        if (failedRecipients.length > 0) {
+                            crud.setSuccess(
+                                `Channel "${channelName}" created successfully, ` +
+                                `but failed to add recipients: ${failedRecipients.join(', ')}.`
                             );
                         }
+                        // Refresh to show updated recipient counts
+                        crud.fetchChannels();
                     }
-                    setPendingRecipients([]);
                 }
-
-                crud.setSuccess(`Channel "${form.name.trim()}" created successfully.`);
+                return; // Early return since we already handled cleanup
             }
 
             crud.closeDialog();
@@ -262,65 +302,92 @@ const AdminEmailChannels: React.FC = () => {
         }
 
         // In edit mode, persist via API
+        const channelId = crud.editingChannel.id;
         try {
             setRecipientSaving(true);
             crud.setDialogError(null);
             await apiPost(
-                `/api/v1/notification-channels/${crud.editingChannel.id}/recipients`,
+                `/api/v1/notification-channels/${channelId}/recipients`,
                 {
                     email_address: email,
                     display_name: name,
                     enabled: true,
                 }
             );
-            fetchRecipients(crud.editingChannel.id);
+            // Guard against stale responses
+            if (editingChannelIdRef.current === channelId) {
+                fetchRecipients(channelId);
+            }
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                crud.setDialogError(err.message);
-            } else {
-                crud.setDialogError('Failed to add recipient');
+            // Only show error if still editing the same channel
+            if (editingChannelIdRef.current === channelId) {
+                if (err instanceof Error) {
+                    crud.setDialogError(err.message);
+                } else {
+                    crud.setDialogError('Failed to add recipient');
+                }
             }
         } finally {
-            setRecipientSaving(false);
+            if (editingChannelIdRef.current === channelId) {
+                setRecipientSaving(false);
+            }
         }
     };
 
     const handleToggleRecipientEnabled = async (recipient: EmailRecipient) => {
         if (!crud.editingChannel) { return; }
+        const channelId = crud.editingChannel.id;
         try {
             setRecipientSaving(true);
             await apiPut(
-                `/api/v1/notification-channels/${crud.editingChannel.id}/recipients/${recipient.id}`,
+                `/api/v1/notification-channels/${channelId}/recipients/${recipient.id}`,
                 { enabled: !recipient.enabled }
             );
-            fetchRecipients(crud.editingChannel.id);
+            // Guard against stale responses
+            if (editingChannelIdRef.current === channelId) {
+                fetchRecipients(channelId);
+            }
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                crud.setDialogError(err.message);
-            } else {
-                crud.setDialogError('Failed to update recipient');
+            // Only show error if still editing the same channel
+            if (editingChannelIdRef.current === channelId) {
+                if (err instanceof Error) {
+                    crud.setDialogError(err.message);
+                } else {
+                    crud.setDialogError('Failed to update recipient');
+                }
             }
         } finally {
-            setRecipientSaving(false);
+            if (editingChannelIdRef.current === channelId) {
+                setRecipientSaving(false);
+            }
         }
     };
 
     const handleDeleteRecipient = async (recipient: EmailRecipient) => {
         if (!crud.editingChannel) { return; }
+        const channelId = crud.editingChannel.id;
         try {
             setRecipientSaving(true);
             await apiDelete(
-                `/api/v1/notification-channels/${crud.editingChannel.id}/recipients/${recipient.id}`
+                `/api/v1/notification-channels/${channelId}/recipients/${recipient.id}`
             );
-            fetchRecipients(crud.editingChannel.id);
+            // Guard against stale responses
+            if (editingChannelIdRef.current === channelId) {
+                fetchRecipients(channelId);
+            }
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                crud.setDialogError(err.message);
-            } else {
-                crud.setDialogError('Failed to delete recipient');
+            // Only show error if still editing the same channel
+            if (editingChannelIdRef.current === channelId) {
+                if (err instanceof Error) {
+                    crud.setDialogError(err.message);
+                } else {
+                    crud.setDialogError('Failed to delete recipient');
+                }
             }
         } finally {
-            setRecipientSaving(false);
+            if (editingChannelIdRef.current === channelId) {
+                setRecipientSaving(false);
+            }
         }
     };
 

--- a/client/src/components/AdminPanel/AdminEmailChannels.tsx
+++ b/client/src/components/AdminPanel/AdminEmailChannels.tsx
@@ -80,7 +80,11 @@ const AdminEmailChannels: React.FC = () => {
             );
             // Guard against stale responses: only update if still editing same channel
             if (editingChannelIdRef.current !== channelId) { return; }
-            const raw = (data.recipients || data || []) as Record<string, unknown>[];
+            const raw = Array.isArray(data.recipients)
+                ? (data.recipients as Record<string, unknown>[])
+                : Array.isArray(data)
+                    ? (data as Record<string, unknown>[])
+                    : [];
             const mapped: EmailRecipient[] = raw.map(
                 (r: Record<string, unknown>) => ({
                     id: r.id as number,
@@ -154,6 +158,7 @@ const AdminEmailChannels: React.FC = () => {
     // --- Save handler ---
 
     const handleSaveChannel = async () => {
+        if (crud.saving || recipientSaving) { return; }
         if (!form.name.trim()) {
             crud.setDialogError('Name is required.');
             return;
@@ -333,9 +338,7 @@ const AdminEmailChannels: React.FC = () => {
                 }
             }
         } finally {
-            if (editingChannelIdRef.current === channelId) {
-                setRecipientSaving(false);
-            }
+            setRecipientSaving(false);
         }
     };
 
@@ -362,9 +365,7 @@ const AdminEmailChannels: React.FC = () => {
                 }
             }
         } finally {
-            if (editingChannelIdRef.current === channelId) {
-                setRecipientSaving(false);
-            }
+            setRecipientSaving(false);
         }
     };
 
@@ -390,9 +391,7 @@ const AdminEmailChannels: React.FC = () => {
                 }
             }
         } finally {
-            if (editingChannelIdRef.current === channelId) {
-                setRecipientSaving(false);
-            }
+            setRecipientSaving(false);
         }
     };
 
@@ -446,7 +445,8 @@ const AdminEmailChannels: React.FC = () => {
                 saveDisabled={
                     !form.name.trim() ||
                     !form.smtp_host.trim() ||
-                    !form.from_address.trim()
+                    !form.from_address.trim() ||
+                    recipientSaving
                 }
                 saveLabel={crud.editingChannel ? 'Save' : 'Create'}
                 maxWidth="sm"

--- a/client/src/components/AdminPanel/AdminEmailChannels.tsx
+++ b/client/src/components/AdminPanel/AdminEmailChannels.tsx
@@ -8,180 +8,60 @@
  *-------------------------------------------------------------------------
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
-import {
-    Box,
-    Typography,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    Paper,
-    Button,
-    IconButton,
-    Switch,
-    TextField,
-    Chip,
-    Tooltip,
-    CircularProgress,
-    Alert,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
-    FormControlLabel,
-    Tab,
-    Tabs,
-} from '@mui/material';
-import { useTheme } from '@mui/material/styles';
-import {
-    Add as AddIcon,
-    Edit as EditIcon,
-    Delete as DeleteIcon,
-    Send as SendIcon,
-} from '@mui/icons-material';
+import React, { useState, useCallback } from 'react';
+import { Chip } from '@mui/material';
 import DeleteConfirmationDialog from '../DeleteConfirmationDialog';
 import { apiGet, apiPost, apiPut, apiDelete } from '../../utils/apiClient';
-import { truncateDescription } from '../../utils/textHelpers';
 import {
-    tableHeaderCellSx,
-    dialogTitleSx,
-    dialogActionsSx,
-    pageHeadingSx,
-    loadingContainerSx,
-    emptyRowSx,
-    emptyRowTextSx,
-    getContainedButtonSx,
-    getDeleteIconSx,
-    getTableContainerSx,
-} from './styles';
+    useChannelCRUD,
+    ChannelTable,
+    ChannelDialogShell,
+    ChannelColumnDef,
+} from './channels';
+import {
+    EmailChannel,
+    EmailRecipient,
+    EmailFormState,
+    DEFAULT_EMAIL_FORM,
+    EmailSettingsTab,
+    EmailRecipientsTab,
+} from './email';
 
-interface EmailChannel {
-    id: number;
-    name: string;
-    description: string;
-    enabled: boolean;
-    is_estate_default: boolean;
-    smtp_host: string;
-    smtp_port: number;
-    smtp_username: string;
-    use_tls: boolean;
-    from_address: string;
-    from_name: string;
-    recipient_count: number;
-}
-
-interface EmailRecipient {
-    id: number;
-    email: string;
-    display_name: string;
-    enabled: boolean;
-}
-
-interface ChannelFormState {
-    name: string;
-    description: string;
-    enabled: boolean;
-    is_estate_default: boolean;
-    smtp_host: string;
-    smtp_port: string;
-    smtp_username: string;
-    smtp_password: string;
-    use_tls: boolean;
-    from_address: string;
-    from_name: string;
-}
-
-const DEFAULT_FORM_STATE: ChannelFormState = {
-    name: '',
-    description: '',
-    enabled: true,
-    is_estate_default: false,
-    smtp_host: '',
-    smtp_port: '587',
-    smtp_username: '',
-    smtp_password: '',
-    use_tls: true,
-    from_address: '',
-    from_name: '',
-};
+/** Map raw API response to EmailChannel type. */
+const mapEmailChannel = (ch: Record<string, unknown>): EmailChannel => ({
+    id: ch.id as number,
+    name: ch.name as string,
+    description: (ch.description as string) || '',
+    enabled: ch.enabled as boolean,
+    is_estate_default: ch.is_estate_default as boolean,
+    smtp_host: (ch.smtp_host as string) || '',
+    smtp_port: (ch.smtp_port as number) || 587,
+    smtp_username: (ch.smtp_username as string) || '',
+    use_tls: ch.smtp_use_tls as boolean,
+    from_address: (ch.from_address as string) || '',
+    from_name: (ch.from_name as string) || '',
+    recipient_count: Array.isArray(ch.recipients)
+        ? (ch.recipients as unknown[]).length
+        : 0,
+});
 
 const AdminEmailChannels: React.FC = () => {
-    const theme = useTheme();
+    const crud = useChannelCRUD<EmailChannel>('email', mapEmailChannel);
 
-    const [channels, setChannels] = useState<EmailChannel[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
+    // Form state
+    const [form, setForm] = useState<EmailFormState>(DEFAULT_EMAIL_FORM);
 
-    // Create/Edit dialog state
-    const [dialogOpen, setDialogOpen] = useState(false);
-    const [dialogTab, setDialogTab] = useState(0);
-    const [editingChannel, setEditingChannel] = useState<EmailChannel | null>(null);
-    const [form, setForm] = useState<ChannelFormState>(DEFAULT_FORM_STATE);
-    const [saving, setSaving] = useState(false);
-    const [dialogError, setDialogError] = useState<string | null>(null);
-
-    // Recipients state (shown inside the edit dialog)
+    // Recipients state (for edit mode)
     const [recipients, setRecipients] = useState<EmailRecipient[]>([]);
     const [recipientsLoading, setRecipientsLoading] = useState(false);
-    const [newRecipientEmail, setNewRecipientEmail] = useState('');
-    const [newRecipientName, setNewRecipientName] = useState('');
     const [recipientSaving, setRecipientSaving] = useState(false);
 
-    // Pending recipients for create mode (before channel exists)
-    const [pendingRecipients, setPendingRecipients] = useState<Array<{ email: string; name: string }>>([]);
+    // Pending recipients (for create mode)
+    const [pendingRecipients, setPendingRecipients] = useState<
+        Array<{ email: string; name: string }>
+    >([]);
 
-    // Test channel state
-    const [testingChannelId, setTestingChannelId] = useState<number | null>(null);
-
-    // Delete channel confirmation
-    const [deleteOpen, setDeleteOpen] = useState(false);
-    const [deleteChannel, setDeleteChannel] = useState<EmailChannel | null>(null);
-    const [deleteLoading, setDeleteLoading] = useState(false);
-
-    // --- Data fetching ---
-
-    const fetchChannels = useCallback(async () => {
-        try {
-            setLoading(true);
-            const data = await apiGet<Record<string, unknown>>('/api/v1/notification-channels');
-            const allChannels = (data.notification_channels || data || []) as Record<string, unknown>[];
-            const emailChannels: EmailChannel[] = allChannels
-                .filter((ch: Record<string, unknown>) => ch.channel_type === 'email')
-                .map((ch: Record<string, unknown>) => ({
-                    id: ch.id as number,
-                    name: ch.name as string,
-                    description: (ch.description as string) || '',
-                    enabled: ch.enabled as boolean,
-                    is_estate_default: ch.is_estate_default as boolean,
-                    smtp_host: (ch.smtp_host as string) || '',
-                    smtp_port: (ch.smtp_port as number) || 587,
-                    smtp_username: (ch.smtp_username as string) || '',
-                    use_tls: ch.smtp_use_tls as boolean,
-                    from_address: (ch.from_address as string) || '',
-                    from_name: (ch.from_name as string) || '',
-                    recipient_count: Array.isArray(ch.recipients)
-                        ? (ch.recipients as unknown[]).length
-                        : 0,
-                }));
-            setChannels(emailChannels);
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setLoading(false);
-        }
-    }, []);
-
-    useEffect(() => {
-        fetchChannels();
-    }, [fetchChannels]);
+    // --- Fetch recipients ---
 
     const fetchRecipients = useCallback(async (channelId: number) => {
         try {
@@ -201,32 +81,32 @@ const AdminEmailChannels: React.FC = () => {
             setRecipients(mapped);
         } catch (err: unknown) {
             if (err instanceof Error) {
-                setDialogError(err.message);
+                crud.setDialogError(err.message);
             } else {
-                setDialogError('Failed to load recipients');
+                crud.setDialogError('Failed to load recipients');
             }
         } finally {
             setRecipientsLoading(false);
         }
-    }, []);
+    }, [crud]);
 
-    // --- Create / Edit dialog ---
+    // --- Form change handler ---
+
+    const handleFormChange = (field: keyof EmailFormState, value: string | boolean) => {
+        setForm((prev) => ({ ...prev, [field]: value }));
+    };
+
+    // --- Dialog open handlers ---
 
     const handleOpenCreate = () => {
-        setEditingChannel(null);
-        setForm(DEFAULT_FORM_STATE);
+        crud.openCreate();
+        setForm(DEFAULT_EMAIL_FORM);
         setRecipients([]);
         setPendingRecipients([]);
-        setDialogError(null);
-        setDialogTab(0);
-        setNewRecipientEmail('');
-        setNewRecipientName('');
-        setDialogOpen(true);
     };
 
     const handleOpenEdit = (e: React.MouseEvent, channel: EmailChannel) => {
-        e.stopPropagation();
-        setEditingChannel(channel);
+        crud.openEdit(e, channel);
         setForm({
             name: channel.name,
             description: channel.description,
@@ -240,88 +120,80 @@ const AdminEmailChannels: React.FC = () => {
             from_address: channel.from_address,
             from_name: channel.from_name,
         });
-        setDialogError(null);
-        setDialogTab(0);
-        setNewRecipientEmail('');
-        setNewRecipientName('');
-        setDialogOpen(true);
         fetchRecipients(channel.id);
     };
 
     const handleCloseDialog = () => {
-        if (saving || recipientSaving) {return;}
-        setDialogOpen(false);
-        setEditingChannel(null);
+        if (crud.saving || recipientSaving) { return; }
+        crud.closeDialog();
         setRecipients([]);
         setPendingRecipients([]);
     };
 
-    const handleFormChange = (field: keyof ChannelFormState, value: string | boolean) => {
-        setForm((prev) => ({ ...prev, [field]: value }));
-    };
+    // --- Save handler ---
 
     const handleSaveChannel = async () => {
         if (!form.name.trim()) {
-            setDialogError('Name is required.');
+            crud.setDialogError('Name is required.');
             return;
         }
         if (!form.smtp_host.trim()) {
-            setDialogError('SMTP host is required.');
+            crud.setDialogError('SMTP host is required.');
             return;
         }
         if (!form.from_address.trim()) {
-            setDialogError('From address is required.');
+            crud.setDialogError('From address is required.');
             return;
         }
         const portNum = parseInt(form.smtp_port, 10);
         if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
-            setDialogError('SMTP port must be a valid port number (1-65535).');
+            crud.setDialogError('SMTP port must be a valid port number (1-65535).');
             return;
         }
 
         try {
-            setSaving(true);
-            setDialogError(null);
+            crud.setSaving(true);
+            crud.setDialogError(null);
 
-            if (editingChannel) {
+            if (crud.editingChannel) {
                 // Update - send only changed fields
                 const body: Record<string, unknown> = {};
-                if (form.name.trim() !== editingChannel.name) {
+                if (form.name.trim() !== crud.editingChannel.name) {
                     body.name = form.name.trim();
                 }
-                if (form.description.trim() !== editingChannel.description) {
+                if (form.description.trim() !== crud.editingChannel.description) {
                     body.description = form.description.trim();
                 }
-                if (form.enabled !== editingChannel.enabled) {
+                if (form.enabled !== crud.editingChannel.enabled) {
                     body.enabled = form.enabled;
                 }
-                if (form.is_estate_default !== editingChannel.is_estate_default) {
+                if (form.is_estate_default !== crud.editingChannel.is_estate_default) {
                     body.is_estate_default = form.is_estate_default;
                 }
-                if (form.smtp_host.trim() !== editingChannel.smtp_host) {
+                if (form.smtp_host.trim() !== crud.editingChannel.smtp_host) {
                     body.smtp_host = form.smtp_host.trim();
                 }
-                if (portNum !== editingChannel.smtp_port) {
+                if (portNum !== crud.editingChannel.smtp_port) {
                     body.smtp_port = portNum;
                 }
-                if (form.smtp_username.trim() !== editingChannel.smtp_username) {
+                if (form.smtp_username.trim() !== crud.editingChannel.smtp_username) {
                     body.smtp_username = form.smtp_username.trim();
                 }
                 if (form.smtp_password) {
                     body.smtp_password = form.smtp_password;
                 }
-                if (form.use_tls !== editingChannel.use_tls) {
+                if (form.use_tls !== crud.editingChannel.use_tls) {
                     body.smtp_use_tls = form.use_tls;
                 }
-                if (form.from_address.trim() !== editingChannel.from_address) {
+                if (form.from_address.trim() !== crud.editingChannel.from_address) {
                     body.from_address = form.from_address.trim();
                 }
-                if (form.from_name.trim() !== editingChannel.from_name) {
+                if (form.from_name.trim() !== crud.editingChannel.from_name) {
                     body.from_name = form.from_name.trim();
                 }
 
-                await apiPut(`/api/v1/notification-channels/${editingChannel.id}`, body);
-                setSuccess(`Channel "${form.name.trim()}" updated successfully.`);
+                await apiPut(`/api/v1/notification-channels/${crud.editingChannel.id}`, body);
+                crud.setSuccess(`Channel "${form.name.trim()}" updated successfully.`);
             } else {
                 // Create
                 const body = {
@@ -338,11 +210,15 @@ const AdminEmailChannels: React.FC = () => {
                     from_address: form.from_address.trim(),
                     from_name: form.from_name.trim(),
                 };
-                const createData = await apiPost<Record<string, unknown>>('/api/v1/notification-channels', body);
+                const createData = await apiPost<Record<string, unknown>>(
+                    '/api/v1/notification-channels',
+                    body
+                );
 
                 // Add any pending recipients to the newly created channel
                 if (pendingRecipients.length > 0) {
-                    const newChannelId = createData.id || (createData.channel as Record<string, unknown>)?.id;
+                    const newChannelId = createData.id ||
+                        (createData.channel as Record<string, unknown>)?.id;
                     if (newChannelId) {
                         for (const pending of pendingRecipients) {
                             await apiPost(
@@ -358,124 +234,51 @@ const AdminEmailChannels: React.FC = () => {
                     setPendingRecipients([]);
                 }
 
-                setSuccess(`Channel "${form.name.trim()}" created successfully.`);
+                crud.setSuccess(`Channel "${form.name.trim()}" created successfully.`);
             }
 
-            setDialogOpen(false);
-            setEditingChannel(null);
+            crud.closeDialog();
             setRecipients([]);
             setPendingRecipients([]);
-            fetchChannels();
+            crud.fetchChannels();
         } catch (err: unknown) {
             if (err instanceof Error) {
-                setDialogError(err.message);
+                crud.setDialogError(err.message);
             } else {
-                setDialogError('An unexpected error occurred');
+                crud.setDialogError('An unexpected error occurred');
             }
         } finally {
-            setSaving(false);
+            crud.setSaving(false);
         }
     };
 
-    // --- Delete channel ---
+    // --- Recipient handlers ---
 
-    const handleOpenDelete = (e: React.MouseEvent, channel: EmailChannel) => {
-        e.stopPropagation();
-        setDeleteChannel(channel);
-        setDeleteOpen(true);
-    };
-
-    const handleDeleteChannel = async () => {
-        if (!deleteChannel) {return;}
-        try {
-            setDeleteLoading(true);
-            await apiDelete(`/api/v1/notification-channels/${deleteChannel.id}`);
-            setDeleteOpen(false);
-            setDeleteChannel(null);
-            setSuccess(`Channel "${deleteChannel.name}" deleted successfully.`);
-            fetchChannels();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setDeleteLoading(false);
-        }
-    };
-
-    // --- Inline toggle enabled on main table ---
-
-    const handleToggleEnabled = async (channel: EmailChannel) => {
-        try {
-            await apiPut(`/api/v1/notification-channels/${channel.id}`, { enabled: !channel.enabled });
-            fetchChannels();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        }
-    };
-
-    // --- Test channel ---
-
-    const handleTestChannel = async (e: React.MouseEvent, channel: EmailChannel) => {
-        e.stopPropagation();
-        try {
-            setTestingChannelId(channel.id);
-            setError(null);
-            await apiPost(`/api/v1/notification-channels/${channel.id}/test`);
-            setSuccess(`Test email sent successfully for "${channel.name}".`);
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('Failed to send test email');
-            }
-        } finally {
-            setTestingChannelId(null);
-        }
-    };
-
-    // --- Recipients management ---
-
-    const handleAddRecipient = async () => {
-        if (!newRecipientEmail.trim()) {return;}
-
+    const handleAddRecipient = async (email: string, name: string) => {
         // In create mode, add to pending recipients locally
-        if (!editingChannel) {
-            setPendingRecipients((prev) => [
-                ...prev,
-                { email: newRecipientEmail.trim(), name: newRecipientName.trim() },
-            ]);
-            setNewRecipientEmail('');
-            setNewRecipientName('');
+        if (!crud.editingChannel) {
+            setPendingRecipients((prev) => [...prev, { email, name }]);
             return;
         }
 
         // In edit mode, persist via API
         try {
             setRecipientSaving(true);
-            setDialogError(null);
+            crud.setDialogError(null);
             await apiPost(
-                `/api/v1/notification-channels/${editingChannel.id}/recipients`,
+                `/api/v1/notification-channels/${crud.editingChannel.id}/recipients`,
                 {
-                    email_address: newRecipientEmail.trim(),
-                    display_name: newRecipientName.trim(),
+                    email_address: email,
+                    display_name: name,
                     enabled: true,
                 }
             );
-            setNewRecipientEmail('');
-            setNewRecipientName('');
-            fetchRecipients(editingChannel.id);
+            fetchRecipients(crud.editingChannel.id);
         } catch (err: unknown) {
             if (err instanceof Error) {
-                setDialogError(err.message);
+                crud.setDialogError(err.message);
             } else {
-                setDialogError('Failed to add recipient');
+                crud.setDialogError('Failed to add recipient');
             }
         } finally {
             setRecipientSaving(false);
@@ -483,19 +286,19 @@ const AdminEmailChannels: React.FC = () => {
     };
 
     const handleToggleRecipientEnabled = async (recipient: EmailRecipient) => {
-        if (!editingChannel) {return;}
+        if (!crud.editingChannel) { return; }
         try {
             setRecipientSaving(true);
             await apiPut(
-                `/api/v1/notification-channels/${editingChannel.id}/recipients/${recipient.id}`,
+                `/api/v1/notification-channels/${crud.editingChannel.id}/recipients/${recipient.id}`,
                 { enabled: !recipient.enabled }
             );
-            fetchRecipients(editingChannel.id);
+            fetchRecipients(crud.editingChannel.id);
         } catch (err: unknown) {
             if (err instanceof Error) {
-                setDialogError(err.message);
+                crud.setDialogError(err.message);
             } else {
-                setDialogError('Failed to update recipient');
+                crud.setDialogError('Failed to update recipient');
             }
         } finally {
             setRecipientSaving(false);
@@ -503,480 +306,111 @@ const AdminEmailChannels: React.FC = () => {
     };
 
     const handleDeleteRecipient = async (recipient: EmailRecipient) => {
-        if (!editingChannel) {return;}
+        if (!crud.editingChannel) { return; }
         try {
             setRecipientSaving(true);
             await apiDelete(
-                `/api/v1/notification-channels/${editingChannel.id}/recipients/${recipient.id}`
+                `/api/v1/notification-channels/${crud.editingChannel.id}/recipients/${recipient.id}`
             );
-            fetchRecipients(editingChannel.id);
+            fetchRecipients(crud.editingChannel.id);
         } catch (err: unknown) {
             if (err instanceof Error) {
-                setDialogError(err.message);
+                crud.setDialogError(err.message);
             } else {
-                setDialogError('Failed to delete recipient');
+                crud.setDialogError('Failed to delete recipient');
             }
         } finally {
             setRecipientSaving(false);
         }
     };
 
-    // --- Render ---
+    // --- Extra column for recipient count ---
 
-    if (loading) {
-        return (
-            <Box sx={loadingContainerSx}>
-                <CircularProgress aria-label="Loading email channels" />
-            </Box>
-        );
-    }
-
-    const containedButtonSx = getContainedButtonSx(theme);
-    const deleteIconSx = getDeleteIconSx(theme);
-    const tableContainerSx = getTableContainerSx(theme);
-    const isEditing = editingChannel !== null;
+    const recipientCountColumn: ChannelColumnDef<EmailChannel> = {
+        label: 'Recipients',
+        render: (channel) => (
+            <Chip
+                label={channel.recipient_count}
+                size="small"
+                variant="outlined"
+            />
+        ),
+    };
 
     return (
-        <Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                <Typography variant="h6" sx={pageHeadingSx}>
-                    Email channels
-                </Typography>
-                <Button
-                    variant="contained"
-                    startIcon={<AddIcon />}
-                    onClick={handleOpenCreate}
-                    sx={containedButtonSx}
-                >
-                    Add Channel
-                </Button>
-            </Box>
-
-            {error && (
-                <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setError(null); }}>
-                    {error}
-                </Alert>
-            )}
-            {success && (
-                <Alert severity="success" sx={{ mb: 2, borderRadius: 1 }} onClose={() => setSuccess(null)}>
-                    {success}
-                </Alert>
-            )}
-
-            <TableContainer
-                component={Paper}
-                elevation={0}
-                sx={tableContainerSx}
-            >
-                <Table size="small">
-                    <TableHead>
-                        <TableRow>
-                            <TableCell sx={tableHeaderCellSx}>Name</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Description</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Recipients</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Enabled</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Estate Default</TableCell>
-                            <TableCell sx={tableHeaderCellSx} align="right">Actions</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {channels.length > 0 ? (
-                            channels.map((channel) => (
-                                <TableRow key={channel.id} hover>
-                                    <TableCell>
-                                        {channel.name}
-                                    </TableCell>
-                                    <TableCell>
-                                        {truncateDescription(channel.description)}
-                                    </TableCell>
-                                    <TableCell>
-                                        <Chip
-                                            label={channel.recipient_count}
-                                            size="small"
-                                            variant="outlined"
-                                        />
-                                    </TableCell>
-                                    <TableCell>
-                                        <Switch
-                                            checked={channel.enabled}
-                                            size="small"
-                                            onChange={() => handleToggleEnabled(channel)}
-                                            inputProps={{ 'aria-label': 'Toggle channel enabled' }}
-                                        />
-                                    </TableCell>
-                                    <TableCell>
-                                        <Switch
-                                            checked={channel.is_estate_default}
-                                            size="small"
-                                            disabled
-                                            inputProps={{ 'aria-label': 'Toggle estate default' }}
-                                        />
-                                    </TableCell>
-                                    <TableCell align="right">
-                                        <Tooltip title="Send test email">
-                                            <span>
-                                                <IconButton
-                                                    size="small"
-                                                    onClick={(e) => handleTestChannel(e, channel)}
-                                                    aria-label="send test email"
-                                                    disabled={testingChannelId === channel.id}
-                                                >
-                                                    {testingChannelId === channel.id ? (
-                                                        <CircularProgress size={18} aria-label="Sending test email" />
-                                                    ) : (
-                                                        <SendIcon fontSize="small" />
-                                                    )}
-                                                </IconButton>
-                                            </span>
-                                        </Tooltip>
-                                        <Tooltip title="Edit channel">
-                                            <IconButton
-                                                size="small"
-                                                onClick={(e) => handleOpenEdit(e, channel)}
-                                                aria-label="edit channel"
-                                            >
-                                                <EditIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="Delete channel">
-                                            <IconButton
-                                                size="small"
-                                                onClick={(e) => handleOpenDelete(e, channel)}
-                                                aria-label="delete channel"
-                                                sx={deleteIconSx}
-                                            >
-                                                <DeleteIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </TableCell>
-                                </TableRow>
-                            ))
-                        ) : (
-                            <TableRow>
-                                <TableCell colSpan={6} align="center" sx={emptyRowSx}>
-                                    <Typography color="text.secondary" sx={emptyRowTextSx}>
-                                        No email channels configured.
-                                    </Typography>
-                                </TableCell>
-                            </TableRow>
-                        )}
-                    </TableBody>
-                </Table>
-            </TableContainer>
-
-            {/* Create / Edit Channel Dialog */}
-            <Dialog
-                open={dialogOpen}
+        <>
+            <ChannelTable
+                channels={crud.channels}
+                loading={crud.loading}
+                extraColumns={[recipientCountColumn]}
+                testingChannelId={crud.testingChannelId}
+                onEdit={handleOpenEdit}
+                onDelete={crud.openDelete}
+                onToggleEnabled={crud.toggleEnabled}
+                onTest={crud.testChannel}
+                onAdd={handleOpenCreate}
+                emptyMessage="No email channels configured."
+                testTooltip="Send test email"
+                testAriaLabel="send test email"
+                testingAriaLabel="Sending test email"
+                title="Email channels"
+                error={crud.error}
+                success={crud.success}
+                onClearError={() => crud.setError(null)}
+                onClearSuccess={() => crud.setSuccess(null)}
+            />
+            <ChannelDialogShell
+                open={crud.dialogOpen}
                 onClose={handleCloseDialog}
+                title={crud.editingChannel
+                    ? `Edit channel: ${crud.editingChannel.name}`
+                    : 'Create email channel'}
+                tabs={['Settings', 'Recipients']}
+                activeTab={crud.dialogTab}
+                onTabChange={crud.setDialogTab}
+                error={crud.dialogError}
+                saving={crud.saving}
+                onSave={handleSaveChannel}
+                saveDisabled={
+                    !form.name.trim() ||
+                    !form.smtp_host.trim() ||
+                    !form.from_address.trim()
+                }
+                saveLabel={crud.editingChannel ? 'Save' : 'Create'}
                 maxWidth="sm"
-                fullWidth
             >
-                <DialogTitle sx={dialogTitleSx}>
-                    {isEditing ? `Edit channel: ${editingChannel.name}` : 'Create email channel'}
-                </DialogTitle>
-                <DialogContent>
-                    {dialogError && (
-                        <Alert severity="error" sx={{ mb: 2, mt: 1, borderRadius: 1 }}>
-                            {dialogError}
-                        </Alert>
-                    )}
-                    <Tabs
-                        value={dialogTab}
-                        onChange={(_e, newValue: number) => setDialogTab(newValue)}
-                        sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
-                    >
-                        <Tab label="Settings" />
-                        <Tab label="Recipients" />
-                    </Tabs>
-
-                    {/* Tab 0: Settings */}
-                    <Box sx={{ display: dialogTab === 0 ? 'block' : 'none' }}>
-                        <TextField
-                            autoFocus
-                            fullWidth
-                            label="Name"
-                            value={form.name}
-                            onChange={(e) => handleFormChange('name', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            required
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="Description"
-                            value={form.description}
-                            onChange={(e) => handleFormChange('description', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            multiline
-                            rows={2}
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="SMTP Host"
-                            value={form.smtp_host}
-                            onChange={(e) => handleFormChange('smtp_host', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            required
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="SMTP Port"
-                            type="number"
-                            value={form.smtp_port}
-                            onChange={(e) => handleFormChange('smtp_port', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            inputProps={{ min: 1, max: 65535 }}
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="SMTP Username"
-                            value={form.smtp_username}
-                            onChange={(e) => handleFormChange('smtp_username', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="SMTP Password"
-                            type="password"
-                            value={form.smtp_password}
-                            onChange={(e) => handleFormChange('smtp_password', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            placeholder={isEditing ? '(unchanged)' : ''}
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="From Address"
-                            value={form.from_address}
-                            onChange={(e) => handleFormChange('from_address', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            required
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="From Name"
-                            value={form.from_name}
-                            onChange={(e) => handleFormChange('from_name', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
-                            <FormControlLabel
-                                sx={{ ml: 0, gap: 1 }}
-                                control={
-                                    <Switch
-                                        checked={form.use_tls}
-                                        onChange={(e) => handleFormChange('use_tls', e.target.checked)}
-                                        disabled={saving}
-                                        inputProps={{ 'aria-label': 'Toggle use TLS' }}
-                                    />
-                                }
-                                label="Use TLS"
-                            />
-                            <FormControlLabel
-                                sx={{ ml: 0, gap: 1 }}
-                                control={
-                                    <Switch
-                                        checked={form.enabled}
-                                        onChange={(e) => handleFormChange('enabled', e.target.checked)}
-                                        disabled={saving}
-                                        inputProps={{ 'aria-label': 'Toggle channel enabled' }}
-                                    />
-                                }
-                                label="Enabled"
-                            />
-                            <FormControlLabel
-                                sx={{ ml: 0, gap: 1 }}
-                                control={
-                                    <Switch
-                                        checked={form.is_estate_default}
-                                        onChange={(e) => handleFormChange('is_estate_default', e.target.checked)}
-                                        disabled={saving}
-                                        inputProps={{ 'aria-label': 'Toggle estate default' }}
-                                    />
-                                }
-                                label={
-                                    <Box>
-                                        <Typography variant="body1">Estate Default</Typography>
-                                        <Typography variant="caption" color="text.secondary">
-                                            When enabled, this channel is active for all servers by default
-                                        </Typography>
-                                    </Box>
-                                }
-                            />
-                        </Box>
-                    </Box>
-
-                    {/* Tab 1: Recipients */}
-                    <Box sx={{ display: dialogTab === 1 ? 'block' : 'none' }}>
-                        {isEditing && recipientsLoading ? (
-                            <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
-                                <CircularProgress size={24} aria-label="Loading recipients" />
-                            </Box>
-                        ) : (
-                            <TableContainer
-                                component={Paper}
-                                elevation={0}
-                                sx={tableContainerSx}
-                            >
-                                <Table size="small">
-                                    <TableHead>
-                                        <TableRow>
-                                            <TableCell sx={tableHeaderCellSx}>Email</TableCell>
-                                            <TableCell sx={tableHeaderCellSx}>Display Name</TableCell>
-                                            {isEditing && (
-                                                <TableCell sx={tableHeaderCellSx}>Enabled</TableCell>
-                                            )}
-                                            <TableCell sx={tableHeaderCellSx} align="right">Actions</TableCell>
-                                        </TableRow>
-                                    </TableHead>
-                                    <TableBody>
-                                        {isEditing && recipients.map((recipient) => (
-                                            <TableRow key={recipient.id}>
-                                                <TableCell>{recipient.email}</TableCell>
-                                                <TableCell>{recipient.display_name || '-'}</TableCell>
-                                                <TableCell>
-                                                    <Switch
-                                                        checked={recipient.enabled}
-                                                        size="small"
-                                                        onChange={() => handleToggleRecipientEnabled(recipient)}
-                                                        disabled={recipientSaving}
-                                                        inputProps={{ 'aria-label': 'Toggle recipient enabled' }}
-                                                    />
-                                                </TableCell>
-                                                <TableCell align="right">
-                                                    <IconButton
-                                                        size="small"
-                                                        onClick={() => handleDeleteRecipient(recipient)}
-                                                        aria-label="delete recipient"
-                                                        sx={deleteIconSx}
-                                                        disabled={recipientSaving}
-                                                    >
-                                                        <DeleteIcon fontSize="small" />
-                                                    </IconButton>
-                                                </TableCell>
-                                            </TableRow>
-                                        ))}
-                                        {!isEditing && pendingRecipients.map((pending, index) => (
-                                            <TableRow key={`pending-${index}`}>
-                                                <TableCell>{pending.email}</TableCell>
-                                                <TableCell>{pending.name || '-'}</TableCell>
-                                                <TableCell align="right">
-                                                    <IconButton
-                                                        size="small"
-                                                        onClick={() => setPendingRecipients(
-                                                            (prev) => prev.filter((_, i) => i !== index)
-                                                        )}
-                                                        aria-label="remove pending recipient"
-                                                        sx={deleteIconSx}
-                                                    >
-                                                        <DeleteIcon fontSize="small" />
-                                                    </IconButton>
-                                                </TableCell>
-                                            </TableRow>
-                                        ))}
-                                        {((isEditing && recipients.length === 0) ||
-                                          (!isEditing && pendingRecipients.length === 0)) && (
-                                            <TableRow>
-                                                <TableCell
-                                                    colSpan={isEditing ? 4 : 3}
-                                                    align="center"
-                                                    sx={emptyRowSx}
-                                                >
-                                                    <Typography color="text.secondary" sx={emptyRowTextSx}>
-                                                        No recipients configured.
-                                                    </Typography>
-                                                </TableCell>
-                                            </TableRow>
-                                        )}
-                                        {/* Add recipient row */}
-                                        <TableRow>
-                                            <TableCell>
-                                                <TextField
-                                                    size="small"
-                                                    placeholder="Email address"
-                                                    value={newRecipientEmail}
-                                                    onChange={(e) => setNewRecipientEmail(e.target.value)}
-                                                    disabled={recipientSaving}
-                                                    fullWidth
-                                                    variant="standard"
-                                                />
-                                            </TableCell>
-                                            <TableCell>
-                                                <TextField
-                                                    size="small"
-                                                    placeholder="Display name"
-                                                    value={newRecipientName}
-                                                    onChange={(e) => setNewRecipientName(e.target.value)}
-                                                    disabled={recipientSaving}
-                                                    fullWidth
-                                                    variant="standard"
-                                                />
-                                            </TableCell>
-                                            <TableCell
-                                                colSpan={isEditing ? 2 : 1}
-                                                align="right"
-                                            >
-                                                <Button
-                                                    size="small"
-                                                    variant="contained"
-                                                    startIcon={recipientSaving
-                                                        ? <CircularProgress size={14} color="inherit" aria-label="Adding recipient" />
-                                                        : <AddIcon />
-                                                    }
-                                                    onClick={handleAddRecipient}
-                                                    disabled={recipientSaving || !newRecipientEmail.trim()}
-                                                    sx={containedButtonSx}
-                                                >
-                                                    Add
-                                                </Button>
-                                            </TableCell>
-                                        </TableRow>
-                                    </TableBody>
-                                </Table>
-                            </TableContainer>
-                        )}
-                    </Box>
-                </DialogContent>
-                <DialogActions sx={dialogActionsSx}>
-                    <Button onClick={handleCloseDialog} disabled={saving}>
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={handleSaveChannel}
-                        variant="contained"
-                        disabled={saving || !form.name.trim() || !form.smtp_host.trim() || !form.from_address.trim()}
-                        sx={containedButtonSx}
-                    >
-                        {saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : (isEditing ? 'Save' : 'Create')}
-                    </Button>
-                </DialogActions>
-            </Dialog>
-
-            {/* Delete Confirmation Dialog */}
+                <EmailSettingsTab
+                    form={form}
+                    onChange={handleFormChange}
+                    saving={crud.saving}
+                    isEditing={!!crud.editingChannel}
+                    visible={crud.dialogTab === 0}
+                />
+                <EmailRecipientsTab
+                    visible={crud.dialogTab === 1}
+                    isEditing={!!crud.editingChannel}
+                    recipients={recipients}
+                    recipientsLoading={recipientsLoading}
+                    recipientSaving={recipientSaving}
+                    onToggleRecipientEnabled={handleToggleRecipientEnabled}
+                    onDeleteRecipient={handleDeleteRecipient}
+                    onAddRecipient={handleAddRecipient}
+                    pendingRecipients={pendingRecipients}
+                    onRemovePending={(index) =>
+                        setPendingRecipients((prev) => prev.filter((_, i) => i !== index))
+                    }
+                />
+            </ChannelDialogShell>
             <DeleteConfirmationDialog
-                open={deleteOpen}
-                onClose={() => { setDeleteOpen(false); setDeleteChannel(null); }}
-                onConfirm={handleDeleteChannel}
+                open={crud.deleteOpen}
+                onClose={crud.closeDelete}
+                onConfirm={crud.confirmDelete}
                 title="Delete Email Channel"
                 message="Are you sure you want to delete the email channel"
-                itemName={deleteChannel?.name ? `"${deleteChannel.name}"?` : '?'}
-                loading={deleteLoading}
+                itemName={crud.deleteChannel?.name ? `"${crud.deleteChannel.name}"?` : '?'}
+                loading={crud.deleteLoading}
             />
-        </Box>
+        </>
     );
 };
 

--- a/client/src/components/AdminPanel/AdminWebhookChannels.tsx
+++ b/client/src/components/AdminPanel/AdminWebhookChannels.tsx
@@ -8,379 +8,150 @@
  *-------------------------------------------------------------------------
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
-import {
-    Box,
-    Typography,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    Paper,
-    Button,
-    IconButton,
-    Switch,
-    TextField,
-    Tooltip,
-    CircularProgress,
-    Alert,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
-    FormControlLabel,
-    Tab,
-    Tabs,
-    MenuItem,
-} from '@mui/material';
-import { useTheme } from '@mui/material/styles';
-import {
-    Add as AddIcon,
-    Edit as EditIcon,
-    Delete as DeleteIcon,
-    Send as SendIcon,
-} from '@mui/icons-material';
+import React, { useState, useCallback } from 'react';
 import DeleteConfirmationDialog from '../DeleteConfirmationDialog';
-import { apiGet, apiPost, apiPut, apiDelete } from '../../utils/apiClient';
-import { truncateDescription } from '../../utils/textHelpers';
-import { SELECT_FIELD_SX } from '../shared/formStyles';
+import { apiPost, apiPut } from '../../utils/apiClient';
+import { useChannelCRUD, ChannelTable, ChannelDialogShell } from './channels';
 import {
-    tableHeaderCellSx,
-    dialogTitleSx,
-    dialogActionsSx,
-    pageHeadingSx,
-    loadingContainerSx,
-    emptyRowSx,
-    emptyRowTextSx,
-    getContainedButtonSx,
-    getDeleteIconSx,
-    getTableContainerSx,
-} from './styles';
-
-interface WebhookChannel {
-    id: number;
-    name: string;
-    description: string;
-    enabled: boolean;
-    is_estate_default: boolean;
-    endpoint_url: string;
-    http_method: string;
-    headers: Record<string, string>;
-    auth_type: string;
-    auth_credentials: string;
-    template_alert_fire: string;
-    template_alert_clear: string;
-    template_reminder: string;
-}
-
-interface ChannelFormState {
-    name: string;
-    description: string;
-    endpoint_url: string;
-    http_method: string;
-    headers: { key: string; value: string }[];
-    auth_type: string;
-    auth_credentials: string;
-    enabled: boolean;
-    is_estate_default: boolean;
-    template_alert_fire: string;
-    template_alert_clear: string;
-    template_reminder: string;
-}
-
-const DEFAULT_ALERT_FIRE_TEMPLATE = `{
-  "event": "alert_fire",
-  "alert_id": {{.AlertID}},
-  "title": "{{.AlertTitle}}",
-  "description": "{{.AlertDescription}}",
-  "severity": "{{.Severity}}",
-  "server": {
-    "name": "{{.ServerName}}",
-    "host": "{{.ServerHost}}",
-    "port": {{.ServerPort}}
-  },
-  {{- if .DatabaseName}}
-  "database": "{{.DatabaseName}}",
-  {{- end}}
-  {{- if .MetricName}}
-  "metric": {
-    "name": "{{.MetricName}}"
-    {{- if .MetricValue}}, "value": {{.MetricValue}}{{end}}
-    {{- if .ThresholdValue}}, "threshold": {{.ThresholdValue}}{{end}}
-    {{- if .Operator}}, "operator": "{{.Operator}}"{{end}}
-  },
-  {{- end}}
-  "triggered_at": "{{.TriggeredAt.Format "2006-01-02T15:04:05Z07:00"}}"
-}`;
-
-const DEFAULT_ALERT_CLEAR_TEMPLATE = `{
-  "event": "alert_clear",
-  "alert_id": {{.AlertID}},
-  "title": "{{.AlertTitle}}",
-  "server": {
-    "name": "{{.ServerName}}",
-    "host": "{{.ServerHost}}",
-    "port": {{.ServerPort}}
-  },
-  "triggered_at": "{{.TriggeredAt.Format "2006-01-02T15:04:05Z07:00"}}"
-  {{- if .ClearedAt}},
-  "cleared_at": "{{.ClearedAt.Format "2006-01-02T15:04:05Z07:00"}}"
-  {{- end}},
-  "duration": "{{.Duration}}"
-}`;
-
-const DEFAULT_REMINDER_TEMPLATE = `{
-  "event": "reminder",
-  "alert_id": {{.AlertID}},
-  "title": "{{.AlertTitle}}",
-  "description": "{{.AlertDescription}}",
-  "severity": "{{.Severity}}",
-  "server": {
-    "name": "{{.ServerName}}",
-    "host": "{{.ServerHost}}",
-    "port": {{.ServerPort}}
-  },
-  "triggered_at": "{{.TriggeredAt.Format "2006-01-02T15:04:05Z07:00"}}",
-  "reminder_count": {{.ReminderCount}}
-}`;
-
-const DEFAULT_FORM_STATE: ChannelFormState = {
-    name: '',
-    description: '',
-    endpoint_url: '',
-    http_method: 'POST',
-    headers: [],
-    auth_type: 'none',
-    auth_credentials: '',
-    enabled: true,
-    is_estate_default: false,
-    template_alert_fire: '',
-    template_alert_clear: '',
-    template_reminder: '',
-};
-
-const HTTP_METHODS = ['POST', 'GET', 'PUT', 'PATCH'];
-
-const AUTH_TYPES = [
-    { value: 'none', label: 'None' },
-    { value: 'basic', label: 'Basic' },
-    { value: 'bearer', label: 'Bearer Token' },
-    { value: 'api_key', label: 'API Key' },
-];
+    WebhookChannel,
+    WebhookFormState,
+    DEFAULT_WEBHOOK_FORM,
+    parseAuthCredentials,
+    buildAuthCredentials,
+    headersObjectToArray,
+    headersArrayToObject,
+    WebhookSettingsTab,
+    WebhookHeadersTab,
+    WebhookAuthTab,
+    WebhookTemplatesTab,
+} from './webhook';
 
 /**
- * Parse auth_credentials based on auth_type into individual fields.
+ * Map raw API data to a typed WebhookChannel object.
  */
-const parseAuthCredentials = (authType: string, credentials: string): Record<string, string> => {
-    switch (authType) {
-        case 'basic': {
-            const separatorIndex = credentials.indexOf(':');
-            if (separatorIndex === -1) {return { username: credentials, password: '' };}
-            return {
-                username: credentials.substring(0, separatorIndex),
-                password: credentials.substring(separatorIndex + 1),
-            };
-        }
-        case 'bearer':
-            return { token: credentials };
-        case 'api_key': {
-            const separatorIndex = credentials.indexOf(':');
-            if (separatorIndex === -1) {return { headerName: credentials, apiKeyValue: '' };}
-            return {
-                headerName: credentials.substring(0, separatorIndex),
-                apiKeyValue: credentials.substring(separatorIndex + 1),
-            };
-        }
-        default:
-            return {};
-    }
-};
+const mapWebhookChannel = (ch: Record<string, unknown>): WebhookChannel => ({
+    id: ch.id as number,
+    name: ch.name as string,
+    description: (ch.description as string) || '',
+    enabled: ch.enabled as boolean,
+    is_estate_default: ch.is_estate_default as boolean,
+    endpoint_url: (ch.endpoint_url as string) || '',
+    http_method: (ch.http_method as string) || 'POST',
+    headers: (ch.headers as Record<string, string>) || {},
+    auth_type: (ch.auth_type as string) || 'none',
+    auth_credentials: (ch.auth_credentials as string) || '',
+    template_alert_fire: (ch.template_alert_fire as string) || '',
+    template_alert_clear: (ch.template_alert_clear as string) || '',
+    template_reminder: (ch.template_reminder as string) || '',
+});
 
-/**
- * Build auth_credentials string from individual fields based on auth_type.
- */
-const buildAuthCredentials = (authType: string, fields: Record<string, string>): string => {
-    switch (authType) {
-        case 'basic':
-            return `${fields.username || ''}:${fields.password || ''}`;
-        case 'bearer':
-            return fields.token || '';
-        case 'api_key':
-            return `${fields.headerName || ''}:${fields.apiKeyValue || ''}`;
-        default:
-            return '';
-    }
-};
+const DIALOG_TABS = ['Settings', 'Headers', 'Authentication', 'Templates'];
 
 const AdminWebhookChannels: React.FC = () => {
-    const theme = useTheme();
+    const crud = useChannelCRUD<WebhookChannel>('webhook', mapWebhookChannel);
 
-    const [channels, setChannels] = useState<WebhookChannel[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
-
-    // Create/Edit dialog state
-    const [dialogOpen, setDialogOpen] = useState(false);
-    const [dialogTab, setDialogTab] = useState(0);
-    const [editingChannel, setEditingChannel] = useState<WebhookChannel | null>(null);
-    const [form, setForm] = useState<ChannelFormState>(DEFAULT_FORM_STATE);
+    // Local form state
+    const [form, setForm] = useState<WebhookFormState>(DEFAULT_WEBHOOK_FORM);
     const [authFields, setAuthFields] = useState<Record<string, string>>({});
-    const [saving, setSaving] = useState(false);
-    const [dialogError, setDialogError] = useState<string | null>(null);
 
-    // Test channel state
-    const [testingChannelId, setTestingChannelId] = useState<number | null>(null);
+    // --- Form management ---
 
-    // Delete channel confirmation
-    const [deleteOpen, setDeleteOpen] = useState(false);
-    const [deleteChannel, setDeleteChannel] = useState<WebhookChannel | null>(null);
-    const [deleteLoading, setDeleteLoading] = useState(false);
+    const handleFormChange = useCallback(
+        (field: keyof WebhookFormState, value: string | boolean) => {
+            setForm((prev) => ({ ...prev, [field]: value }));
+        },
+        [],
+    );
 
-    // --- Data fetching ---
+    // --- Dialog open handlers ---
 
-    const fetchChannels = useCallback(async () => {
-        try {
-            setLoading(true);
-            const data = await apiGet<Record<string, unknown>>('/api/v1/notification-channels');
-            const allChannels = (data.notification_channels || data || []) as Record<string, unknown>[];
-            const webhookChannels: WebhookChannel[] = allChannels
-                .filter((ch: Record<string, unknown>) => ch.channel_type === 'webhook')
-                .map((ch: Record<string, unknown>) => ({
-                    id: ch.id as number,
-                    name: ch.name as string,
-                    description: (ch.description as string) || '',
-                    enabled: ch.enabled as boolean,
-                    is_estate_default: ch.is_estate_default as boolean,
-                    endpoint_url: (ch.endpoint_url as string) || '',
-                    http_method: (ch.http_method as string) || 'POST',
-                    headers: (ch.headers as Record<string, string>) || {},
-                    auth_type: (ch.auth_type as string) || 'none',
-                    auth_credentials: (ch.auth_credentials as string) || '',
-                    template_alert_fire: (ch.template_alert_fire as string) || '',
-                    template_alert_clear: (ch.template_alert_clear as string) || '',
-                    template_reminder: (ch.template_reminder as string) || '',
-                }));
-            setChannels(webhookChannels);
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setLoading(false);
-        }
+    const handleOpenCreate = useCallback(() => {
+        setForm(DEFAULT_WEBHOOK_FORM);
+        setAuthFields({});
+        crud.openCreate();
+    }, [crud]);
+
+    const handleOpenEdit = useCallback(
+        (e: React.MouseEvent, channel: WebhookChannel) => {
+            const parsedAuth = parseAuthCredentials(
+                channel.auth_type,
+                channel.auth_credentials,
+            );
+            setForm({
+                name: channel.name,
+                description: channel.description,
+                endpoint_url: channel.endpoint_url,
+                http_method: channel.http_method,
+                headers: headersObjectToArray(channel.headers),
+                auth_type: channel.auth_type || 'none',
+                auth_credentials: channel.auth_credentials,
+                enabled: channel.enabled,
+                is_estate_default: channel.is_estate_default,
+                template_alert_fire: channel.template_alert_fire || '',
+                template_alert_clear: channel.template_alert_clear || '',
+                template_reminder: channel.template_reminder || '',
+            });
+            setAuthFields(parsedAuth);
+            crud.openEdit(e, channel);
+        },
+        [crud],
+    );
+
+    const handleCloseDialog = useCallback(() => {
+        crud.closeDialog();
+    }, [crud]);
+
+    // --- Header management ---
+
+    const handleAddHeader = useCallback(() => {
+        setForm((prev) => ({
+            ...prev,
+            headers: [
+                ...prev.headers,
+                { id: crypto.randomUUID(), key: '', value: '' },
+            ],
+        }));
     }, []);
 
-    useEffect(() => {
-        void fetchChannels();
-    }, [fetchChannels]);
+    const handleHeaderChange = useCallback(
+        (id: string, field: 'key' | 'value', value: string) => {
+            setForm((prev) => ({
+                ...prev,
+                headers: prev.headers.map((h) =>
+                    h.id === id ? { ...h, [field]: value } : h,
+                ),
+            }));
+        },
+        [],
+    );
 
-    // --- Helpers ---
+    const handleRemoveHeader = useCallback((id: string) => {
+        setForm((prev) => ({
+            ...prev,
+            headers: prev.headers.filter((h) => h.id !== id),
+        }));
+    }, []);
 
-    const headersObjectToArray = (headers: Record<string, string>): { key: string; value: string }[] => {
-        const entries = Object.entries(headers);
-        if (entries.length === 0) {return [];}
-        return entries.map(([key, value]) => ({ key, value }));
-    };
+    // --- Auth management ---
 
-    const headersArrayToObject = (headers: { key: string; value: string }[]): Record<string, string> => {
-        return headers.reduce<Record<string, string>>((acc, h) => {
-            if (h.key.trim()) {acc[h.key.trim()] = h.value;}
-            return acc;
-        }, {});
-    };
-
-    // --- Create / Edit dialog ---
-
-    const handleOpenCreate = () => {
-        setEditingChannel(null);
-        setForm(DEFAULT_FORM_STATE);
-        setAuthFields({});
-        setDialogError(null);
-        setDialogTab(0);
-        setDialogOpen(true);
-    };
-
-    const handleOpenEdit = (e: React.MouseEvent, channel: WebhookChannel) => {
-        e.stopPropagation();
-        setEditingChannel(channel);
-        const parsedAuth = parseAuthCredentials(channel.auth_type, channel.auth_credentials);
-        setForm({
-            name: channel.name,
-            description: channel.description,
-            endpoint_url: channel.endpoint_url,
-            http_method: channel.http_method,
-            headers: headersObjectToArray(channel.headers),
-            auth_type: channel.auth_type || 'none',
-            auth_credentials: channel.auth_credentials,
-            enabled: channel.enabled,
-            is_estate_default: channel.is_estate_default,
-            template_alert_fire: channel.template_alert_fire || '',
-            template_alert_clear: channel.template_alert_clear || '',
-            template_reminder: channel.template_reminder || '',
-        });
-        setAuthFields(parsedAuth);
-        setDialogError(null);
-        setDialogTab(0);
-        setDialogOpen(true);
-    };
-
-    const handleCloseDialog = () => {
-        if (saving) {return;}
-        setDialogOpen(false);
-        setEditingChannel(null);
-    };
-
-    const handleFormChange = (field: keyof ChannelFormState, value: string | boolean) => {
-        setForm((prev) => ({ ...prev, [field]: value }));
-    };
-
-    const handleAuthTypeChange = (newAuthType: string) => {
+    const handleAuthTypeChange = useCallback((newAuthType: string) => {
         setForm((prev) => ({ ...prev, auth_type: newAuthType }));
         setAuthFields({});
-    };
+    }, []);
 
-    const handleAuthFieldChange = (field: string, value: string) => {
+    const handleAuthFieldChange = useCallback((field: string, value: string) => {
         setAuthFields((prev) => ({ ...prev, [field]: value }));
-    };
-
-    // --- Headers management ---
-
-    const handleAddHeader = () => {
-        setForm((prev) => ({
-            ...prev,
-            headers: [...prev.headers, { key: '', value: '' }],
-        }));
-    };
-
-    const handleHeaderChange = (index: number, field: 'key' | 'value', value: string) => {
-        setForm((prev) => {
-            const updated = [...prev.headers];
-            updated[index] = { ...updated[index], [field]: value };
-            return { ...prev, headers: updated };
-        });
-    };
-
-    const handleRemoveHeader = (index: number) => {
-        setForm((prev) => ({
-            ...prev,
-            headers: prev.headers.filter((_, i) => i !== index),
-        }));
-    };
+    }, []);
 
     // --- Save channel ---
 
-    const handleSaveChannel = async () => {
+    const handleSaveChannel = useCallback(async () => {
         if (!form.name.trim()) {
-            setDialogError('Name is required.');
+            crud.setDialogError('Name is required.');
             return;
         }
         if (!form.endpoint_url.trim()) {
-            setDialogError('Endpoint URL is required.');
+            crud.setDialogError('Endpoint URL is required.');
             return;
         }
 
@@ -388,51 +159,66 @@ const AdminWebhookChannels: React.FC = () => {
         const authCredentials = buildAuthCredentials(form.auth_type, authFields);
 
         try {
-            setSaving(true);
-            setDialogError(null);
+            crud.setSaving(true);
+            crud.setDialogError(null);
 
-            if (editingChannel) {
+            if (crud.editingChannel) {
                 // Update - send only changed fields
                 const body: Record<string, unknown> = {};
-                if (form.name.trim() !== editingChannel.name) {
+                if (form.name.trim() !== crud.editingChannel.name) {
                     body.name = form.name.trim();
                 }
-                if (form.description.trim() !== editingChannel.description) {
+                if (form.description.trim() !== crud.editingChannel.description) {
                     body.description = form.description.trim();
                 }
-                if (form.enabled !== editingChannel.enabled) {
+                if (form.enabled !== crud.editingChannel.enabled) {
                     body.enabled = form.enabled;
                 }
-                if (form.is_estate_default !== editingChannel.is_estate_default) {
+                if (form.is_estate_default !== crud.editingChannel.is_estate_default) {
                     body.is_estate_default = form.is_estate_default;
                 }
-                if (form.endpoint_url.trim() !== editingChannel.endpoint_url) {
+                if (form.endpoint_url.trim() !== crud.editingChannel.endpoint_url) {
                     body.endpoint_url = form.endpoint_url.trim();
                 }
-                if (form.http_method !== editingChannel.http_method) {
+                if (form.http_method !== crud.editingChannel.http_method) {
                     body.http_method = form.http_method;
                 }
-                if (JSON.stringify(headersObj) !== JSON.stringify(editingChannel.headers)) {
+                if (
+                    JSON.stringify(headersObj) !==
+                    JSON.stringify(crud.editingChannel.headers)
+                ) {
                     body.headers = headersObj;
                 }
-                if (form.auth_type !== editingChannel.auth_type) {
+                if (form.auth_type !== crud.editingChannel.auth_type) {
                     body.auth_type = form.auth_type;
                 }
-                if (authCredentials !== editingChannel.auth_credentials) {
+                if (authCredentials !== crud.editingChannel.auth_credentials) {
                     body.auth_credentials = authCredentials;
                 }
-                if (form.template_alert_fire.trim() !== (editingChannel.template_alert_fire || '')) {
+                if (
+                    form.template_alert_fire.trim() !==
+                    (crud.editingChannel.template_alert_fire || '')
+                ) {
                     body.template_alert_fire = form.template_alert_fire.trim();
                 }
-                if (form.template_alert_clear.trim() !== (editingChannel.template_alert_clear || '')) {
+                if (
+                    form.template_alert_clear.trim() !==
+                    (crud.editingChannel.template_alert_clear || '')
+                ) {
                     body.template_alert_clear = form.template_alert_clear.trim();
                 }
-                if (form.template_reminder.trim() !== (editingChannel.template_reminder || '')) {
+                if (
+                    form.template_reminder.trim() !==
+                    (crud.editingChannel.template_reminder || '')
+                ) {
                     body.template_reminder = form.template_reminder.trim();
                 }
 
-                await apiPut(`/api/v1/notification-channels/${editingChannel.id}`, body);
-                setSuccess(`Channel "${form.name.trim()}" updated successfully.`);
+                await apiPut(
+                    `/api/v1/notification-channels/${crud.editingChannel.id}`,
+                    body,
+                );
+                crud.setSuccess(`Channel "${form.name.trim()}" updated successfully.`);
             } else {
                 // Create
                 const body = {
@@ -446,569 +232,118 @@ const AdminWebhookChannels: React.FC = () => {
                     auth_credentials: authCredentials,
                     enabled: form.enabled,
                     is_estate_default: form.is_estate_default,
-                    ...(form.template_alert_fire.trim() ? { template_alert_fire: form.template_alert_fire.trim() } : {}),
-                    ...(form.template_alert_clear.trim() ? { template_alert_clear: form.template_alert_clear.trim() } : {}),
-                    ...(form.template_reminder.trim() ? { template_reminder: form.template_reminder.trim() } : {}),
+                    ...(form.template_alert_fire.trim()
+                        ? { template_alert_fire: form.template_alert_fire.trim() }
+                        : {}),
+                    ...(form.template_alert_clear.trim()
+                        ? { template_alert_clear: form.template_alert_clear.trim() }
+                        : {}),
+                    ...(form.template_reminder.trim()
+                        ? { template_reminder: form.template_reminder.trim() }
+                        : {}),
                 };
                 await apiPost('/api/v1/notification-channels', body);
-                setSuccess(`Channel "${form.name.trim()}" created successfully.`);
+                crud.setSuccess(`Channel "${form.name.trim()}" created successfully.`);
             }
 
-            setDialogOpen(false);
-            setEditingChannel(null);
-            fetchChannels();
+            crud.closeDialog();
+            crud.fetchChannels();
         } catch (err: unknown) {
             if (err instanceof Error) {
-                setDialogError(err.message);
+                crud.setDialogError(err.message);
             } else {
-                setDialogError('An unexpected error occurred');
+                crud.setDialogError('An unexpected error occurred');
             }
         } finally {
-            setSaving(false);
+            crud.setSaving(false);
         }
-    };
-
-    // --- Delete channel ---
-
-    const handleOpenDelete = (e: React.MouseEvent, channel: WebhookChannel) => {
-        e.stopPropagation();
-        setDeleteChannel(channel);
-        setDeleteOpen(true);
-    };
-
-    const handleDeleteChannel = async () => {
-        if (!deleteChannel) {return;}
-        try {
-            setDeleteLoading(true);
-            await apiDelete(`/api/v1/notification-channels/${deleteChannel.id}`);
-            setDeleteOpen(false);
-            setDeleteChannel(null);
-            setSuccess(`Channel "${deleteChannel.name}" deleted successfully.`);
-            fetchChannels();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setDeleteLoading(false);
-        }
-    };
-
-    // --- Inline toggle enabled on main table ---
-
-    const handleToggleEnabled = async (channel: WebhookChannel) => {
-        try {
-            await apiPut(`/api/v1/notification-channels/${channel.id}`, { enabled: !channel.enabled });
-            fetchChannels();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        }
-    };
-
-    // --- Test channel ---
-
-    const handleTestChannel = async (e: React.MouseEvent, channel: WebhookChannel) => {
-        e.stopPropagation();
-        try {
-            setTestingChannelId(channel.id);
-            setError(null);
-            await apiPost(`/api/v1/notification-channels/${channel.id}/test`);
-            setSuccess(`Test notification sent successfully for "${channel.name}".`);
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('Failed to send test notification');
-            }
-        } finally {
-            setTestingChannelId(null);
-        }
-    };
+    }, [form, authFields, crud]);
 
     // --- Render ---
 
-    if (loading) {
-        return (
-            <Box sx={loadingContainerSx}>
-                <CircularProgress aria-label="Loading webhook channels" />
-            </Box>
-        );
-    }
-
-    const containedButtonSx = getContainedButtonSx(theme);
-    const deleteIconSx = getDeleteIconSx(theme);
-    const tableContainerSx = getTableContainerSx(theme);
-    const isEditing = editingChannel !== null;
+    const isEditing = crud.editingChannel !== null;
+    const dialogTitle = isEditing
+        ? `Edit channel: ${crud.editingChannel?.name}`
+        : 'Create webhook channel';
 
     return (
-        <Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                <Typography variant="h6" sx={pageHeadingSx}>
-                    Webhook channels
-                </Typography>
-                <Button
-                    variant="contained"
-                    startIcon={<AddIcon />}
-                    onClick={handleOpenCreate}
-                    sx={containedButtonSx}
-                >
-                    Add Channel
-                </Button>
-            </Box>
+        <>
+            <ChannelTable
+                channels={crud.channels}
+                loading={crud.loading}
+                testingChannelId={crud.testingChannelId}
+                onEdit={handleOpenEdit}
+                onDelete={crud.openDelete}
+                onToggleEnabled={crud.toggleEnabled}
+                onTest={crud.testChannel}
+                onAdd={handleOpenCreate}
+                emptyMessage="No webhook channels configured."
+                testTooltip="Send test notification"
+                testAriaLabel="send test notification"
+                testingAriaLabel="Sending test"
+                title="Webhook channels"
+                error={crud.error}
+                success={crud.success}
+                onClearError={() => crud.setError(null)}
+                onClearSuccess={() => crud.setSuccess(null)}
+            />
 
-            {error && (
-                <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }} onClose={() => setError(null)}>
-                    {error}
-                </Alert>
-            )}
-            {success && (
-                <Alert severity="success" sx={{ mb: 2, borderRadius: 1 }} onClose={() => setSuccess(null)}>
-                    {success}
-                </Alert>
-            )}
-
-            <TableContainer
-                component={Paper}
-                elevation={0}
-                sx={tableContainerSx}
-            >
-                <Table size="small">
-                    <TableHead>
-                        <TableRow>
-                            <TableCell sx={tableHeaderCellSx}>Name</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Description</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Enabled</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Estate Default</TableCell>
-                            <TableCell sx={tableHeaderCellSx} align="right">Actions</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {channels.length > 0 ? (
-                            channels.map((channel) => (
-                                <TableRow key={channel.id} hover>
-                                    <TableCell>
-                                        {channel.name}
-                                    </TableCell>
-                                    <TableCell>
-                                        {truncateDescription(channel.description)}
-                                    </TableCell>
-                                    <TableCell>
-                                        <Switch
-                                            checked={channel.enabled}
-                                            size="small"
-                                            onChange={() => handleToggleEnabled(channel)}
-                                            inputProps={{ 'aria-label': 'Toggle channel enabled' }}
-                                        />
-                                    </TableCell>
-                                    <TableCell>
-                                        <Switch
-                                            checked={channel.is_estate_default}
-                                            size="small"
-                                            disabled
-                                            inputProps={{ 'aria-label': 'Toggle estate default' }}
-                                        />
-                                    </TableCell>
-                                    <TableCell align="right">
-                                        <Tooltip title="Send test notification">
-                                            <span>
-                                                <IconButton
-                                                    size="small"
-                                                    onClick={(e) => handleTestChannel(e, channel)}
-                                                    aria-label="send test notification"
-                                                    disabled={testingChannelId === channel.id}
-                                                >
-                                                    {testingChannelId === channel.id ? (
-                                                        <CircularProgress size={18} aria-label="Sending test" />
-                                                    ) : (
-                                                        <SendIcon fontSize="small" />
-                                                    )}
-                                                </IconButton>
-                                            </span>
-                                        </Tooltip>
-                                        <Tooltip title="Edit channel">
-                                            <IconButton
-                                                size="small"
-                                                onClick={(e) => handleOpenEdit(e, channel)}
-                                                aria-label="edit channel"
-                                            >
-                                                <EditIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="Delete channel">
-                                            <IconButton
-                                                size="small"
-                                                onClick={(e) => handleOpenDelete(e, channel)}
-                                                aria-label="delete channel"
-                                                sx={deleteIconSx}
-                                            >
-                                                <DeleteIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </TableCell>
-                                </TableRow>
-                            ))
-                        ) : (
-                            <TableRow>
-                                <TableCell colSpan={5} align="center" sx={emptyRowSx}>
-                                    <Typography color="text.secondary" sx={emptyRowTextSx}>
-                                        No webhook channels configured.
-                                    </Typography>
-                                </TableCell>
-                            </TableRow>
-                        )}
-                    </TableBody>
-                </Table>
-            </TableContainer>
-
-            {/* Create / Edit Channel Dialog */}
-            <Dialog
-                open={dialogOpen}
+            <ChannelDialogShell
+                open={crud.dialogOpen}
                 onClose={handleCloseDialog}
+                title={dialogTitle}
+                tabs={DIALOG_TABS}
+                activeTab={crud.dialogTab}
+                onTabChange={crud.setDialogTab}
+                error={crud.dialogError}
+                saving={crud.saving}
+                onSave={handleSaveChannel}
+                saveDisabled={!form.name.trim() || !form.endpoint_url.trim()}
+                saveLabel={isEditing ? 'Save' : 'Create'}
                 maxWidth="md"
-                fullWidth
             >
-                <DialogTitle sx={dialogTitleSx}>
-                    {isEditing ? `Edit channel: ${editingChannel.name}` : 'Create webhook channel'}
-                </DialogTitle>
-                <DialogContent>
-                    {dialogError && (
-                        <Alert severity="error" sx={{ mb: 2, mt: 1, borderRadius: 1 }}>
-                            {dialogError}
-                        </Alert>
-                    )}
-                    <Tabs
-                        value={dialogTab}
-                        onChange={(_e, newValue: number) => setDialogTab(newValue)}
-                        sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
-                    >
-                        <Tab label="Settings" />
-                        <Tab label="Headers" />
-                        <Tab label="Authentication" />
-                        <Tab label="Templates" />
-                    </Tabs>
+                <WebhookSettingsTab
+                    form={form}
+                    onChange={handleFormChange}
+                    saving={crud.saving}
+                    visible={crud.dialogTab === 0}
+                />
+                <WebhookHeadersTab
+                    headers={form.headers}
+                    onAddHeader={handleAddHeader}
+                    onChangeHeader={handleHeaderChange}
+                    onRemoveHeader={handleRemoveHeader}
+                    saving={crud.saving}
+                    visible={crud.dialogTab === 1}
+                />
+                <WebhookAuthTab
+                    authType={form.auth_type}
+                    authFields={authFields}
+                    onAuthTypeChange={handleAuthTypeChange}
+                    onAuthFieldChange={handleAuthFieldChange}
+                    saving={crud.saving}
+                    visible={crud.dialogTab === 2}
+                />
+                <WebhookTemplatesTab
+                    form={form}
+                    onChange={handleFormChange}
+                    saving={crud.saving}
+                    visible={crud.dialogTab === 3}
+                />
+            </ChannelDialogShell>
 
-                    {/* Tab 0: Settings */}
-                    <Box sx={{ display: dialogTab === 0 ? 'block' : 'none' }}>
-                        <TextField
-                            autoFocus
-                            fullWidth
-                            label="Name"
-                            value={form.name}
-                            onChange={(e) => handleFormChange('name', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            required
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="Description"
-                            value={form.description}
-                            onChange={(e) => handleFormChange('description', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            multiline
-                            rows={2}
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="Endpoint URL"
-                            value={form.endpoint_url}
-                            onChange={(e) => handleFormChange('endpoint_url', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            required
-                            InputLabelProps={{ shrink: true }}
-                        />
-                        <TextField
-                            fullWidth
-                            select
-                            label="HTTP Method"
-                            value={form.http_method}
-                            onChange={(e) => handleFormChange('http_method', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            InputLabelProps={{ shrink: true }}
-                            sx={SELECT_FIELD_SX}
-                        >
-                            {HTTP_METHODS.map((method) => (
-                                <MenuItem key={method} value={method}>
-                                    {method}
-                                </MenuItem>
-                            ))}
-                        </TextField>
-                        <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
-                            <FormControlLabel
-                                sx={{ ml: 0, gap: 1 }}
-                                control={
-                                    <Switch
-                                        checked={form.enabled}
-                                        onChange={(e) => handleFormChange('enabled', e.target.checked)}
-                                        disabled={saving}
-                                        inputProps={{ 'aria-label': 'Toggle channel enabled' }}
-                                    />
-                                }
-                                label="Enabled"
-                            />
-                            <FormControlLabel
-                                sx={{ ml: 0, gap: 1 }}
-                                control={
-                                    <Switch
-                                        checked={form.is_estate_default}
-                                        onChange={(e) => handleFormChange('is_estate_default', e.target.checked)}
-                                        disabled={saving}
-                                        inputProps={{ 'aria-label': 'Toggle estate default' }}
-                                    />
-                                }
-                                label={
-                                    <Box>
-                                        <Typography variant="body1">Estate Default</Typography>
-                                        <Typography variant="caption" color="text.secondary">
-                                            When enabled, this channel is active for all servers by default
-                                        </Typography>
-                                    </Box>
-                                }
-                            />
-                        </Box>
-                    </Box>
-
-                    {/* Tab 1: Headers */}
-                    <Box sx={{ display: dialogTab === 1 ? 'block' : 'none' }}>
-                        {form.headers.length > 0 ? (
-                            form.headers.map((header, index) => (
-                                <Box
-                                    key={index}
-                                    sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 1 }}
-                                >
-                                    <TextField
-                                        label="Key"
-                                        value={header.key}
-                                        onChange={(e) => handleHeaderChange(index, 'key', e.target.value)}
-                                        disabled={saving}
-                                        size="small"
-                                        sx={{ flex: 1 }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <TextField
-                                        label="Value"
-                                        value={header.value}
-                                        onChange={(e) => handleHeaderChange(index, 'value', e.target.value)}
-                                        disabled={saving}
-                                        size="small"
-                                        sx={{ flex: 1 }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <IconButton
-                                        size="small"
-                                        onClick={() => handleRemoveHeader(index)}
-                                        aria-label="remove header"
-                                        sx={deleteIconSx}
-                                        disabled={saving}
-                                    >
-                                        <DeleteIcon fontSize="small" />
-                                    </IconButton>
-                                </Box>
-                            ))
-                        ) : (
-                            <Typography
-                                color="text.secondary"
-                                sx={{ fontSize: '1rem', mb: 2, mt: 1 }}
-                            >
-                                No custom headers configured.
-                            </Typography>
-                        )}
-                        <Button
-                            size="small"
-                            variant="contained"
-                            startIcon={<AddIcon />}
-                            onClick={handleAddHeader}
-                            disabled={saving}
-                            sx={containedButtonSx}
-                        >
-                            Add Header
-                        </Button>
-                    </Box>
-
-                    {/* Tab 2: Authentication */}
-                    <Box sx={{ display: dialogTab === 2 ? 'block' : 'none' }}>
-                        <TextField
-                            fullWidth
-                            select
-                            label="Auth Type"
-                            value={form.auth_type}
-                            onChange={(e) => handleAuthTypeChange(e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            InputLabelProps={{ shrink: true }}
-                            sx={SELECT_FIELD_SX}
-                        >
-                            {AUTH_TYPES.map((type) => (
-                                <MenuItem key={type.value} value={type.value}>
-                                    {type.label}
-                                </MenuItem>
-                            ))}
-                        </TextField>
-
-                        {/* Basic auth fields */}
-                        {form.auth_type === 'basic' && (
-                            <>
-                                <TextField
-                                    fullWidth
-                                    label="Username"
-                                    value={authFields.username || ''}
-                                    onChange={(e) => handleAuthFieldChange('username', e.target.value)}
-                                    disabled={saving}
-                                    margin="dense"
-                                    InputLabelProps={{ shrink: true }}
-                                />
-                                <TextField
-                                    fullWidth
-                                    label="Password"
-                                    type="password"
-                                    value={authFields.password || ''}
-                                    onChange={(e) => handleAuthFieldChange('password', e.target.value)}
-                                    disabled={saving}
-                                    margin="dense"
-                                    InputLabelProps={{ shrink: true }}
-                                />
-                            </>
-                        )}
-
-                        {/* Bearer token field */}
-                        {form.auth_type === 'bearer' && (
-                            <TextField
-                                fullWidth
-                                label="Token"
-                                value={authFields.token || ''}
-                                onChange={(e) => handleAuthFieldChange('token', e.target.value)}
-                                disabled={saving}
-                                margin="dense"
-                                InputLabelProps={{ shrink: true }}
-                            />
-                        )}
-
-                        {/* API Key fields */}
-                        {form.auth_type === 'api_key' && (
-                            <>
-                                <TextField
-                                    fullWidth
-                                    label="Header Name"
-                                    value={authFields.headerName || ''}
-                                    onChange={(e) => handleAuthFieldChange('headerName', e.target.value)}
-                                    disabled={saving}
-                                    margin="dense"
-                                    InputLabelProps={{ shrink: true }}
-                                />
-                                <TextField
-                                    fullWidth
-                                    label="API Key Value"
-                                    value={authFields.apiKeyValue || ''}
-                                    onChange={(e) => handleAuthFieldChange('apiKeyValue', e.target.value)}
-                                    disabled={saving}
-                                    margin="dense"
-                                    InputLabelProps={{ shrink: true }}
-                                />
-                            </>
-                        )}
-                    </Box>
-
-                    {/* Tab 3: Templates */}
-                    <Box sx={{ display: dialogTab === 3 ? 'block' : 'none' }}>
-                        <Typography
-                            variant="body2"
-                            color="text.secondary"
-                            sx={{ mb: 2, mt: 1 }}
-                        >
-                            Templates use{' '}
-                            <a
-                                href="https://pkg.go.dev/text/template"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                style={{ color: 'inherit' }}
-                            >
-                                Go template syntax
-                            </a>
-                            . Leave blank to use the
-                            defaults shown as placeholders. Available variables: AlertID,
-                            AlertTitle, AlertDescription, Severity, SeverityColor,
-                            SeverityEmoji, ServerName, ServerHost, ServerPort, DatabaseName,
-                            MetricName, MetricValue, ThresholdValue, Operator, TriggeredAt,
-                            ClearedAt, Duration, ReminderCount, Timestamp.
-                        </Typography>
-                        <TextField
-                            fullWidth
-                            label="Alert Fire Template"
-                            value={form.template_alert_fire}
-                            onChange={(e) => handleFormChange('template_alert_fire', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            multiline
-                            rows={12}
-                            placeholder={DEFAULT_ALERT_FIRE_TEMPLATE}
-                            InputLabelProps={{ shrink: true }}
-                            InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.8rem' } }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="Alert Clear Template"
-                            value={form.template_alert_clear}
-                            onChange={(e) => handleFormChange('template_alert_clear', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            multiline
-                            rows={10}
-                            placeholder={DEFAULT_ALERT_CLEAR_TEMPLATE}
-                            InputLabelProps={{ shrink: true }}
-                            InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.8rem' } }}
-                        />
-                        <TextField
-                            fullWidth
-                            label="Alert Reminder Template"
-                            value={form.template_reminder}
-                            onChange={(e) => handleFormChange('template_reminder', e.target.value)}
-                            disabled={saving}
-                            margin="dense"
-                            multiline
-                            rows={10}
-                            placeholder={DEFAULT_REMINDER_TEMPLATE}
-                            InputLabelProps={{ shrink: true }}
-                            InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.8rem' } }}
-                        />
-                    </Box>
-                </DialogContent>
-                <DialogActions sx={dialogActionsSx}>
-                    <Button onClick={handleCloseDialog} disabled={saving}>
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={handleSaveChannel}
-                        variant="contained"
-                        disabled={saving || !form.name.trim() || !form.endpoint_url.trim()}
-                        sx={containedButtonSx}
-                    >
-                        {saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : (isEditing ? 'Save' : 'Create')}
-                    </Button>
-                </DialogActions>
-            </Dialog>
-
-            {/* Delete Confirmation Dialog */}
             <DeleteConfirmationDialog
-                open={deleteOpen}
-                onClose={() => { setDeleteOpen(false); setDeleteChannel(null); }}
-                onConfirm={handleDeleteChannel}
+                open={crud.deleteOpen}
+                onClose={crud.closeDelete}
+                onConfirm={crud.confirmDelete}
                 title="Delete Webhook Channel"
                 message="Are you sure you want to delete the webhook channel"
-                itemName={deleteChannel?.name ? `"${deleteChannel.name}"?` : '?'}
-                loading={deleteLoading}
+                itemName={
+                    crud.deleteChannel?.name ? `"${crud.deleteChannel.name}"?` : '?'
+                }
+                loading={crud.deleteLoading}
             />
-        </Box>
+        </>
     );
 };
 

--- a/client/src/components/AdminPanel/__tests__/AdminEmailChannels.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminEmailChannels.test.tsx
@@ -1239,5 +1239,109 @@ describe('AdminEmailChannels', () => {
                 );
             });
         });
+
+        it('shows warning when some recipients fail to add', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            // First call succeeds (channel creation), second call fails (recipient)
+            mockApiPost
+                .mockResolvedValueOnce({ id: 10 })
+                .mockRejectedValueOnce(new Error('Recipient error'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            const dialog = screen.getByRole('dialog');
+
+            // Fill in required fields
+            fireEvent.change(getFieldByLabel(dialog, 'Name'), { target: { value: 'New Channel' } });
+            fireEvent.change(getFieldByLabel(dialog, 'SMTP Host'), { target: { value: 'smtp.new.com' } });
+            fireEvent.change(getFieldByLabel(dialog, 'From Address'), { target: { value: 'new@example.com' } });
+
+            // Add a pending recipient
+            await user.click(within(dialog).getByRole('tab', { name: /Recipients/i }));
+            fireEvent.change(within(dialog).getByPlaceholderText('Email address'), { target: { value: 'fail@test.com' } });
+            await user.click(within(dialog).getByRole('button', { name: /^Add$/i }));
+
+            await waitFor(() => {
+                expect(within(dialog).getByText('fail@test.com')).toBeInTheDocument();
+            });
+
+            // Save the channel
+            await user.click(within(dialog).getByRole('button', { name: /Create/i }));
+
+            // Dialog should close immediately after channel creation
+            await waitFor(() => {
+                expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+            });
+
+            // Should show warning about failed recipients
+            await waitFor(() => {
+                expect(screen.getByText(/created successfully.*but failed to add recipients.*fail@test\.com/)).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Email validation', () => {
+        it('disables Add button when email has no @ sign', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            const emailInput = screen.getByPlaceholderText('Email address');
+            const addButton = screen.getByRole('button', { name: /^Add$/i });
+
+            // Enter email without @ sign
+            fireEvent.change(emailInput, { target: { value: 'invalidemail' } });
+
+            // Add button should be disabled
+            expect(addButton).toBeDisabled();
+
+            // Enter valid email with @ sign
+            fireEvent.change(emailInput, { target: { value: 'valid@email.com' } });
+
+            // Add button should be enabled
+            expect(addButton).not.toBeDisabled();
+        });
+
+        it('does not add pending recipient when email lacks @ sign', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            const emailInput = screen.getByPlaceholderText('Email address');
+
+            // Enter email without @ sign
+            fireEvent.change(emailInput, { target: { value: 'invalidemail' } });
+
+            // Force-enable the button by directly calling the handler via click
+            // The button is disabled, so clicking should do nothing
+            const addButton = screen.getByRole('button', { name: /^Add$/i });
+            expect(addButton).toBeDisabled();
+
+            // Verify no recipient was added
+            expect(screen.queryByText('invalidemail')).not.toBeInTheDocument();
+        });
     });
 });

--- a/client/src/components/AdminPanel/__tests__/AdminEmailChannels.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminEmailChannels.test.tsx
@@ -228,9 +228,9 @@ describe('AdminEmailChannels', () => {
             const dialog = screen.getByRole('dialog');
 
             // Fill in required fields
-            await user.type(getFieldByLabel(dialog, 'Name'), 'New Email Channel');
-            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.new.com');
-            await user.type(getFieldByLabel(dialog, 'From Address'), 'new@example.com');
+            fireEvent.change(getFieldByLabel(dialog, 'Name'), { target: { value: 'New Email Channel' } });
+            fireEvent.change(getFieldByLabel(dialog, 'SMTP Host'), { target: { value: 'smtp.new.com' } });
+            fireEvent.change(getFieldByLabel(dialog, 'From Address'), { target: { value: 'new@example.com' } });
 
             // Create button should now be enabled
             const createButton = within(dialog).getByRole('button', { name: /Create/i });
@@ -270,14 +270,13 @@ describe('AdminEmailChannels', () => {
             const dialog = screen.getByRole('dialog');
 
             // Fill in required fields with invalid port
-            await user.type(getFieldByLabel(dialog, 'Name'), 'Test');
-            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.test.com');
-            await user.type(getFieldByLabel(dialog, 'From Address'), 'test@test.com');
+            fireEvent.change(getFieldByLabel(dialog, 'Name'), { target: { value: 'Test' } });
+            fireEvent.change(getFieldByLabel(dialog, 'SMTP Host'), { target: { value: 'smtp.test.com' } });
+            fireEvent.change(getFieldByLabel(dialog, 'From Address'), { target: { value: 'test@test.com' } });
 
             // Clear port and type invalid value
             const portField = getFieldByLabel(dialog, 'SMTP Port');
-            await user.clear(portField);
-            await user.type(portField, '99999');
+            fireEvent.change(portField, { target: { value: '99999' } });
 
             await user.click(within(dialog).getByRole('button', { name: /Create/i }));
 
@@ -353,8 +352,7 @@ describe('AdminEmailChannels', () => {
 
             // Change only the name
             const nameField = getFieldByLabel(dialog, 'Name');
-            await user.clear(nameField);
-            await user.type(nameField, 'Updated Email');
+            fireEvent.change(nameField, { target: { value: 'Updated Email' } });
 
             await user.click(within(dialog).getByRole('button', { name: /Save/i }));
 
@@ -529,9 +527,9 @@ describe('AdminEmailChannels', () => {
 
             const dialog = screen.getByRole('dialog');
 
-            await user.type(getFieldByLabel(dialog, 'Name'), 'Test');
-            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.test.com');
-            await user.type(getFieldByLabel(dialog, 'From Address'), 'test@test.com');
+            fireEvent.change(getFieldByLabel(dialog, 'Name'), { target: { value: 'Test' } });
+            fireEvent.change(getFieldByLabel(dialog, 'SMTP Host'), { target: { value: 'smtp.test.com' } });
+            fireEvent.change(getFieldByLabel(dialog, 'From Address'), { target: { value: 'test@test.com' } });
 
             await user.click(within(dialog).getByRole('button', { name: /Create/i }));
 
@@ -560,9 +558,9 @@ describe('AdminEmailChannels', () => {
 
             const dialog = screen.getByRole('dialog');
 
-            await user.type(getFieldByLabel(dialog, 'Name'), 'Test');
-            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.test.com');
-            await user.type(getFieldByLabel(dialog, 'From Address'), 'test@test.com');
+            fireEvent.change(getFieldByLabel(dialog, 'Name'), { target: { value: 'Test' } });
+            fireEvent.change(getFieldByLabel(dialog, 'SMTP Host'), { target: { value: 'smtp.test.com' } });
+            fireEvent.change(getFieldByLabel(dialog, 'From Address'), { target: { value: 'test@test.com' } });
 
             await user.click(within(dialog).getByRole('button', { name: /Create/i }));
 
@@ -657,8 +655,8 @@ describe('AdminEmailChannels', () => {
             const emailInput = screen.getByPlaceholderText('Email address');
             const nameInput = screen.getByPlaceholderText('Display name');
 
-            await user.type(emailInput, 'newrecipient@test.com');
-            await user.type(nameInput, 'New Recipient');
+            fireEvent.change(emailInput, { target: { value: 'newrecipient@test.com' } });
+            fireEvent.change(nameInput, { target: { value: 'New Recipient' } });
 
             await user.click(screen.getByRole('button', { name: /Add/i }));
 
@@ -687,7 +685,7 @@ describe('AdminEmailChannels', () => {
             await user.click(screen.getByRole('tab', { name: /Recipients/i }));
 
             const emailInput = screen.getByPlaceholderText('Email address');
-            await user.type(emailInput, 'temp@test.com');
+            fireEvent.change(emailInput, { target: { value: 'temp@test.com' } });
 
             await user.click(screen.getByRole('button', { name: /Add/i }));
 
@@ -732,7 +730,7 @@ describe('AdminEmailChannels', () => {
             await user.click(screen.getByRole('tab', { name: /Recipients/i }));
 
             const emailInput = screen.getByPlaceholderText('Email address');
-            await user.type(emailInput, 'newuser@example.com');
+            fireEvent.change(emailInput, { target: { value: 'newuser@example.com' } });
 
             await user.click(screen.getByRole('button', { name: /Add/i }));
 
@@ -776,7 +774,7 @@ describe('AdminEmailChannels', () => {
             await user.click(screen.getByRole('tab', { name: /Recipients/i }));
 
             const emailInput = screen.getByPlaceholderText('Email address');
-            await user.type(emailInput, 'newuser@example.com');
+            fireEvent.change(emailInput, { target: { value: 'newuser@example.com' } });
 
             await user.click(screen.getByRole('button', { name: /Add/i }));
 
@@ -815,7 +813,7 @@ describe('AdminEmailChannels', () => {
             await user.click(screen.getByRole('tab', { name: /Recipients/i }));
 
             const emailInput = screen.getByPlaceholderText('Email address');
-            await user.type(emailInput, 'newuser@example.com');
+            fireEvent.change(emailInput, { target: { value: 'newuser@example.com' } });
 
             await user.click(screen.getByRole('button', { name: /Add/i }));
 
@@ -1149,9 +1147,9 @@ describe('AdminEmailChannels', () => {
 
             const dialog = screen.getByRole('dialog');
 
-            await user.type(getFieldByLabel(dialog, 'Name'), 'New Channel');
-            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.new.com');
-            await user.type(getFieldByLabel(dialog, 'From Address'), 'new@example.com');
+            fireEvent.change(getFieldByLabel(dialog, 'Name'), { target: { value: 'New Channel' } });
+            fireEvent.change(getFieldByLabel(dialog, 'SMTP Host'), { target: { value: 'smtp.new.com' } });
+            fireEvent.change(getFieldByLabel(dialog, 'From Address'), { target: { value: 'new@example.com' } });
 
             await user.click(within(dialog).getByRole('button', { name: /Create/i }));
 
@@ -1205,13 +1203,13 @@ describe('AdminEmailChannels', () => {
             const dialog = screen.getByRole('dialog');
 
             // Fill in required fields
-            await user.type(getFieldByLabel(dialog, 'Name'), 'New Channel');
-            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.new.com');
-            await user.type(getFieldByLabel(dialog, 'From Address'), 'new@example.com');
+            fireEvent.change(getFieldByLabel(dialog, 'Name'), { target: { value: 'New Channel' } });
+            fireEvent.change(getFieldByLabel(dialog, 'SMTP Host'), { target: { value: 'smtp.new.com' } });
+            fireEvent.change(getFieldByLabel(dialog, 'From Address'), { target: { value: 'new@example.com' } });
 
             // Add a pending recipient
             await user.click(within(dialog).getByRole('tab', { name: /Recipients/i }));
-            await user.type(within(dialog).getByPlaceholderText('Email address'), 'pending@test.com');
+            fireEvent.change(within(dialog).getByPlaceholderText('Email address'), { target: { value: 'pending@test.com' } });
             await user.click(within(dialog).getByRole('button', { name: /^Add$/i }));
 
             await waitFor(() => {

--- a/client/src/components/AdminPanel/__tests__/AdminEmailChannels.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminEmailChannels.test.tsx
@@ -1,0 +1,1245 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+const mockApiPut = vi.fn();
+const mockApiDelete = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+}));
+
+import AdminEmailChannels from '../AdminEmailChannels';
+
+/**
+ * Helper to find form fields in the dialog by their label text.
+ * MUI labels may have "(optional)" or "*" appended.
+ */
+const getFieldByLabel = (container: HTMLElement, labelText: string): HTMLElement => {
+    const labels = within(container).getAllByText(new RegExp(`^${labelText}`, 'i'));
+    // Find the label that is actually a form label
+    for (const label of labels) {
+        const forAttr = label.getAttribute('for');
+        if (forAttr) {
+            // Use getElementById to avoid CSS selector escaping issues with colons
+            const input = document.getElementById(forAttr);
+            if (input) {
+                return input as HTMLElement;
+            }
+        }
+    }
+    throw new Error(`Could not find field with label: ${labelText}`);
+};
+
+const mockEmailChannels = [
+    {
+        id: 1,
+        channel_type: 'email',
+        name: 'Test Email',
+        description: 'Test description',
+        enabled: true,
+        is_estate_default: false,
+        smtp_host: 'smtp.example.com',
+        smtp_port: 587,
+        smtp_username: 'user@example.com',
+        smtp_use_tls: true,
+        from_address: 'from@example.com',
+        from_name: 'Test Sender',
+        recipients: [],
+    },
+    {
+        id: 2,
+        channel_type: 'email',
+        name: 'Production Email',
+        description: 'Production notifications',
+        enabled: false,
+        is_estate_default: true,
+        smtp_host: 'smtp.prod.com',
+        smtp_port: 465,
+        smtp_username: 'prod@example.com',
+        smtp_use_tls: true,
+        from_address: 'alerts@prod.com',
+        from_name: 'Production Alerts',
+        recipients: [{ id: 1 }, { id: 2 }],
+    },
+];
+
+const mockRecipients = [
+    {
+        id: 1,
+        email_address: 'recipient1@example.com',
+        display_name: 'Recipient One',
+        enabled: true,
+    },
+    {
+        id: 2,
+        email_address: 'recipient2@example.com',
+        display_name: 'Recipient Two',
+        enabled: false,
+    },
+];
+
+describe('AdminEmailChannels', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('Loading and Initial State', () => {
+        it('renders loading state then channel list after fetch', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                return Promise.resolve({});
+            });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            // Check loading state
+            expect(screen.getByRole('progressbar')).toBeInTheDocument();
+
+            // Wait for channels to load
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            expect(screen.getByText('Production Email')).toBeInTheDocument();
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/notification-channels');
+        });
+
+        it('renders empty state when no email channels', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+        });
+
+        it('filters out non-email channels', async () => {
+            mockApiGet.mockResolvedValue({
+                notification_channels: [
+                    ...mockEmailChannels,
+                    {
+                        id: 3,
+                        channel_type: 'webhook',
+                        name: 'Webhook Channel',
+                        description: 'A webhook',
+                        enabled: true,
+                    },
+                ],
+            });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            expect(screen.queryByText('Webhook Channel')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('Create Dialog', () => {
+        it('opens create dialog with empty form', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            // Check form fields are empty - use the dialog context
+            const dialog = screen.getByRole('dialog');
+            expect(getFieldByLabel(dialog, 'Name')).toHaveValue('');
+            expect(getFieldByLabel(dialog, 'SMTP Host')).toHaveValue('');
+            expect(getFieldByLabel(dialog, 'SMTP Port')).toHaveValue(587);
+            expect(getFieldByLabel(dialog, 'From Address')).toHaveValue('');
+        });
+
+        it('validates required fields', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            // Create button should be disabled when required fields are empty
+            const dialog = screen.getByRole('dialog');
+            const createButton = within(dialog).getByRole('button', { name: /Create/i });
+            expect(createButton).toBeDisabled();
+        });
+
+        it('creates channel via API on save', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            mockApiPost.mockResolvedValue({ id: 10 });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            const dialog = screen.getByRole('dialog');
+
+            // Fill in required fields
+            await user.type(getFieldByLabel(dialog, 'Name'), 'New Email Channel');
+            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.new.com');
+            await user.type(getFieldByLabel(dialog, 'From Address'), 'new@example.com');
+
+            // Create button should now be enabled
+            const createButton = within(dialog).getByRole('button', { name: /Create/i });
+            expect(createButton).not.toBeDisabled();
+
+            await user.click(createButton);
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels',
+                    expect.objectContaining({
+                        channel_type: 'email',
+                        name: 'New Email Channel',
+                        smtp_host: 'smtp.new.com',
+                        from_address: 'new@example.com',
+                    })
+                );
+            });
+        });
+
+        it('shows validation error for invalid port', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            const dialog = screen.getByRole('dialog');
+
+            // Fill in required fields with invalid port
+            await user.type(getFieldByLabel(dialog, 'Name'), 'Test');
+            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.test.com');
+            await user.type(getFieldByLabel(dialog, 'From Address'), 'test@test.com');
+
+            // Clear port and type invalid value
+            const portField = getFieldByLabel(dialog, 'SMTP Port');
+            await user.clear(portField);
+            await user.type(portField, '99999');
+
+            await user.click(within(dialog).getByRole('button', { name: /Create/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText(/SMTP port must be a valid port number/)).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Edit Dialog', () => {
+        it('opens edit dialog populated with channel data', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: mockRecipients });
+                }
+                return Promise.resolve({});
+            });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            // Click edit on first channel
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            const dialog = screen.getByRole('dialog');
+
+            // Check form is populated
+            expect(getFieldByLabel(dialog, 'Name')).toHaveValue('Test Email');
+            expect(getFieldByLabel(dialog, 'SMTP Host')).toHaveValue('smtp.example.com');
+            expect(getFieldByLabel(dialog, 'SMTP Port')).toHaveValue(587);
+            expect(getFieldByLabel(dialog, 'From Address')).toHaveValue('from@example.com');
+        });
+
+        it('updates channel via API on save (sends only changed fields)', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: [] });
+                }
+                return Promise.resolve({});
+            });
+            mockApiPut.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            const dialog = screen.getByRole('dialog');
+
+            // Change only the name
+            const nameField = getFieldByLabel(dialog, 'Name');
+            await user.clear(nameField);
+            await user.type(nameField, 'Updated Email');
+
+            await user.click(within(dialog).getByRole('button', { name: /Save/i }));
+
+            await waitFor(() => {
+                expect(mockApiPut).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels/1',
+                    expect.objectContaining({
+                        name: 'Updated Email',
+                    })
+                );
+            });
+
+            // Should NOT include unchanged fields
+            const putCall = mockApiPut.mock.calls[0];
+            expect(putCall[1]).not.toHaveProperty('smtp_host');
+            expect(putCall[1]).not.toHaveProperty('smtp_port');
+        });
+    });
+
+    describe('Delete Channel', () => {
+        it('deletes channel via confirmation dialog', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const deleteButtons = screen.getAllByRole('button', { name: /delete channel/i });
+            await user.click(deleteButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Delete Email Channel')).toBeInTheDocument();
+            });
+
+            expect(screen.getByText(/Are you sure you want to delete the email channel/)).toBeInTheDocument();
+            expect(screen.getByText(/"Test Email"\?/)).toBeInTheDocument();
+
+            await user.click(screen.getByRole('button', { name: /Delete/i }));
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/notification-channels/1');
+            });
+        });
+
+        it('closes delete dialog on cancel', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const deleteButtons = screen.getAllByRole('button', { name: /delete channel/i });
+            await user.click(deleteButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Delete Email Channel')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+            await waitFor(() => {
+                expect(screen.queryByText('Delete Email Channel')).not.toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Toggle Enabled', () => {
+        it('toggles channel enabled state', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            mockApiPut.mockResolvedValue({});
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const enabledSwitches = screen.getAllByRole('checkbox', {
+                name: 'Toggle channel enabled',
+            });
+
+            // First channel is enabled
+            expect(enabledSwitches[0]).toBeChecked();
+
+            fireEvent.click(enabledSwitches[0]);
+
+            await waitFor(() => {
+                expect(mockApiPut).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels/1',
+                    { enabled: false }
+                );
+            });
+        });
+    });
+
+    describe('Test Email', () => {
+        it('sends test email', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            mockApiPost.mockResolvedValue({});
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const testButtons = screen.getAllByRole('button', { name: /send test email/i });
+            fireEvent.click(testButtons[0]);
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith('/api/v1/notification-channels/1/test');
+            });
+
+            await waitFor(() => {
+                expect(screen.getByText(/Test notification sent successfully/)).toBeInTheDocument();
+            });
+        });
+
+        it('shows spinner while testing', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            mockApiPost.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 100)));
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const testButtons = screen.getAllByRole('button', { name: /send test email/i });
+            fireEvent.click(testButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText('Sending test email')).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Error Handling', () => {
+        it('displays fetch error', async () => {
+            mockApiGet.mockRejectedValue(new Error('Network error'));
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Network error')).toBeInTheDocument();
+            });
+        });
+
+        it('displays save error in dialog', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            mockApiPost.mockRejectedValue(new Error('Failed to create channel'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            const dialog = screen.getByRole('dialog');
+
+            await user.type(getFieldByLabel(dialog, 'Name'), 'Test');
+            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.test.com');
+            await user.type(getFieldByLabel(dialog, 'From Address'), 'test@test.com');
+
+            await user.click(within(dialog).getByRole('button', { name: /Create/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Failed to create channel')).toBeInTheDocument();
+            });
+        });
+
+        it('displays fallback error when save throws non-Error', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            // Reject with a non-Error value
+            mockApiPost.mockRejectedValue('network error string');
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            const dialog = screen.getByRole('dialog');
+
+            await user.type(getFieldByLabel(dialog, 'Name'), 'Test');
+            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.test.com');
+            await user.type(getFieldByLabel(dialog, 'From Address'), 'test@test.com');
+
+            await user.click(within(dialog).getByRole('button', { name: /Create/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('An unexpected error occurred')).toBeInTheDocument();
+            });
+        });
+
+        it('displays delete error', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            mockApiDelete.mockRejectedValue(new Error('Cannot delete channel'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const deleteButtons = screen.getAllByRole('button', { name: /delete channel/i });
+            await user.click(deleteButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Delete Email Channel')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Delete/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Cannot delete channel')).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Recipients Tab', () => {
+        it('renders recipients in edit mode', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: mockRecipients });
+                }
+                return Promise.resolve({});
+            });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            // Click Recipients tab
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('recipient1@example.com')).toBeInTheDocument();
+            });
+
+            expect(screen.getByText('Recipient One')).toBeInTheDocument();
+            expect(screen.getByText('recipient2@example.com')).toBeInTheDocument();
+        });
+
+        it('adds pending recipient in create mode', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            // Click Recipients tab
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            // Add a pending recipient
+            const emailInput = screen.getByPlaceholderText('Email address');
+            const nameInput = screen.getByPlaceholderText('Display name');
+
+            await user.type(emailInput, 'newrecipient@test.com');
+            await user.type(nameInput, 'New Recipient');
+
+            await user.click(screen.getByRole('button', { name: /Add/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('newrecipient@test.com')).toBeInTheDocument();
+            });
+            expect(screen.getByText('New Recipient')).toBeInTheDocument();
+        });
+
+        it('removes pending recipient in create mode', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            const emailInput = screen.getByPlaceholderText('Email address');
+            await user.type(emailInput, 'temp@test.com');
+
+            await user.click(screen.getByRole('button', { name: /Add/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('temp@test.com')).toBeInTheDocument();
+            });
+
+            // Remove the pending recipient
+            await user.click(screen.getByRole('button', { name: /remove pending recipient/i }));
+
+            await waitFor(() => {
+                expect(screen.queryByText('temp@test.com')).not.toBeInTheDocument();
+            });
+        });
+
+        it('adds recipient via API in edit mode', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: [] });
+                }
+                return Promise.resolve({});
+            });
+            mockApiPost.mockResolvedValue({ id: 5 });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            const emailInput = screen.getByPlaceholderText('Email address');
+            await user.type(emailInput, 'newuser@example.com');
+
+            await user.click(screen.getByRole('button', { name: /Add/i }));
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels/1/recipients',
+                    expect.objectContaining({
+                        email_address: 'newuser@example.com',
+                        enabled: true,
+                    })
+                );
+            });
+        });
+
+        it('shows error when add recipient fails in edit mode', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: [] });
+                }
+                return Promise.resolve({});
+            });
+            mockApiPost.mockRejectedValue(new Error('Email already exists'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            const emailInput = screen.getByPlaceholderText('Email address');
+            await user.type(emailInput, 'newuser@example.com');
+
+            await user.click(screen.getByRole('button', { name: /Add/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Email already exists')).toBeInTheDocument();
+            });
+        });
+
+        it('shows fallback error when add recipient throws non-Error in edit mode', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: [] });
+                }
+                return Promise.resolve({});
+            });
+            // Reject with a non-Error value
+            mockApiPost.mockRejectedValue('network failure');
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            const emailInput = screen.getByPlaceholderText('Email address');
+            await user.type(emailInput, 'newuser@example.com');
+
+            await user.click(screen.getByRole('button', { name: /Add/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Failed to add recipient')).toBeInTheDocument();
+            });
+        });
+
+        it('toggles recipient enabled via API in edit mode', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: mockRecipients });
+                }
+                return Promise.resolve({});
+            });
+            mockApiPut.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('recipient1@example.com')).toBeInTheDocument();
+            });
+
+            // Find the toggle switch for the first recipient (enabled: true)
+            const recipientToggles = screen.getAllByRole('checkbox', {
+                name: 'Toggle recipient enabled',
+            });
+            expect(recipientToggles[0]).toBeChecked();
+
+            await user.click(recipientToggles[0]);
+
+            await waitFor(() => {
+                expect(mockApiPut).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels/1/recipients/1',
+                    { enabled: false }
+                );
+            });
+        });
+
+        it('shows error when toggle recipient fails', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: mockRecipients });
+                }
+                return Promise.resolve({});
+            });
+            mockApiPut.mockRejectedValue(new Error('Failed to update recipient'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('recipient1@example.com')).toBeInTheDocument();
+            });
+
+            const recipientToggles = screen.getAllByRole('checkbox', {
+                name: 'Toggle recipient enabled',
+            });
+
+            await user.click(recipientToggles[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Failed to update recipient')).toBeInTheDocument();
+            });
+        });
+
+        it('deletes recipient via API in edit mode', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: mockRecipients });
+                }
+                return Promise.resolve({});
+            });
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('recipient1@example.com')).toBeInTheDocument();
+            });
+
+            // Find and click the delete button for the first recipient
+            const deleteButtons = screen.getAllByRole('button', { name: /delete recipient/i });
+            await user.click(deleteButtons[0]);
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels/1/recipients/1'
+                );
+            });
+        });
+
+        it('shows error when delete recipient fails', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: mockRecipients });
+                }
+                return Promise.resolve({});
+            });
+            mockApiDelete.mockRejectedValue(new Error('Failed to delete recipient'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('recipient1@example.com')).toBeInTheDocument();
+            });
+
+            const deleteButtons = screen.getAllByRole('button', { name: /delete recipient/i });
+            await user.click(deleteButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Failed to delete recipient')).toBeInTheDocument();
+            });
+        });
+
+        it('shows fallback error when toggle recipient throws non-Error', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: mockRecipients });
+                }
+                return Promise.resolve({});
+            });
+            // Reject with a string instead of an Error object
+            mockApiPut.mockRejectedValue('string error');
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('recipient1@example.com')).toBeInTheDocument();
+            });
+
+            const recipientToggles = screen.getAllByRole('checkbox', {
+                name: 'Toggle recipient enabled',
+            });
+
+            await user.click(recipientToggles[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Failed to update recipient')).toBeInTheDocument();
+            });
+        });
+
+        it('shows fallback error when delete recipient throws non-Error', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.resolve({ recipients: mockRecipients });
+                }
+                return Promise.resolve({});
+            });
+            // Reject with a string instead of an Error object
+            mockApiDelete.mockRejectedValue('string error');
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: /Recipients/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('recipient1@example.com')).toBeInTheDocument();
+            });
+
+            const deleteButtons = screen.getAllByRole('button', { name: /delete recipient/i });
+            await user.click(deleteButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Failed to delete recipient')).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Close Dialog', () => {
+        it('closes dialog properly', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+            await waitFor(() => {
+                expect(screen.queryByText('Create email channel')).not.toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Recipient Count Column', () => {
+        it('displays recipient count in table', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            // Check that "Recipients" header exists
+            expect(screen.getByText('Recipients')).toBeInTheDocument();
+
+            // Production Email has 2 recipients
+            expect(screen.getByText('2')).toBeInTheDocument();
+            // Test Email has 0 recipients
+            expect(screen.getByText('0')).toBeInTheDocument();
+        });
+    });
+
+    describe('Success Messages', () => {
+        it('shows success message after channel creation', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            mockApiPost.mockResolvedValue({ id: 10 });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create email channel')).toBeInTheDocument();
+            });
+
+            const dialog = screen.getByRole('dialog');
+
+            await user.type(getFieldByLabel(dialog, 'Name'), 'New Channel');
+            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.new.com');
+            await user.type(getFieldByLabel(dialog, 'From Address'), 'new@example.com');
+
+            await user.click(within(dialog).getByRole('button', { name: /Create/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText(/Channel "New Channel" created successfully/)).toBeInTheDocument();
+            });
+        });
+
+        it('clears success message on dismiss', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockEmailChannels });
+            mockApiPost.mockResolvedValue({});
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            // Trigger success via test email
+            const testButtons = screen.getAllByRole('button', { name: /send test email/i });
+            fireEvent.click(testButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Test notification sent successfully/)).toBeInTheDocument();
+            });
+
+            // Dismiss the alert
+            const closeButton = screen.getByRole('button', { name: /close/i });
+            fireEvent.click(closeButton);
+
+            await waitFor(() => {
+                expect(screen.queryByText(/Test notification sent successfully/)).not.toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Creates channel with pending recipients', () => {
+        it('creates channel then adds pending recipients', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            mockApiPost.mockResolvedValue({ id: 10 });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No email channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            const dialog = screen.getByRole('dialog');
+
+            // Fill in required fields
+            await user.type(getFieldByLabel(dialog, 'Name'), 'New Channel');
+            await user.type(getFieldByLabel(dialog, 'SMTP Host'), 'smtp.new.com');
+            await user.type(getFieldByLabel(dialog, 'From Address'), 'new@example.com');
+
+            // Add a pending recipient
+            await user.click(within(dialog).getByRole('tab', { name: /Recipients/i }));
+            await user.type(within(dialog).getByPlaceholderText('Email address'), 'pending@test.com');
+            await user.click(within(dialog).getByRole('button', { name: /^Add$/i }));
+
+            await waitFor(() => {
+                expect(within(dialog).getByText('pending@test.com')).toBeInTheDocument();
+            });
+
+            // Save the channel
+            await user.click(within(dialog).getByRole('button', { name: /Create/i }));
+
+            await waitFor(() => {
+                // First call creates the channel
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels',
+                    expect.objectContaining({
+                        name: 'New Channel',
+                    })
+                );
+            });
+
+            await waitFor(() => {
+                // Second call adds the recipient
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels/10/recipients',
+                    expect.objectContaining({
+                        email_address: 'pending@test.com',
+                    })
+                );
+            });
+        });
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminWebhookChannels.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminWebhookChannels.test.tsx
@@ -1,0 +1,832 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+const mockApiPut = vi.fn();
+const mockApiDelete = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+}));
+
+import AdminWebhookChannels from '../AdminWebhookChannels';
+
+let uuidCounter = 0;
+
+const mockWebhookChannels = [
+    {
+        id: 1,
+        channel_type: 'webhook',
+        name: 'Test Webhook',
+        description: 'Test webhook description',
+        enabled: true,
+        is_estate_default: false,
+        endpoint_url: 'https://example.com/webhook',
+        http_method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        auth_type: 'bearer',
+        auth_credentials: 'test-token',
+        template_alert_fire: '',
+        template_alert_clear: '',
+        template_reminder: '',
+    },
+    {
+        id: 2,
+        channel_type: 'webhook',
+        name: 'Another Webhook',
+        description: 'Another description',
+        enabled: false,
+        is_estate_default: true,
+        endpoint_url: 'https://other.com/api',
+        http_method: 'PUT',
+        headers: {},
+        auth_type: 'basic',
+        auth_credentials: 'user:pass',
+        template_alert_fire: '{"custom": true}',
+        template_alert_clear: '',
+        template_reminder: '',
+    },
+];
+
+describe('AdminWebhookChannels', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        uuidCounter = 0;
+        vi.stubGlobal('crypto', {
+            randomUUID: vi.fn(() => `test-uuid-${++uuidCounter}`),
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('displays loading state initially', () => {
+        mockApiGet.mockReturnValue(new Promise(() => {}));
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(screen.getByLabelText('Loading webhook channels')).toBeInTheDocument();
+    });
+
+    it('renders channel list after loading', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('Another Webhook')).toBeInTheDocument();
+        expect(screen.getByText('Webhook channels')).toBeInTheDocument();
+    });
+
+    it('renders empty state when no webhook channels exist', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: [] });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No webhook channels configured.')).toBeInTheDocument();
+        });
+    });
+
+    it('filters out non-webhook channels', async () => {
+        const mixedChannels = [
+            ...mockWebhookChannels,
+            { id: 3, channel_type: 'email', name: 'Email Channel' },
+        ];
+        mockApiGet.mockResolvedValue({ notification_channels: mixedChannels });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+        });
+
+        expect(screen.queryByText('Email Channel')).not.toBeInTheDocument();
+    });
+
+    it('opens create dialog with empty form', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: [] });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No webhook channels configured.')).toBeInTheDocument();
+        });
+
+        const addButton = screen.getByRole('button', { name: /Add Channel/i });
+        await user.click(addButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
+        });
+
+        expect(screen.getByLabelText('Name *')).toHaveValue('');
+        expect(screen.getByLabelText('Endpoint URL *')).toHaveValue('');
+    });
+
+    it('opens edit dialog populated with channel data', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Edit channel: Test Webhook')).toBeInTheDocument();
+        });
+
+        expect(screen.getByLabelText('Name *')).toHaveValue('Test Webhook');
+        expect(screen.getByLabelText('Endpoint URL *')).toHaveValue('https://example.com/webhook');
+    });
+
+    it('validates required fields on save', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: [] });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No webhook channels configured.')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
+        });
+
+        // Try to save without filling in required fields
+        // The Create button should be disabled
+        const createButton = screen.getByRole('button', { name: 'Create' });
+        expect(createButton).toBeDisabled();
+
+        // Fill in name only
+        await user.type(screen.getByLabelText('Name *'), 'New Webhook');
+
+        // Should still be disabled (missing endpoint_url)
+        expect(createButton).toBeDisabled();
+
+        // Fill in endpoint URL
+        await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com/hook');
+
+        // Now should be enabled
+        expect(createButton).not.toBeDisabled();
+    });
+
+    it('creates channel via API on save', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: [] });
+        mockApiPost.mockResolvedValue({ id: 99 });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No webhook channels configured.')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
+        });
+
+        await user.type(screen.getByLabelText('Name *'), 'New Webhook');
+        await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com/hook');
+
+        await user.click(screen.getByRole('button', { name: 'Create' }));
+
+        await waitFor(() => {
+            expect(mockApiPost).toHaveBeenCalledWith(
+                '/api/v1/notification-channels',
+                expect.objectContaining({
+                    channel_type: 'webhook',
+                    name: 'New Webhook',
+                    endpoint_url: 'https://test.com/hook',
+                }),
+            );
+        });
+    });
+
+    it('updates channel via API with only changed fields', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+        mockApiPut.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Edit channel: Test Webhook')).toBeInTheDocument();
+        });
+
+        // Clear and change the name
+        const nameField = screen.getByLabelText('Name *');
+        await user.clear(nameField);
+        await user.type(nameField, 'Updated Webhook Name');
+
+        await user.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/notification-channels/1',
+                expect.objectContaining({
+                    name: 'Updated Webhook Name',
+                }),
+            );
+        });
+
+        // Should not include unchanged fields
+        const [, body] = mockApiPut.mock.calls[0];
+        expect(body).not.toHaveProperty('endpoint_url');
+        expect(body).not.toHaveProperty('http_method');
+    });
+
+    it('deletes channel via confirmation dialog', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+        mockApiDelete.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+        });
+
+        const deleteButtons = screen.getAllByRole('button', { name: 'delete channel' });
+        await user.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Delete Webhook Channel')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText(/"Test Webhook"\?/)).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+        await waitFor(() => {
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/notification-channels/1');
+        });
+    });
+
+    it('toggles channel enabled state', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+        mockApiPut.mockResolvedValue({});
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+        });
+
+        const switches = screen.getAllByRole('checkbox', { name: 'Toggle channel enabled' });
+        fireEvent.click(switches[0]);
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/notification-channels/1',
+                { enabled: false },
+            );
+        });
+    });
+
+    it('sends test notification', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+        mockApiPost.mockResolvedValue({});
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+        });
+
+        const testButtons = screen.getAllByRole('button', { name: 'send test notification' });
+        await user.click(testButtons[0]);
+
+        await waitFor(() => {
+            expect(mockApiPost).toHaveBeenCalledWith('/api/v1/notification-channels/1/test');
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText(/Test notification sent successfully/)).toBeInTheDocument();
+        });
+    });
+
+    it('displays error messages from API', async () => {
+        mockApiGet.mockRejectedValue(new Error('Network error'));
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Network error')).toBeInTheDocument();
+        });
+    });
+
+    it('displays success message after channel creation', async () => {
+        mockApiGet.mockResolvedValue({ notification_channels: [] });
+        mockApiPost.mockResolvedValue({ id: 99 });
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminWebhookChannels />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No webhook channels configured.')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
+        });
+
+        await user.type(screen.getByLabelText('Name *'), 'New Webhook');
+        await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com/hook');
+        await user.click(screen.getByRole('button', { name: 'Create' }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/Channel "New Webhook" created successfully/)).toBeInTheDocument();
+        });
+    });
+
+    describe('Headers tab', () => {
+        it('adds headers in the Headers tab', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            mockApiPost.mockResolvedValue({ id: 99 });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No webhook channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
+            });
+
+            // Fill required fields first
+            await user.type(screen.getByLabelText('Name *'), 'Test');
+            await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com');
+
+            // Navigate to Headers tab
+            await user.click(screen.getByRole('tab', { name: 'Headers' }));
+
+            expect(screen.getByText('No custom headers configured.')).toBeInTheDocument();
+
+            // Add a header
+            await user.click(screen.getByRole('button', { name: /Add Header/i }));
+
+            // Fill in header key and value
+            const keyField = screen.getByLabelText('Key');
+            const valueField = screen.getByLabelText('Value');
+            await user.type(keyField, 'X-Custom-Header');
+            await user.type(valueField, 'custom-value');
+
+            // Verify the "No custom headers" message is gone
+            expect(screen.queryByText('No custom headers configured.')).not.toBeInTheDocument();
+        });
+
+        it('removes headers in the Headers tab', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Webhook')).toBeInTheDocument();
+            });
+
+            // Navigate to Headers tab
+            await user.click(screen.getByRole('tab', { name: 'Headers' }));
+
+            // The existing header should be displayed
+            expect(screen.getByDisplayValue('Content-Type')).toBeInTheDocument();
+
+            // Remove the header
+            const removeButton = screen.getByRole('button', { name: 'remove header' });
+            await user.click(removeButton);
+
+            // Should now show empty state
+            expect(screen.getByText('No custom headers configured.')).toBeInTheDocument();
+        });
+
+        it('changes header key and value', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Headers' }));
+
+            const keyField = screen.getByDisplayValue('Content-Type');
+            await user.clear(keyField);
+            await user.type(keyField, 'X-New-Header');
+
+            expect(screen.getByDisplayValue('X-New-Header')).toBeInTheDocument();
+        });
+    });
+
+    describe('Authentication tab', () => {
+        it('displays bearer auth fields when bearer type is selected', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Authentication' }));
+
+            // Bearer is already selected for this channel
+            expect(screen.getByLabelText('Token')).toHaveValue('test-token');
+        });
+
+        it('displays basic auth fields when basic type is selected', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Another Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[1]); // Second channel has basic auth
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Another Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Authentication' }));
+
+            expect(screen.getByLabelText('Username')).toHaveValue('user');
+            expect(screen.getByLabelText('Password')).toHaveValue('pass');
+        });
+
+        it('displays different auth fields based on channel auth type', async () => {
+            // Test that basic auth shows username/password
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Another Webhook')).toBeInTheDocument();
+            });
+
+            // Second channel has basic auth type
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[1]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Another Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Authentication' }));
+
+            // Basic auth fields should be visible
+            expect(screen.getByLabelText('Username')).toHaveValue('user');
+            expect(screen.getByLabelText('Password')).toHaveValue('pass');
+
+            // Bearer token field should not be visible
+            expect(screen.queryByLabelText('Token')).not.toBeInTheDocument();
+            // API Key fields should not be visible
+            expect(screen.queryByLabelText('Header Name')).not.toBeInTheDocument();
+        });
+
+        it('shows no auth fields for none auth type', async () => {
+            // Create a channel with 'none' auth type
+            const channelWithNoAuth = [{
+                id: 3,
+                channel_type: 'webhook',
+                name: 'No Auth Webhook',
+                description: 'Test',
+                enabled: true,
+                is_estate_default: false,
+                endpoint_url: 'https://example.com/hook',
+                http_method: 'POST',
+                headers: {},
+                auth_type: 'none',
+                auth_credentials: '',
+                template_alert_fire: '',
+                template_alert_clear: '',
+                template_reminder: '',
+            }];
+            mockApiGet.mockResolvedValue({ notification_channels: channelWithNoAuth });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No Auth Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: No Auth Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Authentication' }));
+
+            // No credential fields should be visible for 'none' auth type
+            expect(screen.queryByLabelText('Token')).not.toBeInTheDocument();
+            expect(screen.queryByLabelText('Username')).not.toBeInTheDocument();
+            expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+            expect(screen.queryByLabelText('Header Name')).not.toBeInTheDocument();
+            expect(screen.queryByLabelText('API Key Value')).not.toBeInTheDocument();
+        });
+
+        it('displays api key auth fields', async () => {
+            // Create a channel with api_key auth type
+            const channelWithApiKey = [{
+                id: 4,
+                channel_type: 'webhook',
+                name: 'API Key Webhook',
+                description: 'Test',
+                enabled: true,
+                is_estate_default: false,
+                endpoint_url: 'https://example.com/hook',
+                http_method: 'POST',
+                headers: {},
+                auth_type: 'api_key',
+                auth_credentials: 'X-Api-Key:secret123',
+                template_alert_fire: '',
+                template_alert_clear: '',
+                template_reminder: '',
+            }];
+            mockApiGet.mockResolvedValue({ notification_channels: channelWithApiKey });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('API Key Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: API Key Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Authentication' }));
+
+            // API Key fields should be visible
+            expect(screen.getByLabelText('Header Name')).toHaveValue('X-Api-Key');
+            expect(screen.getByLabelText('API Key Value')).toHaveValue('secret123');
+
+            // Other auth fields should not be visible
+            expect(screen.queryByLabelText('Token')).not.toBeInTheDocument();
+            expect(screen.queryByLabelText('Username')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('Templates tab', () => {
+        it('displays template fields', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Another Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[1]); // Second channel has custom template
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Another Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Templates' }));
+
+            expect(screen.getByLabelText('Alert Fire Template')).toHaveValue('{"custom": true}');
+            expect(screen.getByText(/Go template syntax/)).toBeInTheDocument();
+        });
+
+        it('edits template content', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            mockApiPut.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Templates' }));
+
+            const alertFireField = screen.getByLabelText('Alert Fire Template');
+            // Use fireEvent.change to avoid userEvent curly brace parsing issues
+            fireEvent.change(alertFireField, { target: { value: '{"event": "test"}' } });
+
+            await user.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => {
+                expect(mockApiPut).toHaveBeenCalledWith(
+                    '/api/v1/notification-channels/1',
+                    expect.objectContaining({
+                        template_alert_fire: '{"event": "test"}',
+                    }),
+                );
+            });
+        });
+    });
+
+    describe('dialog behavior', () => {
+        it('closes dialog when Cancel is clicked', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No webhook channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+            await waitFor(() => {
+                expect(screen.queryByText('Create webhook channel')).not.toBeInTheDocument();
+            });
+        });
+
+        it('displays dialog error when save fails', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: [] });
+            mockApiPost.mockRejectedValue(new Error('Server error'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No webhook channels configured.')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
+            });
+
+            await user.type(screen.getByLabelText('Name *'), 'New Webhook');
+            await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com/hook');
+            await user.click(screen.getByRole('button', { name: 'Create' }));
+
+            await waitFor(() => {
+                const dialog = screen.getByRole('dialog');
+                expect(within(dialog).getByText('Server error')).toBeInTheDocument();
+            });
+        });
+
+        it('closes delete confirmation dialog when Cancel is clicked', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+            });
+
+            const deleteButtons = screen.getAllByRole('button', { name: 'delete channel' });
+            await user.click(deleteButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Delete Webhook Channel')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+            await waitFor(() => {
+                expect(screen.queryByText('Delete Webhook Channel')).not.toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('error dismissal', () => {
+        it('can dismiss error alerts', async () => {
+            mockApiGet.mockRejectedValue(new Error('Network error'));
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Network error')).toBeInTheDocument();
+            });
+
+            const closeButton = screen.getByRole('button', { name: /close/i });
+            fireEvent.click(closeButton);
+
+            await waitFor(() => {
+                expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+            });
+        });
+
+        it('can dismiss success alerts', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            mockApiPost.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+            });
+
+            const testButtons = screen.getAllByRole('button', { name: 'send test notification' });
+            await user.click(testButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Test notification sent successfully/)).toBeInTheDocument();
+            });
+
+            const closeButtons = screen.getAllByRole('button', { name: /close/i });
+            fireEvent.click(closeButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.queryByText(/Test notification sent successfully/)).not.toBeInTheDocument();
+            });
+        });
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminWebhookChannels.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminWebhookChannels.test.tsx
@@ -644,6 +644,78 @@ describe('AdminWebhookChannels', () => {
             expect(screen.queryByLabelText('Token')).not.toBeInTheDocument();
             expect(screen.queryByLabelText('Username')).not.toBeInTheDocument();
         });
+
+        it('masks sensitive credentials with password input type', async () => {
+            mockApiGet.mockResolvedValue({ notification_channels: mockWebhookChannels });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+            });
+
+            // Edit the first channel (bearer token auth)
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Authentication' }));
+
+            // Bearer token should be masked with password type
+            const tokenField = screen.getByLabelText('Token');
+            expect(tokenField).toHaveAttribute('type', 'password');
+            expect(tokenField).toHaveAttribute('autocomplete', 'off');
+        });
+
+        it('masks API key value with password input type', async () => {
+            // Create a channel with api_key auth type
+            const channelWithApiKey = [{
+                id: 4,
+                channel_type: 'webhook',
+                name: 'API Key Webhook',
+                description: 'Test',
+                enabled: true,
+                is_estate_default: false,
+                endpoint_url: 'https://example.com/hook',
+                http_method: 'POST',
+                headers: {},
+                auth_type: 'api_key',
+                auth_credentials: 'X-Api-Key:secret123',
+                template_alert_fire: '',
+                template_alert_clear: '',
+                template_reminder: '',
+            }];
+            mockApiGet.mockResolvedValue({ notification_channels: channelWithApiKey });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminWebhookChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('API Key Webhook')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: 'edit channel' });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: API Key Webhook')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('tab', { name: 'Authentication' }));
+
+            // API Key Value should be masked with password type
+            const apiKeyField = screen.getByLabelText('API Key Value');
+            expect(apiKeyField).toHaveAttribute('type', 'password');
+            expect(apiKeyField).toHaveAttribute('autocomplete', 'off');
+
+            // Header Name should NOT be masked (not a secret)
+            const headerNameField = screen.getByLabelText('Header Name');
+            expect(headerNameField).not.toHaveAttribute('type', 'password');
+        });
     });
 
     describe('Templates tab', () => {

--- a/client/src/components/AdminPanel/__tests__/AdminWebhookChannels.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminWebhookChannels.test.tsx
@@ -189,13 +189,13 @@ describe('AdminWebhookChannels', () => {
         expect(createButton).toBeDisabled();
 
         // Fill in name only
-        await user.type(screen.getByLabelText('Name *'), 'New Webhook');
+        fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'New Webhook' } });
 
         // Should still be disabled (missing endpoint_url)
         expect(createButton).toBeDisabled();
 
         // Fill in endpoint URL
-        await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com/hook');
+        fireEvent.change(screen.getByLabelText('Endpoint URL *'), { target: { value: 'https://test.com/hook' } });
 
         // Now should be enabled
         expect(createButton).not.toBeDisabled();
@@ -218,8 +218,8 @@ describe('AdminWebhookChannels', () => {
             expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
         });
 
-        await user.type(screen.getByLabelText('Name *'), 'New Webhook');
-        await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com/hook');
+        fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'New Webhook' } });
+        fireEvent.change(screen.getByLabelText('Endpoint URL *'), { target: { value: 'https://test.com/hook' } });
 
         await user.click(screen.getByRole('button', { name: 'Create' }));
 
@@ -255,8 +255,7 @@ describe('AdminWebhookChannels', () => {
 
         // Clear and change the name
         const nameField = screen.getByLabelText('Name *');
-        await user.clear(nameField);
-        await user.type(nameField, 'Updated Webhook Name');
+        fireEvent.change(nameField, { target: { value: 'Updated Webhook Name' } });
 
         await user.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -373,8 +372,8 @@ describe('AdminWebhookChannels', () => {
             expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
         });
 
-        await user.type(screen.getByLabelText('Name *'), 'New Webhook');
-        await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com/hook');
+        fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'New Webhook' } });
+        fireEvent.change(screen.getByLabelText('Endpoint URL *'), { target: { value: 'https://test.com/hook' } });
         await user.click(screen.getByRole('button', { name: 'Create' }));
 
         await waitFor(() => {
@@ -401,8 +400,8 @@ describe('AdminWebhookChannels', () => {
             });
 
             // Fill required fields first
-            await user.type(screen.getByLabelText('Name *'), 'Test');
-            await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com');
+            fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Test' } });
+            fireEvent.change(screen.getByLabelText('Endpoint URL *'), { target: { value: 'https://test.com' } });
 
             // Navigate to Headers tab
             await user.click(screen.getByRole('tab', { name: 'Headers' }));
@@ -415,8 +414,8 @@ describe('AdminWebhookChannels', () => {
             // Fill in header key and value
             const keyField = screen.getByLabelText('Key');
             const valueField = screen.getByLabelText('Value');
-            await user.type(keyField, 'X-Custom-Header');
-            await user.type(valueField, 'custom-value');
+            fireEvent.change(keyField, { target: { value: 'X-Custom-Header' } });
+            fireEvent.change(valueField, { target: { value: 'custom-value' } });
 
             // Verify the "No custom headers" message is gone
             expect(screen.queryByText('No custom headers configured.')).not.toBeInTheDocument();
@@ -473,8 +472,7 @@ describe('AdminWebhookChannels', () => {
             await user.click(screen.getByRole('tab', { name: 'Headers' }));
 
             const keyField = screen.getByDisplayValue('Content-Type');
-            await user.clear(keyField);
-            await user.type(keyField, 'X-New-Header');
+            fireEvent.change(keyField, { target: { value: 'X-New-Header' } });
 
             expect(screen.getByDisplayValue('X-New-Header')).toBeInTheDocument();
         });
@@ -750,8 +748,8 @@ describe('AdminWebhookChannels', () => {
                 expect(screen.getByText('Create webhook channel')).toBeInTheDocument();
             });
 
-            await user.type(screen.getByLabelText('Name *'), 'New Webhook');
-            await user.type(screen.getByLabelText('Endpoint URL *'), 'https://test.com/hook');
+            fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'New Webhook' } });
+            fireEvent.change(screen.getByLabelText('Endpoint URL *'), { target: { value: 'https://test.com/hook' } });
             await user.click(screen.getByRole('button', { name: 'Create' }));
 
             await waitFor(() => {

--- a/client/src/components/AdminPanel/channels/ChannelDialogShell.tsx
+++ b/client/src/components/AdminPanel/channels/ChannelDialogShell.tsx
@@ -1,0 +1,112 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Tab,
+    Tabs,
+    Alert,
+    CircularProgress,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { dialogTitleSx, dialogActionsSx, getContainedButtonSx } from '../styles';
+
+export interface ChannelDialogShellProps {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    tabs: string[];
+    activeTab: number;
+    onTabChange: (tab: number) => void;
+    error: string | null;
+    saving: boolean;
+    onSave: () => void;
+    saveDisabled: boolean;
+    saveLabel: string;
+    maxWidth?: 'sm' | 'md';
+    children: React.ReactNode;
+}
+
+export function ChannelDialogShell({
+    open,
+    onClose,
+    title,
+    tabs,
+    activeTab,
+    onTabChange,
+    error,
+    saving,
+    onSave,
+    saveDisabled,
+    saveLabel,
+    maxWidth = 'sm',
+    children,
+}: ChannelDialogShellProps): React.ReactElement | null {
+    const theme = useTheme();
+    const containedButtonSx = getContainedButtonSx(theme);
+
+    if (!open) {
+        return null;
+    }
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth={maxWidth}
+            fullWidth
+        >
+            <DialogTitle sx={dialogTitleSx}>{title}</DialogTitle>
+            <DialogContent>
+                {error && (
+                    <Alert severity="error" sx={{ mb: 2, mt: 1, borderRadius: 1 }}>
+                        {error}
+                    </Alert>
+                )}
+                <Tabs
+                    value={activeTab}
+                    onChange={(_e, newValue: number) => onTabChange(newValue)}
+                    sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+                >
+                    {tabs.map((label, index) => (
+                        <Tab key={index} label={label} />
+                    ))}
+                </Tabs>
+                {children}
+            </DialogContent>
+            <DialogActions sx={dialogActionsSx}>
+                <Button onClick={onClose} disabled={saving}>
+                    Cancel
+                </Button>
+                <Button
+                    onClick={onSave}
+                    variant="contained"
+                    disabled={saving || saveDisabled}
+                    sx={containedButtonSx}
+                >
+                    {saving ? (
+                        <CircularProgress
+                            size={20}
+                            color="inherit"
+                            aria-label="Saving"
+                        />
+                    ) : (
+                        saveLabel
+                    )}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/client/src/components/AdminPanel/channels/ChannelTable.tsx
+++ b/client/src/components/AdminPanel/channels/ChannelTable.tsx
@@ -1,0 +1,262 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import {
+    Box,
+    Typography,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Paper,
+    Button,
+    IconButton,
+    Switch,
+    Tooltip,
+    CircularProgress,
+    Alert,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import {
+    Add as AddIcon,
+    Edit as EditIcon,
+    Delete as DeleteIcon,
+    Send as SendIcon,
+} from '@mui/icons-material';
+import { truncateDescription } from '../../../utils/textHelpers';
+import {
+    tableHeaderCellSx,
+    pageHeadingSx,
+    loadingContainerSx,
+    emptyRowSx,
+    emptyRowTextSx,
+    getContainedButtonSx,
+    getDeleteIconSx,
+    getTableContainerSx,
+} from '../styles';
+import { BaseChannel, ChannelColumnDef } from './channelTypes';
+
+export interface ChannelTableProps<T extends BaseChannel> {
+    channels: T[];
+    loading: boolean;
+    extraColumns?: ChannelColumnDef<T>[];
+    testingChannelId: number | null;
+    onEdit: (e: React.MouseEvent, channel: T) => void;
+    onDelete: (e: React.MouseEvent, channel: T) => void;
+    onToggleEnabled: (channel: T) => void;
+    onTest: (e: React.MouseEvent, channel: T) => void;
+    onAdd: () => void;
+    emptyMessage: string;
+    testTooltip: string;
+    testAriaLabel: string;
+    testingAriaLabel: string;
+    title: string;
+    error: string | null;
+    success: string | null;
+    onClearError: () => void;
+    onClearSuccess: () => void;
+}
+
+export function ChannelTable<T extends BaseChannel>({
+    channels,
+    loading,
+    extraColumns = [],
+    testingChannelId,
+    onEdit,
+    onDelete,
+    onToggleEnabled,
+    onTest,
+    onAdd,
+    emptyMessage,
+    testTooltip,
+    testAriaLabel,
+    testingAriaLabel,
+    title,
+    error,
+    success,
+    onClearError,
+    onClearSuccess,
+}: ChannelTableProps<T>): React.ReactElement {
+    const theme = useTheme();
+
+    const containedButtonSx = getContainedButtonSx(theme);
+    const deleteIconSx = getDeleteIconSx(theme);
+    const tableContainerSx = getTableContainerSx(theme);
+
+    // Base columns (4) + extra columns + actions column (1)
+    const totalColumnCount = 4 + extraColumns.length + 1;
+
+    if (loading) {
+        return (
+            <Box sx={loadingContainerSx}>
+                <CircularProgress aria-label={`Loading ${title.toLowerCase()}`} />
+            </Box>
+        );
+    }
+
+    return (
+        <Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                <Typography variant="h6" sx={pageHeadingSx}>
+                    {title}
+                </Typography>
+                <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={onAdd}
+                    sx={containedButtonSx}
+                >
+                    Add Channel
+                </Button>
+            </Box>
+
+            {error && (
+                <Alert
+                    severity="error"
+                    sx={{ mb: 2, borderRadius: 1 }}
+                    onClose={onClearError}
+                >
+                    {error}
+                </Alert>
+            )}
+            {success && (
+                <Alert
+                    severity="success"
+                    sx={{ mb: 2, borderRadius: 1 }}
+                    onClose={onClearSuccess}
+                >
+                    {success}
+                </Alert>
+            )}
+
+            <TableContainer
+                component={Paper}
+                elevation={0}
+                sx={tableContainerSx}
+            >
+                <Table size="small">
+                    <TableHead>
+                        <TableRow>
+                            <TableCell sx={tableHeaderCellSx}>Name</TableCell>
+                            <TableCell sx={tableHeaderCellSx}>Description</TableCell>
+                            {extraColumns.map((col, index) => (
+                                <TableCell key={index} sx={tableHeaderCellSx}>
+                                    {col.label}
+                                </TableCell>
+                            ))}
+                            <TableCell sx={tableHeaderCellSx}>Enabled</TableCell>
+                            <TableCell sx={tableHeaderCellSx}>Estate Default</TableCell>
+                            <TableCell sx={tableHeaderCellSx} align="right">
+                                Actions
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {channels.length > 0 ? (
+                            channels.map((channel) => (
+                                <TableRow key={channel.id} hover>
+                                    <TableCell>{channel.name}</TableCell>
+                                    <TableCell>
+                                        {truncateDescription(channel.description)}
+                                    </TableCell>
+                                    {extraColumns.map((col, index) => (
+                                        <TableCell key={index}>
+                                            {col.render(channel)}
+                                        </TableCell>
+                                    ))}
+                                    <TableCell>
+                                        <Switch
+                                            checked={channel.enabled}
+                                            size="small"
+                                            onChange={() => onToggleEnabled(channel)}
+                                            inputProps={{
+                                                'aria-label': 'Toggle channel enabled',
+                                            }}
+                                        />
+                                    </TableCell>
+                                    <TableCell>
+                                        <Switch
+                                            checked={channel.is_estate_default}
+                                            size="small"
+                                            disabled
+                                            inputProps={{
+                                                'aria-label': 'Toggle estate default',
+                                            }}
+                                        />
+                                    </TableCell>
+                                    <TableCell align="right">
+                                        <Tooltip title={testTooltip}>
+                                            <span>
+                                                <IconButton
+                                                    size="small"
+                                                    onClick={(e) => onTest(e, channel)}
+                                                    aria-label={testAriaLabel}
+                                                    disabled={
+                                                        testingChannelId === channel.id
+                                                    }
+                                                >
+                                                    {testingChannelId === channel.id ? (
+                                                        <CircularProgress
+                                                            size={18}
+                                                            aria-label={testingAriaLabel}
+                                                        />
+                                                    ) : (
+                                                        <SendIcon fontSize="small" />
+                                                    )}
+                                                </IconButton>
+                                            </span>
+                                        </Tooltip>
+                                        <Tooltip title="Edit channel">
+                                            <IconButton
+                                                size="small"
+                                                onClick={(e) => onEdit(e, channel)}
+                                                aria-label="edit channel"
+                                            >
+                                                <EditIcon fontSize="small" />
+                                            </IconButton>
+                                        </Tooltip>
+                                        <Tooltip title="Delete channel">
+                                            <IconButton
+                                                size="small"
+                                                onClick={(e) => onDelete(e, channel)}
+                                                aria-label="delete channel"
+                                                sx={deleteIconSx}
+                                            >
+                                                <DeleteIcon fontSize="small" />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        ) : (
+                            <TableRow>
+                                <TableCell
+                                    colSpan={totalColumnCount}
+                                    align="center"
+                                    sx={emptyRowSx}
+                                >
+                                    <Typography
+                                        color="text.secondary"
+                                        sx={emptyRowTextSx}
+                                    >
+                                        {emptyMessage}
+                                    </Typography>
+                                </TableCell>
+                            </TableRow>
+                        )}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        </Box>
+    );
+}

--- a/client/src/components/AdminPanel/channels/__tests__/ChannelDialogShell.test.tsx
+++ b/client/src/components/AdminPanel/channels/__tests__/ChannelDialogShell.test.tsx
@@ -1,0 +1,236 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import renderWithTheme from '../../../../test/renderWithTheme';
+import {
+    ChannelDialogShell,
+    ChannelDialogShellProps,
+} from '../ChannelDialogShell';
+
+const createDefaultProps = (
+    overrides: Partial<ChannelDialogShellProps> = {}
+): ChannelDialogShellProps => ({
+    open: true,
+    onClose: vi.fn(),
+    title: 'Test Dialog',
+    tabs: ['Settings', 'Recipients'],
+    activeTab: 0,
+    onTabChange: vi.fn(),
+    error: null,
+    saving: false,
+    onSave: vi.fn(),
+    saveDisabled: false,
+    saveLabel: 'Save',
+    maxWidth: 'sm',
+    children: <div data-testid="dialog-content">Dialog content</div>,
+    ...overrides,
+});
+
+describe('ChannelDialogShell', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not render when open is false', () => {
+        const props = createDefaultProps({ open: false });
+
+        const { container } = renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders title when open', () => {
+        const props = createDefaultProps({ title: 'Edit Channel: My Channel' });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(screen.getByText('Edit Channel: My Channel')).toBeInTheDocument();
+    });
+
+    it('renders tabs', () => {
+        const props = createDefaultProps({
+            tabs: ['Settings', 'Headers', 'Authentication'],
+        });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(screen.getByRole('tab', { name: 'Settings' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Headers' })).toBeInTheDocument();
+        expect(
+            screen.getByRole('tab', { name: 'Authentication' })
+        ).toBeInTheDocument();
+    });
+
+    it('shows error alert when error is set', () => {
+        const props = createDefaultProps({ error: 'Failed to save channel' });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(screen.getByText('Failed to save channel')).toBeInTheDocument();
+    });
+
+    it('does not show error alert when error is null', () => {
+        const props = createDefaultProps({ error: null });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('calls onTabChange when tab is clicked', () => {
+        const onTabChange = vi.fn();
+        const props = createDefaultProps({
+            tabs: ['Settings', 'Recipients'],
+            activeTab: 0,
+            onTabChange,
+        });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        const recipientsTab = screen.getByRole('tab', { name: 'Recipients' });
+        fireEvent.click(recipientsTab);
+
+        expect(onTabChange).toHaveBeenCalledWith(1);
+    });
+
+    it('calls onSave when save button is clicked', () => {
+        const onSave = vi.fn();
+        const props = createDefaultProps({ onSave, saveLabel: 'Create' });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        const saveButton = screen.getByRole('button', { name: 'Create' });
+        fireEvent.click(saveButton);
+
+        expect(onSave).toHaveBeenCalled();
+    });
+
+    it('calls onClose when cancel is clicked', () => {
+        const onClose = vi.fn();
+        const props = createDefaultProps({ onClose });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+        fireEvent.click(cancelButton);
+
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('shows spinner when saving', () => {
+        const props = createDefaultProps({ saving: true, saveLabel: 'Save' });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(screen.getByLabelText('Saving')).toBeInTheDocument();
+        expect(screen.queryByText('Save')).not.toBeInTheDocument();
+    });
+
+    it('disables save button when saveDisabled is true', () => {
+        const props = createDefaultProps({ saveDisabled: true, saveLabel: 'Save' });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        const saveButton = screen.getByRole('button', { name: 'Save' });
+        expect(saveButton).toBeDisabled();
+    });
+
+    it('disables save button when saving is true', () => {
+        const props = createDefaultProps({ saving: true });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        // Find by progressbar since label text is hidden when saving
+        const progressbar = screen.getByLabelText('Saving');
+        const saveButton = progressbar.closest('button');
+        expect(saveButton).toBeDisabled();
+    });
+
+    it('disables cancel button when saving is true', () => {
+        const props = createDefaultProps({ saving: true });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+        expect(cancelButton).toBeDisabled();
+    });
+
+    it('renders children', () => {
+        const props = createDefaultProps({
+            children: <div data-testid="custom-content">Custom content</div>,
+        });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(screen.getByTestId('custom-content')).toBeInTheDocument();
+        expect(screen.getByText('Custom content')).toBeInTheDocument();
+    });
+
+    it('renders with correct active tab', () => {
+        const props = createDefaultProps({
+            tabs: ['Settings', 'Recipients'],
+            activeTab: 1,
+        });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        const recipientsTab = screen.getByRole('tab', { name: 'Recipients' });
+        expect(recipientsTab).toHaveAttribute('aria-selected', 'true');
+
+        const settingsTab = screen.getByRole('tab', { name: 'Settings' });
+        expect(settingsTab).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('uses custom saveLabel', () => {
+        const props = createDefaultProps({ saveLabel: 'Update Channel' });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(
+            screen.getByRole('button', { name: 'Update Channel' })
+        ).toBeInTheDocument();
+    });
+
+    it('enables save button when saveDisabled is false and not saving', () => {
+        const props = createDefaultProps({
+            saveDisabled: false,
+            saving: false,
+            saveLabel: 'Save',
+        });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        const saveButton = screen.getByRole('button', { name: 'Save' });
+        expect(saveButton).not.toBeDisabled();
+    });
+
+    it('renders single tab', () => {
+        const props = createDefaultProps({
+            tabs: ['Settings'],
+        });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(screen.getByRole('tab', { name: 'Settings' })).toBeInTheDocument();
+        expect(screen.getAllByRole('tab')).toHaveLength(1);
+    });
+
+    it('renders multiple tabs', () => {
+        const props = createDefaultProps({
+            tabs: ['Settings', 'Headers', 'Auth', 'Templates'],
+        });
+
+        renderWithTheme(<ChannelDialogShell {...props} />);
+
+        expect(screen.getAllByRole('tab')).toHaveLength(4);
+    });
+});

--- a/client/src/components/AdminPanel/channels/__tests__/ChannelTable.test.tsx
+++ b/client/src/components/AdminPanel/channels/__tests__/ChannelTable.test.tsx
@@ -1,0 +1,362 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Chip } from '@mui/material';
+import renderWithTheme from '../../../../test/renderWithTheme';
+import { ChannelTable, ChannelTableProps } from '../ChannelTable';
+import { BaseChannel, ChannelColumnDef } from '../channelTypes';
+
+interface TestChannel extends BaseChannel {
+    extra_field: string;
+}
+
+const createMockChannel = (overrides: Partial<TestChannel> = {}): TestChannel => ({
+    id: 1,
+    name: 'Test Channel',
+    description: 'A test channel description',
+    enabled: true,
+    is_estate_default: false,
+    extra_field: 'extra value',
+    ...overrides,
+});
+
+const createDefaultProps = (
+    overrides: Partial<ChannelTableProps<TestChannel>> = {}
+): ChannelTableProps<TestChannel> => ({
+    channels: [],
+    loading: false,
+    extraColumns: [],
+    testingChannelId: null,
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onToggleEnabled: vi.fn(),
+    onTest: vi.fn(),
+    onAdd: vi.fn(),
+    emptyMessage: 'No channels configured.',
+    testTooltip: 'Send test notification',
+    testAriaLabel: 'send test notification',
+    testingAriaLabel: 'Sending test',
+    title: 'Test channels',
+    error: null,
+    success: null,
+    onClearError: vi.fn(),
+    onClearSuccess: vi.fn(),
+    ...overrides,
+});
+
+describe('ChannelTable', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders loading spinner when loading is true', () => {
+        const props = createDefaultProps({ loading: true });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(
+            screen.getByLabelText('Loading test channels')
+        ).toBeInTheDocument();
+    });
+
+    it('renders empty state message when channels is empty', () => {
+        const props = createDefaultProps({
+            channels: [],
+            emptyMessage: 'No channels configured.',
+        });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(screen.getByText('No channels configured.')).toBeInTheDocument();
+    });
+
+    it('renders channel rows with name and description', () => {
+        const channels = [
+            createMockChannel({ id: 1, name: 'Email Channel', description: 'Sends emails' }),
+            createMockChannel({ id: 2, name: 'Webhook Channel', description: 'Sends webhooks' }),
+        ];
+        const props = createDefaultProps({ channels });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(screen.getByText('Email Channel')).toBeInTheDocument();
+        expect(screen.getByText('Sends emails')).toBeInTheDocument();
+        expect(screen.getByText('Webhook Channel')).toBeInTheDocument();
+        expect(screen.getByText('Sends webhooks')).toBeInTheDocument();
+    });
+
+    it('renders enabled switch for each channel', () => {
+        const channels = [
+            createMockChannel({ id: 1, enabled: true }),
+            createMockChannel({ id: 2, enabled: false }),
+        ];
+        const props = createDefaultProps({ channels });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        const switches = screen.getAllByRole('checkbox', {
+            name: 'Toggle channel enabled',
+        });
+        expect(switches).toHaveLength(2);
+        expect(switches[0]).toBeChecked();
+        expect(switches[1]).not.toBeChecked();
+    });
+
+    it('renders action buttons for each channel', () => {
+        const channels = [createMockChannel()];
+        const props = createDefaultProps({ channels });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(
+            screen.getByRole('button', { name: 'send test notification' })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'edit channel' })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'delete channel' })
+        ).toBeInTheDocument();
+    });
+
+    it('calls onToggleEnabled when switch is clicked', () => {
+        const onToggleEnabled = vi.fn();
+        const channel = createMockChannel();
+        const props = createDefaultProps({
+            channels: [channel],
+            onToggleEnabled,
+        });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        const enabledSwitch = screen.getByRole('checkbox', {
+            name: 'Toggle channel enabled',
+        });
+        fireEvent.click(enabledSwitch);
+
+        expect(onToggleEnabled).toHaveBeenCalledWith(channel);
+    });
+
+    it('calls onEdit when edit button is clicked', () => {
+        const onEdit = vi.fn();
+        const channel = createMockChannel();
+        const props = createDefaultProps({ channels: [channel], onEdit });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        const editButton = screen.getByRole('button', { name: 'edit channel' });
+        fireEvent.click(editButton);
+
+        expect(onEdit).toHaveBeenCalledWith(expect.any(Object), channel);
+    });
+
+    it('calls onDelete when delete button is clicked', () => {
+        const onDelete = vi.fn();
+        const channel = createMockChannel();
+        const props = createDefaultProps({ channels: [channel], onDelete });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        const deleteButton = screen.getByRole('button', {
+            name: 'delete channel',
+        });
+        fireEvent.click(deleteButton);
+
+        expect(onDelete).toHaveBeenCalledWith(expect.any(Object), channel);
+    });
+
+    it('calls onTest when test button is clicked', () => {
+        const onTest = vi.fn();
+        const channel = createMockChannel();
+        const props = createDefaultProps({ channels: [channel], onTest });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        const testButton = screen.getByRole('button', {
+            name: 'send test notification',
+        });
+        fireEvent.click(testButton);
+
+        expect(onTest).toHaveBeenCalledWith(expect.any(Object), channel);
+    });
+
+    it('calls onAdd when Add Channel button is clicked', () => {
+        const onAdd = vi.fn();
+        const props = createDefaultProps({ onAdd });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        const addButton = screen.getByRole('button', { name: /Add Channel/i });
+        fireEvent.click(addButton);
+
+        expect(onAdd).toHaveBeenCalled();
+    });
+
+    it('renders extra columns when provided', () => {
+        const extraColumns: ChannelColumnDef<TestChannel>[] = [
+            {
+                label: 'Recipients',
+                render: (channel) => (
+                    <Chip label={channel.extra_field} size="small" />
+                ),
+            },
+        ];
+        const channels = [createMockChannel({ extra_field: '5' })];
+        const props = createDefaultProps({ channels, extraColumns });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(screen.getByText('Recipients')).toBeInTheDocument();
+        expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
+    it('renders error alert when error is set', () => {
+        const onClearError = vi.fn();
+        const props = createDefaultProps({
+            error: 'Failed to load channels',
+            onClearError,
+        });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(screen.getByText('Failed to load channels')).toBeInTheDocument();
+
+        const closeButton = screen.getByRole('button', { name: /close/i });
+        fireEvent.click(closeButton);
+
+        expect(onClearError).toHaveBeenCalled();
+    });
+
+    it('renders success alert when success is set', () => {
+        const onClearSuccess = vi.fn();
+        const props = createDefaultProps({
+            success: 'Channel created successfully',
+            onClearSuccess,
+        });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(
+            screen.getByText('Channel created successfully')
+        ).toBeInTheDocument();
+
+        const closeButton = screen.getByRole('button', { name: /close/i });
+        fireEvent.click(closeButton);
+
+        expect(onClearSuccess).toHaveBeenCalled();
+    });
+
+    it('shows testing spinner for the channel being tested', () => {
+        const channel = createMockChannel({ id: 42 });
+        const props = createDefaultProps({
+            channels: [channel],
+            testingChannelId: 42,
+            testingAriaLabel: 'Sending test email',
+        });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(screen.getByLabelText('Sending test email')).toBeInTheDocument();
+
+        const testButton = screen.getByRole('button', {
+            name: 'send test notification',
+        });
+        expect(testButton).toBeDisabled();
+    });
+
+    it('does not show testing spinner for channels not being tested', () => {
+        const channels = [
+            createMockChannel({ id: 1 }),
+            createMockChannel({ id: 2, name: 'Other Channel' }),
+        ];
+        const props = createDefaultProps({
+            channels,
+            testingChannelId: 1,
+        });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        const testButtons = screen.getAllByRole('button', {
+            name: 'send test notification',
+        });
+        expect(testButtons[0]).toBeDisabled();
+        expect(testButtons[1]).not.toBeDisabled();
+    });
+
+    it('renders title in the header', () => {
+        const props = createDefaultProps({ title: 'Email channels' });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(
+            screen.getByRole('heading', { name: 'Email channels' })
+        ).toBeInTheDocument();
+    });
+
+    it('renders estate default switch as disabled for each channel', () => {
+        const channels = [createMockChannel({ is_estate_default: true })];
+        const props = createDefaultProps({ channels });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        const estateDefaultSwitch = screen.getByRole('checkbox', {
+            name: 'Toggle estate default',
+        });
+        expect(estateDefaultSwitch).toBeDisabled();
+        expect(estateDefaultSwitch).toBeChecked();
+    });
+
+    it('truncates long descriptions', () => {
+        const longDescription =
+            'This is a very long description that should be truncated when displayed in the table view to prevent overflow issues';
+        const channels = [
+            createMockChannel({ description: longDescription }),
+        ];
+        const props = createDefaultProps({ channels });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(
+            screen.queryByText(longDescription)
+        ).not.toBeInTheDocument();
+        expect(screen.getByText(/This is a very long/)).toBeInTheDocument();
+    });
+
+    it('renders table headers', () => {
+        const props = createDefaultProps();
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(screen.getByText('Name')).toBeInTheDocument();
+        expect(screen.getByText('Description')).toBeInTheDocument();
+        expect(screen.getByText('Enabled')).toBeInTheDocument();
+        expect(screen.getByText('Estate Default')).toBeInTheDocument();
+        expect(screen.getByText('Actions')).toBeInTheDocument();
+    });
+
+    it('renders multiple extra columns in correct order', () => {
+        const extraColumns: ChannelColumnDef<TestChannel>[] = [
+            { label: 'Column A', render: () => 'Value A' },
+            { label: 'Column B', render: () => 'Value B' },
+        ];
+        const channels = [createMockChannel()];
+        const props = createDefaultProps({ channels, extraColumns });
+
+        renderWithTheme(<ChannelTable {...props} />);
+
+        expect(screen.getByText('Column A')).toBeInTheDocument();
+        expect(screen.getByText('Column B')).toBeInTheDocument();
+        expect(screen.getByText('Value A')).toBeInTheDocument();
+        expect(screen.getByText('Value B')).toBeInTheDocument();
+    });
+});

--- a/client/src/components/AdminPanel/channels/__tests__/useChannelCRUD.test.ts
+++ b/client/src/components/AdminPanel/channels/__tests__/useChannelCRUD.test.ts
@@ -1,0 +1,782 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useChannelCRUD, BaseChannel } from '../index';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+const mockApiPut = vi.fn();
+const mockApiDelete = vi.fn();
+
+vi.mock('../../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Test Types and Helpers
+// ---------------------------------------------------------------------------
+
+interface TestChannel extends BaseChannel {
+    extra_field: string;
+}
+
+const mapTestChannel = (raw: Record<string, unknown>): TestChannel => ({
+    id: raw.id as number,
+    name: raw.name as string,
+    description: (raw.description as string) || '',
+    enabled: raw.enabled as boolean,
+    is_estate_default: raw.is_estate_default as boolean,
+    extra_field: (raw.extra_field as string) || '',
+});
+
+function makeRawChannels(type: 'email' | 'webhook' = 'email'): Record<string, unknown>[] {
+    return [
+        {
+            id: 1,
+            name: 'Channel One',
+            description: 'First channel',
+            enabled: true,
+            is_estate_default: false,
+            channel_type: type,
+            extra_field: 'extra1',
+        },
+        {
+            id: 2,
+            name: 'Channel Two',
+            description: 'Second channel',
+            enabled: false,
+            is_estate_default: true,
+            channel_type: type,
+            extra_field: 'extra2',
+        },
+    ];
+}
+
+function makeApiResponse(channels: Record<string, unknown>[]): Record<string, unknown> {
+    return { notification_channels: channels };
+}
+
+function createMockMouseEvent(): React.MouseEvent {
+    return {
+        stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useChannelCRUD', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    // -----------------------------------------------------------------------
+    // Initial State and Fetch Tests
+    // -----------------------------------------------------------------------
+
+    describe('fetching channels', () => {
+        it('fetches channels on mount and filters by channel_type', async () => {
+            const emailChannels = makeRawChannels('email');
+            const webhookChannels = makeRawChannels('webhook').map((ch) => ({
+                ...ch,
+                id: ch.id as number + 10,
+                channel_type: 'webhook',
+            }));
+            const allChannels = [...emailChannels, ...webhookChannels];
+            mockApiGet.mockResolvedValueOnce(makeApiResponse(allChannels));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            // Initially loading
+            expect(result.current.loading).toBe(true);
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(mockApiGet).toHaveBeenCalledTimes(1);
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/notification-channels');
+            expect(result.current.channels).toHaveLength(2);
+            expect(result.current.channels[0].id).toBe(1);
+            expect(result.current.channels[1].id).toBe(2);
+            expect(result.current.error).toBeNull();
+        });
+
+        it('handles fetch error', async () => {
+            mockApiGet.mockRejectedValueOnce(new Error('Network error'));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.error).toBe('Network error');
+            });
+
+            expect(result.current.channels).toHaveLength(0);
+            expect(result.current.loading).toBe(false);
+        });
+
+        it('handles non-Error fetch failure', async () => {
+            mockApiGet.mockRejectedValueOnce('Some string error');
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.error).toBe('An unexpected error occurred');
+            });
+        });
+
+        it('handles response without notification_channels wrapper', async () => {
+            const channels = makeRawChannels('email');
+            mockApiGet.mockResolvedValueOnce(channels);
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.channels).toHaveLength(2);
+        });
+
+        it('refetches when fetchChannels is called', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(mockApiGet).toHaveBeenCalledTimes(1);
+            });
+
+            await act(async () => {
+                await result.current.fetchChannels();
+            });
+
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Toggle Enabled Tests
+    // -----------------------------------------------------------------------
+
+    describe('toggleEnabled', () => {
+        it('calls apiPut with negated enabled and refetches', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiPut.mockResolvedValueOnce({});
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            const channel = result.current.channels[0];
+            expect(channel.enabled).toBe(true);
+
+            await act(async () => {
+                await result.current.toggleEnabled(channel);
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/notification-channels/1',
+                { enabled: false }
+            );
+            expect(mockApiGet).toHaveBeenCalledTimes(2);
+        });
+
+        it('sets error on toggleEnabled failure', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiPut.mockRejectedValueOnce(new Error('Toggle failed'));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            await act(async () => {
+                await result.current.toggleEnabled(result.current.channels[0]);
+            });
+
+            expect(result.current.error).toBe('Toggle failed');
+        });
+
+        it('handles non-Error toggleEnabled failure', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiPut.mockRejectedValueOnce('String error');
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            await act(async () => {
+                await result.current.toggleEnabled(result.current.channels[0]);
+            });
+
+            expect(result.current.error).toBe('An unexpected error occurred');
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Test Channel Tests
+    // -----------------------------------------------------------------------
+
+    describe('testChannel', () => {
+        it('sets testingChannelId, calls apiPost, and sets success', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiPost.mockResolvedValueOnce({});
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            const mockEvent = createMockMouseEvent();
+            const channel = result.current.channels[0];
+
+            // Use a promise to track the test operation
+            let testPromise: Promise<void>;
+            act(() => {
+                testPromise = result.current.testChannel(mockEvent, channel);
+            });
+
+            // Check testingChannelId was set
+            expect(result.current.testingChannelId).toBe(1);
+
+            await act(async () => {
+                await testPromise;
+            });
+
+            expect(mockEvent.stopPropagation).toHaveBeenCalled();
+            expect(mockApiPost).toHaveBeenCalledWith('/api/v1/notification-channels/1/test');
+            expect(result.current.success).toBe('Test notification sent successfully for "Channel One".');
+            expect(result.current.testingChannelId).toBeNull();
+        });
+
+        it('sets error on testChannel failure', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiPost.mockRejectedValueOnce(new Error('Test failed'));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            const mockEvent = createMockMouseEvent();
+
+            await act(async () => {
+                await result.current.testChannel(mockEvent, result.current.channels[0]);
+            });
+
+            expect(result.current.error).toBe('Test failed');
+            expect(result.current.testingChannelId).toBeNull();
+        });
+
+        it('handles non-Error testChannel failure', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiPost.mockRejectedValueOnce('String error');
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            const mockEvent = createMockMouseEvent();
+
+            await act(async () => {
+                await result.current.testChannel(mockEvent, result.current.channels[0]);
+            });
+
+            expect(result.current.error).toBe('Failed to send test notification');
+        });
+
+        it('clears previous error when testChannel is called', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiPost.mockResolvedValueOnce({});
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            // Set an error first
+            act(() => {
+                result.current.setError('Previous error');
+            });
+            expect(result.current.error).toBe('Previous error');
+
+            const mockEvent = createMockMouseEvent();
+
+            await act(async () => {
+                await result.current.testChannel(mockEvent, result.current.channels[0]);
+            });
+
+            // Error should be null after successful test
+            expect(result.current.error).toBeNull();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Delete Flow Tests
+    // -----------------------------------------------------------------------
+
+    describe('delete flow', () => {
+        it('openDelete sets deleteChannel and deleteOpen', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            const mockEvent = createMockMouseEvent();
+
+            act(() => {
+                result.current.openDelete(mockEvent, result.current.channels[0]);
+            });
+
+            expect(mockEvent.stopPropagation).toHaveBeenCalled();
+            expect(result.current.deleteOpen).toBe(true);
+            expect(result.current.deleteChannel).toEqual(result.current.channels[0]);
+        });
+
+        it('confirmDelete calls apiDelete, refetches, and clears state', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiDelete.mockResolvedValueOnce({});
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            // Open delete dialog
+            const mockEvent = createMockMouseEvent();
+            act(() => {
+                result.current.openDelete(mockEvent, result.current.channels[0]);
+            });
+
+            // Confirm delete
+            await act(async () => {
+                await result.current.confirmDelete();
+            });
+
+            expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/notification-channels/1');
+            expect(result.current.deleteOpen).toBe(false);
+            expect(result.current.deleteChannel).toBeNull();
+            expect(result.current.success).toBe('Channel "Channel One" deleted successfully.');
+            expect(mockApiGet).toHaveBeenCalledTimes(2); // Initial + refetch
+        });
+
+        it('confirmDelete does nothing if deleteChannel is null', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            // Try to confirm without opening delete dialog
+            await act(async () => {
+                await result.current.confirmDelete();
+            });
+
+            expect(mockApiDelete).not.toHaveBeenCalled();
+        });
+
+        it('confirmDelete sets error on failure', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiDelete.mockRejectedValueOnce(new Error('Delete failed'));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            // Open delete dialog
+            const mockEvent = createMockMouseEvent();
+            act(() => {
+                result.current.openDelete(mockEvent, result.current.channels[0]);
+            });
+
+            // Confirm delete
+            await act(async () => {
+                await result.current.confirmDelete();
+            });
+
+            expect(result.current.error).toBe('Delete failed');
+            expect(result.current.deleteLoading).toBe(false);
+        });
+
+        it('handles non-Error delete failure', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+            mockApiDelete.mockRejectedValueOnce('String error');
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            const mockEvent = createMockMouseEvent();
+            act(() => {
+                result.current.openDelete(mockEvent, result.current.channels[0]);
+            });
+
+            await act(async () => {
+                await result.current.confirmDelete();
+            });
+
+            expect(result.current.error).toBe('An unexpected error occurred');
+        });
+
+        it('closeDelete clears state', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            // Open delete dialog
+            const mockEvent = createMockMouseEvent();
+            act(() => {
+                result.current.openDelete(mockEvent, result.current.channels[0]);
+            });
+
+            expect(result.current.deleteOpen).toBe(true);
+
+            // Close
+            act(() => {
+                result.current.closeDelete();
+            });
+
+            expect(result.current.deleteOpen).toBe(false);
+            expect(result.current.deleteChannel).toBeNull();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Dialog State Tests
+    // -----------------------------------------------------------------------
+
+    describe('dialog state', () => {
+        it('openCreate resets editing to null and opens dialog', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            act(() => {
+                result.current.openCreate();
+            });
+
+            expect(result.current.dialogOpen).toBe(true);
+            expect(result.current.editingChannel).toBeNull();
+            expect(result.current.dialogTab).toBe(0);
+            expect(result.current.dialogError).toBeNull();
+        });
+
+        it('openEdit stores channel and opens dialog', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            const mockEvent = createMockMouseEvent();
+            const channel = result.current.channels[0];
+
+            act(() => {
+                result.current.openEdit(mockEvent, channel);
+            });
+
+            expect(mockEvent.stopPropagation).toHaveBeenCalled();
+            expect(result.current.dialogOpen).toBe(true);
+            expect(result.current.editingChannel).toEqual(channel);
+            expect(result.current.dialogTab).toBe(0);
+            expect(result.current.dialogError).toBeNull();
+        });
+
+        it('closeDialog clears dialog state when not saving', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            // Open edit dialog
+            const mockEvent = createMockMouseEvent();
+            act(() => {
+                result.current.openEdit(mockEvent, result.current.channels[0]);
+            });
+
+            expect(result.current.dialogOpen).toBe(true);
+            expect(result.current.editingChannel).not.toBeNull();
+
+            // Close
+            act(() => {
+                result.current.closeDialog();
+            });
+
+            expect(result.current.dialogOpen).toBe(false);
+            expect(result.current.editingChannel).toBeNull();
+        });
+
+        it('closeDialog does nothing when saving', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.channels).toHaveLength(2);
+            });
+
+            // Open dialog and set saving
+            act(() => {
+                result.current.openCreate();
+            });
+
+            act(() => {
+                result.current.setSaving(true);
+            });
+
+            expect(result.current.dialogOpen).toBe(true);
+            expect(result.current.saving).toBe(true);
+
+            // Try to close - should not work
+            act(() => {
+                result.current.closeDialog();
+            });
+
+            expect(result.current.dialogOpen).toBe(true);
+        });
+
+        it('setDialogTab updates the tab', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            act(() => {
+                result.current.openCreate();
+            });
+
+            expect(result.current.dialogTab).toBe(0);
+
+            act(() => {
+                result.current.setDialogTab(2);
+            });
+
+            expect(result.current.dialogTab).toBe(2);
+        });
+
+        it('setDialogError updates the dialog error', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            act(() => {
+                result.current.setDialogError('Validation error');
+            });
+
+            expect(result.current.dialogError).toBe('Validation error');
+        });
+
+        it('setSaving updates the saving state', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.saving).toBe(false);
+
+            act(() => {
+                result.current.setSaving(true);
+            });
+
+            expect(result.current.saving).toBe(true);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // State Setter Tests
+    // -----------------------------------------------------------------------
+
+    describe('state setters', () => {
+        it('setError updates error state', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            act(() => {
+                result.current.setError('Custom error');
+            });
+
+            expect(result.current.error).toBe('Custom error');
+
+            act(() => {
+                result.current.setError(null);
+            });
+
+            expect(result.current.error).toBeNull();
+        });
+
+        it('setSuccess updates success state', async () => {
+            mockApiGet.mockResolvedValue(makeApiResponse(makeRawChannels('email')));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('email', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            act(() => {
+                result.current.setSuccess('Operation completed');
+            });
+
+            expect(result.current.success).toBe('Operation completed');
+
+            act(() => {
+                result.current.setSuccess(null);
+            });
+
+            expect(result.current.success).toBeNull();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Channel Type Filtering Tests
+    // -----------------------------------------------------------------------
+
+    describe('channel type filtering', () => {
+        it('filters webhook channels when channelType is webhook', async () => {
+            const emailChannels = makeRawChannels('email');
+            const webhookChannels = makeRawChannels('webhook').map((ch) => ({
+                ...ch,
+                id: (ch.id as number) + 100,
+                channel_type: 'webhook',
+            }));
+            const allChannels = [...emailChannels, ...webhookChannels];
+            mockApiGet.mockResolvedValueOnce(makeApiResponse(allChannels));
+
+            const { result } = renderHook(() =>
+                useChannelCRUD<TestChannel>('webhook', mapTestChannel)
+            );
+
+            await waitFor(() => {
+                expect(result.current.loading).toBe(false);
+            });
+
+            expect(result.current.channels).toHaveLength(2);
+            expect(result.current.channels[0].id).toBe(101);
+            expect(result.current.channels[1].id).toBe(102);
+        });
+    });
+});

--- a/client/src/components/AdminPanel/channels/channelTypes.ts
+++ b/client/src/components/AdminPanel/channels/channelTypes.ts
@@ -1,0 +1,26 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { ReactNode } from 'react';
+
+/** Fields common to every notification channel. */
+export interface BaseChannel {
+    id: number;
+    name: string;
+    description: string;
+    enabled: boolean;
+    is_estate_default: boolean;
+}
+
+/** Definition for an extra column in the channel table. */
+export interface ChannelColumnDef<T> {
+    label: string;
+    render: (channel: T) => ReactNode;
+}

--- a/client/src/components/AdminPanel/channels/index.ts
+++ b/client/src/components/AdminPanel/channels/index.ts
@@ -1,0 +1,17 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+export { useChannelCRUD } from './useChannelCRUD';
+export type { ChannelCRUDResult } from './useChannelCRUD';
+export type { BaseChannel, ChannelColumnDef } from './channelTypes';
+export { ChannelTable } from './ChannelTable';
+export type { ChannelTableProps } from './ChannelTable';
+export { ChannelDialogShell } from './ChannelDialogShell';
+export type { ChannelDialogShellProps } from './ChannelDialogShell';

--- a/client/src/components/AdminPanel/channels/useChannelCRUD.ts
+++ b/client/src/components/AdminPanel/channels/useChannelCRUD.ts
@@ -85,7 +85,10 @@ export interface ChannelCRUDResult<T extends BaseChannel> {
  * dialog state management.
  *
  * @param channelType - The type of channel ('email' or 'webhook')
- * @param mapChannel - Function to map raw API data to the channel type
+ * @param mapChannel - Function to map raw API data to the channel type.
+ *   **Warning:** This function must be stable (defined at module scope or
+ *   memoized with `useCallback`) to prevent infinite re-fetch loops, since
+ *   it is included in the `fetchChannels` dependency array.
  * @returns All state and handlers for channel CRUD operations
  */
 export function useChannelCRUD<T extends BaseChannel>(

--- a/client/src/components/AdminPanel/channels/useChannelCRUD.ts
+++ b/client/src/components/AdminPanel/channels/useChannelCRUD.ts
@@ -8,7 +8,7 @@
  *-------------------------------------------------------------------------
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { apiGet, apiPost, apiPut, apiDelete } from '../../../utils/apiClient';
 import { BaseChannel } from './channelTypes';
 
@@ -116,9 +116,13 @@ export function useChannelCRUD<T extends BaseChannel>(
     const [saving, setSaving] = useState(false);
     const [dialogError, setDialogError] = useState<string | null>(null);
 
+    // Request ID counter for stale response guard
+    const fetchRequestIdRef = useRef(0);
+
     // --- Data fetching ---
 
     const fetchChannels = useCallback(async () => {
+        const requestId = ++fetchRequestIdRef.current;
         try {
             setLoading(true);
             const data = await apiGet<Record<string, unknown>>('/api/v1/notification-channels');
@@ -126,15 +130,21 @@ export function useChannelCRUD<T extends BaseChannel>(
             const filtered: T[] = allChannels
                 .filter((ch: Record<string, unknown>) => ch.channel_type === channelType)
                 .map(mapChannel);
-            setChannels(filtered);
+            if (requestId === fetchRequestIdRef.current) {
+                setChannels(filtered);
+            }
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
+            if (requestId === fetchRequestIdRef.current) {
+                if (err instanceof Error) {
+                    setError(err.message);
+                } else {
+                    setError('An unexpected error occurred');
+                }
             }
         } finally {
-            setLoading(false);
+            if (requestId === fetchRequestIdRef.current) {
+                setLoading(false);
+            }
         }
     }, [channelType, mapChannel]);
 

--- a/client/src/components/AdminPanel/channels/useChannelCRUD.ts
+++ b/client/src/components/AdminPanel/channels/useChannelCRUD.ts
@@ -1,0 +1,266 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import { apiGet, apiPost, apiPut, apiDelete } from '../../../utils/apiClient';
+import { BaseChannel } from './channelTypes';
+
+/**
+ * Result type for the useChannelCRUD hook.
+ * Contains all state and handlers for managing channel CRUD operations.
+ */
+export interface ChannelCRUDResult<T extends BaseChannel> {
+    /** List of channels of the specified type. */
+    channels: T[];
+    /** Whether the initial fetch is in progress. */
+    loading: boolean;
+    /** Error message from the last failed operation. */
+    error: string | null;
+    /** Set the error message. */
+    setError: (error: string | null) => void;
+    /** Success message from the last successful operation. */
+    success: string | null;
+    /** Set the success message. */
+    setSuccess: (success: string | null) => void;
+    /** Fetch all channels from the API. */
+    fetchChannels: () => Promise<void>;
+    /** Toggle the enabled state of a channel. */
+    toggleEnabled: (channel: T) => Promise<void>;
+    /** Send a test notification for the channel. */
+    testChannel: (e: React.MouseEvent, channel: T) => Promise<void>;
+    /** ID of the channel currently being tested. */
+    testingChannelId: number | null;
+
+    // Delete state
+    /** Whether the delete confirmation dialog is open. */
+    deleteOpen: boolean;
+    /** The channel being deleted. */
+    deleteChannel: T | null;
+    /** Whether a delete operation is in progress. */
+    deleteLoading: boolean;
+    /** Open the delete confirmation dialog. */
+    openDelete: (e: React.MouseEvent, channel: T) => void;
+    /** Confirm and execute the delete operation. */
+    confirmDelete: () => Promise<void>;
+    /** Close the delete confirmation dialog. */
+    closeDelete: () => void;
+
+    // Dialog state
+    /** Whether the create/edit dialog is open. */
+    dialogOpen: boolean;
+    /** The channel being edited, or null for create mode. */
+    editingChannel: T | null;
+    /** The currently selected tab in the dialog. */
+    dialogTab: number;
+    /** Whether a save operation is in progress. */
+    saving: boolean;
+    /** Error message displayed in the dialog. */
+    dialogError: string | null;
+    /** Open the dialog in create mode. */
+    openCreate: () => void;
+    /** Open the dialog in edit mode. */
+    openEdit: (e: React.MouseEvent, channel: T) => void;
+    /** Close the dialog. */
+    closeDialog: () => void;
+    /** Set the active tab in the dialog. */
+    setDialogTab: (tab: number) => void;
+    /** Set the saving state. */
+    setSaving: (saving: boolean) => void;
+    /** Set the dialog error message. */
+    setDialogError: (error: string | null) => void;
+}
+
+/**
+ * Generic hook for managing channel CRUD operations.
+ *
+ * This hook encapsulates all the state management shared by email and webhook
+ * channel components, including fetching, toggling, testing, deleting, and
+ * dialog state management.
+ *
+ * @param channelType - The type of channel ('email' or 'webhook')
+ * @param mapChannel - Function to map raw API data to the channel type
+ * @returns All state and handlers for channel CRUD operations
+ */
+export function useChannelCRUD<T extends BaseChannel>(
+    channelType: 'email' | 'webhook',
+    mapChannel: (raw: Record<string, unknown>) => T,
+): ChannelCRUDResult<T> {
+    // Main list state
+    const [channels, setChannels] = useState<T[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState<string | null>(null);
+
+    // Test channel state
+    const [testingChannelId, setTestingChannelId] = useState<number | null>(null);
+
+    // Delete confirmation state
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [deleteChannel, setDeleteChannel] = useState<T | null>(null);
+    const [deleteLoading, setDeleteLoading] = useState(false);
+
+    // Create/Edit dialog state
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [editingChannel, setEditingChannel] = useState<T | null>(null);
+    const [dialogTab, setDialogTab] = useState(0);
+    const [saving, setSaving] = useState(false);
+    const [dialogError, setDialogError] = useState<string | null>(null);
+
+    // --- Data fetching ---
+
+    const fetchChannels = useCallback(async () => {
+        try {
+            setLoading(true);
+            const data = await apiGet<Record<string, unknown>>('/api/v1/notification-channels');
+            const allChannels = (data.notification_channels || data || []) as Record<string, unknown>[];
+            const filtered: T[] = allChannels
+                .filter((ch: Record<string, unknown>) => ch.channel_type === channelType)
+                .map(mapChannel);
+            setChannels(filtered);
+        } catch (err: unknown) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('An unexpected error occurred');
+            }
+        } finally {
+            setLoading(false);
+        }
+    }, [channelType, mapChannel]);
+
+    useEffect(() => {
+        void fetchChannels();
+    }, [fetchChannels]);
+
+    // --- Toggle enabled ---
+
+    const toggleEnabled = useCallback(async (channel: T) => {
+        try {
+            await apiPut(`/api/v1/notification-channels/${channel.id}`, {
+                enabled: !channel.enabled,
+            });
+            await fetchChannels();
+        } catch (err: unknown) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('An unexpected error occurred');
+            }
+        }
+    }, [fetchChannels]);
+
+    // --- Test channel ---
+
+    const testChannel = useCallback(async (e: React.MouseEvent, channel: T) => {
+        e.stopPropagation();
+        try {
+            setTestingChannelId(channel.id);
+            setError(null);
+            await apiPost(`/api/v1/notification-channels/${channel.id}/test`);
+            setSuccess(`Test notification sent successfully for "${channel.name}".`);
+        } catch (err: unknown) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('Failed to send test notification');
+            }
+        } finally {
+            setTestingChannelId(null);
+        }
+    }, []);
+
+    // --- Delete operations ---
+
+    const openDelete = useCallback((e: React.MouseEvent, channel: T) => {
+        e.stopPropagation();
+        setDeleteChannel(channel);
+        setDeleteOpen(true);
+    }, []);
+
+    const confirmDelete = useCallback(async () => {
+        if (!deleteChannel) { return; }
+        try {
+            setDeleteLoading(true);
+            await apiDelete(`/api/v1/notification-channels/${deleteChannel.id}`);
+            setDeleteOpen(false);
+            setSuccess(`Channel "${deleteChannel.name}" deleted successfully.`);
+            setDeleteChannel(null);
+            await fetchChannels();
+        } catch (err: unknown) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('An unexpected error occurred');
+            }
+        } finally {
+            setDeleteLoading(false);
+        }
+    }, [deleteChannel, fetchChannels]);
+
+    const closeDelete = useCallback(() => {
+        setDeleteOpen(false);
+        setDeleteChannel(null);
+    }, []);
+
+    // --- Dialog operations ---
+
+    const openCreate = useCallback(() => {
+        setEditingChannel(null);
+        setDialogError(null);
+        setDialogTab(0);
+        setDialogOpen(true);
+    }, []);
+
+    const openEdit = useCallback((e: React.MouseEvent, channel: T) => {
+        e.stopPropagation();
+        setEditingChannel(channel);
+        setDialogError(null);
+        setDialogTab(0);
+        setDialogOpen(true);
+    }, []);
+
+    const closeDialog = useCallback(() => {
+        if (saving) { return; }
+        setDialogOpen(false);
+        setEditingChannel(null);
+    }, [saving]);
+
+    return {
+        channels,
+        loading,
+        error,
+        setError,
+        success,
+        setSuccess,
+        fetchChannels,
+        toggleEnabled,
+        testChannel,
+        testingChannelId,
+        // Delete state
+        deleteOpen,
+        deleteChannel,
+        deleteLoading,
+        openDelete,
+        confirmDelete,
+        closeDelete,
+        // Dialog state
+        dialogOpen,
+        editingChannel,
+        dialogTab,
+        saving,
+        dialogError,
+        openCreate,
+        openEdit,
+        closeDialog,
+        setDialogTab,
+        setSaving,
+        setDialogError,
+    };
+}

--- a/client/src/components/AdminPanel/email/EmailRecipientsTab.tsx
+++ b/client/src/components/AdminPanel/email/EmailRecipientsTab.tsx
@@ -1,0 +1,218 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React, { useState } from 'react';
+import {
+    Box,
+    Typography,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Paper,
+    Button,
+    IconButton,
+    Switch,
+    TextField,
+    CircularProgress,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import {
+    Add as AddIcon,
+    Delete as DeleteIcon,
+} from '@mui/icons-material';
+import {
+    tableHeaderCellSx,
+    emptyRowSx,
+    emptyRowTextSx,
+    getContainedButtonSx,
+    getDeleteIconSx,
+    getTableContainerSx,
+} from '../styles';
+import { EmailRecipient } from './emailTypes';
+
+export interface EmailRecipientsTabProps {
+    visible: boolean;
+    isEditing: boolean;
+    recipients: EmailRecipient[];
+    recipientsLoading: boolean;
+    recipientSaving: boolean;
+    onToggleRecipientEnabled: (recipient: EmailRecipient) => void;
+    onDeleteRecipient: (recipient: EmailRecipient) => void;
+    onAddRecipient: (email: string, name: string) => void;
+    pendingRecipients: Array<{ email: string; name: string }>;
+    onRemovePending: (index: number) => void;
+}
+
+/**
+ * Recipients tab content for email channel create/edit dialog.
+ * Manages existing recipients (edit mode) or pending recipients (create mode).
+ */
+export const EmailRecipientsTab: React.FC<EmailRecipientsTabProps> = ({
+    visible,
+    isEditing,
+    recipients,
+    recipientsLoading,
+    recipientSaving,
+    onToggleRecipientEnabled,
+    onDeleteRecipient,
+    onAddRecipient,
+    pendingRecipients,
+    onRemovePending,
+}) => {
+    const theme = useTheme();
+    const [newRecipientEmail, setNewRecipientEmail] = useState('');
+    const [newRecipientName, setNewRecipientName] = useState('');
+
+    const containedButtonSx = getContainedButtonSx(theme);
+    const deleteIconSx = getDeleteIconSx(theme);
+    const tableContainerSx = getTableContainerSx(theme);
+
+    const handleAddRecipient = () => {
+        if (!newRecipientEmail.trim()) { return; }
+        onAddRecipient(newRecipientEmail.trim(), newRecipientName.trim());
+        setNewRecipientEmail('');
+        setNewRecipientName('');
+    };
+
+    return (
+        <Box sx={{ display: visible ? 'block' : 'none' }}>
+            {isEditing && recipientsLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                    <CircularProgress size={24} aria-label="Loading recipients" />
+                </Box>
+            ) : (
+                <TableContainer
+                    component={Paper}
+                    elevation={0}
+                    sx={tableContainerSx}
+                >
+                    <Table size="small">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell sx={tableHeaderCellSx}>Email</TableCell>
+                                <TableCell sx={tableHeaderCellSx}>Display Name</TableCell>
+                                {isEditing && (
+                                    <TableCell sx={tableHeaderCellSx}>Enabled</TableCell>
+                                )}
+                                <TableCell sx={tableHeaderCellSx} align="right">Actions</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {isEditing && recipients.map((recipient) => (
+                                <TableRow key={recipient.id}>
+                                    <TableCell>{recipient.email}</TableCell>
+                                    <TableCell>{recipient.display_name || '-'}</TableCell>
+                                    <TableCell>
+                                        <Switch
+                                            checked={recipient.enabled}
+                                            size="small"
+                                            onChange={() => onToggleRecipientEnabled(recipient)}
+                                            disabled={recipientSaving}
+                                            inputProps={{ 'aria-label': 'Toggle recipient enabled' }}
+                                        />
+                                    </TableCell>
+                                    <TableCell align="right">
+                                        <IconButton
+                                            size="small"
+                                            onClick={() => onDeleteRecipient(recipient)}
+                                            aria-label="delete recipient"
+                                            sx={deleteIconSx}
+                                            disabled={recipientSaving}
+                                        >
+                                            <DeleteIcon fontSize="small" />
+                                        </IconButton>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                            {!isEditing && pendingRecipients.map((pending, index) => (
+                                <TableRow key={`pending-${index}`}>
+                                    <TableCell>{pending.email}</TableCell>
+                                    <TableCell>{pending.name || '-'}</TableCell>
+                                    <TableCell align="right">
+                                        <IconButton
+                                            size="small"
+                                            onClick={() => onRemovePending(index)}
+                                            aria-label="remove pending recipient"
+                                            sx={deleteIconSx}
+                                        >
+                                            <DeleteIcon fontSize="small" />
+                                        </IconButton>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                            {((isEditing && recipients.length === 0) ||
+                              (!isEditing && pendingRecipients.length === 0)) && (
+                                <TableRow>
+                                    <TableCell
+                                        colSpan={isEditing ? 4 : 3}
+                                        align="center"
+                                        sx={emptyRowSx}
+                                    >
+                                        <Typography color="text.secondary" sx={emptyRowTextSx}>
+                                            No recipients configured.
+                                        </Typography>
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {/* Add recipient row */}
+                            <TableRow>
+                                <TableCell>
+                                    <TextField
+                                        size="small"
+                                        placeholder="Email address"
+                                        value={newRecipientEmail}
+                                        onChange={(e) => setNewRecipientEmail(e.target.value)}
+                                        disabled={recipientSaving}
+                                        fullWidth
+                                        variant="standard"
+                                    />
+                                </TableCell>
+                                <TableCell>
+                                    <TextField
+                                        size="small"
+                                        placeholder="Display name"
+                                        value={newRecipientName}
+                                        onChange={(e) => setNewRecipientName(e.target.value)}
+                                        disabled={recipientSaving}
+                                        fullWidth
+                                        variant="standard"
+                                    />
+                                </TableCell>
+                                <TableCell
+                                    colSpan={isEditing ? 2 : 1}
+                                    align="right"
+                                >
+                                    <Button
+                                        size="small"
+                                        variant="contained"
+                                        startIcon={recipientSaving
+                                            ? <CircularProgress size={14} color="inherit" aria-label="Adding recipient" />
+                                            : <AddIcon />
+                                        }
+                                        onClick={handleAddRecipient}
+                                        disabled={recipientSaving || !newRecipientEmail.trim()}
+                                        sx={containedButtonSx}
+                                    >
+                                        Add
+                                    </Button>
+                                </TableCell>
+                            </TableRow>
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            )}
+        </Box>
+    );
+};
+
+export default EmailRecipientsTab;

--- a/client/src/components/AdminPanel/email/EmailRecipientsTab.tsx
+++ b/client/src/components/AdminPanel/email/EmailRecipientsTab.tsx
@@ -78,8 +78,9 @@ export const EmailRecipientsTab: React.FC<EmailRecipientsTabProps> = ({
     const tableContainerSx = getTableContainerSx(theme);
 
     const handleAddRecipient = () => {
-        if (!newRecipientEmail.trim()) { return; }
-        onAddRecipient(newRecipientEmail.trim(), newRecipientName.trim());
+        const email = newRecipientEmail.trim();
+        if (!email || !email.includes('@')) { return; }
+        onAddRecipient(email, newRecipientName.trim());
         setNewRecipientEmail('');
         setNewRecipientName('');
     };
@@ -200,7 +201,7 @@ export const EmailRecipientsTab: React.FC<EmailRecipientsTabProps> = ({
                                             : <AddIcon />
                                         }
                                         onClick={handleAddRecipient}
-                                        disabled={recipientSaving || !newRecipientEmail.trim()}
+                                        disabled={recipientSaving || !newRecipientEmail.trim() || !newRecipientEmail.includes('@')}
                                         sx={containedButtonSx}
                                     >
                                         Add

--- a/client/src/components/AdminPanel/email/EmailSettingsTab.tsx
+++ b/client/src/components/AdminPanel/email/EmailSettingsTab.tsx
@@ -1,0 +1,173 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import {
+    Box,
+    TextField,
+    Switch,
+    Typography,
+    FormControlLabel,
+} from '@mui/material';
+import { EmailFormState } from './emailTypes';
+
+export interface EmailSettingsTabProps {
+    form: EmailFormState;
+    onChange: (field: keyof EmailFormState, value: string | boolean) => void;
+    saving: boolean;
+    isEditing: boolean;
+    visible: boolean;
+}
+
+/**
+ * Settings tab content for email channel create/edit dialog.
+ * Renders SMTP configuration form fields.
+ */
+export const EmailSettingsTab: React.FC<EmailSettingsTabProps> = ({
+    form,
+    onChange,
+    saving,
+    isEditing,
+    visible,
+}) => {
+    return (
+        <Box sx={{ display: visible ? 'block' : 'none' }}>
+            <TextField
+                autoFocus
+                fullWidth
+                label="Name"
+                value={form.name}
+                onChange={(e) => onChange('name', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                required
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="Description"
+                value={form.description}
+                onChange={(e) => onChange('description', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                multiline
+                rows={2}
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="SMTP Host"
+                value={form.smtp_host}
+                onChange={(e) => onChange('smtp_host', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                required
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="SMTP Port"
+                type="number"
+                value={form.smtp_port}
+                onChange={(e) => onChange('smtp_port', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                inputProps={{ min: 1, max: 65535 }}
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="SMTP Username"
+                value={form.smtp_username}
+                onChange={(e) => onChange('smtp_username', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="SMTP Password"
+                type="password"
+                value={form.smtp_password}
+                onChange={(e) => onChange('smtp_password', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                placeholder={isEditing ? '(unchanged)' : ''}
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="From Address"
+                value={form.from_address}
+                onChange={(e) => onChange('from_address', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                required
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="From Name"
+                value={form.from_name}
+                onChange={(e) => onChange('from_name', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                InputLabelProps={{ shrink: true }}
+            />
+            <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <FormControlLabel
+                    sx={{ ml: 0, gap: 1 }}
+                    control={
+                        <Switch
+                            checked={form.use_tls}
+                            onChange={(e) => onChange('use_tls', e.target.checked)}
+                            disabled={saving}
+                            inputProps={{ 'aria-label': 'Toggle use TLS' }}
+                        />
+                    }
+                    label="Use TLS"
+                />
+                <FormControlLabel
+                    sx={{ ml: 0, gap: 1 }}
+                    control={
+                        <Switch
+                            checked={form.enabled}
+                            onChange={(e) => onChange('enabled', e.target.checked)}
+                            disabled={saving}
+                            inputProps={{ 'aria-label': 'Toggle channel enabled' }}
+                        />
+                    }
+                    label="Enabled"
+                />
+                <FormControlLabel
+                    sx={{ ml: 0, gap: 1 }}
+                    control={
+                        <Switch
+                            checked={form.is_estate_default}
+                            onChange={(e) => onChange('is_estate_default', e.target.checked)}
+                            disabled={saving}
+                            inputProps={{ 'aria-label': 'Toggle estate default' }}
+                        />
+                    }
+                    label={
+                        <Box>
+                            <Typography variant="body1">Estate Default</Typography>
+                            <Typography variant="caption" color="text.secondary">
+                                When enabled, this channel is active for all servers by default
+                            </Typography>
+                        </Box>
+                    }
+                />
+            </Box>
+        </Box>
+    );
+};
+
+export default EmailSettingsTab;

--- a/client/src/components/AdminPanel/email/emailTypes.ts
+++ b/client/src/components/AdminPanel/email/emailTypes.ts
@@ -1,0 +1,60 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { BaseChannel } from '../channels/channelTypes';
+
+/** Email channel with SMTP configuration and recipient count. */
+export interface EmailChannel extends BaseChannel {
+    smtp_host: string;
+    smtp_port: number;
+    smtp_username: string;
+    use_tls: boolean;
+    from_address: string;
+    from_name: string;
+    recipient_count: number;
+}
+
+/** Email recipient for a channel. */
+export interface EmailRecipient {
+    id: number;
+    email: string;
+    display_name: string;
+    enabled: boolean;
+}
+
+/** Form state for creating or editing an email channel. */
+export interface EmailFormState {
+    name: string;
+    description: string;
+    enabled: boolean;
+    is_estate_default: boolean;
+    smtp_host: string;
+    smtp_port: string;
+    smtp_username: string;
+    smtp_password: string;
+    use_tls: boolean;
+    from_address: string;
+    from_name: string;
+}
+
+/** Default values for the email channel form. */
+export const DEFAULT_EMAIL_FORM: EmailFormState = {
+    name: '',
+    description: '',
+    enabled: true,
+    is_estate_default: false,
+    smtp_host: '',
+    smtp_port: '587',
+    smtp_username: '',
+    smtp_password: '',
+    use_tls: true,
+    from_address: '',
+    from_name: '',
+};

--- a/client/src/components/AdminPanel/email/index.ts
+++ b/client/src/components/AdminPanel/email/index.ts
@@ -1,0 +1,20 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+export type {
+    EmailChannel,
+    EmailRecipient,
+    EmailFormState,
+} from './emailTypes';
+export { DEFAULT_EMAIL_FORM } from './emailTypes';
+export { EmailSettingsTab } from './EmailSettingsTab';
+export type { EmailSettingsTabProps } from './EmailSettingsTab';
+export { EmailRecipientsTab } from './EmailRecipientsTab';
+export type { EmailRecipientsTabProps } from './EmailRecipientsTab';

--- a/client/src/components/AdminPanel/webhook/WebhookAuthTab.tsx
+++ b/client/src/components/AdminPanel/webhook/WebhookAuthTab.tsx
@@ -84,6 +84,8 @@ const WebhookAuthTab: React.FC<WebhookAuthTabProps> = ({
                 <TextField
                     fullWidth
                     label="Token"
+                    type="password"
+                    autoComplete="off"
                     value={authFields.token || ''}
                     onChange={(e) => onAuthFieldChange('token', e.target.value)}
                     disabled={saving}
@@ -107,6 +109,8 @@ const WebhookAuthTab: React.FC<WebhookAuthTabProps> = ({
                     <TextField
                         fullWidth
                         label="API Key Value"
+                        type="password"
+                        autoComplete="off"
                         value={authFields.apiKeyValue || ''}
                         onChange={(e) => onAuthFieldChange('apiKeyValue', e.target.value)}
                         disabled={saving}

--- a/client/src/components/AdminPanel/webhook/WebhookAuthTab.tsx
+++ b/client/src/components/AdminPanel/webhook/WebhookAuthTab.tsx
@@ -1,0 +1,122 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { Box, TextField, MenuItem } from '@mui/material';
+import { SELECT_FIELD_SX } from '../../shared/formStyles';
+import { AUTH_TYPES } from './webhookHelpers';
+
+export interface WebhookAuthTabProps {
+    authType: string;
+    authFields: Record<string, string>;
+    onAuthTypeChange: (newType: string) => void;
+    onAuthFieldChange: (field: string, value: string) => void;
+    saving: boolean;
+    visible: boolean;
+}
+
+/**
+ * Authentication tab for the webhook channel dialog.
+ * Allows selecting auth type and configuring credentials.
+ */
+const WebhookAuthTab: React.FC<WebhookAuthTabProps> = ({
+    authType,
+    authFields,
+    onAuthTypeChange,
+    onAuthFieldChange,
+    saving,
+    visible,
+}) => {
+    return (
+        <Box sx={{ display: visible ? 'block' : 'none' }}>
+            <TextField
+                fullWidth
+                select
+                label="Auth Type"
+                value={authType}
+                onChange={(e) => onAuthTypeChange(e.target.value)}
+                disabled={saving}
+                margin="dense"
+                InputLabelProps={{ shrink: true }}
+                sx={SELECT_FIELD_SX}
+            >
+                {AUTH_TYPES.map((type) => (
+                    <MenuItem key={type.value} value={type.value}>
+                        {type.label}
+                    </MenuItem>
+                ))}
+            </TextField>
+
+            {/* Basic auth fields */}
+            {authType === 'basic' && (
+                <>
+                    <TextField
+                        fullWidth
+                        label="Username"
+                        value={authFields.username || ''}
+                        onChange={(e) => onAuthFieldChange('username', e.target.value)}
+                        disabled={saving}
+                        margin="dense"
+                        InputLabelProps={{ shrink: true }}
+                    />
+                    <TextField
+                        fullWidth
+                        label="Password"
+                        type="password"
+                        value={authFields.password || ''}
+                        onChange={(e) => onAuthFieldChange('password', e.target.value)}
+                        disabled={saving}
+                        margin="dense"
+                        InputLabelProps={{ shrink: true }}
+                    />
+                </>
+            )}
+
+            {/* Bearer token field */}
+            {authType === 'bearer' && (
+                <TextField
+                    fullWidth
+                    label="Token"
+                    value={authFields.token || ''}
+                    onChange={(e) => onAuthFieldChange('token', e.target.value)}
+                    disabled={saving}
+                    margin="dense"
+                    InputLabelProps={{ shrink: true }}
+                />
+            )}
+
+            {/* API Key fields */}
+            {authType === 'api_key' && (
+                <>
+                    <TextField
+                        fullWidth
+                        label="Header Name"
+                        value={authFields.headerName || ''}
+                        onChange={(e) => onAuthFieldChange('headerName', e.target.value)}
+                        disabled={saving}
+                        margin="dense"
+                        InputLabelProps={{ shrink: true }}
+                    />
+                    <TextField
+                        fullWidth
+                        label="API Key Value"
+                        value={authFields.apiKeyValue || ''}
+                        onChange={(e) => onAuthFieldChange('apiKeyValue', e.target.value)}
+                        disabled={saving}
+                        margin="dense"
+                        InputLabelProps={{ shrink: true }}
+                    />
+                </>
+            )}
+        </Box>
+    );
+};
+
+export default WebhookAuthTab;

--- a/client/src/components/AdminPanel/webhook/WebhookHeadersTab.tsx
+++ b/client/src/components/AdminPanel/webhook/WebhookHeadersTab.tsx
@@ -1,0 +1,102 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { Box, TextField, IconButton, Button, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import { HeaderEntry } from './webhookTypes';
+import { getContainedButtonSx, getDeleteIconSx } from '../styles';
+
+export interface WebhookHeadersTabProps {
+    headers: HeaderEntry[];
+    onAddHeader: () => void;
+    onChangeHeader: (id: string, field: 'key' | 'value', value: string) => void;
+    onRemoveHeader: (id: string) => void;
+    saving: boolean;
+    visible: boolean;
+}
+
+/**
+ * Headers tab for the webhook channel dialog.
+ * Allows adding, editing, and removing custom HTTP headers.
+ */
+const WebhookHeadersTab: React.FC<WebhookHeadersTabProps> = ({
+    headers,
+    onAddHeader,
+    onChangeHeader,
+    onRemoveHeader,
+    saving,
+    visible,
+}) => {
+    const theme = useTheme();
+    const containedButtonSx = getContainedButtonSx(theme);
+    const deleteIconSx = getDeleteIconSx(theme);
+
+    return (
+        <Box sx={{ display: visible ? 'block' : 'none' }}>
+            {headers.length > 0 ? (
+                headers.map((header) => (
+                    <Box
+                        key={header.id}
+                        sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 1 }}
+                    >
+                        <TextField
+                            label="Key"
+                            value={header.key}
+                            onChange={(e) => onChangeHeader(header.id, 'key', e.target.value)}
+                            disabled={saving}
+                            size="small"
+                            sx={{ flex: 1 }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <TextField
+                            label="Value"
+                            value={header.value}
+                            onChange={(e) => onChangeHeader(header.id, 'value', e.target.value)}
+                            disabled={saving}
+                            size="small"
+                            sx={{ flex: 1 }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <IconButton
+                            size="small"
+                            onClick={() => onRemoveHeader(header.id)}
+                            aria-label="remove header"
+                            sx={deleteIconSx}
+                            disabled={saving}
+                        >
+                            <DeleteIcon fontSize="small" />
+                        </IconButton>
+                    </Box>
+                ))
+            ) : (
+                <Typography
+                    color="text.secondary"
+                    sx={{ fontSize: '1rem', mb: 2, mt: 1 }}
+                >
+                    No custom headers configured.
+                </Typography>
+            )}
+            <Button
+                size="small"
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={onAddHeader}
+                disabled={saving}
+                sx={containedButtonSx}
+            >
+                Add Header
+            </Button>
+        </Box>
+    );
+};
+
+export default WebhookHeadersTab;

--- a/client/src/components/AdminPanel/webhook/WebhookSettingsTab.tsx
+++ b/client/src/components/AdminPanel/webhook/WebhookSettingsTab.tsx
@@ -1,0 +1,129 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import {
+    Box,
+    TextField,
+    Switch,
+    FormControlLabel,
+    MenuItem,
+    Typography,
+} from '@mui/material';
+import { SELECT_FIELD_SX } from '../../shared/formStyles';
+import { WebhookFormState } from './webhookTypes';
+import { HTTP_METHODS } from './webhookHelpers';
+
+export interface WebhookSettingsTabProps {
+    form: WebhookFormState;
+    onChange: (field: keyof WebhookFormState, value: string | boolean) => void;
+    saving: boolean;
+    visible: boolean;
+}
+
+/**
+ * Settings tab for the webhook channel dialog.
+ * Contains name, description, endpoint URL, HTTP method, and toggle switches.
+ */
+const WebhookSettingsTab: React.FC<WebhookSettingsTabProps> = ({
+    form,
+    onChange,
+    saving,
+    visible,
+}) => {
+    return (
+        <Box sx={{ display: visible ? 'block' : 'none' }}>
+            <TextField
+                autoFocus
+                fullWidth
+                label="Name"
+                value={form.name}
+                onChange={(e) => onChange('name', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                required
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="Description"
+                value={form.description}
+                onChange={(e) => onChange('description', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                multiline
+                rows={2}
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                label="Endpoint URL"
+                value={form.endpoint_url}
+                onChange={(e) => onChange('endpoint_url', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                required
+                InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+                fullWidth
+                select
+                label="HTTP Method"
+                value={form.http_method}
+                onChange={(e) => onChange('http_method', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                InputLabelProps={{ shrink: true }}
+                sx={SELECT_FIELD_SX}
+            >
+                {HTTP_METHODS.map((method) => (
+                    <MenuItem key={method} value={method}>
+                        {method}
+                    </MenuItem>
+                ))}
+            </TextField>
+            <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <FormControlLabel
+                    sx={{ ml: 0, gap: 1 }}
+                    control={
+                        <Switch
+                            checked={form.enabled}
+                            onChange={(e) => onChange('enabled', e.target.checked)}
+                            disabled={saving}
+                            inputProps={{ 'aria-label': 'Toggle channel enabled' }}
+                        />
+                    }
+                    label="Enabled"
+                />
+                <FormControlLabel
+                    sx={{ ml: 0, gap: 1 }}
+                    control={
+                        <Switch
+                            checked={form.is_estate_default}
+                            onChange={(e) => onChange('is_estate_default', e.target.checked)}
+                            disabled={saving}
+                            inputProps={{ 'aria-label': 'Toggle estate default' }}
+                        />
+                    }
+                    label={
+                        <Box>
+                            <Typography variant="body1">Estate Default</Typography>
+                            <Typography variant="caption" color="text.secondary">
+                                When enabled, this channel is active for all servers by default
+                            </Typography>
+                        </Box>
+                    }
+                />
+            </Box>
+        </Box>
+    );
+};
+
+export default WebhookSettingsTab;

--- a/client/src/components/AdminPanel/webhook/WebhookTemplatesTab.tsx
+++ b/client/src/components/AdminPanel/webhook/WebhookTemplatesTab.tsx
@@ -1,0 +1,103 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { Box, TextField, Typography } from '@mui/material';
+import { WebhookFormState } from './webhookTypes';
+import {
+    DEFAULT_ALERT_FIRE_TEMPLATE,
+    DEFAULT_ALERT_CLEAR_TEMPLATE,
+    DEFAULT_REMINDER_TEMPLATE,
+} from './webhookHelpers';
+
+export interface WebhookTemplatesTabProps {
+    form: WebhookFormState;
+    onChange: (field: keyof WebhookFormState, value: string) => void;
+    saving: boolean;
+    visible: boolean;
+}
+
+/**
+ * Templates tab for the webhook channel dialog.
+ * Allows configuring Go templates for different notification types.
+ */
+const WebhookTemplatesTab: React.FC<WebhookTemplatesTabProps> = ({
+    form,
+    onChange,
+    saving,
+    visible,
+}) => {
+    return (
+        <Box sx={{ display: visible ? 'block' : 'none' }}>
+            <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 2, mt: 1 }}
+            >
+                Templates use{' '}
+                <a
+                    href="https://pkg.go.dev/text/template"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: 'inherit' }}
+                >
+                    Go template syntax
+                </a>
+                . Leave blank to use the
+                defaults shown as placeholders. Available variables: AlertID,
+                AlertTitle, AlertDescription, Severity, SeverityColor,
+                SeverityEmoji, ServerName, ServerHost, ServerPort, DatabaseName,
+                MetricName, MetricValue, ThresholdValue, Operator, TriggeredAt,
+                ClearedAt, Duration, ReminderCount, Timestamp.
+            </Typography>
+            <TextField
+                fullWidth
+                label="Alert Fire Template"
+                value={form.template_alert_fire}
+                onChange={(e) => onChange('template_alert_fire', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                multiline
+                rows={12}
+                placeholder={DEFAULT_ALERT_FIRE_TEMPLATE}
+                InputLabelProps={{ shrink: true }}
+                InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.8rem' } }}
+            />
+            <TextField
+                fullWidth
+                label="Alert Clear Template"
+                value={form.template_alert_clear}
+                onChange={(e) => onChange('template_alert_clear', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                multiline
+                rows={10}
+                placeholder={DEFAULT_ALERT_CLEAR_TEMPLATE}
+                InputLabelProps={{ shrink: true }}
+                InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.8rem' } }}
+            />
+            <TextField
+                fullWidth
+                label="Alert Reminder Template"
+                value={form.template_reminder}
+                onChange={(e) => onChange('template_reminder', e.target.value)}
+                disabled={saving}
+                margin="dense"
+                multiline
+                rows={10}
+                placeholder={DEFAULT_REMINDER_TEMPLATE}
+                InputLabelProps={{ shrink: true }}
+                InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.8rem' } }}
+            />
+        </Box>
+    );
+};
+
+export default WebhookTemplatesTab;

--- a/client/src/components/AdminPanel/webhook/__tests__/webhookHelpers.test.ts
+++ b/client/src/components/AdminPanel/webhook/__tests__/webhookHelpers.test.ts
@@ -1,0 +1,417 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    parseAuthCredentials,
+    buildAuthCredentials,
+    headersObjectToArray,
+    headersArrayToObject,
+    HTTP_METHODS,
+    AUTH_TYPES,
+    DEFAULT_ALERT_FIRE_TEMPLATE,
+    DEFAULT_ALERT_CLEAR_TEMPLATE,
+    DEFAULT_REMINDER_TEMPLATE,
+} from '../webhookHelpers';
+import { HeaderEntry } from '../webhookTypes';
+
+describe('webhookHelpers', () => {
+    describe('constants', () => {
+        it('exports HTTP_METHODS array', () => {
+            expect(HTTP_METHODS).toEqual(['POST', 'GET', 'PUT', 'PATCH']);
+        });
+
+        it('exports AUTH_TYPES array', () => {
+            expect(AUTH_TYPES).toHaveLength(4);
+            expect(AUTH_TYPES[0]).toEqual({ value: 'none', label: 'None' });
+            expect(AUTH_TYPES[1]).toEqual({ value: 'basic', label: 'Basic' });
+            expect(AUTH_TYPES[2]).toEqual({ value: 'bearer', label: 'Bearer Token' });
+            expect(AUTH_TYPES[3]).toEqual({ value: 'api_key', label: 'API Key' });
+        });
+
+        it('exports default template strings', () => {
+            expect(DEFAULT_ALERT_FIRE_TEMPLATE).toContain('"event": "alert_fire"');
+            expect(DEFAULT_ALERT_CLEAR_TEMPLATE).toContain('"event": "alert_clear"');
+            expect(DEFAULT_REMINDER_TEMPLATE).toContain('"event": "reminder"');
+        });
+    });
+
+    describe('parseAuthCredentials', () => {
+        describe('basic auth', () => {
+            it('parses credentials with colon separator', () => {
+                const result = parseAuthCredentials('basic', 'myuser:mypassword');
+                expect(result).toEqual({
+                    username: 'myuser',
+                    password: 'mypassword',
+                });
+            });
+
+            it('handles password containing colons', () => {
+                const result = parseAuthCredentials('basic', 'user:pass:with:colons');
+                expect(result).toEqual({
+                    username: 'user',
+                    password: 'pass:with:colons',
+                });
+            });
+
+            it('handles credentials without colon separator', () => {
+                const result = parseAuthCredentials('basic', 'usernameonly');
+                expect(result).toEqual({
+                    username: 'usernameonly',
+                    password: '',
+                });
+            });
+
+            it('handles empty credentials', () => {
+                const result = parseAuthCredentials('basic', '');
+                expect(result).toEqual({
+                    username: '',
+                    password: '',
+                });
+            });
+
+            it('handles empty username with password', () => {
+                const result = parseAuthCredentials('basic', ':password');
+                expect(result).toEqual({
+                    username: '',
+                    password: 'password',
+                });
+            });
+        });
+
+        describe('bearer auth', () => {
+            it('parses bearer token', () => {
+                const result = parseAuthCredentials('bearer', 'my-jwt-token');
+                expect(result).toEqual({ token: 'my-jwt-token' });
+            });
+
+            it('handles empty token', () => {
+                const result = parseAuthCredentials('bearer', '');
+                expect(result).toEqual({ token: '' });
+            });
+        });
+
+        describe('api_key auth', () => {
+            it('parses credentials with colon separator', () => {
+                const result = parseAuthCredentials('api_key', 'X-API-Key:secret123');
+                expect(result).toEqual({
+                    headerName: 'X-API-Key',
+                    apiKeyValue: 'secret123',
+                });
+            });
+
+            it('handles API key value containing colons', () => {
+                const result = parseAuthCredentials('api_key', 'X-Key:value:with:colons');
+                expect(result).toEqual({
+                    headerName: 'X-Key',
+                    apiKeyValue: 'value:with:colons',
+                });
+            });
+
+            it('handles credentials without colon separator', () => {
+                const result = parseAuthCredentials('api_key', 'headernameonly');
+                expect(result).toEqual({
+                    headerName: 'headernameonly',
+                    apiKeyValue: '',
+                });
+            });
+
+            it('handles empty credentials', () => {
+                const result = parseAuthCredentials('api_key', '');
+                expect(result).toEqual({
+                    headerName: '',
+                    apiKeyValue: '',
+                });
+            });
+        });
+
+        describe('none and unknown auth', () => {
+            it('returns empty object for none auth type', () => {
+                const result = parseAuthCredentials('none', 'anything');
+                expect(result).toEqual({});
+            });
+
+            it('returns empty object for unknown auth type', () => {
+                const result = parseAuthCredentials('oauth', 'credentials');
+                expect(result).toEqual({});
+            });
+
+            it('returns empty object for empty auth type', () => {
+                const result = parseAuthCredentials('', 'credentials');
+                expect(result).toEqual({});
+            });
+        });
+    });
+
+    describe('buildAuthCredentials', () => {
+        describe('basic auth', () => {
+            it('builds credentials from username and password', () => {
+                const result = buildAuthCredentials('basic', {
+                    username: 'myuser',
+                    password: 'mypassword',
+                });
+                expect(result).toBe('myuser:mypassword');
+            });
+
+            it('handles missing username', () => {
+                const result = buildAuthCredentials('basic', {
+                    password: 'mypassword',
+                });
+                expect(result).toBe(':mypassword');
+            });
+
+            it('handles missing password', () => {
+                const result = buildAuthCredentials('basic', {
+                    username: 'myuser',
+                });
+                expect(result).toBe('myuser:');
+            });
+
+            it('handles empty fields object', () => {
+                const result = buildAuthCredentials('basic', {});
+                expect(result).toBe(':');
+            });
+        });
+
+        describe('bearer auth', () => {
+            it('builds credentials from token', () => {
+                const result = buildAuthCredentials('bearer', { token: 'jwt-token' });
+                expect(result).toBe('jwt-token');
+            });
+
+            it('handles missing token', () => {
+                const result = buildAuthCredentials('bearer', {});
+                expect(result).toBe('');
+            });
+        });
+
+        describe('api_key auth', () => {
+            it('builds credentials from header name and value', () => {
+                const result = buildAuthCredentials('api_key', {
+                    headerName: 'X-API-Key',
+                    apiKeyValue: 'secret123',
+                });
+                expect(result).toBe('X-API-Key:secret123');
+            });
+
+            it('handles missing header name', () => {
+                const result = buildAuthCredentials('api_key', {
+                    apiKeyValue: 'secret',
+                });
+                expect(result).toBe(':secret');
+            });
+
+            it('handles missing API key value', () => {
+                const result = buildAuthCredentials('api_key', {
+                    headerName: 'X-Key',
+                });
+                expect(result).toBe('X-Key:');
+            });
+
+            it('handles empty fields object', () => {
+                const result = buildAuthCredentials('api_key', {});
+                expect(result).toBe(':');
+            });
+        });
+
+        describe('none and unknown auth', () => {
+            it('returns empty string for none auth type', () => {
+                const result = buildAuthCredentials('none', { anything: 'value' });
+                expect(result).toBe('');
+            });
+
+            it('returns empty string for unknown auth type', () => {
+                const result = buildAuthCredentials('oauth', { token: 'value' });
+                expect(result).toBe('');
+            });
+
+            it('returns empty string for empty auth type', () => {
+                const result = buildAuthCredentials('', { token: 'value' });
+                expect(result).toBe('');
+            });
+        });
+    });
+
+    describe('headersObjectToArray', () => {
+        beforeEach(() => {
+            vi.stubGlobal('crypto', {
+                randomUUID: vi.fn()
+                    .mockReturnValueOnce('uuid-1')
+                    .mockReturnValueOnce('uuid-2')
+                    .mockReturnValueOnce('uuid-3'),
+            });
+        });
+
+        it('converts empty object to empty array', () => {
+            const result = headersObjectToArray({});
+            expect(result).toEqual([]);
+        });
+
+        it('converts single entry with generated ID', () => {
+            const result = headersObjectToArray({ 'Content-Type': 'application/json' });
+            expect(result).toEqual([
+                { id: 'uuid-1', key: 'Content-Type', value: 'application/json' },
+            ]);
+        });
+
+        it('converts multiple entries with unique IDs', () => {
+            const result = headersObjectToArray({
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer token',
+            });
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual({
+                id: 'uuid-1',
+                key: 'Content-Type',
+                value: 'application/json',
+            });
+            expect(result[1]).toEqual({
+                id: 'uuid-2',
+                key: 'Authorization',
+                value: 'Bearer token',
+            });
+        });
+
+        it('generates unique IDs for each entry', () => {
+            const result = headersObjectToArray({
+                'X-Header-1': 'value1',
+                'X-Header-2': 'value2',
+                'X-Header-3': 'value3',
+            });
+            const ids = result.map((h) => h.id);
+            expect(ids).toEqual(['uuid-1', 'uuid-2', 'uuid-3']);
+        });
+
+        it('preserves empty values', () => {
+            const result = headersObjectToArray({ 'X-Empty': '' });
+            expect(result).toEqual([{ id: 'uuid-1', key: 'X-Empty', value: '' }]);
+        });
+    });
+
+    describe('headersArrayToObject', () => {
+        it('converts empty array to empty object', () => {
+            const result = headersArrayToObject([]);
+            expect(result).toEqual({});
+        });
+
+        it('converts single entry', () => {
+            const headers: HeaderEntry[] = [
+                { id: 'id-1', key: 'Content-Type', value: 'application/json' },
+            ];
+            const result = headersArrayToObject(headers);
+            expect(result).toEqual({ 'Content-Type': 'application/json' });
+        });
+
+        it('converts multiple entries', () => {
+            const headers: HeaderEntry[] = [
+                { id: 'id-1', key: 'Content-Type', value: 'application/json' },
+                { id: 'id-2', key: 'Authorization', value: 'Bearer token' },
+            ];
+            const result = headersArrayToObject(headers);
+            expect(result).toEqual({
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer token',
+            });
+        });
+
+        it('filters out entries with blank keys', () => {
+            const headers: HeaderEntry[] = [
+                { id: 'id-1', key: 'Valid-Key', value: 'valid-value' },
+                { id: 'id-2', key: '', value: 'orphan-value' },
+                { id: 'id-3', key: '   ', value: 'whitespace-key' },
+            ];
+            const result = headersArrayToObject(headers);
+            expect(result).toEqual({ 'Valid-Key': 'valid-value' });
+        });
+
+        it('trims key names', () => {
+            const headers: HeaderEntry[] = [
+                { id: 'id-1', key: '  Content-Type  ', value: 'application/json' },
+            ];
+            const result = headersArrayToObject(headers);
+            expect(result).toEqual({ 'Content-Type': 'application/json' });
+        });
+
+        it('preserves empty values', () => {
+            const headers: HeaderEntry[] = [
+                { id: 'id-1', key: 'X-Empty', value: '' },
+            ];
+            const result = headersArrayToObject(headers);
+            expect(result).toEqual({ 'X-Empty': '' });
+        });
+
+        it('ignores the id field in output', () => {
+            const headers: HeaderEntry[] = [
+                { id: 'should-not-appear', key: 'X-Test', value: 'test' },
+            ];
+            const result = headersArrayToObject(headers);
+            expect(result).toEqual({ 'X-Test': 'test' });
+            expect('id' in result).toBe(false);
+        });
+    });
+
+    describe('round-trip conversions', () => {
+        beforeEach(() => {
+            let counter = 0;
+            vi.stubGlobal('crypto', {
+                randomUUID: vi.fn(() => `uuid-${++counter}`),
+            });
+        });
+
+        it('parse then build basic auth preserves data', () => {
+            const original = 'myuser:mypassword';
+            const parsed = parseAuthCredentials('basic', original);
+            const rebuilt = buildAuthCredentials('basic', parsed);
+            expect(rebuilt).toBe(original);
+        });
+
+        it('parse then build bearer auth preserves data', () => {
+            const original = 'my-jwt-token';
+            const parsed = parseAuthCredentials('bearer', original);
+            const rebuilt = buildAuthCredentials('bearer', parsed);
+            expect(rebuilt).toBe(original);
+        });
+
+        it('parse then build api_key auth preserves data', () => {
+            const original = 'X-API-Key:secret123';
+            const parsed = parseAuthCredentials('api_key', original);
+            const rebuilt = buildAuthCredentials('api_key', parsed);
+            expect(rebuilt).toBe(original);
+        });
+
+        it('array to object to array preserves header data (excluding IDs)', () => {
+            const original: HeaderEntry[] = [
+                { id: 'orig-1', key: 'Content-Type', value: 'application/json' },
+                { id: 'orig-2', key: 'Authorization', value: 'Bearer token' },
+            ];
+            const asObject = headersArrayToObject(original);
+            const backToArray = headersObjectToArray(asObject);
+
+            // IDs will be different, but keys and values should match
+            expect(backToArray).toHaveLength(2);
+            const keys = backToArray.map((h) => h.key);
+            const values = backToArray.map((h) => h.value);
+            expect(keys).toContain('Content-Type');
+            expect(keys).toContain('Authorization');
+            expect(values).toContain('application/json');
+            expect(values).toContain('Bearer token');
+        });
+
+        it('object to array to object preserves header data', () => {
+            const original: Record<string, string> = {
+                'Content-Type': 'application/json',
+                'X-Custom': 'custom-value',
+            };
+            const asArray = headersObjectToArray(original);
+            const backToObject = headersArrayToObject(asArray);
+            expect(backToObject).toEqual(original);
+        });
+    });
+});

--- a/client/src/components/AdminPanel/webhook/index.ts
+++ b/client/src/components/AdminPanel/webhook/index.ts
@@ -1,0 +1,40 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+export type {
+    WebhookChannel,
+    HeaderEntry,
+    WebhookFormState,
+} from './webhookTypes';
+export { DEFAULT_WEBHOOK_FORM } from './webhookTypes';
+
+export {
+    HTTP_METHODS,
+    AUTH_TYPES,
+    DEFAULT_ALERT_FIRE_TEMPLATE,
+    DEFAULT_ALERT_CLEAR_TEMPLATE,
+    DEFAULT_REMINDER_TEMPLATE,
+    parseAuthCredentials,
+    buildAuthCredentials,
+    headersObjectToArray,
+    headersArrayToObject,
+} from './webhookHelpers';
+
+export { default as WebhookSettingsTab } from './WebhookSettingsTab';
+export type { WebhookSettingsTabProps } from './WebhookSettingsTab';
+
+export { default as WebhookHeadersTab } from './WebhookHeadersTab';
+export type { WebhookHeadersTabProps } from './WebhookHeadersTab';
+
+export { default as WebhookAuthTab } from './WebhookAuthTab';
+export type { WebhookAuthTabProps } from './WebhookAuthTab';
+
+export { default as WebhookTemplatesTab } from './WebhookTemplatesTab';
+export type { WebhookTemplatesTabProps } from './WebhookTemplatesTab';

--- a/client/src/components/AdminPanel/webhook/webhookHelpers.ts
+++ b/client/src/components/AdminPanel/webhook/webhookHelpers.ts
@@ -1,0 +1,183 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { HeaderEntry } from './webhookTypes';
+
+/** Supported HTTP methods for webhook channels. */
+export const HTTP_METHODS = ['POST', 'GET', 'PUT', 'PATCH'];
+
+/** Authentication type options for the webhook auth select. */
+export const AUTH_TYPES = [
+    { value: 'none', label: 'None' },
+    { value: 'basic', label: 'Basic' },
+    { value: 'bearer', label: 'Bearer Token' },
+    { value: 'api_key', label: 'API Key' },
+];
+
+/** Default template for alert fire notifications. */
+export const DEFAULT_ALERT_FIRE_TEMPLATE = `{
+  "event": "alert_fire",
+  "alert_id": {{.AlertID}},
+  "title": "{{.AlertTitle}}",
+  "description": "{{.AlertDescription}}",
+  "severity": "{{.Severity}}",
+  "server": {
+    "name": "{{.ServerName}}",
+    "host": "{{.ServerHost}}",
+    "port": {{.ServerPort}}
+  },
+  {{- if .DatabaseName}}
+  "database": "{{.DatabaseName}}",
+  {{- end}}
+  {{- if .MetricName}}
+  "metric": {
+    "name": "{{.MetricName}}"
+    {{- if .MetricValue}}, "value": {{.MetricValue}}{{end}}
+    {{- if .ThresholdValue}}, "threshold": {{.ThresholdValue}}{{end}}
+    {{- if .Operator}}, "operator": "{{.Operator}}"{{end}}
+  },
+  {{- end}}
+  "triggered_at": "{{.TriggeredAt.Format "2006-01-02T15:04:05Z07:00"}}"
+}`;
+
+/** Default template for alert clear notifications. */
+export const DEFAULT_ALERT_CLEAR_TEMPLATE = `{
+  "event": "alert_clear",
+  "alert_id": {{.AlertID}},
+  "title": "{{.AlertTitle}}",
+  "server": {
+    "name": "{{.ServerName}}",
+    "host": "{{.ServerHost}}",
+    "port": {{.ServerPort}}
+  },
+  "triggered_at": "{{.TriggeredAt.Format "2006-01-02T15:04:05Z07:00"}}"
+  {{- if .ClearedAt}},
+  "cleared_at": "{{.ClearedAt.Format "2006-01-02T15:04:05Z07:00"}}"
+  {{- end}},
+  "duration": "{{.Duration}}"
+}`;
+
+/** Default template for reminder notifications. */
+export const DEFAULT_REMINDER_TEMPLATE = `{
+  "event": "reminder",
+  "alert_id": {{.AlertID}},
+  "title": "{{.AlertTitle}}",
+  "description": "{{.AlertDescription}}",
+  "severity": "{{.Severity}}",
+  "server": {
+    "name": "{{.ServerName}}",
+    "host": "{{.ServerHost}}",
+    "port": {{.ServerPort}}
+  },
+  "triggered_at": "{{.TriggeredAt.Format "2006-01-02T15:04:05Z07:00"}}",
+  "reminder_count": {{.ReminderCount}}
+}`;
+
+/**
+ * Parse auth_credentials based on auth_type into individual fields.
+ *
+ * @param authType - The authentication type (basic, bearer, api_key, etc.)
+ * @param credentials - The raw credentials string from the API
+ * @returns An object with parsed credential fields
+ */
+export const parseAuthCredentials = (
+    authType: string,
+    credentials: string,
+): Record<string, string> => {
+    switch (authType) {
+        case 'basic': {
+            const separatorIndex = credentials.indexOf(':');
+            if (separatorIndex === -1) {
+                return { username: credentials, password: '' };
+            }
+            return {
+                username: credentials.substring(0, separatorIndex),
+                password: credentials.substring(separatorIndex + 1),
+            };
+        }
+        case 'bearer':
+            return { token: credentials };
+        case 'api_key': {
+            const separatorIndex = credentials.indexOf(':');
+            if (separatorIndex === -1) {
+                return { headerName: credentials, apiKeyValue: '' };
+            }
+            return {
+                headerName: credentials.substring(0, separatorIndex),
+                apiKeyValue: credentials.substring(separatorIndex + 1),
+            };
+        }
+        default:
+            return {};
+    }
+};
+
+/**
+ * Build auth_credentials string from individual fields based on auth_type.
+ *
+ * @param authType - The authentication type (basic, bearer, api_key, etc.)
+ * @param fields - An object with credential field values
+ * @returns The combined credentials string for the API
+ */
+export const buildAuthCredentials = (
+    authType: string,
+    fields: Record<string, string>,
+): string => {
+    switch (authType) {
+        case 'basic':
+            return `${fields.username || ''}:${fields.password || ''}`;
+        case 'bearer':
+            return fields.token || '';
+        case 'api_key':
+            return `${fields.headerName || ''}:${fields.apiKeyValue || ''}`;
+        default:
+            return '';
+    }
+};
+
+/**
+ * Convert a headers object from the API into an array of HeaderEntry objects.
+ * Each entry receives a unique ID for use as a React key.
+ *
+ * @param headers - The headers object from the API
+ * @returns An array of HeaderEntry objects with generated IDs
+ */
+export const headersObjectToArray = (
+    headers: Record<string, string>,
+): HeaderEntry[] => {
+    const entries = Object.entries(headers);
+    if (entries.length === 0) {
+        return [];
+    }
+    return entries.map(([key, value]) => ({
+        id: crypto.randomUUID(),
+        key,
+        value,
+    }));
+};
+
+/**
+ * Convert an array of HeaderEntry objects into a headers object for the API.
+ * Filters out entries with blank keys and trims key names.
+ *
+ * @param headers - The array of HeaderEntry objects
+ * @returns A headers object suitable for the API
+ */
+export const headersArrayToObject = (
+    headers: HeaderEntry[],
+): Record<string, string> => {
+    return headers.reduce<Record<string, string>>((acc, h) => {
+        const trimmedKey = h.key.trim();
+        if (trimmedKey) {
+            acc[trimmedKey] = h.value;
+        }
+        return acc;
+    }, {});
+};

--- a/client/src/components/AdminPanel/webhook/webhookTypes.ts
+++ b/client/src/components/AdminPanel/webhook/webhookTypes.ts
@@ -1,0 +1,62 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { BaseChannel } from '../channels/channelTypes';
+
+/** Webhook notification channel returned by the API. */
+export interface WebhookChannel extends BaseChannel {
+    endpoint_url: string;
+    http_method: string;
+    headers: Record<string, string>;
+    auth_type: string;
+    auth_credentials: string;
+    template_alert_fire: string;
+    template_alert_clear: string;
+    template_reminder: string;
+}
+
+/** A single HTTP header entry with a stable ID for React keys. */
+export interface HeaderEntry {
+    id: string;
+    key: string;
+    value: string;
+}
+
+/** Form state for creating or editing a webhook channel. */
+export interface WebhookFormState {
+    name: string;
+    description: string;
+    endpoint_url: string;
+    http_method: string;
+    headers: HeaderEntry[];
+    auth_type: string;
+    auth_credentials: string;
+    enabled: boolean;
+    is_estate_default: boolean;
+    template_alert_fire: string;
+    template_alert_clear: string;
+    template_reminder: string;
+}
+
+/** Default form state for creating a new webhook channel. */
+export const DEFAULT_WEBHOOK_FORM: WebhookFormState = {
+    name: '',
+    description: '',
+    endpoint_url: '',
+    http_method: 'POST',
+    headers: [],
+    auth_type: 'none',
+    auth_credentials: '',
+    enabled: true,
+    is_estate_default: false,
+    template_alert_fire: '',
+    template_alert_clear: '',
+    template_reminder: '',
+};


### PR DESCRIPTION
## Summary

- Extract shared CRUD state management from `AdminEmailChannels` (983→417 lines) and `AdminWebhookChannels` (1015→350 lines) into a reusable `useChannelCRUD` hook, `ChannelTable`, and `ChannelDialogShell` components.
- Decompose each channel component into focused sub-components (settings, recipients, headers, auth, templates tabs).
- Fix `key={index}` anti-pattern in webhook headers by generating stable UUIDs for header entries.
- Add 168 new tests across 7 test files covering shared infrastructure, both channel orchestrators, webhook helpers, and all edge cases.

### Before/After Line Counts

| File | Before | After |
|------|--------|-------|
| AdminEmailChannels.tsx | 983 | 417 |
| AdminWebhookChannels.tsx | 1,015 | 350 |

### New Shared Components

| File | Lines | Purpose |
|------|-------|---------|
| channels/useChannelCRUD.ts | 266 | Shared CRUD hook (fetch, toggle, test, delete, dialog) |
| channels/ChannelTable.tsx | 262 | Shared channel list table |
| channels/ChannelDialogShell.tsx | 112 | Shared dialog wrapper with tabs |
| channels/channelTypes.ts | 26 | BaseChannel, ChannelColumnDef types |

### Coverage

All new/modified files meet the 90% line coverage floor:
- useChannelCRUD.ts: 100%
- ChannelTable.tsx: 100%
- ChannelDialogShell.tsx: 100%
- AdminEmailChannels.tsx: 91.36%
- AdminWebhookChannels.tsx: 90.28%
- webhookHelpers.ts: 100%

## Test plan

- [x] All 168 new tests pass
- [x] Existing AdminPanel tests pass (AdminTokenScopes, AdminProbes — 24 tests)
- [x] Hook tests pass (237 tests)
- [x] Utils tests pass (318 tests)
- [x] ESLint: zero errors on all new/modified files
- [x] TypeScript: no new type errors introduced
- [ ] CI pipeline passes
- [ ] CodeRabbit review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New reusable channel table and tabbed dialog shell; added email recipients/settings and webhook settings/headers/auth/templates tabs and recipient-count display.
  * New shared channel types, form defaults, and webhook helper utilities for auth/headers/templates.

* **Refactor**
  * Centralized channel CRUD/dialog state and flows for email and webhook panels with unified loading, saving, error, success, and pending-recipient handling.

* **Tests**
  * Expanded unit and UI tests covering CRUD flows, toggles, test-send, recipients/headers/auth/templates, and the shared CRUD hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->