### PR TITLE
Decompose useChat hook and fix key={index} anti-patterns (#80)

### DIFF
--- a/client/src/components/AdminPanel/channels/ChannelDialogShell.tsx
+++ b/client/src/components/AdminPanel/channels/ChannelDialogShell.tsx
@@ -80,8 +80,8 @@ export function ChannelDialogShell({
                     onChange={(_e, newValue: number) => onTabChange(newValue)}
                     sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
                 >
-                    {tabs.map((label, index) => (
-                        <Tab key={index} label={label} />
+                    {tabs.map((label) => (
+                        <Tab key={label} label={label} />
                     ))}
                 </Tabs>
                 {children}

--- a/client/src/components/AdminPanel/channels/ChannelTable.tsx
+++ b/client/src/components/AdminPanel/channels/ChannelTable.tsx
@@ -149,8 +149,8 @@ export function ChannelTable<T extends BaseChannel>({
                         <TableRow>
                             <TableCell sx={tableHeaderCellSx}>Name</TableCell>
                             <TableCell sx={tableHeaderCellSx}>Description</TableCell>
-                            {extraColumns.map((col, index) => (
-                                <TableCell key={index} sx={tableHeaderCellSx}>
+                            {extraColumns.map((col) => (
+                                <TableCell key={col.label} sx={tableHeaderCellSx}>
                                     {col.label}
                                 </TableCell>
                             ))}
@@ -169,8 +169,8 @@ export function ChannelTable<T extends BaseChannel>({
                                     <TableCell>
                                         {truncateDescription(channel.description)}
                                     </TableCell>
-                                    {extraColumns.map((col, index) => (
-                                        <TableCell key={index}>
+                                    {extraColumns.map((col) => (
+                                        <TableCell key={col.label}>
                                             {col.render(channel)}
                                         </TableCell>
                                     ))}

--- a/client/src/hooks/chat/__tests__/chatAgenticLoop.test.ts
+++ b/client/src/hooks/chat/__tests__/chatAgenticLoop.test.ts
@@ -1,0 +1,867 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    runAgenticLoop,
+    AgenticLoopParams,
+    FetchFunction,
+    ITERATION_LIMIT_MESSAGE,
+} from '../chatAgenticLoop';
+import { APIMessage, ToolDefinition } from '../chatTypes';
+import { LLMResponse, ToolCallResponse } from '../../../types/llm';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create sample tools for testing.
+ */
+function createSampleTools(): ToolDefinition[] {
+    return [
+        {
+            name: 'list_connections',
+            description: 'List database connections',
+            inputSchema: {
+                type: 'object',
+                properties: {},
+                required: [],
+            },
+        },
+        {
+            name: 'query_database',
+            description: 'Execute SQL query',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    query: { type: 'string', description: 'SQL query' },
+                },
+                required: ['query'],
+            },
+        },
+    ];
+}
+
+/**
+ * Create default loop params for testing.
+ */
+function createLoopParams(
+    overrides: Partial<AgenticLoopParams> = {},
+): AgenticLoopParams {
+    return {
+        apiMessages: [{ role: 'user', content: 'Hello' }],
+        availableTools: createSampleTools(),
+        systemPrompt: 'You are a helpful assistant.',
+        maxIterations: 10,
+        abortSignal: new AbortController().signal,
+        fetchFn: vi.fn(),
+        onToolActivity: vi.fn(),
+        ...overrides,
+    };
+}
+
+/**
+ * Create an LLM response with only text content (no tool calls).
+ */
+function createTextResponse(text: string): LLMResponse {
+    return {
+        content: [{ type: 'text', text }],
+        stop_reason: 'end_turn',
+    };
+}
+
+/**
+ * Create an LLM response with tool use requests.
+ */
+function createToolUseResponse(
+    tools: Array<{ id: string; name: string; input: Record<string, unknown> }>,
+    text?: string,
+): LLMResponse {
+    const content = tools.map(t => ({
+        type: 'tool_use',
+        id: t.id,
+        name: t.name,
+        input: t.input,
+    }));
+    if (text) {
+        content.unshift({ type: 'text', text, id: '', name: '', input: {} });
+    }
+    return { content };
+}
+
+/**
+ * Create a tool call response.
+ */
+function createToolCallResponse(
+    text: string,
+    isError = false,
+): ToolCallResponse {
+    return {
+        content: [{ text }],
+        isError,
+    };
+}
+
+/**
+ * Create a mock fetch function that returns different responses
+ * based on the URL.
+ */
+function createMockFetch(
+    llmResponses: LLMResponse[],
+    toolResponses: Map<string, ToolCallResponse> = new Map(),
+): FetchFunction {
+    let llmCallIndex = 0;
+
+    return vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+        if (url === '/api/v1/llm/chat') {
+            const response = llmResponses[llmCallIndex] ?? createTextResponse('');
+            llmCallIndex++;
+            return {
+                ok: true,
+                json: () => Promise.resolve(response),
+                text: () => Promise.resolve(''),
+            };
+        }
+
+        if (url === '/api/v1/mcp/tools/call') {
+            const body = JSON.parse(init?.body as string);
+            const toolResponse =
+                toolResponses.get(body.name) ??
+                createToolCallResponse('Tool result');
+            return {
+                ok: true,
+                json: () => Promise.resolve(toolResponse),
+                text: () => Promise.resolve(''),
+            };
+        }
+
+        return {
+            ok: false,
+            json: () => Promise.reject(new Error('Unknown endpoint')),
+            text: () => Promise.resolve('Unknown endpoint'),
+        };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('chatAgenticLoop', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    describe('runAgenticLoop', () => {
+        describe('simple text responses (no tool calls)', () => {
+            it('returns final message when LLM responds with text only', async () => {
+                const mockFetch = createMockFetch([
+                    createTextResponse('Hello! How can I help?'),
+                ]);
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.role).toBe('assistant');
+                expect(result.finalMessage.content).toBe('Hello! How can I help?');
+                expect(result.finalMessage.timestamp).toBe('2024-01-15T12:00:00.000Z');
+                expect(result.finalMessage.activity).toBeUndefined();
+            });
+
+            it('updates API messages with assistant response', async () => {
+                const initialMessages: APIMessage[] = [
+                    { role: 'user', content: 'Hi' },
+                ];
+                const mockFetch = createMockFetch([
+                    createTextResponse('Hello!'),
+                ]);
+                const params = createLoopParams({
+                    apiMessages: initialMessages,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.updatedApiMessages).toHaveLength(2);
+                expect(result.updatedApiMessages[0]).toEqual({
+                    role: 'user',
+                    content: 'Hi',
+                });
+                expect(result.updatedApiMessages[1]).toEqual({
+                    role: 'assistant',
+                    content: 'Hello!',
+                });
+            });
+
+            it('joins multiple text blocks with newlines', async () => {
+                const mockFetch = createMockFetch([
+                    {
+                        content: [
+                            { type: 'text', text: 'First line' },
+                            { type: 'text', text: 'Second line' },
+                        ],
+                    },
+                ]);
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.content).toBe('First line\nSecond line');
+            });
+
+            it('handles empty text response', async () => {
+                const mockFetch = createMockFetch([{ content: [] }]);
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.content).toBe('');
+            });
+        });
+
+        describe('tool execution', () => {
+            it('executes single tool and returns final response', async () => {
+                const toolResponses = new Map([
+                    ['list_connections', createToolCallResponse('Connection 1, Connection 2')],
+                ]);
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 'tool-1', name: 'list_connections', input: {} },
+                        ]),
+                        createTextResponse('Here are your connections: Connection 1, Connection 2'),
+                    ],
+                    toolResponses,
+                );
+                const onToolActivity = vi.fn();
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    onToolActivity,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.content).toContain('Here are your connections');
+                expect(result.finalMessage.activity).toHaveLength(1);
+                const activity = result.finalMessage.activity;
+                if (!activity) {
+                    throw new Error('expected activity');
+                }
+                expect(activity[0].name).toBe('list_connections');
+                expect(activity[0].status).toBe('completed');
+            });
+
+            it('executes multiple tools sequentially', async () => {
+                const toolResponses = new Map([
+                    ['list_connections', createToolCallResponse('Conn 1')],
+                    ['query_database', createToolCallResponse('Query result')],
+                ]);
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 'tool-1', name: 'list_connections', input: {} },
+                            { id: 'tool-2', name: 'query_database', input: { query: 'SELECT 1' } },
+                        ]),
+                        createTextResponse('Done'),
+                    ],
+                    toolResponses,
+                );
+                const onToolActivity = vi.fn();
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    onToolActivity,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.activity).toHaveLength(2);
+                expect(onToolActivity).toHaveBeenCalled();
+            });
+
+            it('handles tool error and continues', async () => {
+                const toolResponses = new Map([
+                    ['list_connections', createToolCallResponse('Error: permission denied', true)],
+                ]);
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 'tool-1', name: 'list_connections', input: {} },
+                        ]),
+                        createTextResponse('Sorry, I could not list connections.'),
+                    ],
+                    toolResponses,
+                );
+                const onToolActivity = vi.fn();
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    onToolActivity,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                const activity = result.finalMessage.activity;
+                if (!activity) {
+                    throw new Error('expected activity');
+                }
+                expect(activity[0].status).toBe('error');
+            });
+
+            it('handles tool call network failure', async () => {
+                let llmCallCount = 0;
+                const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+                    if (url === '/api/v1/llm/chat') {
+                        llmCallCount++;
+                        if (llmCallCount === 1) {
+                            return {
+                                ok: true,
+                                json: () =>
+                                    Promise.resolve(
+                                        createToolUseResponse([
+                                            { id: 'tool-1', name: 'list_connections', input: {} },
+                                        ]),
+                                    ),
+                            };
+                        }
+                        return {
+                            ok: true,
+                            json: () => Promise.resolve(createTextResponse('Error handled')),
+                        };
+                    }
+                    if (url === '/api/v1/mcp/tools/call') {
+                        return {
+                            ok: false,
+                            status: 500,
+                            text: () => Promise.resolve('Internal Server Error'),
+                        };
+                    }
+                    return { ok: false, text: () => Promise.resolve('') };
+                });
+
+                const onToolActivity = vi.fn();
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    onToolActivity,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                const activity = result.finalMessage.activity;
+                if (!activity) {
+                    throw new Error('expected activity');
+                }
+                expect(activity[0].status).toBe('error');
+            });
+
+            it('appends tool results to API messages', async () => {
+                const toolResponses = new Map([
+                    ['list_connections', createToolCallResponse('Result data')],
+                ]);
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 'tool-abc', name: 'list_connections', input: {} },
+                        ]),
+                        createTextResponse('Done'),
+                    ],
+                    toolResponses,
+                );
+                const params = createLoopParams({
+                    apiMessages: [{ role: 'user', content: 'List connections' }],
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                // Messages: user, assistant (tool_use), user (tool_result), assistant (text)
+                expect(result.updatedApiMessages.length).toBeGreaterThanOrEqual(4);
+
+                // Find the tool result message
+                const toolResultMsg = result.updatedApiMessages.find(
+                    m => m.role === 'user' && Array.isArray(m.content),
+                );
+                expect(toolResultMsg).toBeDefined();
+            });
+
+            it('handles tool with missing id', async () => {
+                const mockFetch = createMockFetch(
+                    [
+                        {
+                            content: [
+                                {
+                                    type: 'tool_use',
+                                    name: 'list_connections',
+                                    input: {},
+                                    // No id field
+                                },
+                            ],
+                        },
+                        createTextResponse('Done'),
+                    ],
+                    new Map([
+                        ['list_connections', createToolCallResponse('Result')],
+                    ]),
+                );
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                // Should complete without error, using empty string for id
+                expect(result.finalMessage.content).toBe('Done');
+            });
+
+            it('handles tool with missing name', async () => {
+                const mockFetch = createMockFetch(
+                    [
+                        {
+                            content: [
+                                {
+                                    type: 'tool_use',
+                                    id: 'tool-1',
+                                    input: {},
+                                    // No name field
+                                },
+                            ],
+                        },
+                        createTextResponse('Done'),
+                    ],
+                    new Map(),
+                );
+                const onToolActivity = vi.fn();
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    onToolActivity,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                // Should use 'unknown' as tool name
+                const activity = result.finalMessage.activity;
+                if (!activity) {
+                    throw new Error('expected activity');
+                }
+                expect(activity[0].name).toBe('unknown');
+            });
+
+            it('handles tool response with no content', async () => {
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 'tool-1', name: 'list_connections', input: {} },
+                        ]),
+                        createTextResponse('Done'),
+                    ],
+                    new Map([
+                        ['list_connections', { isError: false }],
+                    ]),
+                );
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.content).toBe('Done');
+            });
+
+            it('handles tool response isError with no content text', async () => {
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 'tool-1', name: 'list_connections', input: {} },
+                        ]),
+                        createTextResponse('Error handled'),
+                    ],
+                    new Map([
+                        ['list_connections', { content: [], isError: true }],
+                    ]),
+                );
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                const activity = result.finalMessage.activity;
+                if (!activity) {
+                    throw new Error('expected activity');
+                }
+                expect(activity[0].status).toBe('error');
+            });
+        });
+
+        describe('multi-iteration scenarios', () => {
+            it('handles multiple iterations with different tools', async () => {
+                const toolResponses = new Map([
+                    ['list_connections', createToolCallResponse('Connections: A, B')],
+                    ['query_database', createToolCallResponse('Query result: 42')],
+                ]);
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 't1', name: 'list_connections', input: {} },
+                        ]),
+                        createToolUseResponse([
+                            { id: 't2', name: 'query_database', input: { query: 'SELECT 1' } },
+                        ]),
+                        createTextResponse('Final answer: 42'),
+                    ],
+                    toolResponses,
+                );
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.content).toBe('Final answer: 42');
+                expect(result.finalMessage.activity).toHaveLength(2);
+            });
+        });
+
+        describe('iteration limit', () => {
+            it('returns error when max iterations exceeded', async () => {
+                // Always return tool use, never text
+                const mockFetch = createMockFetch(
+                    Array(10).fill(
+                        createToolUseResponse([
+                            { id: 'tool-1', name: 'list_connections', input: {} },
+                        ]),
+                    ),
+                    new Map([['list_connections', createToolCallResponse('Result')]]),
+                );
+                const params = createLoopParams({
+                    maxIterations: 3,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.content).toBe(ITERATION_LIMIT_MESSAGE);
+                expect(result.finalMessage.isError).toBe(true);
+            });
+
+            it('includes tool activity in error message when limit exceeded', async () => {
+                const mockFetch = createMockFetch(
+                    Array(5).fill(
+                        createToolUseResponse([
+                            { id: 'tool-1', name: 'list_connections', input: {} },
+                        ]),
+                    ),
+                    new Map([['list_connections', createToolCallResponse('Result')]]),
+                );
+                const params = createLoopParams({
+                    maxIterations: 2,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.activity).toHaveLength(2);
+            });
+
+            it('appends error message to API messages when limit exceeded', async () => {
+                const mockFetch = createMockFetch(
+                    Array(5).fill(
+                        createToolUseResponse([
+                            { id: 'tool-1', name: 'list_connections', input: {} },
+                        ]),
+                    ),
+                    new Map([['list_connections', createToolCallResponse('Result')]]),
+                );
+                const params = createLoopParams({
+                    maxIterations: 1,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                const lastMessage =
+                    result.updatedApiMessages[result.updatedApiMessages.length - 1];
+                expect(lastMessage.role).toBe('assistant');
+                expect(lastMessage.content).toBe(ITERATION_LIMIT_MESSAGE);
+            });
+        });
+
+        describe('abort handling', () => {
+            it('throws AbortError when signal is already aborted', async () => {
+                const abortController = new AbortController();
+                abortController.abort();
+                const params = createLoopParams({
+                    abortSignal: abortController.signal,
+                });
+
+                await expect(runAgenticLoop(params)).rejects.toThrow('Aborted');
+            });
+
+            it('throws AbortError when aborted during LLM call', async () => {
+                const abortController = new AbortController();
+                const mockFetch = vi.fn().mockImplementation(async () => {
+                    abortController.abort();
+                    const error = new Error('Aborted');
+                    error.name = 'AbortError';
+                    throw error;
+                });
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    abortSignal: abortController.signal,
+                });
+
+                await expect(runAgenticLoop(params)).rejects.toThrow('Aborted');
+            });
+
+            it('throws AbortError when aborted during tool call', async () => {
+                const abortController = new AbortController();
+                const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+                    if (url === '/api/v1/llm/chat') {
+                        return {
+                            ok: true,
+                            json: () =>
+                                Promise.resolve(
+                                    createToolUseResponse([
+                                        { id: 't1', name: 'list_connections', input: {} },
+                                    ]),
+                                ),
+                        };
+                    }
+                    if (url === '/api/v1/mcp/tools/call') {
+                        abortController.abort();
+                        const error = new Error('Aborted');
+                        error.name = 'AbortError';
+                        throw error;
+                    }
+                    return { ok: false, text: () => Promise.resolve('') };
+                });
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    abortSignal: abortController.signal,
+                });
+
+                await expect(runAgenticLoop(params)).rejects.toThrow('Aborted');
+            });
+        });
+
+        describe('error handling', () => {
+            it('throws error when LLM request fails', async () => {
+                const mockFetch = vi.fn().mockResolvedValue({
+                    ok: false,
+                    text: () => Promise.resolve('Rate limit exceeded'),
+                });
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                await expect(runAgenticLoop(params)).rejects.toThrow(
+                    'LLM request failed: Rate limit exceeded',
+                );
+            });
+
+            it('throws error when LLM returns invalid JSON', async () => {
+                const mockFetch = vi.fn().mockResolvedValue({
+                    ok: true,
+                    json: () => Promise.reject(new Error('Invalid JSON')),
+                });
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                await expect(runAgenticLoop(params)).rejects.toThrow('Invalid JSON');
+            });
+
+            it('handles network error during LLM call', async () => {
+                const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                await expect(runAgenticLoop(params)).rejects.toThrow('Network error');
+            });
+
+            it('records tool execution error in results', async () => {
+                let callCount = 0;
+                const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+                    if (url === '/api/v1/llm/chat') {
+                        callCount++;
+                        if (callCount === 1) {
+                            return {
+                                ok: true,
+                                json: () =>
+                                    Promise.resolve(
+                                        createToolUseResponse([
+                                            { id: 't1', name: 'list_connections', input: {} },
+                                        ]),
+                                    ),
+                            };
+                        }
+                        return {
+                            ok: true,
+                            json: () => Promise.resolve(createTextResponse('Done')),
+                        };
+                    }
+                    if (url === '/api/v1/mcp/tools/call') {
+                        throw new Error('Connection refused');
+                    }
+                    return { ok: false, text: () => Promise.resolve('') };
+                });
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                // Tool error should be recorded and loop should continue
+                const activity = result.finalMessage.activity;
+                if (!activity) {
+                    throw new Error('expected activity');
+                }
+                expect(activity[0].status).toBe('error');
+            });
+        });
+
+        describe('API message formatting', () => {
+            it('sends correct request body to LLM endpoint', async () => {
+                const mockFetch = createMockFetch([createTextResponse('Hi')]);
+                const params = createLoopParams({
+                    apiMessages: [{ role: 'user', content: 'Hello' }],
+                    systemPrompt: 'Be helpful',
+                    fetchFn: mockFetch,
+                });
+
+                await runAgenticLoop(params);
+
+                expect(mockFetch).toHaveBeenCalledWith(
+                    '/api/v1/llm/chat',
+                    expect.objectContaining({
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                    }),
+                );
+
+                const call = mockFetch.mock.calls[0];
+                const body = JSON.parse(call[1]?.body as string);
+                expect(body.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+                expect(body.system).toBe('Be helpful');
+                expect(body.tools).toEqual(params.availableTools);
+            });
+
+            it('sends correct request body to tool call endpoint', async () => {
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 't1', name: 'query_database', input: { query: 'SELECT 1' } },
+                        ]),
+                        createTextResponse('Done'),
+                    ],
+                    new Map([['query_database', createToolCallResponse('1')]]),
+                );
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                await runAgenticLoop(params);
+
+                // Find the tool call
+                const toolCall = mockFetch.mock.calls.find(
+                    c => c[0] === '/api/v1/mcp/tools/call',
+                );
+                if (!toolCall) {
+                    throw new Error('expected toolCall');
+                }
+
+                const body = JSON.parse(toolCall[1]?.body as string);
+                expect(body.name).toBe('query_database');
+                expect(body.arguments).toEqual({ query: 'SELECT 1' });
+            });
+
+            it('passes abort signal to fetch calls', async () => {
+                const abortController = new AbortController();
+                const mockFetch = createMockFetch([createTextResponse('Hi')]);
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    abortSignal: abortController.signal,
+                });
+
+                await runAgenticLoop(params);
+
+                expect(mockFetch).toHaveBeenCalledWith(
+                    '/api/v1/llm/chat',
+                    expect.objectContaining({
+                        signal: abortController.signal,
+                    }),
+                );
+            });
+        });
+
+        describe('tool activity callbacks', () => {
+            it('calls onToolActivity when tool starts running', async () => {
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 't1', name: 'list_connections', input: {} },
+                        ]),
+                        createTextResponse('Done'),
+                    ],
+                    new Map([['list_connections', createToolCallResponse('Result')]]),
+                );
+                const activityHistory: Array<Array<{ status: string }>> = [];
+                const onToolActivity = vi.fn().mockImplementation(activities => {
+                    // Capture a copy of each activity state
+                    activityHistory.push(activities.map((a: { status: string }) => ({ ...a })));
+                });
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    onToolActivity,
+                });
+
+                await runAgenticLoop(params);
+
+                // Should be called at least twice: once for running, once for completed
+                expect(onToolActivity).toHaveBeenCalled();
+                // First call should have status 'running'
+                expect(activityHistory[0][0].status).toBe('running');
+            });
+
+            it('calls onToolActivity when tool completes', async () => {
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 't1', name: 'list_connections', input: {} },
+                        ]),
+                        createTextResponse('Done'),
+                    ],
+                    new Map([['list_connections', createToolCallResponse('Result')]]),
+                );
+                const onToolActivity = vi.fn();
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    onToolActivity,
+                });
+
+                await runAgenticLoop(params);
+
+                const lastCall = onToolActivity.mock.calls[onToolActivity.mock.calls.length - 1][0];
+                expect(lastCall[0].status).toBe('completed');
+            });
+
+            it('calls onToolActivity when tool errors', async () => {
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 't1', name: 'list_connections', input: {} },
+                        ]),
+                        createTextResponse('Error handled'),
+                    ],
+                    new Map([['list_connections', createToolCallResponse('Error', true)]]),
+                );
+                const onToolActivity = vi.fn();
+                const params = createLoopParams({
+                    fetchFn: mockFetch,
+                    onToolActivity,
+                });
+
+                await runAgenticLoop(params);
+
+                const lastCall = onToolActivity.mock.calls[onToolActivity.mock.calls.length - 1][0];
+                expect(lastCall[0].status).toBe('error');
+            });
+        });
+    });
+});

--- a/client/src/hooks/chat/__tests__/chatCompaction.test.ts
+++ b/client/src/hooks/chat/__tests__/chatCompaction.test.ts
@@ -1,0 +1,286 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { maybeCompact, FetchFunction } from '../chatCompaction';
+import { APIMessage } from '../chatTypes';
+import {
+    COMPACTION_MAX_TOKENS,
+    COMPACTION_RECENT_WINDOW,
+} from '../chatConstants';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock fetch function that returns the specified response.
+ */
+function createMockFetch(
+    ok: boolean,
+    data?: object,
+    text?: string,
+): FetchFunction {
+    return vi.fn().mockResolvedValue({
+        ok,
+        json: vi.fn().mockResolvedValue(data ?? {}),
+        text: vi.fn().mockResolvedValue(text ?? ''),
+    });
+}
+
+/**
+ * Create a large message array that exceeds the compaction threshold.
+ * Each message contributes approximately 4 + (content.length / 4) tokens.
+ */
+function createLargeMessageArray(): APIMessage[] {
+    // To exceed COMPACTION_TOKEN_THRESHOLD (80,000), we need messages
+    // that sum to at least 80,000 tokens.
+    // Each message with 400 chars of content = 4 + 100 = 104 tokens.
+    // 80,000 / 104 = ~769 messages needed.
+    const messages: APIMessage[] = [];
+    const content = 'x'.repeat(400); // 400 chars = 100 tokens + 4 overhead
+    for (let i = 0; i < 800; i++) {
+        messages.push({
+            role: i % 2 === 0 ? 'user' : 'assistant',
+            content,
+        });
+    }
+    return messages;
+}
+
+/**
+ * Create a small message array that is below the compaction threshold.
+ */
+function createSmallMessageArray(): APIMessage[] {
+    return [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('chatCompaction', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('maybeCompact', () => {
+        it('returns original messages when below token threshold', async () => {
+            const msgs = createSmallMessageArray();
+            const mockFetch = createMockFetch(true);
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(result).toBe(msgs);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('returns original messages for empty array', async () => {
+            const msgs: APIMessage[] = [];
+            const mockFetch = createMockFetch(true);
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(result).toBe(msgs);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('calls compaction endpoint when above threshold', async () => {
+            const msgs = createLargeMessageArray();
+            const compactedMsgs = [
+                { role: 'assistant', content: 'Summary of conversation' },
+            ];
+            const mockFetch = createMockFetch(true, {
+                messages: compactedMsgs,
+            });
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/chat/compact',
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                }),
+            );
+            expect(result).toEqual(compactedMsgs);
+        });
+
+        it('sends correct request body to compaction endpoint', async () => {
+            const msgs = createLargeMessageArray();
+            const mockFetch = createMockFetch(true, { messages: msgs });
+
+            await maybeCompact(msgs, mockFetch);
+
+            const call = mockFetch.mock.calls[0];
+            const body = JSON.parse(call[1]?.body as string);
+
+            expect(body).toEqual({
+                messages: msgs,
+                max_tokens: COMPACTION_MAX_TOKENS,
+                recent_window: COMPACTION_RECENT_WINDOW,
+                keep_anchors: true,
+                options: {
+                    preserve_tool_results: true,
+                    enable_summarization: true,
+                },
+            });
+        });
+
+        it('returns original messages when compaction endpoint fails', async () => {
+            const msgs = createLargeMessageArray();
+            const mockFetch = createMockFetch(false, undefined, 'Server error');
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(result).toBe(msgs);
+        });
+
+        it('returns original messages when compaction response has no messages', async () => {
+            const msgs = createLargeMessageArray();
+            const mockFetch = createMockFetch(true, { messages: null });
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(result).toBe(msgs);
+        });
+
+        it('returns original messages when compaction response is empty object', async () => {
+            const msgs = createLargeMessageArray();
+            const mockFetch = createMockFetch(true, {});
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(result).toBe(msgs);
+        });
+
+        it('returns original messages when fetch throws an error', async () => {
+            const msgs = createLargeMessageArray();
+            const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(result).toBe(msgs);
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Chat compaction failed:',
+                expect.any(Error),
+            );
+        });
+
+        it('returns original messages when json parsing fails', async () => {
+            const msgs = createLargeMessageArray();
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+            });
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(result).toBe(msgs);
+            expect(consoleSpy).toHaveBeenCalled();
+        });
+
+        it('handles messages exactly at threshold boundary', async () => {
+            // Create messages that are just below the threshold
+            // COMPACTION_TOKEN_THRESHOLD is 80,000
+            // Each message with 396 chars = 4 + 99 = 103 tokens
+            // 776 messages * 103 = 79,928 tokens (just below threshold)
+            const messages: APIMessage[] = [];
+            const content = 'x'.repeat(396);
+            for (let i = 0; i < 776; i++) {
+                messages.push({
+                    role: i % 2 === 0 ? 'user' : 'assistant',
+                    content,
+                });
+            }
+            const mockFetch = createMockFetch(true);
+
+            const result = await maybeCompact(messages, mockFetch);
+
+            // Should not call compaction because we're below threshold
+            expect(result).toBe(messages);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('compacts when exactly at threshold', async () => {
+            // Create messages that are exactly at the threshold
+            // Each message with 400 chars = 4 + 100 = 104 tokens
+            // 770 messages * 104 = 80,080 tokens (just above threshold)
+            const messages: APIMessage[] = [];
+            const content = 'x'.repeat(400);
+            for (let i = 0; i < 770; i++) {
+                messages.push({
+                    role: i % 2 === 0 ? 'user' : 'assistant',
+                    content,
+                });
+            }
+            const compactedMsgs = [{ role: 'assistant', content: 'Summary' }];
+            const mockFetch = createMockFetch(true, { messages: compactedMsgs });
+
+            const result = await maybeCompact(messages, mockFetch);
+
+            expect(mockFetch).toHaveBeenCalled();
+            expect(result).toEqual(compactedMsgs);
+        });
+
+        it('handles messages with content block arrays', async () => {
+            // Create messages with content blocks to exceed threshold
+            const messages: APIMessage[] = [];
+            const textBlock = { type: 'text', text: 'x'.repeat(400) };
+            for (let i = 0; i < 800; i++) {
+                messages.push({
+                    role: 'assistant',
+                    content: [textBlock],
+                });
+            }
+            const compactedMsgs = [{ role: 'assistant', content: 'Summary' }];
+            const mockFetch = createMockFetch(true, { messages: compactedMsgs });
+
+            const result = await maybeCompact(messages, mockFetch);
+
+            expect(mockFetch).toHaveBeenCalled();
+            expect(result).toEqual(compactedMsgs);
+        });
+
+        it('returns compacted messages array when valid', async () => {
+            const msgs = createLargeMessageArray();
+            const compactedMsgs: APIMessage[] = [
+                { role: 'user', content: 'Summarized user message' },
+                { role: 'assistant', content: 'Summarized assistant response' },
+            ];
+            const mockFetch = createMockFetch(true, { messages: compactedMsgs });
+
+            const result = await maybeCompact(msgs, mockFetch);
+
+            expect(result).toEqual(compactedMsgs);
+            expect(result).not.toBe(msgs);
+        });
+
+        it('does not modify original messages array', async () => {
+            const msgs = createLargeMessageArray();
+            const originalLength = msgs.length;
+            const compactedMsgs = [{ role: 'assistant', content: 'Summary' }];
+            const mockFetch = createMockFetch(true, { messages: compactedMsgs });
+
+            await maybeCompact(msgs, mockFetch);
+
+            expect(msgs.length).toBe(originalLength);
+        });
+    });
+});

--- a/client/src/hooks/chat/__tests__/chatConversation.test.ts
+++ b/client/src/hooks/chat/__tests__/chatConversation.test.ts
@@ -1,0 +1,404 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    createConversation,
+    updateConversation,
+    fetchConversation,
+    FetchFunction,
+} from '../chatConversation';
+import { ChatMessageData } from '../../../components/ChatPanel/ChatMessage';
+import { ConversationDetail } from '../chatTypes';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock fetch function that returns the specified response.
+ */
+function createMockFetch(
+    ok: boolean,
+    data?: object,
+    text?: string,
+): FetchFunction {
+    return vi.fn().mockResolvedValue({
+        ok,
+        json: vi.fn().mockResolvedValue(data ?? {}),
+        text: vi.fn().mockResolvedValue(text ?? ''),
+    });
+}
+
+/**
+ * Create sample chat messages for testing.
+ */
+function createSampleMessages(): ChatMessageData[] {
+    return [
+        {
+            role: 'user',
+            content: 'Hello',
+            timestamp: '2024-01-01T00:00:00Z',
+        },
+        {
+            role: 'assistant',
+            content: 'Hi there!',
+            timestamp: '2024-01-01T00:00:01Z',
+        },
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('chatConversation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('createConversation', () => {
+        it('returns conversation ID on successful creation', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = createMockFetch(true, {
+                id: 'conv-123',
+                title: 'New Conversation',
+            });
+
+            const result = await createConversation(messages, mockFetch);
+
+            expect(result).toBe('conv-123');
+        });
+
+        it('calls correct endpoint with POST method', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = createMockFetch(true, { id: 'conv-123' });
+
+            await createConversation(messages, mockFetch);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/conversations',
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                }),
+            );
+        });
+
+        it('sends correct request body', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = createMockFetch(true, { id: 'conv-123' });
+
+            await createConversation(messages, mockFetch);
+
+            const call = mockFetch.mock.calls[0];
+            const body = JSON.parse(call[1]?.body as string);
+
+            expect(body).toEqual({
+                messages,
+                provider: '',
+                model: '',
+            });
+        });
+
+        it('returns null when response is not ok', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 400,
+                text: vi.fn().mockResolvedValue('Bad Request'),
+            });
+            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const result = await createConversation(messages, mockFetch);
+
+            expect(result).toBeNull();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Failed to create conversation:',
+                400,
+                'Bad Request',
+            );
+        });
+
+        it('returns null when fetch throws error', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const result = await createConversation(messages, mockFetch);
+
+            expect(result).toBeNull();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Failed to create conversation:',
+                expect.any(Error),
+            );
+        });
+
+        it('returns null when JSON parsing fails', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+            });
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const result = await createConversation(messages, mockFetch);
+
+            expect(result).toBeNull();
+            expect(consoleSpy).toHaveBeenCalled();
+        });
+
+        it('handles empty messages array', async () => {
+            const mockFetch = createMockFetch(true, { id: 'conv-empty' });
+
+            const result = await createConversation([], mockFetch);
+
+            expect(result).toBe('conv-empty');
+            const call = mockFetch.mock.calls[0];
+            const body = JSON.parse(call[1]?.body as string);
+            expect(body.messages).toEqual([]);
+        });
+
+        it('handles 500 server error', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 500,
+                text: vi.fn().mockResolvedValue('Internal Server Error'),
+            });
+            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const result = await createConversation(messages, mockFetch);
+
+            expect(result).toBeNull();
+            expect(consoleSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('updateConversation', () => {
+        it('returns true on successful update', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = createMockFetch(true);
+
+            const result = await updateConversation('conv-123', messages, mockFetch);
+
+            expect(result).toBe(true);
+        });
+
+        it('calls correct endpoint with PUT method', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = createMockFetch(true);
+
+            await updateConversation('conv-456', messages, mockFetch);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/conversations/conv-456',
+                expect.objectContaining({
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                }),
+            );
+        });
+
+        it('sends correct request body with messages only', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = createMockFetch(true);
+
+            await updateConversation('conv-123', messages, mockFetch);
+
+            const call = mockFetch.mock.calls[0];
+            const body = JSON.parse(call[1]?.body as string);
+
+            expect(body).toEqual({ messages });
+        });
+
+        it('returns false when response is not ok', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 404,
+                text: vi.fn().mockResolvedValue('Not Found'),
+            });
+            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const result = await updateConversation('conv-123', messages, mockFetch);
+
+            expect(result).toBe(false);
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Failed to update conversation:',
+                404,
+                'Not Found',
+            );
+        });
+
+        it('returns false when fetch throws error', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const result = await updateConversation('conv-123', messages, mockFetch);
+
+            expect(result).toBe(false);
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Failed to update conversation:',
+                expect.any(Error),
+            );
+        });
+
+        it('handles empty messages array', async () => {
+            const mockFetch = createMockFetch(true);
+
+            const result = await updateConversation('conv-123', [], mockFetch);
+
+            expect(result).toBe(true);
+            const call = mockFetch.mock.calls[0];
+            const body = JSON.parse(call[1]?.body as string);
+            expect(body.messages).toEqual([]);
+        });
+
+        it('handles 404 not found error', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 404,
+                text: vi.fn().mockResolvedValue('Conversation not found'),
+            });
+            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const result = await updateConversation('nonexistent', messages, mockFetch);
+
+            expect(result).toBe(false);
+            expect(consoleSpy).toHaveBeenCalled();
+        });
+
+        it('uses provided conversation ID in URL', async () => {
+            const messages = createSampleMessages();
+            const mockFetch = createMockFetch(true);
+
+            await updateConversation('special-id-789', messages, mockFetch);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/conversations/special-id-789',
+                expect.any(Object),
+            );
+        });
+    });
+
+    describe('fetchConversation', () => {
+        it('returns conversation detail on success', async () => {
+            const expectedData: ConversationDetail = {
+                id: 'conv-123',
+                title: 'Test Conversation',
+                messages: createSampleMessages(),
+            };
+            const mockFetch = createMockFetch(true, expectedData);
+
+            const result = await fetchConversation('conv-123', mockFetch);
+
+            expect(result).toEqual(expectedData);
+        });
+
+        it('calls correct endpoint with GET method (default)', async () => {
+            const mockFetch = createMockFetch(true, {
+                id: 'conv-123',
+                title: 'Test',
+                messages: [],
+            });
+
+            await fetchConversation('conv-456', mockFetch);
+
+            expect(mockFetch).toHaveBeenCalledWith('/api/v1/conversations/conv-456');
+        });
+
+        it('throws error when response is not ok', async () => {
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: false,
+                text: vi.fn().mockResolvedValue('Conversation not found'),
+            });
+
+            await expect(
+                fetchConversation('conv-123', mockFetch),
+            ).rejects.toThrow('Failed to load conversation: Conversation not found');
+        });
+
+        it('throws error when fetch fails', async () => {
+            const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+            await expect(
+                fetchConversation('conv-123', mockFetch),
+            ).rejects.toThrow('Network error');
+        });
+
+        it('throws error when JSON parsing fails', async () => {
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+            });
+
+            await expect(
+                fetchConversation('conv-123', mockFetch),
+            ).rejects.toThrow('Invalid JSON');
+        });
+
+        it('returns conversation with empty messages', async () => {
+            const expectedData: ConversationDetail = {
+                id: 'conv-empty',
+                title: 'Empty Chat',
+                messages: [],
+            };
+            const mockFetch = createMockFetch(true, expectedData);
+
+            const result = await fetchConversation('conv-empty', mockFetch);
+
+            expect(result.messages).toEqual([]);
+        });
+
+        it('uses provided conversation ID in URL', async () => {
+            const mockFetch = createMockFetch(true, {
+                id: 'special-id',
+                title: 'Test',
+                messages: [],
+            });
+
+            await fetchConversation('special-id-999', mockFetch);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/conversations/special-id-999',
+            );
+        });
+
+        it('handles 500 server error with proper error message', async () => {
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 500,
+                text: vi.fn().mockResolvedValue('Internal Server Error'),
+            });
+
+            await expect(
+                fetchConversation('conv-123', mockFetch),
+            ).rejects.toThrow('Failed to load conversation: Internal Server Error');
+        });
+
+        it('handles empty error text', async () => {
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: false,
+                text: vi.fn().mockResolvedValue(''),
+            });
+
+            await expect(
+                fetchConversation('conv-123', mockFetch),
+            ).rejects.toThrow('Failed to load conversation: ');
+        });
+    });
+});

--- a/client/src/hooks/chat/__tests__/useChat.test.ts
+++ b/client/src/hooks/chat/__tests__/useChat.test.ts
@@ -1,0 +1,747 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useChat } from '../useChat';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock the extracted modules
+const mockRunAgenticLoop = vi.fn();
+const mockMaybeCompact = vi.fn();
+const mockCreateConversation = vi.fn();
+const mockUpdateConversation = vi.fn();
+const mockFetchConversation = vi.fn();
+const mockApiFetch = vi.fn();
+const mockLoadInputHistory = vi.fn();
+const mockSaveInputHistory = vi.fn();
+const mockToAPIMessages = vi.fn();
+
+vi.mock('../chatAgenticLoop', () => ({
+    runAgenticLoop: (...args: unknown[]) => mockRunAgenticLoop(...args),
+}));
+
+vi.mock('../chatCompaction', () => ({
+    maybeCompact: (...args: unknown[]) => mockMaybeCompact(...args),
+}));
+
+vi.mock('../chatConversation', () => ({
+    createConversation: (...args: unknown[]) => mockCreateConversation(...args),
+    updateConversation: (...args: unknown[]) => mockUpdateConversation(...args),
+    fetchConversation: (...args: unknown[]) => mockFetchConversation(...args),
+}));
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+vi.mock('../../../contexts/AICapabilitiesContext', () => ({
+    useAICapabilities: () => ({ maxIterations: 10 }),
+}));
+
+vi.mock('../chatHelpers', () => ({
+    loadInputHistory: () => mockLoadInputHistory(),
+    saveInputHistory: (...args: unknown[]) => mockSaveInputHistory(...args),
+    toAPIMessages: (...args: unknown[]) => mockToAPIMessages(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// localStorage mock
+// ---------------------------------------------------------------------------
+
+const localStorageMock = (() => {
+    let store: Record<string, string> = {};
+    return {
+        getItem: vi.fn((key: string) => store[key] || null),
+        setItem: vi.fn((key: string, value: string) => {
+            store[key] = value;
+        }),
+        removeItem: vi.fn((key: string) => {
+            delete store[key];
+        }),
+        clear: vi.fn(() => {
+            store = {};
+        }),
+    };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useChat', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorageMock.clear();
+
+        // Default mock implementations
+        mockLoadInputHistory.mockReturnValue([]);
+        mockSaveInputHistory.mockImplementation(() => {});
+        mockToAPIMessages.mockImplementation(
+            (msgs: Array<{ role: string; content: string }>) =>
+                msgs.map(m => ({ role: m.role, content: m.content })),
+        );
+
+        // Mock needs a microtask delay to allow React to commit the user message
+        // state update before runAgenticLoop returns
+        mockRunAgenticLoop.mockImplementation(async () => {
+            // Allow React to process pending state updates
+            await Promise.resolve();
+            return {
+                finalMessage: {
+                    role: 'assistant',
+                    content: 'Hello! How can I help?',
+                    timestamp: new Date().toISOString(),
+                },
+                updatedApiMessages: [
+                    { role: 'user', content: 'Hi' },
+                    { role: 'assistant', content: 'Hello! How can I help?' },
+                ],
+            };
+        });
+
+        mockMaybeCompact.mockImplementation(msgs => Promise.resolve(msgs));
+        mockCreateConversation.mockResolvedValue('new-conv-123');
+        mockUpdateConversation.mockResolvedValue(true);
+        mockFetchConversation.mockResolvedValue({
+            id: 'conv-123',
+            title: 'Test Conversation',
+            messages: [
+                { role: 'user', content: 'Hello', timestamp: '2024-01-01T00:00:00Z' },
+                { role: 'assistant', content: 'Hi!', timestamp: '2024-01-01T00:00:01Z' },
+            ],
+        });
+
+        mockApiFetch.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ tools: [] }),
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('initial state', () => {
+        it('returns correct initial state', () => {
+            const { result } = renderHook(() => useChat());
+
+            expect(result.current.messages).toEqual([]);
+            expect(result.current.activeTools).toEqual([]);
+            expect(result.current.currentConversationId).toBeNull();
+            expect(result.current.isLoading).toBe(false);
+            expect(result.current.error).toBeNull();
+            expect(result.current.conversationTitle).toBe('New Chat');
+        });
+
+        it('loads input history on mount', () => {
+            renderHook(() => useChat());
+
+            expect(mockLoadInputHistory).toHaveBeenCalled();
+        });
+
+        it('fetches tools on mount', async () => {
+            renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+            });
+        });
+
+        it('provides backward-compatible aliases', () => {
+            const { result } = renderHook(() => useChat());
+
+            expect(result.current.conversationId).toBeNull();
+            expect(result.current.clearChat).toBe(result.current.newChat);
+        });
+    });
+
+    describe('sendMessage', () => {
+        it('does nothing for empty message', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('');
+            });
+
+            expect(mockRunAgenticLoop).not.toHaveBeenCalled();
+        });
+
+        it('does nothing for whitespace-only message', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('   ');
+            });
+
+            expect(mockRunAgenticLoop).not.toHaveBeenCalled();
+        });
+
+        it('sets isLoading to true during send', async () => {
+            let resolveLoop: ((value: unknown) => void) | undefined;
+            mockRunAgenticLoop.mockImplementation(
+                () =>
+                    new Promise(resolve => {
+                        resolveLoop = resolve;
+                    }),
+            );
+
+            const { result } = renderHook(() => useChat());
+
+            let sendPromise: Promise<void>;
+            act(() => {
+                sendPromise = result.current.sendMessage('Hello');
+            });
+
+            // isLoading should be true while waiting
+            expect(result.current.isLoading).toBe(true);
+
+            await act(async () => {
+                if (!resolveLoop) {
+                    throw new Error('expected resolveLoop');
+                }
+                resolveLoop({
+                    finalMessage: {
+                        role: 'assistant',
+                        content: 'Done',
+                        timestamp: new Date().toISOString(),
+                    },
+                    updatedApiMessages: [],
+                });
+                await sendPromise;
+            });
+
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        it('adds user message to messages array', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            // After the complete send cycle, we should have both messages
+            await waitFor(() => {
+                expect(result.current.messages.length).toBe(2);
+            });
+            expect(result.current.messages[0].role).toBe('user');
+            expect(result.current.messages[0].content).toBe('Hello');
+        });
+
+        it('adds assistant response to messages array', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            // Wait for all state updates to propagate
+            await waitFor(() => {
+                expect(result.current.messages.length).toBe(2);
+            });
+            expect(result.current.messages[1].role).toBe('assistant');
+            expect(result.current.messages[1].content).toBe('Hello! How can I help?');
+        });
+
+        it('calls runAgenticLoop with correct parameters', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Test message');
+            });
+
+            expect(mockRunAgenticLoop).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    apiMessages: expect.arrayContaining([
+                        { role: 'user', content: 'Test message' },
+                    ]),
+                    maxIterations: 10,
+                }),
+            );
+        });
+
+        it('saves input to history', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Test input');
+            });
+
+            expect(mockSaveInputHistory).toHaveBeenCalled();
+        });
+
+        it('creates new conversation on first message', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            expect(mockCreateConversation).toHaveBeenCalled();
+            expect(result.current.currentConversationId).toBe('new-conv-123');
+        });
+
+        it('updates existing conversation on subsequent messages', async () => {
+            mockCreateConversation.mockResolvedValue('conv-abc');
+
+            const { result } = renderHook(() => useChat());
+
+            // First message creates conversation
+            await act(async () => {
+                await result.current.sendMessage('First');
+            });
+
+            mockRunAgenticLoop.mockResolvedValue({
+                finalMessage: {
+                    role: 'assistant',
+                    content: 'Second response',
+                    timestamp: new Date().toISOString(),
+                },
+                updatedApiMessages: [],
+            });
+
+            // Second message updates conversation
+            await act(async () => {
+                await result.current.sendMessage('Second');
+            });
+
+            expect(mockUpdateConversation).toHaveBeenCalledWith(
+                'conv-abc',
+                expect.any(Array),
+                expect.any(Function),
+            );
+        });
+
+        it('calls maybeCompact after successful message', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            expect(mockMaybeCompact).toHaveBeenCalled();
+        });
+
+        it('handles agentic loop error', async () => {
+            mockRunAgenticLoop.mockRejectedValue(new Error('LLM error'));
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            expect(result.current.error).toBe('LLM error');
+            expect(result.current.messages.length).toBe(2); // user + error
+            expect(result.current.messages[1].isError).toBe(true);
+
+            consoleSpy.mockRestore();
+        });
+
+        it('handles abort gracefully', async () => {
+            const abortError = new Error('Aborted');
+            abortError.name = 'AbortError';
+            mockRunAgenticLoop.mockRejectedValue(abortError);
+
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            // Should not set error for abort
+            expect(result.current.error).toBeNull();
+        });
+
+        it('clears active tools on completion', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            expect(result.current.activeTools).toEqual([]);
+        });
+
+        it('handles conversation creation failure gracefully', async () => {
+            // Conversation creation returns null (failure)
+            mockCreateConversation.mockResolvedValue(null);
+
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            // Verify createConversation was called
+            expect(mockCreateConversation).toHaveBeenCalled();
+
+            // Wait for state to stabilize
+            await waitFor(() => {
+                expect(result.current.isLoading).toBe(false);
+            });
+
+            // Should still have messages even if conversation creation failed
+            await waitFor(() => {
+                expect(result.current.messages.length).toBe(2);
+            });
+            expect(result.current.currentConversationId).toBeNull();
+        });
+
+        it('handles compaction failure gracefully', async () => {
+            // This test verifies that maybeCompact is called and failures are non-fatal
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            // Verify compaction was attempted
+            expect(mockMaybeCompact).toHaveBeenCalled();
+
+            // Wait for state to stabilize
+            await waitFor(() => {
+                expect(result.current.isLoading).toBe(false);
+            });
+
+            // Chat should complete successfully regardless of compaction result
+            await waitFor(() => {
+                expect(result.current.messages.length).toBe(2);
+            });
+        });
+    });
+
+    describe('newChat', () => {
+        it('clears all messages', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            expect(result.current.messages.length).toBeGreaterThan(0);
+
+            act(() => {
+                result.current.newChat();
+            });
+
+            expect(result.current.messages).toEqual([]);
+        });
+
+        it('clears conversation ID', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            expect(result.current.currentConversationId).not.toBeNull();
+
+            act(() => {
+                result.current.newChat();
+            });
+
+            expect(result.current.currentConversationId).toBeNull();
+        });
+
+        it('resets conversation title', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.loadConversation('conv-123');
+            });
+
+            expect(result.current.conversationTitle).toBe('Test Conversation');
+
+            act(() => {
+                result.current.newChat();
+            });
+
+            expect(result.current.conversationTitle).toBe('New Chat');
+        });
+
+        it('clears error state', async () => {
+            mockRunAgenticLoop.mockRejectedValue(new Error('Test error'));
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            expect(result.current.error).not.toBeNull();
+
+            act(() => {
+                result.current.newChat();
+            });
+
+            expect(result.current.error).toBeNull();
+        });
+
+        it('clears active tools', () => {
+            const { result } = renderHook(() => useChat());
+
+            act(() => {
+                result.current.newChat();
+            });
+
+            expect(result.current.activeTools).toEqual([]);
+        });
+
+        it('sets isLoading to false', () => {
+            const { result } = renderHook(() => useChat());
+
+            act(() => {
+                result.current.newChat();
+            });
+
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        it('clearChat is alias for newChat', () => {
+            const { result } = renderHook(() => useChat());
+
+            expect(result.current.clearChat).toBe(result.current.newChat);
+        });
+    });
+
+    describe('loadConversation', () => {
+        it('loads conversation by ID', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.loadConversation('conv-123');
+            });
+
+            expect(mockFetchConversation).toHaveBeenCalledWith(
+                'conv-123',
+                expect.any(Function),
+            );
+        });
+
+        it('sets messages from loaded conversation', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.loadConversation('conv-123');
+            });
+
+            expect(result.current.messages.length).toBe(2);
+            expect(result.current.messages[0].role).toBe('user');
+            expect(result.current.messages[1].role).toBe('assistant');
+        });
+
+        it('sets conversation ID', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.loadConversation('conv-123');
+            });
+
+            expect(result.current.currentConversationId).toBe('conv-123');
+        });
+
+        it('sets conversation title', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.loadConversation('conv-123');
+            });
+
+            expect(result.current.conversationTitle).toBe('Test Conversation');
+        });
+
+        it('sets isLoading during load', async () => {
+            let resolveLoad: ((value: unknown) => void) | undefined;
+            mockFetchConversation.mockImplementation(
+                () =>
+                    new Promise(resolve => {
+                        resolveLoad = resolve;
+                    }),
+            );
+
+            const { result } = renderHook(() => useChat());
+
+            let loadPromise: Promise<void>;
+            act(() => {
+                loadPromise = result.current.loadConversation('conv-123');
+            });
+
+            expect(result.current.isLoading).toBe(true);
+
+            await act(async () => {
+                if (!resolveLoad) {
+                    throw new Error('expected resolveLoad');
+                }
+                resolveLoad({
+                    id: 'conv-123',
+                    title: 'Test',
+                    messages: [],
+                });
+                await loadPromise;
+            });
+
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        it('handles load error', async () => {
+            mockFetchConversation.mockRejectedValue(
+                new Error('Conversation not found'),
+            );
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.loadConversation('nonexistent');
+            });
+
+            expect(result.current.error).toBe('Conversation not found');
+
+            consoleSpy.mockRestore();
+        });
+
+        it('clears error before loading', async () => {
+            mockRunAgenticLoop.mockRejectedValueOnce(new Error('Previous error'));
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            expect(result.current.error).not.toBeNull();
+
+            mockRunAgenticLoop.mockResolvedValue({
+                finalMessage: { role: 'assistant', content: 'Hi', timestamp: '' },
+                updatedApiMessages: [],
+            });
+
+            await act(async () => {
+                await result.current.loadConversation('conv-123');
+            });
+
+            expect(result.current.error).toBeNull();
+        });
+
+        it('handles conversation with missing title', async () => {
+            mockFetchConversation.mockResolvedValue({
+                id: 'conv-123',
+                title: '',
+                messages: [],
+            });
+
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.loadConversation('conv-123');
+            });
+
+            expect(result.current.conversationTitle).toBe('Conversation');
+        });
+
+        it('handles conversation with null messages', async () => {
+            mockFetchConversation.mockResolvedValue({
+                id: 'conv-123',
+                title: 'Test',
+                messages: undefined,
+            });
+
+            const { result } = renderHook(() => useChat());
+
+            await act(async () => {
+                await result.current.loadConversation('conv-123');
+            });
+
+            expect(result.current.messages).toEqual([]);
+        });
+    });
+
+    describe('tool fetching', () => {
+        it('updates available tools when fetch succeeds', async () => {
+            mockApiFetch.mockResolvedValue({
+                ok: true,
+                json: () =>
+                    Promise.resolve({
+                        tools: [
+                            {
+                                name: 'custom_tool',
+                                description: 'A custom tool',
+                                inputSchema: { type: 'object', properties: {}, required: [] },
+                            },
+                        ],
+                    }),
+            } as Response);
+
+            renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+            });
+        });
+
+        it('handles tool fetch failure gracefully', async () => {
+            mockApiFetch.mockRejectedValue(new Error('Network error'));
+
+            const { result } = renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+            });
+
+            // Should still be functional with default tools
+            expect(result.current.error).toBeNull();
+        });
+
+        it('handles empty tools response', async () => {
+            mockApiFetch.mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ tools: [] }),
+            } as Response);
+
+            const { result } = renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+            });
+
+            // Should still be functional
+            expect(result.current.error).toBeNull();
+        });
+
+        it('handles non-ok response for tools', async () => {
+            mockApiFetch.mockResolvedValue({
+                ok: false,
+                json: () => Promise.reject(new Error('Not found')),
+            } as Response);
+
+            const { result } = renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/mcp/tools');
+            });
+
+            // Should still be functional with default tools
+            expect(result.current.error).toBeNull();
+        });
+    });
+});

--- a/client/src/hooks/chat/chatAgenticLoop.ts
+++ b/client/src/hooks/chat/chatAgenticLoop.ts
@@ -1,0 +1,266 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Agentic loop module.
+ *
+ * Implements the core LLM tool-use loop that iteratively calls the
+ * language model and executes tool requests until a final text
+ * response is produced or the iteration limit is reached.
+ */
+
+import { ChatMessageData } from '../../components/ChatPanel/ChatMessage';
+import { ToolActivity } from '../../components/ChatPanel/ToolStatus';
+import {
+    LLMContentBlock,
+    LLMResponse,
+    ToolCallResponse,
+    ToolResult,
+} from '../../types/llm';
+import { APIMessage, ToolDefinition } from './chatTypes';
+
+/**
+ * Type alias for the fetch function signature used by the agentic
+ * loop. This allows dependency injection for testing.
+ */
+export type FetchFunction = (
+    url: string,
+    init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Parameters for running the agentic LLM loop.
+ */
+export interface AgenticLoopParams {
+    /** Current API message history including the user's new message. */
+    apiMessages: APIMessage[];
+    /** Available tools the LLM can call. */
+    availableTools: ToolDefinition[];
+    /** System prompt for the LLM. */
+    systemPrompt: string;
+    /** Maximum number of LLM iterations before giving up. */
+    maxIterations: number;
+    /** Abort signal for cancellation. */
+    abortSignal: AbortSignal;
+    /** Fetch function for API calls. */
+    fetchFn: FetchFunction;
+    /** Callback invoked when tool activity updates. */
+    onToolActivity: (activities: ToolActivity[]) => void;
+}
+
+/**
+ * Result of a successful agentic loop execution.
+ */
+export interface AgenticLoopResult {
+    /** The final assistant message to display to the user. */
+    finalMessage: ChatMessageData;
+    /** The updated API message history after the loop completes. */
+    updatedApiMessages: APIMessage[];
+}
+
+/**
+ * Error message returned when the iteration limit is reached.
+ */
+export const ITERATION_LIMIT_MESSAGE =
+    'I was unable to complete the request within the allowed number of ' +
+    'steps. Please try rephrasing your question.';
+
+/**
+ * Run the agentic LLM tool-use loop.
+ *
+ * This function calls the LLM with the current message history. If the
+ * LLM requests tool calls, it executes them and feeds the results back
+ * to the LLM. This continues until either:
+ *
+ * 1. The LLM returns a text response without tool calls (success).
+ * 2. The maximum iteration count is reached (returns error message).
+ * 3. The abort signal is triggered (throws AbortError).
+ * 4. An unrecoverable error occurs (throws Error).
+ *
+ * @param params - The loop parameters.
+ * @returns The final assistant message and updated API messages.
+ * @throws AbortError if the request was cancelled.
+ * @throws Error if an unrecoverable error occurs.
+ */
+export async function runAgenticLoop(
+    params: AgenticLoopParams,
+): Promise<AgenticLoopResult> {
+    const {
+        apiMessages,
+        availableTools,
+        systemPrompt,
+        maxIterations,
+        abortSignal,
+        fetchFn,
+        onToolActivity,
+    } = params;
+
+    let currentMessages = [...apiMessages];
+    let iterations = 0;
+    const collectedActivity: ToolActivity[] = [];
+
+    while (iterations < maxIterations) {
+        if (abortSignal.aborted) {
+            const abortError = new Error('Aborted');
+            abortError.name = 'AbortError';
+            throw abortError;
+        }
+        iterations++;
+
+        // Call the LLM with current message history and tools
+        const response = await fetchFn('/api/v1/llm/chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                messages: currentMessages,
+                tools: availableTools,
+                system: systemPrompt,
+            }),
+            signal: abortSignal,
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`LLM request failed: ${errorText}`);
+        }
+
+        const data: LLMResponse = await response.json();
+
+        const toolUses =
+            data.content?.filter(c => c.type === 'tool_use') || [];
+        const textBlocks =
+            data.content?.filter(c => c.type === 'text') || [];
+
+        if (toolUses.length === 0) {
+            // No tool calls - extract final text response
+            const assistantText =
+                textBlocks.map(c => c.text).join('\n') || '';
+
+            const finalMessage: ChatMessageData = {
+                role: 'assistant',
+                content: assistantText,
+                timestamp: new Date().toISOString(),
+                activity:
+                    collectedActivity.length > 0
+                        ? [...collectedActivity]
+                        : undefined,
+            };
+
+            // Append to API history
+            currentMessages = [
+                ...currentMessages,
+                { role: 'assistant', content: assistantText },
+            ];
+
+            return { finalMessage, updatedApiMessages: currentMessages };
+        }
+
+        // --- Tool execution phase ---
+
+        // Append the assistant message (with tool_use blocks) to history
+        currentMessages = [
+            ...currentMessages,
+            { role: 'assistant', content: data.content as LLMContentBlock[] },
+        ];
+
+        // Execute each tool call sequentially
+        const toolResults: ToolResult[] = [];
+
+        for (const toolUse of toolUses) {
+            const toolName = toolUse.name ?? 'unknown';
+
+            // Mark tool as running in the activity tracker
+            const activity: ToolActivity = {
+                name: toolName,
+                status: 'running',
+                startedAt: new Date().toISOString(),
+            };
+            collectedActivity.push(activity);
+            onToolActivity([...collectedActivity]);
+
+            try {
+                const toolResponse = await fetchFn('/api/v1/mcp/tools/call', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        name: toolUse.name,
+                        arguments: toolUse.input,
+                    }),
+                    signal: abortSignal,
+                });
+
+                if (!toolResponse.ok) {
+                    const errorText = await toolResponse.text();
+                    throw new Error(
+                        errorText ||
+                            `Tool call failed with status ${toolResponse.status}`,
+                    );
+                }
+
+                const toolData: ToolCallResponse = await toolResponse.json();
+                const resultText =
+                    toolData.content?.[0]?.text ||
+                    (toolData.isError
+                        ? 'Tool execution failed'
+                        : 'No data returned');
+
+                activity.status = toolData.isError ? 'error' : 'completed';
+                onToolActivity([...collectedActivity]);
+
+                toolResults.push({
+                    type: 'tool_result',
+                    tool_use_id: toolUse.id ?? '',
+                    content: resultText,
+                    is_error: toolData.isError || undefined,
+                });
+            } catch (toolErr) {
+                if ((toolErr as Error).name === 'AbortError') {
+                    throw toolErr;
+                }
+
+                const errMsg = `Tool execution error: ${(toolErr as Error).message}`;
+                activity.status = 'error';
+                onToolActivity([...collectedActivity]);
+
+                toolResults.push({
+                    type: 'tool_result',
+                    tool_use_id: toolUse.id ?? '',
+                    content: errMsg,
+                    is_error: true,
+                });
+            }
+        }
+
+        // Append tool results to API history and loop
+        currentMessages = [
+            ...currentMessages,
+            { role: 'user', content: toolResults },
+        ];
+    }
+
+    // Loop exhausted iterations without a final text response
+    const errorMessage: ChatMessageData = {
+        role: 'assistant',
+        content: ITERATION_LIMIT_MESSAGE,
+        timestamp: new Date().toISOString(),
+        isError: true,
+        activity:
+            collectedActivity.length > 0
+                ? [...collectedActivity]
+                : undefined,
+    };
+
+    currentMessages = [
+        ...currentMessages,
+        { role: 'assistant', content: ITERATION_LIMIT_MESSAGE },
+    ];
+
+    return { finalMessage: errorMessage, updatedApiMessages: currentMessages };
+}

--- a/client/src/hooks/chat/chatCompaction.ts
+++ b/client/src/hooks/chat/chatCompaction.ts
@@ -1,0 +1,78 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Chat compaction module.
+ *
+ * Provides functionality to compact long conversation histories by
+ * summarizing older messages while preserving recent context.
+ */
+
+import { APIMessage, CompactResponse } from './chatTypes';
+import {
+    COMPACTION_TOKEN_THRESHOLD,
+    COMPACTION_MAX_TOKENS,
+    COMPACTION_RECENT_WINDOW,
+} from './chatConstants';
+import { estimateTokenCount } from './chatHelpers';
+
+/**
+ * Type alias for the fetch function signature used by the compaction
+ * module. This allows dependency injection for testing.
+ */
+export type FetchFunction = (
+    url: string,
+    init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Compact the API message history when estimated tokens exceed the
+ * threshold.  Returns the compacted messages if successful, or the
+ * original messages if compaction is not needed or fails.
+ *
+ * @param msgs - The current API message history.
+ * @param fetchFn - The fetch function to use for the compaction request.
+ * @returns The compacted or original messages.
+ */
+export async function maybeCompact(
+    msgs: APIMessage[],
+    fetchFn: FetchFunction,
+): Promise<APIMessage[]> {
+    if (estimateTokenCount(msgs) < COMPACTION_TOKEN_THRESHOLD) {
+        return msgs;
+    }
+
+    try {
+        const response = await fetchFn('/api/v1/chat/compact', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                messages: msgs,
+                max_tokens: COMPACTION_MAX_TOKENS,
+                recent_window: COMPACTION_RECENT_WINDOW,
+                keep_anchors: true,
+                options: {
+                    preserve_tool_results: true,
+                    enable_summarization: true,
+                },
+            }),
+        });
+
+        if (!response.ok) {
+            return msgs;
+        }
+
+        const data: CompactResponse = await response.json();
+        return data.messages ?? msgs;
+    } catch (err) {
+        console.error('Chat compaction failed:', err);
+        return msgs;
+    }
+}

--- a/client/src/hooks/chat/chatConversation.ts
+++ b/client/src/hooks/chat/chatConversation.ts
@@ -1,0 +1,125 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Chat conversation persistence module.
+ *
+ * Provides functions to create, update, and fetch conversations
+ * from the backend API.
+ */
+
+import { ChatMessageData } from '../../components/ChatPanel/ChatMessage';
+import { ConversationCreateResponse, ConversationDetail } from './chatTypes';
+
+/**
+ * Type alias for the fetch function signature used by the conversation
+ * module. This allows dependency injection for testing.
+ */
+export type FetchFunction = (
+    url: string,
+    init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Create a new conversation with the given messages.
+ *
+ * @param messages - The visible chat messages to persist.
+ * @param fetchFn - The fetch function to use for the API request.
+ * @returns The conversation ID if successful, or null on failure.
+ */
+export async function createConversation(
+    messages: ChatMessageData[],
+    fetchFn: FetchFunction,
+): Promise<string | null> {
+    try {
+        const response = await fetchFn('/api/v1/conversations', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                messages,
+                provider: '',
+                model: '',
+            }),
+        });
+
+        if (!response.ok) {
+            console.warn(
+                'Failed to create conversation:',
+                response.status,
+                await response.text(),
+            );
+            return null;
+        }
+
+        const data: ConversationCreateResponse = await response.json();
+        return data.id;
+    } catch (err) {
+        console.error('Failed to create conversation:', err);
+        return null;
+    }
+}
+
+/**
+ * Update an existing conversation with new messages.
+ *
+ * @param id - The conversation ID to update.
+ * @param messages - The updated visible chat messages.
+ * @param fetchFn - The fetch function to use for the API request.
+ * @returns True if the update succeeded, false otherwise.
+ */
+export async function updateConversation(
+    id: string,
+    messages: ChatMessageData[],
+    fetchFn: FetchFunction,
+): Promise<boolean> {
+    try {
+        const response = await fetchFn(`/api/v1/conversations/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ messages }),
+        });
+
+        if (!response.ok) {
+            console.warn(
+                'Failed to update conversation:',
+                response.status,
+                await response.text(),
+            );
+            return false;
+        }
+
+        return true;
+    } catch (err) {
+        console.error('Failed to update conversation:', err);
+        return false;
+    }
+}
+
+/**
+ * Fetch an existing conversation by ID.
+ *
+ * @param id - The conversation ID to fetch.
+ * @param fetchFn - The fetch function to use for the API request.
+ * @returns The conversation detail on success.
+ * @throws Error if the fetch fails.
+ */
+export async function fetchConversation(
+    id: string,
+    fetchFn: FetchFunction,
+): Promise<ConversationDetail> {
+    const response = await fetchFn(`/api/v1/conversations/${id}`);
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to load conversation: ${errorText}`);
+    }
+
+    return response.json();
+}

--- a/client/src/hooks/chat/useChat.ts
+++ b/client/src/hooks/chat/useChat.ts
@@ -16,34 +16,21 @@ import {
     ContentBlock,
 } from '../../components/ChatPanel/ChatMessage';
 import { ToolActivity } from '../../components/ChatPanel/ToolStatus';
-import {
-    LLMContentBlock,
-    LLMResponse,
-    ToolCallResponse,
-    ToolResult,
-} from '../../types/llm';
 
+import { APIMessage, ToolDefinition } from './chatTypes';
+import { INPUT_HISTORY_MAX, SYSTEM_PROMPT, CHAT_TOOLS } from './chatConstants';
 import {
-    APIMessage,
-    ToolDefinition,
-    ConversationCreateResponse,
-    ConversationDetail,
-    CompactResponse,
-} from './chatTypes';
-import {
-    COMPACTION_TOKEN_THRESHOLD,
-    COMPACTION_MAX_TOKENS,
-    COMPACTION_RECENT_WINDOW,
-    INPUT_HISTORY_MAX,
-    SYSTEM_PROMPT,
-    CHAT_TOOLS,
-} from './chatConstants';
-import {
-    estimateTokenCount,
     toAPIMessages,
     loadInputHistory,
     saveInputHistory,
 } from './chatHelpers';
+import { maybeCompact } from './chatCompaction';
+import {
+    createConversation,
+    updateConversation,
+    fetchConversation,
+} from './chatConversation';
+import { runAgenticLoop } from './chatAgenticLoop';
 
 // Re-export types that consuming modules import from this hook.
 // These aliases ensure backward compatibility with modules that
@@ -164,52 +151,7 @@ export function useChat(): UseChatReturn {
     }, []);
 
     // ---------------------------------------------------------------
-    // Compaction
-    // ---------------------------------------------------------------
-
-    /**
-     * Compact the API message history when estimated tokens exceed
-     * the threshold.  The compacted messages replace the in-memory
-     * history; the visible UI messages are not affected.
-     */
-    const maybeCompact = useCallback(
-        async (msgs: APIMessage[]): Promise<APIMessage[]> => {
-            if (estimateTokenCount(msgs) < COMPACTION_TOKEN_THRESHOLD) {
-                return msgs;
-            }
-
-            try {
-                const response = await apiFetch('/api/v1/chat/compact', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        messages: msgs,
-                        max_tokens: COMPACTION_MAX_TOKENS,
-                        recent_window: COMPACTION_RECENT_WINDOW,
-                        keep_anchors: true,
-                        options: {
-                            preserve_tool_results: true,
-                            enable_summarization: true,
-                        },
-                    }),
-                });
-
-                if (!response.ok) {
-                    return msgs;
-                }
-
-                const data: CompactResponse = await response.json();
-                return data.messages ?? msgs;
-            } catch (err) {
-                console.error('Chat compaction failed:', err);
-                return msgs;
-            }
-        },
-        [],
-    );
-
-    // ---------------------------------------------------------------
-    // Agentic loop
+    // Send message (agentic loop orchestrator)
     // ---------------------------------------------------------------
 
     const sendMessage = useCallback(
@@ -266,284 +208,57 @@ export function useChat(): UseChatReturn {
                 userAPIMessage,
             ];
 
-            let iterations = 0;
-            let finalAssistantMessage: ChatMessageData | null = null;
-            const collectedActivity: ToolActivity[] = [];
-
             try {
-                while (iterations < maxIterations) {
-                    if (abortController.signal.aborted) {
-                        return;
-                    }
-                    iterations++;
-
-                    // Call the LLM with current message history and tools
-                    const response = await apiFetch('/api/v1/llm/chat', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({
-                            messages: apiMessagesRef.current,
-                            tools: availableTools,
-                            system: SYSTEM_PROMPT,
-                        }),
-                        signal: abortController.signal,
+                // Run the agentic loop
+                const { finalMessage, updatedApiMessages } =
+                    await runAgenticLoop({
+                        apiMessages: apiMessagesRef.current,
+                        availableTools,
+                        systemPrompt: SYSTEM_PROMPT,
+                        maxIterations,
+                        abortSignal: abortController.signal,
+                        fetchFn: apiFetch,
+                        onToolActivity: setActiveTools,
                     });
 
-                    if (!response.ok) {
-                        const errorText = await response.text();
-                        throw new Error(
-                            `LLM request failed: ${errorText}`,
-                        );
-                    }
+                apiMessagesRef.current = updatedApiMessages;
 
-                    const data: LLMResponse = await response.json();
-
-                    const toolUses =
-                        data.content?.filter(
-                            c => c.type === 'tool_use',
-                        ) || [];
-                    const textBlocks =
-                        data.content?.filter(
-                            c => c.type === 'text',
-                        ) || [];
-
-                    if (toolUses.length === 0) {
-                        // No tool calls - extract final text response
-                        const assistantText =
-                            textBlocks
-                                .map(c => c.text)
-                                .join('\n') || '';
-
-                        finalAssistantMessage = {
-                            role: 'assistant',
-                            content: assistantText,
-                            timestamp: new Date().toISOString(),
-                            activity:
-                                collectedActivity.length > 0
-                                    ? [...collectedActivity]
-                                    : undefined,
-                        };
-
-                        // Append to API history
-                        apiMessagesRef.current = [
-                            ...apiMessagesRef.current,
-                            {
-                                role: 'assistant',
-                                content: assistantText,
-                            },
-                        ];
-
-                        break;
-                    }
-
-                    // --- Tool execution phase ---
-
-                    // Append the assistant message (with tool_use blocks)
-                    // to the API message history
-                    apiMessagesRef.current = [
-                        ...apiMessagesRef.current,
-                        {
-                            role: 'assistant',
-                            content:
-                                data.content as LLMContentBlock[],
-                        },
-                    ];
-
-                    // Execute each tool call sequentially
-                    const toolResults: ToolResult[] = [];
-
-                    for (const toolUse of toolUses) {
-                        const toolName = toolUse.name ?? 'unknown';
-
-                        // Mark tool as running in the activity tracker
-                        const activity: ToolActivity = {
-                            name: toolName,
-                            status: 'running',
-                            startedAt: new Date().toISOString(),
-                        };
-                        collectedActivity.push(activity);
-                        setActiveTools([...collectedActivity]);
-
-                        try {
-                            const toolResponse = await apiFetch(
-                                '/api/v1/mcp/tools/call',
-                                {
-                                    method: 'POST',
-                                    headers: {
-                                        'Content-Type':
-                                            'application/json',
-                                    },
-                                    body: JSON.stringify({
-                                        name: toolUse.name,
-                                        arguments: toolUse.input,
-                                    }),
-                                    signal: abortController.signal,
-                                },
-                            );
-
-                            if (!toolResponse.ok) {
-                                const errorText =
-                                    await toolResponse.text();
-                                throw new Error(
-                                    errorText ||
-                                        `Tool call failed with status ${toolResponse.status}`,
-                                );
-                            }
-
-                            const toolData: ToolCallResponse =
-                                await toolResponse.json();
-                            const resultText =
-                                toolData.content?.[0]?.text ||
-                                (toolData.isError
-                                    ? 'Tool execution failed'
-                                    : 'No data returned');
-
-                            activity.status = toolData.isError
-                                ? 'error'
-                                : 'completed';
-                            setActiveTools([...collectedActivity]);
-
-                            toolResults.push({
-                                type: 'tool_result',
-                                tool_use_id: toolUse.id ?? '',
-                                content: resultText,
-                                is_error:
-                                    toolData.isError || undefined,
-                            });
-                        } catch (toolErr) {
-                            if (
-                                (toolErr as Error).name ===
-                                'AbortError'
-                            ) {
-                                throw toolErr;
-                            }
-
-                            const errMsg = `Tool execution error: ${(toolErr as Error).message}`;
-                            activity.status = 'error';
-                            setActiveTools([...collectedActivity]);
-
-                            toolResults.push({
-                                type: 'tool_result',
-                                tool_use_id: toolUse.id ?? '',
-                                content: errMsg,
-                                is_error: true,
-                            });
-                        }
-                    }
-
-                    // Append tool results to API history and loop
-                    apiMessagesRef.current = [
-                        ...apiMessagesRef.current,
-                        { role: 'user', content: toolResults },
-                    ];
-                }
-
-                // If the loop exhausted iterations without a final text
-                // response, surface an error to the user.
-                if (!finalAssistantMessage) {
-                    finalAssistantMessage = {
-                        role: 'assistant',
-                        content:
-                            'I was unable to complete the request within the ' +
-                            'allowed number of steps. Please try rephrasing ' +
-                            'your question.',
-                        timestamp: new Date().toISOString(),
-                        isError: true,
-                        activity:
-                            collectedActivity.length > 0
-                                ? [...collectedActivity]
-                                : undefined,
-                    };
-                    apiMessagesRef.current = [
-                        ...apiMessagesRef.current,
-                        {
-                            role: 'assistant',
-                            content:
-                                finalAssistantMessage.content as string,
-                        },
-                    ];
-                }
-
-                // Append the assistant reply to visible messages.
-                // Read the latest visible messages from the ref to
-                // avoid stale closure issues.
-                const finalVisibleMessages = [
-                    ...visibleMessagesRef.current,
-                    finalAssistantMessage,
-                ];
-                setMessages(finalVisibleMessages);
-                visibleMessagesRef.current = finalVisibleMessages;
+                // Append the assistant reply to visible messages using
+                // functional update to handle cases where the prior state
+                // update hasn't committed yet (e.g., in tests with sync mocks).
+                setMessages(prev => {
+                    const updated = [...prev, finalMessage];
+                    visibleMessagesRef.current = updated;
+                    return updated;
+                });
 
                 // --- Conversation persistence ---
-
+                // Use the ref which was updated in the setMessages callback
                 try {
                     if (!conversationIdRef.current) {
-                        // Create a new conversation on first response
-                        const createResponse = await apiFetch(
-                            '/api/v1/conversations',
-                            {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type':
-                                        'application/json',
-                                },
-                                body: JSON.stringify({
-                                    messages: finalVisibleMessages,
-                                    provider: '',
-                                    model: '',
-                                }),
-                            },
+                        const newId = await createConversation(
+                            visibleMessagesRef.current,
+                            apiFetch,
                         );
-
-                        if (createResponse.ok) {
-                            const createData: ConversationCreateResponse =
-                                await createResponse.json();
-                            syncConversationId(createData.id);
-                        } else {
-                            console.warn(
-                                'Failed to create conversation:',
-                                createResponse.status,
-                                await createResponse.text(),
-                            );
+                        if (newId) {
+                            syncConversationId(newId);
                         }
                     } else {
-                        // Update the existing conversation
-                        const updateResponse = await apiFetch(
-                            `/api/v1/conversations/${conversationIdRef.current}`,
-                            {
-                                method: 'PUT',
-                                headers: {
-                                    'Content-Type':
-                                        'application/json',
-                                },
-                                body: JSON.stringify({
-                                    messages: finalVisibleMessages,
-                                }),
-                            },
+                        await updateConversation(
+                            conversationIdRef.current,
+                            visibleMessagesRef.current,
+                            apiFetch,
                         );
-                        if (!updateResponse.ok) {
-                            console.warn(
-                                'Failed to update conversation:',
-                                updateResponse.status,
-                                await updateResponse.text(),
-                            );
-                        }
                     }
-                } catch (saveErr) {
-                    console.error(
-                        'Failed to persist conversation:',
-                        saveErr,
-                    );
+                } catch {
                     // Non-fatal: the user can still continue chatting
                 }
 
                 // --- Compaction ---
-
                 try {
                     apiMessagesRef.current = await maybeCompact(
                         apiMessagesRef.current,
+                        apiFetch,
                     );
                 } catch {
                     // Compaction failures are non-fatal
@@ -567,10 +282,6 @@ export function useChat(): UseChatReturn {
                     content: `Sorry, an error occurred: ${errMessage}`,
                     timestamp: new Date().toISOString(),
                     isError: true,
-                    activity:
-                        collectedActivity.length > 0
-                            ? [...collectedActivity]
-                            : undefined,
                 };
                 setMessages(prev => [...prev, errorAssistantMessage]);
             } finally {
@@ -581,7 +292,7 @@ export function useChat(): UseChatReturn {
                 }
             }
         },
-        [availableTools, maxIterations, syncConversationId, maybeCompact],
+        [availableTools, maxIterations, syncConversationId],
     );
 
     // ---------------------------------------------------------------
@@ -623,19 +334,7 @@ export function useChat(): UseChatReturn {
             setActiveTools([]);
 
             try {
-                const response = await apiFetch(
-                    `/api/v1/conversations/${id}`,
-                );
-
-                if (!response.ok) {
-                    const errorText = await response.text();
-                    throw new Error(
-                        `Failed to load conversation: ${errorText}`,
-                    );
-                }
-
-                const data: ConversationDetail =
-                    await response.json();
+                const data = await fetchConversation(id, apiFetch);
 
                 setMessages(data.messages || []);
                 visibleMessagesRef.current = data.messages || [];


### PR DESCRIPTION
## Summary

- Extracts three focused modules from the monolithic `useChat` hook (687→386 lines): `chatAgenticLoop.ts` (core LLM tool-use loop), `chatCompaction.ts` (token-aware message compaction), and `chatConversation.ts` (conversation CRUD).
- Adds 163 tests across all chat modules achieving 97%+ line coverage (previously 0%).
- Fixes `key={index}` anti-patterns in `ChannelTable` and `ChannelDialogShell` by using stable keys (`col.label`, tab label).
- Reviews and confirms all 4 `exhaustive-deps` suppressions are justified (stable string representations preventing unnecessary re-renders).

## Test plan

- [x] All 163 chat hook tests pass (`npx vitest run src/hooks/chat/__tests__/`)
- [x] All 38 ChannelTable/ChannelDialogShell tests pass
- [x] ESLint clean on all modified files (no warnings)
- [x] Coverage: chatAgenticLoop ~99%, chatCompaction 100%, chatConversation 100%, useChat 96%
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured chat system architecture by modularizing core chat loop, message compaction, and conversation persistence functionality for improved maintainability.
  * Optimized React component rendering efficiency through improved key management.

* **Tests**
  * Added comprehensive test suites for chat operations, including agentic loops, message compaction, and conversation management to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->