### PR TITLE
fix: add listen_addresses and missing export to compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@
 #   mkdir -p docker/secret
 #   openssl rand -base64 32 > docker/secret/ai-dba.secret
 #   echo "postgres" > docker/secret/pg-password
+#   export POSTGRES_PASSWORD=postgres
 #
 # Then start all services:
 #

--- a/examples/docker-compose.production.yml
+++ b/examples/docker-compose.production.yml
@@ -27,6 +27,7 @@ services:
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
             POSTGRES_DB: ai_workbench
+        command: ["postgres", "-c", "listen_addresses=*"]
         volumes:
             - pgdata:/var/lib/pgsql/18/data
         ports:


### PR DESCRIPTION
## Summary

- Add missing `listen_addresses=*` postgres command to the production
  compose file — without it, postgres only listens on localhost inside
  its container, so the server, collector, and alerter all get
  connection refused errors over the Docker network.
- Add missing `export POSTGRES_PASSWORD=postgres` to the dev compose
  file header comment, matching what the Getting Started docs already
  document.

## Blog post instructions

The blog post should be updated to the following:

```bash
git clone https://github.com/pgEdge/ai-dba-workbench.git

cd ai-dba-workbench

mkdir -p docker/secret

openssl rand -base64 32 > docker/secret/ai-dba.secret

echo "postgres" > docker/secret/pg-password

export POSTGRES_PASSWORD=postgres

docker compose -f examples/docker-compose.production.yml up -d
```

Two changes from the original blog post:

1. Added `export POSTGRES_PASSWORD=postgres` — the postgres container
   requires this environment variable but the blog post only created
   the secret file.
2. Changed `docker compose up -d` to
   `docker compose -f examples/docker-compose.production.yml up -d` —
   the original command uses the dev compose file which builds all
   images from source. The production file pulls pre-built images
   from GHCR, which is faster and doesn't require build toolchains.

## Test plan

- [ ] Clone fresh, follow corrected blog post instructions with
  production compose file — all five containers come up healthy.
- [ ] Verify `curl http://localhost:8080/health` returns ok.
- [ ] Verify `http://localhost:3000` returns 200.

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database environment setup instructions for improved clarity.

* **Configuration**
  * PostgreSQL in production environments now listens on all network addresses, enabling remote database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->