### PR TITLE
test: raise coverage in crypto + memory and add -race to Go Makefiles (#78)

### DIFF
--- a/alerter/Makefile
+++ b/alerter/Makefile
@@ -31,9 +31,10 @@ build:
 # Use -p=1 to serialize per-package test binaries. Integration tests in
 # internal/database and internal/engine share Postgres schema (DROP/CREATE
 # the same tables), so running their test binaries concurrently races.
+# -race enables the data-race detector; CI runs the same target.
 test: killall
 	@echo "Running tests..."
-	cd src && go test -p=1 -v ./...
+	cd src && go test -race -p=1 -v ./...
 	@$(MAKE) --no-print-directory killall
 
 # Run linting
@@ -58,9 +59,10 @@ fmt-check:
 
 # Run tests with coverage
 # Use -p=1 to serialize per-package test binaries (see note on the test target).
+# -race enables the data-race detector; CI runs the same target.
 coverage:
 	@echo "Running tests with coverage..."
-	cd src && go test -p=1 -coverprofile=coverage.out ./...
+	cd src && go test -race -p=1 -coverprofile=coverage.out ./...
 	cd src && go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: src/coverage.html"
 

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -28,9 +28,10 @@ build:
 	cd src && go build -ldflags="-s -w" -o $(ABS_BIN_DIR)/$(BINARY) .
 
 # Run tests
+# -race enables the data-race detector; CI runs the same target.
 test: killall
 	@echo "Running tests..."
-	cd src && go test -v ./...
+	cd src && go test -race -v ./...
 	@$(MAKE) --no-print-directory killall
 
 # Run linting
@@ -54,9 +55,10 @@ fmt-check:
 	@test -z "$$(cd src && gofmt -l .)" || (echo "Files not formatted:"; cd src && gofmt -l .; exit 1)
 
 # Run tests with coverage
+# -race enables the data-race detector; CI runs the same target.
 coverage:
 	@echo "Running tests with coverage..."
-	cd src && go test -coverprofile=coverage.out ./...
+	cd src && go test -race -coverprofile=coverage.out ./...
 	cd src && go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: src/coverage.html"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,21 +45,22 @@ project adheres to
   `() => cond && voidFn()` into explicit `if` blocks. No
   behavior changes, and all 2,604 Vitest tests pass.
 - Raise line coverage of `server/internal/crypto` from
-  86.8% to 100% by adding tests for the four previously
-  uncovered error branches; the new cases exercise random
-  source failure, `ReadFile` failure, `WriteFile` failure,
-  and the GCM encrypt failure path. (#78)
+  86.8% to 100%. New tests cover four previously uncovered
+  error branches. The branches are random source failure,
+  `ReadFile` failure, `WriteFile` failure, and the GCM
+  encrypt failure path. (#78)
 - Add integration tests for `server/internal/memory.Store`
-  covering all nine public methods (`NewStore`, `Store`,
-  `Search`, `GetPinned`, `ListByUser`, `GetByID`, `Delete`,
-  `DeleteByID`, and `UpdatePinned`) against PostgreSQL,
-  including pgvector similarity ordering, scope visibility,
-  and ownership checks; package line coverage now reaches
+  against PostgreSQL. The tests cover all nine public
+  methods: `NewStore`, `Store`, `Search`, `GetPinned`,
+  `ListByUser`, `GetByID`, `Delete`, `DeleteByID`, and
+  `UpdatePinned`. They also exercise pgvector similarity
+  ordering, scope visibility, and ownership checks.
+  Package line coverage for the memory store now reaches
   92.5%. (#78)
 - Add the `-race` flag to the `test` and `coverage`
   Makefile targets in the `server`, `collector`, and
-  `alerter` sub-projects so the race detector runs in CI
-  and on developer machines. (#78)
+  `alerter` sub-projects. The race detector now runs in
+  CI and on developer machines. (#78)
 
 ### Security
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,22 @@ project adheres to
   rewritten manually by expanding
   `() => cond && voidFn()` into explicit `if` blocks. No
   behavior changes, and all 2,604 Vitest tests pass.
+- Raise line coverage of `server/internal/crypto` from
+  86.8% to 100% by adding tests for the four previously
+  uncovered error branches; the new cases exercise random
+  source failure, `ReadFile` failure, `WriteFile` failure,
+  and the GCM encrypt failure path. (#78)
+- Add integration tests for `server/internal/memory.Store`
+  covering all nine public methods (`NewStore`, `Store`,
+  `Search`, `GetPinned`, `ListByUser`, `GetByID`, `Delete`,
+  `DeleteByID`, and `UpdatePinned`) against PostgreSQL,
+  including pgvector similarity ordering, scope visibility,
+  and ownership checks; package line coverage now reaches
+  92.5%. (#78)
+- Add the `-race` flag to the `test` and `coverage`
+  Makefile targets in the `server`, `collector`, and
+  `alerter` sub-projects so the race detector runs in CI
+  and on developer machines. (#78)
 
 ### Security
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -37,9 +37,10 @@ openapi:
 # internal/database, internal/api, and internal/tools share Postgres schema
 # (DROP/CREATE the same tables), so running their test binaries concurrently
 # races.
+# -race enables the data-race detector; CI runs the same target.
 test: killall
 	@echo "Running tests..."
-	cd src && go test -p=1 -v ./...
+	cd src && go test -race -p=1 -v ./...
 	@$(MAKE) --no-print-directory killall
 
 # Run linting
@@ -64,9 +65,10 @@ fmt-check:
 
 # Run tests with coverage
 # Use -p=1 to serialize per-package test binaries (see note on the test target).
+# -race enables the data-race detector; CI runs the same target.
 coverage:
 	@echo "Running tests with coverage..."
-	cd src && go test -p=1 -coverprofile=coverage.out ./...
+	cd src && go test -race -p=1 -coverprofile=coverage.out ./...
 	cd src && go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: src/coverage.html"
 

--- a/server/src/internal/crypto/encryption.go
+++ b/server/src/internal/crypto/encryption.go
@@ -29,10 +29,18 @@ type EncryptionKey struct {
 	key []byte
 }
 
+// Package-level function variables wrap external dependencies so
+// tests can swap them to exercise otherwise-unreachable error paths.
+// Production callers see the standard library / pkgcrypto behavior.
+var (
+	randRead   = io.ReadFull
+	encryptGCM = pkgcrypto.EncryptGCM
+)
+
 // GenerateKey creates a new random 256-bit encryption key
 func GenerateKey() (*EncryptionKey, error) {
 	key := make([]byte, KeySize)
-	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+	if _, err := randRead(rand.Reader, key); err != nil {
 		return nil, fmt.Errorf("failed to generate random key: %w", err)
 	}
 	return &EncryptionKey{key: key}, nil
@@ -90,7 +98,7 @@ func (k *EncryptionKey) Encrypt(plaintext string) (string, error) {
 		return "", nil
 	}
 
-	nonceCiphertext, err := pkgcrypto.EncryptGCM(k.key, []byte(plaintext))
+	nonceCiphertext, err := encryptGCM(k.key, []byte(plaintext))
 	if err != nil {
 		return "", err
 	}

--- a/server/src/internal/crypto/encryption_test.go
+++ b/server/src/internal/crypto/encryption_test.go
@@ -10,7 +10,10 @@
 package crypto
 
 import (
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -327,5 +330,170 @@ func TestDecryptInvalidCiphertext(t *testing.T) {
 				t.Error("Expected error for invalid ciphertext, got nil")
 			}
 		})
+	}
+}
+
+// TestGenerateKeyRandFailure verifies that GenerateKey wraps and
+// returns an error when the underlying random reader fails. This
+// exercises the io.ReadFull error branch by swapping the package-level
+// randRead hook.
+func TestGenerateKeyRandFailure(t *testing.T) {
+	original := randRead
+	t.Cleanup(func() { randRead = original })
+
+	wantErr := errors.New("simulated rand failure")
+	randRead = func(_ io.Reader, _ []byte) (int, error) {
+		return 0, wantErr
+	}
+
+	key, err := GenerateKey()
+	if err == nil {
+		t.Fatal("Expected error from GenerateKey, got nil")
+	}
+	if key != nil {
+		t.Errorf("Expected nil key on failure, got %v", key)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Expected wrapped %q, got %v", wantErr, err)
+	}
+	if !strings.Contains(err.Error(), "failed to generate random key") {
+		t.Errorf("Expected wrap prefix in error, got %v", err)
+	}
+}
+
+// TestLoadKeyFromFileInvalidSize verifies that LoadKeyFromFile rejects
+// a base64 payload that decodes to a byte count other than KeySize.
+// The existing "wrong size" subtest in TestLoadKeyFromInvalidFile
+// covers a 6-byte payload; this test uses a 16-byte payload to make
+// the intent explicit and to keep the assertion specific to the
+// invalid-size branch.
+func TestLoadKeyFromFileInvalidSize(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pgedge-crypto-invalid-size-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	keyPath := filepath.Join(tmpDir, "short.key")
+	short := make([]byte, 16) // half the expected key size
+	encoded := base64.StdEncoding.EncodeToString(short)
+	if err := os.WriteFile(keyPath, []byte(encoded), 0600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	_, err = LoadKeyFromFile(keyPath)
+	if err == nil {
+		t.Fatal("Expected invalid key size error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid key size") {
+		t.Errorf("Expected 'invalid key size' in error, got %v", err)
+	}
+}
+
+// TestLoadKeyFromFileReadFailure verifies that LoadKeyFromFile
+// surfaces an os.ReadFile error after a successful stat. We achieve a
+// passing-stat / failing-read combination by creating a directory at
+// the target path with mode 0600 — Stat reports the right permissions
+// for a regular-file check, but ReadFile rejects directories.
+func TestLoadKeyFromFileReadFailure(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pgedge-crypto-read-fail-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	dirAsKey := filepath.Join(tmpDir, "dir.key")
+	if err := os.Mkdir(dirAsKey, 0600); err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+
+	_, err = LoadKeyFromFile(dirAsKey)
+	if err == nil {
+		t.Fatal("Expected read error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read key file") {
+		t.Errorf("Expected 'failed to read key file' in error, got %v", err)
+	}
+}
+
+// TestSaveToFileWriteFailure verifies that SaveToFile wraps and
+// returns errors from os.WriteFile. Writing into a path whose parent
+// is a regular file (not a directory) reliably fails with ENOTDIR on
+// Linux without requiring privileged operations.
+func TestSaveToFileWriteFailure(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pgedge-crypto-write-fail-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	parentFile := filepath.Join(tmpDir, "parent")
+	if err := os.WriteFile(parentFile, []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("Failed to create parent file: %v", err)
+	}
+
+	// Using parentFile as a directory component yields ENOTDIR.
+	target := filepath.Join(parentFile, "key")
+
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	err = key.SaveToFile(target)
+	if err == nil {
+		t.Fatal("Expected write error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to write key file") {
+		t.Errorf("Expected 'failed to write key file' in error, got %v", err)
+	}
+}
+
+// TestDecryptEmptyCiphertext verifies the empty-input fast path for
+// Decrypt: an empty ciphertext returns an empty plaintext without
+// invoking base64 decoding or AES-GCM. This mirrors the matching
+// short-circuit in Encrypt.
+func TestDecryptEmptyCiphertext(t *testing.T) {
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	plaintext, err := key.Decrypt("")
+	if err != nil {
+		t.Fatalf("Decrypt(\"\") returned error: %v", err)
+	}
+	if plaintext != "" {
+		t.Errorf("Expected empty plaintext, got %q", plaintext)
+	}
+}
+
+// TestEncryptGCMFailure verifies that Encrypt surfaces errors from
+// the underlying GCM helper. We swap the package-level encryptGCM
+// hook to inject a deterministic failure; the production code path
+// continues to use pkgcrypto.EncryptGCM.
+func TestEncryptGCMFailure(t *testing.T) {
+	original := encryptGCM
+	t.Cleanup(func() { encryptGCM = original })
+
+	wantErr := errors.New("simulated GCM failure")
+	encryptGCM = func(_ []byte, _ []byte) ([]byte, error) {
+		return nil, wantErr
+	}
+
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	ciphertext, err := key.Encrypt("plaintext")
+	if err == nil {
+		t.Fatal("Expected error from Encrypt, got nil")
+	}
+	if ciphertext != "" {
+		t.Errorf("Expected empty ciphertext on failure, got %q", ciphertext)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Expected error to wrap %q, got %v", wantErr, err)
 	}
 }

--- a/server/src/internal/memory/store_db_test.go
+++ b/server/src/internal/memory/store_db_test.go
@@ -431,7 +431,8 @@ func TestStore_ListByUser(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
-	seed := func() {
+	seed := func(t *testing.T) {
+		t.Helper()
 		truncateMemories(t, pool)
 		// Alice rows in two categories.
 		if _, err := store.Store(ctx, "alice", "user", "fact",
@@ -459,7 +460,7 @@ func TestStore_ListByUser(t *testing.T) {
 	}
 
 	t.Run("no category returns own + system", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.ListByUser(ctx, "alice", "", 0)
 		if err != nil {
 			t.Fatalf("ListByUser: %v", err)
@@ -476,7 +477,7 @@ func TestStore_ListByUser(t *testing.T) {
 	})
 
 	t.Run("category filter applies", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.ListByUser(ctx, "alice", "fact", 0)
 		if err != nil {
 			t.Fatalf("ListByUser fact: %v", err)
@@ -493,7 +494,7 @@ func TestStore_ListByUser(t *testing.T) {
 	})
 
 	t.Run("limit caps result size", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.ListByUser(ctx, "alice", "", 2)
 		if err != nil {
 			t.Fatalf("ListByUser limit: %v", err)
@@ -504,7 +505,7 @@ func TestStore_ListByUser(t *testing.T) {
 	})
 
 	t.Run("limit clamps above 100", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.ListByUser(ctx, "alice", "", 9999)
 		if err != nil {
 			t.Fatalf("ListByUser big limit: %v", err)
@@ -516,7 +517,7 @@ func TestStore_ListByUser(t *testing.T) {
 	})
 
 	t.Run("category filter with limit", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.ListByUser(ctx, "alice", "fact", 1)
 		if err != nil {
 			t.Fatalf("ListByUser fact+limit: %v", err)
@@ -532,7 +533,8 @@ func TestStore_Search(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
-	seed := func() {
+	seed := func(t *testing.T) {
+		t.Helper()
 		truncateMemories(t, pool)
 		// Vectors aligned with x, y, z axes. Cosine distance to [1,0,0]
 		// is smallest for the x-axis row, so it should appear first
@@ -571,7 +573,7 @@ func TestStore_Search(t *testing.T) {
 	}
 
 	t.Run("vector search orders by cosine distance", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.Search(ctx, "alice", "", "", "", 0,
 			[]float32{1, 0, 0})
 		if err != nil {
@@ -597,7 +599,7 @@ func TestStore_Search(t *testing.T) {
 	})
 
 	t.Run("vector search with category filter", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.Search(ctx, "alice", "", "fact", "", 0,
 			[]float32{1, 0, 0})
 		if err != nil {
@@ -611,7 +613,7 @@ func TestStore_Search(t *testing.T) {
 	})
 
 	t.Run("vector search with scope filter", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.Search(ctx, "alice", "", "", "system", 0,
 			[]float32{1, 0, 0})
 		if err != nil {
@@ -623,7 +625,7 @@ func TestStore_Search(t *testing.T) {
 	})
 
 	t.Run("text search by content ILIKE", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.Search(ctx, "alice", "axis", "", "", 0, nil)
 		if err != nil {
 			t.Fatalf("Search text: %v", err)
@@ -642,7 +644,7 @@ func TestStore_Search(t *testing.T) {
 	})
 
 	t.Run("text search empty query returns visible rows", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.Search(ctx, "alice", "", "", "", 0, nil)
 		if err != nil {
 			t.Fatalf("Search empty text: %v", err)
@@ -654,7 +656,7 @@ func TestStore_Search(t *testing.T) {
 	})
 
 	t.Run("text search with category and scope filters", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.Search(ctx, "alice", "", "fact", "user", 0, nil)
 		if err != nil {
 			t.Fatalf("Search text+filters: %v", err)
@@ -670,7 +672,7 @@ func TestStore_Search(t *testing.T) {
 	})
 
 	t.Run("limit clamp lower bound", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.Search(ctx, "alice", "", "", "", -5, nil)
 		if err != nil {
 			t.Fatalf("Search neg limit: %v", err)
@@ -683,7 +685,7 @@ func TestStore_Search(t *testing.T) {
 	})
 
 	t.Run("limit clamp upper bound", func(t *testing.T) {
-		seed()
+		seed(t)
 		got, err := store.Search(ctx, "alice", "", "", "", 9999, nil)
 		if err != nil {
 			t.Fatalf("Search huge limit: %v", err)

--- a/server/src/internal/memory/store_db_test.go
+++ b/server/src/internal/memory/store_db_test.go
@@ -1,0 +1,695 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package memory
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// memoryTestSchema mirrors the chat_memories table that store.go reads
+// from and writes to. The vector dimension is intentionally small (3) so
+// tests can supply tiny float slices and still exercise the cosine
+// distance ordering branch.
+const memoryTestSchema = `
+CREATE EXTENSION IF NOT EXISTS vector;
+DROP TABLE IF EXISTS chat_memories CASCADE;
+CREATE TABLE chat_memories (
+    id BIGSERIAL PRIMARY KEY,
+    username TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    category TEXT NOT NULL,
+    content TEXT NOT NULL,
+    pinned BOOLEAN NOT NULL DEFAULT FALSE,
+    embedding vector(3),
+    model_name TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+`
+
+const memoryTestTeardown = `
+DROP TABLE IF EXISTS chat_memories CASCADE;
+`
+
+// newMemoryTestStore wires up a *Store backed by the
+// TEST_AI_WORKBENCH_SERVER Postgres instance and creates the
+// chat_memories table. Tests skip cleanly when the database is not
+// configured or pgvector is unavailable.
+func newMemoryTestStore(t *testing.T) (*Store, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping memory integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, memoryTestSchema); err != nil {
+		pool.Close()
+		t.Skipf("Failed to create memory test schema (pgvector may be missing): %v", err)
+	}
+
+	store := NewStore(pool)
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), memoryTestTeardown); err != nil {
+			t.Logf("memory teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return store, pool, cleanup
+}
+
+// truncateMemories removes all rows and resets identity between subtests
+// so order-dependent assertions can rely on a clean slate.
+func truncateMemories(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`TRUNCATE chat_memories RESTART IDENTITY`); err != nil {
+		t.Fatalf("truncate failed: %v", err)
+	}
+}
+
+func TestStore_Store(t *testing.T) {
+	store, pool, cleanup := newMemoryTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("happy path with embedding", func(t *testing.T) {
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "alice", "user", "pref",
+			"likes coffee", true,
+			[]float32{1, 0, 0}, "model-a")
+		if err != nil {
+			t.Fatalf("Store: %v", err)
+		}
+		if mem.ID == 0 {
+			t.Errorf("expected non-zero id, got %d", mem.ID)
+		}
+		if mem.Username != "alice" || mem.Scope != "user" ||
+			mem.Category != "pref" || mem.Content != "likes coffee" ||
+			!mem.Pinned || mem.ModelName != "model-a" {
+			t.Errorf("returned memory has wrong fields: %+v", mem)
+		}
+
+		// Verify it round-trips through GetByID.
+		got, err := store.GetByID(ctx, mem.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if got.ID != mem.ID || got.Content != "likes coffee" {
+			t.Errorf("GetByID returned %+v, want id=%d content=%q",
+				got, mem.ID, "likes coffee")
+		}
+	})
+
+	t.Run("happy path without embedding", func(t *testing.T) {
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "bob", "user", "fact",
+			"plain text only", false, nil, "")
+		if err != nil {
+			t.Fatalf("Store nil embedding: %v", err)
+		}
+		if mem.ID == 0 {
+			t.Errorf("expected non-zero id")
+		}
+	})
+
+	t.Run("system scope allows empty username", func(t *testing.T) {
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "", "system", "policy",
+			"global rule", false, []float32{0, 1, 0}, "m")
+		if err != nil {
+			t.Fatalf("system scope Store: %v", err)
+		}
+		if mem.Username != "" || mem.Scope != "system" {
+			t.Errorf("unexpected fields: %+v", mem)
+		}
+	})
+
+	t.Run("invalid scope is rejected", func(t *testing.T) {
+		truncateMemories(t, pool)
+		_, err := store.Store(ctx, "alice", "bogus", "c", "x",
+			false, nil, "")
+		if err == nil {
+			t.Fatalf("expected error for invalid scope")
+		}
+	})
+
+	t.Run("user scope requires username", func(t *testing.T) {
+		truncateMemories(t, pool)
+		_, err := store.Store(ctx, "", "user", "c", "x", false, nil, "")
+		if err == nil {
+			t.Fatalf("expected error for empty username")
+		}
+	})
+
+	t.Run("blank content is rejected", func(t *testing.T) {
+		truncateMemories(t, pool)
+		_, err := store.Store(ctx, "alice", "user", "c", "   \t\n",
+			false, nil, "")
+		if err == nil {
+			t.Fatalf("expected error for blank content")
+		}
+	})
+
+	t.Run("insert error surfaces wrapped", func(t *testing.T) {
+		// Force a DB-side failure by passing a wrong-length vector.
+		truncateMemories(t, pool)
+		_, err := store.Store(ctx, "alice", "user", "c", "hi",
+			false, []float32{1, 2, 3, 4, 5}, "m")
+		if err == nil {
+			t.Fatalf("expected wrapped insert error for bad vector dim")
+		}
+	})
+}
+
+func TestStore_GetByID(t *testing.T) {
+	store, pool, cleanup := newMemoryTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("not found returns ErrNotFound", func(t *testing.T) {
+		truncateMemories(t, pool)
+		_, err := store.GetByID(ctx, 9999)
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("happy path returns full row", func(t *testing.T) {
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "alice", "user", "k", "v",
+			false, []float32{1, 0, 0}, "m")
+		if err != nil {
+			t.Fatalf("seed Store: %v", err)
+		}
+		got, err := store.GetByID(ctx, mem.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if got.Username != "alice" || got.Content != "v" ||
+			got.Category != "k" {
+			t.Errorf("unexpected fields: %+v", got)
+		}
+	})
+}
+
+func TestStore_Delete(t *testing.T) {
+	store, pool, cleanup := newMemoryTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("owner can delete", func(t *testing.T) {
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "alice", "user", "k", "v",
+			false, nil, "")
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := store.Delete(ctx, mem.ID, "alice"); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		if _, err := store.GetByID(ctx, mem.ID); !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected row gone, got %v", err)
+		}
+	})
+
+	t.Run("wrong username yields ErrNotFound", func(t *testing.T) {
+		// Delete only matches on (id, username), so a non-owner sees the
+		// same response as a missing row.
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "alice", "user", "k", "v",
+			false, nil, "")
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		err = store.Delete(ctx, mem.ID, "bob")
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound for non-owner, got %v", err)
+		}
+	})
+
+	t.Run("missing id returns ErrNotFound", func(t *testing.T) {
+		truncateMemories(t, pool)
+		err := store.Delete(ctx, 424242, "alice")
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+func TestStore_DeleteByID(t *testing.T) {
+	store, pool, cleanup := newMemoryTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("happy path", func(t *testing.T) {
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "alice", "user", "k", "v",
+			false, nil, "")
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := store.DeleteByID(ctx, mem.ID); err != nil {
+			t.Fatalf("DeleteByID: %v", err)
+		}
+		if _, err := store.GetByID(ctx, mem.ID); !errors.Is(err, ErrNotFound) {
+			t.Errorf("row not deleted: %v", err)
+		}
+	})
+
+	t.Run("missing id returns ErrNotFound", func(t *testing.T) {
+		truncateMemories(t, pool)
+		err := store.DeleteByID(ctx, 7777)
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+func TestStore_UpdatePinned(t *testing.T) {
+	store, pool, cleanup := newMemoryTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("owner toggles pinned", func(t *testing.T) {
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "alice", "user", "k", "v",
+			false, nil, "")
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := store.UpdatePinned(ctx, mem.ID, "alice", true); err != nil {
+			t.Fatalf("UpdatePinned: %v", err)
+		}
+		got, err := store.GetByID(ctx, mem.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if !got.Pinned {
+			t.Errorf("expected pinned=true after update")
+		}
+	})
+
+	t.Run("non-owner cannot pin user-scoped memory", func(t *testing.T) {
+		// UPDATE matches WHERE id=? AND (username=? OR scope='system').
+		// For a user-scoped row owned by alice, bob's update affects 0
+		// rows so the call returns ErrNotFound.
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "alice", "user", "k", "v",
+			false, nil, "")
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		err = store.UpdatePinned(ctx, mem.ID, "bob", true)
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("any user can pin a system-scoped memory", func(t *testing.T) {
+		// system scope short-circuits the username check by design.
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "", "system", "policy",
+			"shared", false, nil, "")
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := store.UpdatePinned(ctx, mem.ID, "anyone", true); err != nil {
+			t.Fatalf("UpdatePinned system: %v", err)
+		}
+		got, err := store.GetByID(ctx, mem.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if !got.Pinned {
+			t.Errorf("system memory should be pinned")
+		}
+	})
+
+	t.Run("missing id returns ErrNotFound", func(t *testing.T) {
+		truncateMemories(t, pool)
+		err := store.UpdatePinned(ctx, 9999, "alice", true)
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+func TestStore_GetPinned(t *testing.T) {
+	store, pool, cleanup := newMemoryTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("returns own pinned plus system pinned", func(t *testing.T) {
+		truncateMemories(t, pool)
+
+		// Alice owns one pinned + one unpinned.
+		if _, err := store.Store(ctx, "alice", "user", "k",
+			"a-pin", true, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := store.Store(ctx, "alice", "user", "k",
+			"a-unpin", false, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		// Bob owns a pinned that alice should NOT see.
+		if _, err := store.Store(ctx, "bob", "user", "k",
+			"b-pin", true, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		// System pinned visible to everyone.
+		if _, err := store.Store(ctx, "", "system", "p",
+			"sys-pin", true, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		// System unpinned excluded by pinned filter.
+		if _, err := store.Store(ctx, "", "system", "p",
+			"sys-unpin", false, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+
+		got, err := store.GetPinned(ctx, "alice")
+		if err != nil {
+			t.Fatalf("GetPinned: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("expected 2 pinned, got %d: %+v", len(got), got)
+		}
+		seen := map[string]bool{}
+		for _, m := range got {
+			seen[m.Content] = true
+		}
+		if !seen["a-pin"] || !seen["sys-pin"] {
+			t.Errorf("missing expected pinned rows: %+v", got)
+		}
+		if seen["b-pin"] {
+			t.Errorf("alice should not see bob's pinned row")
+		}
+	})
+
+	t.Run("empty result for unknown user", func(t *testing.T) {
+		truncateMemories(t, pool)
+		got, err := store.GetPinned(ctx, "ghost")
+		if err != nil {
+			t.Fatalf("GetPinned: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected zero rows, got %d", len(got))
+		}
+	})
+}
+
+func TestStore_ListByUser(t *testing.T) {
+	store, pool, cleanup := newMemoryTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	seed := func() {
+		truncateMemories(t, pool)
+		// Alice rows in two categories.
+		if _, err := store.Store(ctx, "alice", "user", "fact",
+			"a-fact-1", false, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := store.Store(ctx, "alice", "user", "fact",
+			"a-fact-2", false, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := store.Store(ctx, "alice", "user", "pref",
+			"a-pref", false, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		// Bob's row should not appear in alice's list.
+		if _, err := store.Store(ctx, "bob", "user", "fact",
+			"b-fact", false, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		// System row is visible to alice.
+		if _, err := store.Store(ctx, "", "system", "fact",
+			"sys-fact", false, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	t.Run("no category returns own + system", func(t *testing.T) {
+		seed()
+		got, err := store.ListByUser(ctx, "alice", "", 0)
+		if err != nil {
+			t.Fatalf("ListByUser: %v", err)
+		}
+		// 3 alice rows + 1 system = 4. Bob's row excluded.
+		if len(got) != 4 {
+			t.Errorf("expected 4 rows, got %d", len(got))
+		}
+		for _, m := range got {
+			if m.Username == "bob" {
+				t.Errorf("bob row leaked: %+v", m)
+			}
+		}
+	})
+
+	t.Run("category filter applies", func(t *testing.T) {
+		seed()
+		got, err := store.ListByUser(ctx, "alice", "fact", 0)
+		if err != nil {
+			t.Fatalf("ListByUser fact: %v", err)
+		}
+		// 2 alice fact rows + 1 system fact row = 3.
+		if len(got) != 3 {
+			t.Errorf("expected 3 fact rows, got %d: %+v", len(got), got)
+		}
+		for _, m := range got {
+			if m.Category != "fact" {
+				t.Errorf("non-fact category leaked: %+v", m)
+			}
+		}
+	})
+
+	t.Run("limit caps result size", func(t *testing.T) {
+		seed()
+		got, err := store.ListByUser(ctx, "alice", "", 2)
+		if err != nil {
+			t.Fatalf("ListByUser limit: %v", err)
+		}
+		if len(got) != 2 {
+			t.Errorf("expected 2 rows under limit, got %d", len(got))
+		}
+	})
+
+	t.Run("limit clamps above 100", func(t *testing.T) {
+		seed()
+		got, err := store.ListByUser(ctx, "alice", "", 9999)
+		if err != nil {
+			t.Fatalf("ListByUser big limit: %v", err)
+		}
+		// We seeded only 5 rows; limit clamp must not error.
+		if len(got) > 100 {
+			t.Errorf("expected limit clamp, got %d rows", len(got))
+		}
+	})
+
+	t.Run("category filter with limit", func(t *testing.T) {
+		seed()
+		got, err := store.ListByUser(ctx, "alice", "fact", 1)
+		if err != nil {
+			t.Fatalf("ListByUser fact+limit: %v", err)
+		}
+		if len(got) != 1 {
+			t.Errorf("expected 1 row, got %d", len(got))
+		}
+	})
+}
+
+func TestStore_Search(t *testing.T) {
+	store, pool, cleanup := newMemoryTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	seed := func() {
+		truncateMemories(t, pool)
+		// Vectors aligned with x, y, z axes. Cosine distance to [1,0,0]
+		// is smallest for the x-axis row, so it should appear first
+		// when the search is ordered by similarity.
+		if _, err := store.Store(ctx, "alice", "user", "fact",
+			"x-axis vector", false,
+			[]float32{1, 0, 0}, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := store.Store(ctx, "alice", "user", "fact",
+			"y-axis vector", false,
+			[]float32{0, 1, 0}, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := store.Store(ctx, "alice", "user", "pref",
+			"alice preference", false,
+			[]float32{0, 0, 1}, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := store.Store(ctx, "bob", "user", "fact",
+			"bob private fact", false,
+			[]float32{1, 0, 0}, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := store.Store(ctx, "", "system", "policy",
+			"system note", false,
+			[]float32{1, 0, 0}, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		// One row without an embedding to confirm vector search filters
+		// it out via embedding IS NOT NULL.
+		if _, err := store.Store(ctx, "alice", "user", "fact",
+			"no-embed text", false, nil, ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	t.Run("vector search orders by cosine distance", func(t *testing.T) {
+		seed()
+		got, err := store.Search(ctx, "alice", "", "", "", 0,
+			[]float32{1, 0, 0})
+		if err != nil {
+			t.Fatalf("Search vec: %v", err)
+		}
+		if len(got) == 0 {
+			t.Fatalf("expected non-empty result")
+		}
+		// Bob's row must be excluded; only alice's own + system show up.
+		for _, m := range got {
+			if m.Username == "bob" {
+				t.Errorf("bob row leaked: %+v", m)
+			}
+			if m.Content == "no-embed text" {
+				t.Errorf("null-embedding row leaked: %+v", m)
+			}
+		}
+		// The closest match to [1,0,0] is the x-axis row.
+		if got[0].Content != "x-axis vector" &&
+			got[0].Content != "system note" {
+			t.Errorf("unexpected top match: %+v", got[0])
+		}
+	})
+
+	t.Run("vector search with category filter", func(t *testing.T) {
+		seed()
+		got, err := store.Search(ctx, "alice", "", "fact", "", 0,
+			[]float32{1, 0, 0})
+		if err != nil {
+			t.Fatalf("Search vec+cat: %v", err)
+		}
+		for _, m := range got {
+			if m.Category != "fact" {
+				t.Errorf("unexpected category: %+v", m)
+			}
+		}
+	})
+
+	t.Run("vector search with scope filter", func(t *testing.T) {
+		seed()
+		got, err := store.Search(ctx, "alice", "", "", "system", 0,
+			[]float32{1, 0, 0})
+		if err != nil {
+			t.Fatalf("Search vec+scope: %v", err)
+		}
+		if len(got) != 1 || got[0].Scope != "system" {
+			t.Errorf("expected single system row, got %+v", got)
+		}
+	})
+
+	t.Run("text search by content ILIKE", func(t *testing.T) {
+		seed()
+		got, err := store.Search(ctx, "alice", "axis", "", "", 0, nil)
+		if err != nil {
+			t.Fatalf("Search text: %v", err)
+		}
+		// Both x-axis and y-axis rows match; bob excluded.
+		found := map[string]bool{}
+		for _, m := range got {
+			found[m.Content] = true
+			if m.Username == "bob" {
+				t.Errorf("bob leaked in text search: %+v", m)
+			}
+		}
+		if !found["x-axis vector"] || !found["y-axis vector"] {
+			t.Errorf("expected both axis rows, got %+v", got)
+		}
+	})
+
+	t.Run("text search empty query returns visible rows", func(t *testing.T) {
+		seed()
+		got, err := store.Search(ctx, "alice", "", "", "", 0, nil)
+		if err != nil {
+			t.Fatalf("Search empty text: %v", err)
+		}
+		// alice's own (4) + system (1) = 5; no text filter applied.
+		if len(got) != 5 {
+			t.Errorf("expected 5 rows, got %d", len(got))
+		}
+	})
+
+	t.Run("text search with category and scope filters", func(t *testing.T) {
+		seed()
+		got, err := store.Search(ctx, "alice", "", "fact", "user", 0, nil)
+		if err != nil {
+			t.Fatalf("Search text+filters: %v", err)
+		}
+		for _, m := range got {
+			if m.Category != "fact" || m.Scope != "user" {
+				t.Errorf("filter leak: %+v", m)
+			}
+			if m.Username == "bob" {
+				t.Errorf("bob leaked: %+v", m)
+			}
+		}
+	})
+
+	t.Run("limit clamp lower bound", func(t *testing.T) {
+		seed()
+		got, err := store.Search(ctx, "alice", "", "", "", -5, nil)
+		if err != nil {
+			t.Fatalf("Search neg limit: %v", err)
+		}
+		// Negative limit is clamped to 20; we seeded fewer rows so just
+		// confirm the call succeeded and stayed below the cap.
+		if len(got) > 20 {
+			t.Errorf("expected <=20 rows, got %d", len(got))
+		}
+	})
+
+	t.Run("limit clamp upper bound", func(t *testing.T) {
+		seed()
+		got, err := store.Search(ctx, "alice", "", "", "", 9999, nil)
+		if err != nil {
+			t.Fatalf("Search huge limit: %v", err)
+		}
+		if len(got) > 100 {
+			t.Errorf("expected <=100 rows, got %d", len(got))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Addresses a focused subset of issue #78 — the highest-priority items in
the acceptance criteria:

- **`server/internal/crypto` 86.8% → 100%** — covers the four previously
  untested error branches (random source failure, `ReadFile` failure,
  `WriteFile` failure, and `pkgcrypto.EncryptGCM` failure). Two
  unexported function-variable hooks (`randRead`, `encryptGCM`) make
  the `rand.Reader` and GCM dependencies stubbable; tests restore the
  originals via `t.Cleanup`. Production behaviour is unchanged.
- **`server/internal/memory` 0.0% → 92.5%** — new
  `store_db_test.go` exercises all nine public methods on `*Store`
  (`Store`, `Search`, `GetPinned`, `ListByUser`, `GetByID`, `Delete`,
  `DeleteByID`, `UpdatePinned`, `NewStore`) against PostgreSQL with
  pgvector. Subtests cover happy paths, ownership and not-found
  errors, scope visibility (user vs system), category filters, limit
  clamping, and embedding similarity ordering. Skips cleanly when
  `TEST_AI_WORKBENCH_SERVER` is unset or pgvector is unavailable.
- **`-race` flag added** to the `test` and `coverage` targets in the
  `server`, `collector`, and `alerter` Makefiles. CI workflows already
  invoke `make coverage`, so no workflow YAML changes are needed.

The rest of issue #78 (collector/scheduler, alerter packages, untested
API handlers, React component coverage, `skipIfNoDatabase` testutil
extraction) is intentionally out of scope here and should be split
into follow-up PRs to keep this one reviewable.

## Test plan
- [x] `cd server/src && go test -race -coverprofile=/tmp/crypto.out ./internal/crypto/` → 100.0%
- [x] `cd server/src && TEST_AI_WORKBENCH_SERVER=postgres://… go test -race -coverprofile=/tmp/mem.out ./internal/memory/` → 92.5%
- [x] `gofmt -l` clean across changed packages
- [x] `go vet ./...` clean across the server module
- [x] `go build ./...` succeeds for the server module
- [x] `make -n test` in each sub-project shows the `-race` flag now present

https://claude.ai/code/session_01XjkQyWfwBuSUxg4LiHXQqg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjkQyWfwBuSUxg4LiHXQqg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for cryptographic operations and persistent storage, adding cases for error paths, edge conditions, and encryption/decryption behavior.
  * Added end-to-end database integration tests covering storage, retrieval, deletion, authorization, pagination, and vector/text search scenarios.
  * Enabled Go race detector across all test targets to catch concurrency/data-race issues in CI and local runs.

* **Documentation**
  * Updated changelog to reflect test coverage improvements and race-detector enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->