### PR TITLE
fix(collector): filter probe configs by scope and inherit is_enabled (#151)

### DIFF
--- a/collector/src/probes/config_loader.go
+++ b/collector/src/probes/config_loader.go
@@ -22,15 +22,33 @@ import (
 	"github.com/pgedge/ai-workbench/pkg/logger"
 )
 
-// LoadProbeConfigs loads all enabled probe configurations from the database
-// Returns a map of connection ID to probe configs, where connection ID 0 represents global defaults
-func LoadProbeConfigs(ctx context.Context, conn *pgxpool.Conn) (map[int][]ProbeConfig, error) {
-	rows, err := conn.Query(ctx, `
+// loadProbeConfigsQuery is the SELECT used by LoadProbeConfigs.
+//
+// The WHERE clause restricts the result set to scope IN ('global',
+// 'server'). Cluster- and group-scoped rows also have connection_id
+// IS NULL and would otherwise collapse into the global-default bucket
+// (key 0) when grouped by COALESCE(connection_id, 0). Cluster and
+// group inheritance is resolved separately by EnsureProbeConfig when
+// a server-level row is materialized for each connection.
+const loadProbeConfigsQuery = `
         SELECT id, name, description, collection_interval_seconds, retention_days, is_enabled, connection_id
         FROM probe_configs
         WHERE is_enabled = TRUE
+          AND scope IN ('global', 'server')
         ORDER BY COALESCE(connection_id, 0), name
-    `)
+    `
+
+// LoadProbeConfigs loads enabled global and server-scoped probe
+// configurations from the database. The returned map keys server-scoped
+// rows by their connection_id and global rows by 0.
+//
+// Cluster- and group-scoped rows are intentionally excluded because they
+// also have connection_id IS NULL and would otherwise collapse into the
+// global-default bucket (key 0); cluster and group inheritance is
+// resolved separately by EnsureProbeConfig when a server-level row is
+// materialized for each connection.
+func LoadProbeConfigs(ctx context.Context, conn *pgxpool.Conn) (map[int][]ProbeConfig, error) {
+	rows, err := conn.Query(ctx, loadProbeConfigsQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query probe configs: %w", err)
 	}
@@ -143,27 +161,16 @@ func EnsureProbeConfig(ctx context.Context, conn *pgxpool.Conn, connectionID int
 		}
 	}
 
-	// Determine values for the new server-level config
-	var interval, retention int
-	var description string
-
-	if found {
-		interval = parentConfig.CollectionIntervalSeconds
-		retention = parentConfig.RetentionDays
-		description = parentConfig.Description
-	} else {
-		// Step 5: No parent config found; use hardcoded defaults
-		interval = getDefaultInterval(probeName)
-		retention = 28
-		description = fmt.Sprintf("Configuration for %s probe", probeName)
-	}
+	// Determine values for the new server-level config from the
+	// resolved parent (or hardcoded defaults if no parent matched).
+	interval, retention, description, isEnabled := resolveProbeConfigDefaults(probeName, &parentConfig, found)
 
 	// Insert a new server-level config for this connection
 	err = conn.QueryRow(ctx, `
         INSERT INTO probe_configs (name, description, collection_interval_seconds, retention_days, is_enabled, connection_id, scope)
-        VALUES ($1, $2, $3, $4, TRUE, $5, 'server')
+        VALUES ($1, $2, $3, $4, $5, $6, 'server')
         RETURNING id, name, description, collection_interval_seconds, retention_days, is_enabled, connection_id
-    `, probeName, description, interval, retention, connectionID).Scan(
+    `, probeName, description, interval, retention, isEnabled, connectionID).Scan(
 		&config.ID, &config.Name, &config.Description,
 		&config.CollectionIntervalSeconds, &config.RetentionDays, &config.IsEnabled,
 		&config.ConnectionID)
@@ -172,10 +179,37 @@ func EnsureProbeConfig(ctx context.Context, conn *pgxpool.Conn, connectionID int
 		return nil, fmt.Errorf("failed to insert probe config: %w", err)
 	}
 
-	logger.Infof("Created probe config for %s on connection %d (interval: %ds, retention: %dd)",
-		probeName, connectionID, interval, retention)
+	logger.Infof("Created probe config for %s on connection %d (interval: %ds, retention: %dd, enabled: %t)",
+		probeName, connectionID, interval, retention, isEnabled)
 
 	return &config, nil
+}
+
+// resolveProbeConfigDefaults returns the (interval, retention,
+// description, isEnabled) tuple to use when materializing a new
+// server-level probe_configs row.
+//
+// When found is true, all four values are inherited from parentConfig
+// so a disabled cluster/group/global override is not silently
+// re-enabled at the server scope. When found is false, the function
+// falls back to hardcoded defaults: the per-probe default interval,
+// 28 days of retention, a generated description, and is_enabled=TRUE.
+//
+// The function is pure (no I/O, no shared state); callers must pass a
+// non-nil parentConfig only when found is true. When found is false
+// parentConfig is ignored and may be nil.
+func resolveProbeConfigDefaults(probeName string, parentConfig *ProbeConfig, found bool) (int, int, string, bool) {
+	if found && parentConfig != nil {
+		return parentConfig.CollectionIntervalSeconds,
+			parentConfig.RetentionDays,
+			parentConfig.Description,
+			parentConfig.IsEnabled
+	}
+
+	return getDefaultInterval(probeName),
+		28,
+		fmt.Sprintf("Configuration for %s probe", probeName),
+		true
 }
 
 // getDefaultInterval returns the default collection interval for a probe based on its name

--- a/collector/src/probes/config_loader_test.go
+++ b/collector/src/probes/config_loader_test.go
@@ -11,6 +11,7 @@
 package probes
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -201,5 +202,224 @@ func TestAllProbeNameConstants_NoEmptyStrings(t *testing.T) {
 		if probeName == "" {
 			t.Errorf("Empty probe name at index %d in allProbeNameConstants", i)
 		}
+	}
+}
+
+// intPtr returns a pointer to the given int. It is a small helper used
+// by the resolveProbeConfigDefaults tests below to populate the
+// parent ProbeConfig's ConnectionID field, which is *int.
+func intPtr(v int) *int {
+	return &v
+}
+
+// TestLoadProbeConfigsQuery_FiltersByScope is a regression test for
+// issue #151. Cluster- and group-scoped probe_configs rows have
+// connection_id IS NULL just like global rows; without an explicit
+// scope filter they collapse into the connection_id = 0 bucket and
+// get applied as if they were global defaults. The query must
+// restrict the result set to scope IN ('global', 'server').
+//
+// This test pins the SQL string. Removing the scope filter (the
+// pre-fix behavior) makes the test fail.
+func TestLoadProbeConfigsQuery_FiltersByScope(t *testing.T) {
+	if !strings.Contains(loadProbeConfigsQuery, "scope IN ('global', 'server')") {
+		t.Errorf("loadProbeConfigsQuery must restrict scope to global/server\n"+
+			"to prevent cluster- and group-scoped rows (which also have\n"+
+			"connection_id IS NULL) from collapsing into the global bucket.\n"+
+			"Got query:\n%s", loadProbeConfigsQuery)
+	}
+
+	// Sanity: the query must still require the row to be enabled and
+	// must select from probe_configs. These are not the bug fix but
+	// they pin the contract the test is asserting.
+	if !strings.Contains(loadProbeConfigsQuery, "is_enabled = TRUE") {
+		t.Errorf("loadProbeConfigsQuery must filter on is_enabled = TRUE; got:\n%s",
+			loadProbeConfigsQuery)
+	}
+	if !strings.Contains(loadProbeConfigsQuery, "FROM probe_configs") {
+		t.Errorf("loadProbeConfigsQuery must select FROM probe_configs; got:\n%s",
+			loadProbeConfigsQuery)
+	}
+}
+
+// TestLoadProbeConfigsQuery_OrdersByConnectionThenName pins the
+// ORDER BY clause that callers depend on: rows are grouped per
+// connection_id (with NULL coalesced to 0 so global defaults sort
+// first) and then alphabetised by probe name. Changing the ordering
+// would silently reshuffle the per-connection slices in
+// LoadProbeConfigs's returned map.
+func TestLoadProbeConfigsQuery_OrdersByConnectionThenName(t *testing.T) {
+	if !strings.Contains(loadProbeConfigsQuery, "ORDER BY COALESCE(connection_id, 0), name") {
+		t.Errorf("loadProbeConfigsQuery must order by COALESCE(connection_id, 0), name; got:\n%s",
+			loadProbeConfigsQuery)
+	}
+}
+
+// TestResolveProbeConfigDefaults_InheritsDisabledParent is the core
+// regression test for the second half of issue #151. When a parent
+// (cluster, group, or global) probe_config has is_enabled = FALSE,
+// the materialized server-level row must inherit that disabled flag
+// rather than being silently re-enabled. The pre-fix INSERT
+// hard-coded VALUES (..., TRUE, ...), which is exactly what this
+// test guards against.
+func TestResolveProbeConfigDefaults_InheritsDisabledParent(t *testing.T) {
+	parent := &ProbeConfig{
+		ID:                        42,
+		Name:                      ProbeNamePgStatActivity,
+		Description:               "cluster override - paused for maintenance",
+		CollectionIntervalSeconds: 120,
+		RetentionDays:             7,
+		IsEnabled:                 false, // parent explicitly disabled
+		ConnectionID:              nil,   // cluster/group/global rows have NULL
+	}
+
+	interval, retention, description, isEnabled := resolveProbeConfigDefaults(
+		ProbeNamePgStatActivity, parent, true)
+
+	if interval != 120 {
+		t.Errorf("interval: got %d, want 120 (inherited from parent)", interval)
+	}
+	if retention != 7 {
+		t.Errorf("retention: got %d, want 7 (inherited from parent)", retention)
+	}
+	if description != "cluster override - paused for maintenance" {
+		t.Errorf("description: got %q, want parent's description", description)
+	}
+	if isEnabled {
+		t.Errorf("isEnabled: got true, want false (must inherit parent's disabled flag)")
+	}
+}
+
+// TestResolveProbeConfigDefaults_InheritsEnabledParent verifies that
+// when a parent config is enabled, the helper inherits all four
+// fields including IsEnabled = true. This complements the disabled
+// case to confirm the helper truly forwards the parent's flag rather
+// than always returning a fixed value.
+func TestResolveProbeConfigDefaults_InheritsEnabledParent(t *testing.T) {
+	parent := &ProbeConfig{
+		ID:                        7,
+		Name:                      ProbeNamePgStatReplication,
+		Description:               "global default for replication probe",
+		CollectionIntervalSeconds: 45,
+		RetentionDays:             30,
+		IsEnabled:                 true,
+		ConnectionID:              intPtr(99), // server-scoped parent
+	}
+
+	interval, retention, description, isEnabled := resolveProbeConfigDefaults(
+		ProbeNamePgStatReplication, parent, true)
+
+	if interval != 45 {
+		t.Errorf("interval: got %d, want 45", interval)
+	}
+	if retention != 30 {
+		t.Errorf("retention: got %d, want 30", retention)
+	}
+	if description != "global default for replication probe" {
+		t.Errorf("description: got %q, want parent's description", description)
+	}
+	if !isEnabled {
+		t.Errorf("isEnabled: got false, want true (parent was enabled)")
+	}
+}
+
+// TestResolveProbeConfigDefaults_NoParentUsesHardcodedDefaults
+// covers the fallback branch: when no parent config is found, the
+// helper must synthesise sensible defaults including isEnabled=true,
+// the per-probe default interval, 28 days of retention, and a
+// generated description. found=false is the discriminator.
+func TestResolveProbeConfigDefaults_NoParentUsesHardcodedDefaults(t *testing.T) {
+	interval, retention, description, isEnabled := resolveProbeConfigDefaults(
+		ProbeNamePgStatActivity, nil, false)
+
+	wantInterval := getDefaultInterval(ProbeNamePgStatActivity)
+	if interval != wantInterval {
+		t.Errorf("interval: got %d, want %d (probe default)", interval, wantInterval)
+	}
+	if retention != 28 {
+		t.Errorf("retention: got %d, want 28 (hardcoded default)", retention)
+	}
+	wantDescription := "Configuration for " + ProbeNamePgStatActivity + " probe"
+	if description != wantDescription {
+		t.Errorf("description: got %q, want %q", description, wantDescription)
+	}
+	if !isEnabled {
+		t.Errorf("isEnabled: got false, want true (default for synthesised configs)")
+	}
+}
+
+// TestResolveProbeConfigDefaults_NoParentUnknownProbe covers the
+// fallback branch for a probe name that has no entry in
+// getDefaultInterval. The fallback interval is 300 seconds (5
+// minutes) and retention/isEnabled remain at their hardcoded
+// defaults.
+func TestResolveProbeConfigDefaults_NoParentUnknownProbe(t *testing.T) {
+	interval, retention, description, isEnabled := resolveProbeConfigDefaults(
+		"some_brand_new_probe_name", nil, false)
+
+	if interval != 300 {
+		t.Errorf("interval: got %d, want 300 (fallback default for unknown probes)",
+			interval)
+	}
+	if retention != 28 {
+		t.Errorf("retention: got %d, want 28", retention)
+	}
+	if description != "Configuration for some_brand_new_probe_name probe" {
+		t.Errorf("description: got %q", description)
+	}
+	if !isEnabled {
+		t.Errorf("isEnabled: got false, want true")
+	}
+}
+
+// TestResolveProbeConfigDefaults_FoundFalseIgnoresParent guards the
+// helper's contract: when found is false the parentConfig argument
+// is ignored, even if non-nil. Without this guarantee callers in
+// EnsureProbeConfig that pass &parentConfig (the zero value) when
+// no parent matched would accidentally inherit zero-valued fields.
+func TestResolveProbeConfigDefaults_FoundFalseIgnoresParent(t *testing.T) {
+	// A non-nil but zero-valued parent must NOT leak into the result.
+	zeroParent := &ProbeConfig{}
+
+	interval, retention, description, isEnabled := resolveProbeConfigDefaults(
+		ProbeNamePgStatActivity, zeroParent, false)
+
+	if interval != getDefaultInterval(ProbeNamePgStatActivity) {
+		t.Errorf("interval should come from getDefaultInterval, not the zero parent; got %d",
+			interval)
+	}
+	if retention != 28 {
+		t.Errorf("retention should be 28 (default), not parent's zero; got %d", retention)
+	}
+	if description == "" {
+		t.Errorf("description should be the synthesised default, not the parent's empty string")
+	}
+	if !isEnabled {
+		t.Errorf("isEnabled should default to true when no parent is matched")
+	}
+}
+
+// TestResolveProbeConfigDefaults_FoundTrueButNilParent guards the
+// nil-pointer branch in the conditional: if a caller incorrectly
+// passes (true, nil) the helper must fall through to the defaults
+// rather than dereferencing nil and panicking.
+func TestResolveProbeConfigDefaults_FoundTrueButNilParent(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("resolveProbeConfigDefaults panicked on nil parent: %v", r)
+		}
+	}()
+
+	interval, retention, _, isEnabled := resolveProbeConfigDefaults(
+		ProbeNamePgStatActivity, nil, true)
+
+	if interval != getDefaultInterval(ProbeNamePgStatActivity) {
+		t.Errorf("interval: got %d, want probe default", interval)
+	}
+	if retention != 28 {
+		t.Errorf("retention: got %d, want 28", retention)
+	}
+	if !isEnabled {
+		t.Errorf("isEnabled: got false, want true (default fallback)")
 	}
 }

--- a/collector/src/probes/config_loader_test.go
+++ b/collector/src/probes/config_loader_test.go
@@ -325,7 +325,7 @@ func TestResolveProbeConfigDefaults_InheritsEnabledParent(t *testing.T) {
 
 // TestResolveProbeConfigDefaults_NoParentUsesHardcodedDefaults
 // covers the fallback branch: when no parent config is found, the
-// helper must synthesise sensible defaults including isEnabled=true,
+// helper must synthesize sensible defaults including isEnabled=true,
 // the per-probe default interval, 28 days of retention, and a
 // generated description. found=false is the discriminator.
 func TestResolveProbeConfigDefaults_NoParentUsesHardcodedDefaults(t *testing.T) {
@@ -344,7 +344,7 @@ func TestResolveProbeConfigDefaults_NoParentUsesHardcodedDefaults(t *testing.T) 
 		t.Errorf("description: got %q, want %q", description, wantDescription)
 	}
 	if !isEnabled {
-		t.Errorf("isEnabled: got false, want true (default for synthesised configs)")
+		t.Errorf("isEnabled: got false, want true (default for synthesized configs)")
 	}
 }
 
@@ -392,7 +392,7 @@ func TestResolveProbeConfigDefaults_FoundFalseIgnoresParent(t *testing.T) {
 		t.Errorf("retention should be 28 (default), not parent's zero; got %d", retention)
 	}
 	if description == "" {
-		t.Errorf("description should be the synthesised default, not the parent's empty string")
+		t.Errorf("description should be the synthesized default, not the parent's empty string")
 	}
 	if !isEnabled {
 		t.Errorf("isEnabled should default to true when no parent is matched")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -121,6 +121,21 @@ project adheres to
 
 ### Fixed
 
+- Fix the collector probe config loader ignoring scope
+  and silently re-enabling disabled parent overrides;
+  `LoadProbeConfigs` now restricts its query to
+  `scope IN ('global', 'server')` so cluster- and
+  group-scoped rows no longer collapse into the
+  `connection_id = 0` bucket and get misapplied as
+  global defaults, and `EnsureProbeConfig` now inherits
+  the parent config's `is_enabled` value when
+  materializing a server-level row instead of
+  hard-coding it to true. The SQL is extracted into a
+  `loadProbeConfigsQuery` constant and the value
+  resolution moves into a pure
+  `resolveProbeConfigDefaults` helper, both covered by
+  new unit tests. (#151)
+
 - Fix MCP and admin scope privileges granted through a
   wildcard group grant (`"*"`) being silently dropped
   during token scope intersection; the intersection


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in `collector/src/probes/config_loader.go`
identified by CodeRabbit during review of #149.

- `LoadProbeConfigs` now restricts the SELECT to
  `scope IN ('global', 'server')`. Cluster- and group-scoped rows
  (where `connection_id IS NULL`) previously collapsed into the
  `connection_id = 0` bucket, so scoped overrides could be
  misapplied as global defaults.
- `EnsureProbeConfig` now inherits the parent config's `is_enabled`
  value when materializing a server-level row from a cluster, group,
  or global parent. Previously the INSERT hard-coded
  `is_enabled = TRUE`, silently re-enabling a disabled parent
  override on the new server config.

The SQL query is extracted into a `loadProbeConfigsQuery` constant
and the value-resolution logic moves into a pure
`resolveProbeConfigDefaults` helper, both covered by new unit tests.

## Test plan

- [x] `gofmt -l collector/src/` is empty
- [x] `go vet ./...` passes in `collector/`
- [x] `cd collector && SKIP_DB_TESTS=1 make test` passes
- [x] `cd collector && SKIP_DB_TESTS=1 make coverage` passes;
      `resolveProbeConfigDefaults` reaches 100% line coverage
- [x] New tests fail against the pre-fix code (`scope` clause
      assertion + disabled-parent inheritance)
- [x] `make test` passes for collector, server, and alerter
- [ ] CI

Closes #151

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaCdUHwCjNFtqvGV99y2k1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed probe configuration loading to correctly filter database results to global and server scopes only, preventing scoped configuration rows from being incorrectly included as defaults.
  * Updated server-level probe configuration creation to properly inherit the parent configuration's enabled status instead of forcing all new configurations to enabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->