### PR TITLE
fix(server): replace auto-detected relationship set transactionally

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -121,6 +121,21 @@ project adheres to
 
 ### Fixed
 
+- Fix stale auto-detected edges remaining in
+  `cluster_node_relationships` after the cluster
+  topology changed through failover, subscriber
+  removal, or a new parent in a binary chain;
+  `SyncAutoDetectedRelationships` now replaces the
+  auto-detected set transactionally, deleting all
+  existing `is_auto_detected = TRUE` rows for the
+  cluster before inserting the freshly detected set,
+  and the `syncRelationshipsFromTopology` caller no
+  longer short-circuits on an empty detected slice.
+  Manual relationships and auto-detected rows for
+  other clusters are preserved, and a failure during
+  the delete or insert rolls the transaction back to
+  the prior state. (#152)
+
 - Fix MCP and admin scope privileges granted through a
   wildcard group grant (`"*"`) being silently dropped
   during token scope intersection; the intersection

--- a/server/src/internal/database/relationship_queries.go
+++ b/server/src/internal/database/relationship_queries.go
@@ -219,13 +219,32 @@ func (d *Datastore) SetNodeRelationships(ctx context.Context, clusterID int, sou
 	return nil
 }
 
-// SyncAutoDetectedRelationships inserts auto-detected relationships for a
-// cluster. For each detected relationship it performs an INSERT ... ON
-// CONFLICT DO NOTHING so that existing rows are preserved. This method
-// NEVER removes existing rows; auto-detection only adds.
+// SyncAutoDetectedRelationships replaces the auto-detected relationship
+// set for a cluster in a single transaction. All existing
+// is_auto_detected = TRUE rows for the cluster are deleted, then the
+// supplied detected slice is inserted with is_auto_detected = TRUE.
+// Manual rows (is_auto_detected = FALSE) and auto-detected rows for
+// other clusters are left untouched. The transaction rolls back on any
+// failure so the prior auto-detected state survives. ON CONFLICT DO
+// NOTHING guards against duplicate entries within the input slice.
 func (d *Datastore) SyncAutoDetectedRelationships(ctx context.Context, clusterID int, detected []AutoRelationshipInput) error {
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // Rollback is no-op if already committed
+
+	_, err = tx.Exec(ctx,
+		`DELETE FROM cluster_node_relationships
+         WHERE cluster_id = $1 AND is_auto_detected = TRUE`,
+		clusterID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete existing auto-detected relationships: %w", err)
+	}
+
 	for _, rel := range detected {
-		_, err := d.pool.Exec(ctx,
+		_, err = tx.Exec(ctx,
 			`INSERT INTO cluster_node_relationships
              (cluster_id, source_connection_id, target_connection_id, relationship_type, is_auto_detected)
              VALUES ($1, $2, $3, $4, TRUE)
@@ -236,6 +255,10 @@ func (d *Datastore) SyncAutoDetectedRelationships(ctx context.Context, clusterID
 		if err != nil {
 			return fmt.Errorf("failed to sync auto-detected relationship: %w", err)
 		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return nil

--- a/server/src/internal/database/relationship_queries.go
+++ b/server/src/internal/database/relationship_queries.go
@@ -14,6 +14,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // CreateManualCluster creates a cluster with no auto_cluster_key and an
@@ -227,12 +229,39 @@ func (d *Datastore) SetNodeRelationships(ctx context.Context, clusterID int, sou
 // other clusters are left untouched. The transaction rolls back on any
 // failure so the prior auto-detected state survives. ON CONFLICT DO
 // NOTHING guards against duplicate entries within the input slice.
+//
+// To prevent the DELETE-then-INSERT race that READ COMMITTED isolation
+// would otherwise allow (two concurrent syncs for the same cluster
+// each observing an empty initial state and committing the union of
+// their disjoint inserts), the transaction first takes a row-level
+// lock on the cluster row via SELECT ... FOR UPDATE. Concurrent syncs
+// for the SAME cluster serialize on this lock; syncs for DIFFERENT
+// clusters proceed in parallel because the lock is row-scoped.
+//
+// If the supplied clusterID does not exist in the clusters table, the
+// function returns ErrClusterNotFound and makes no changes.
 func (d *Datastore) SyncAutoDetectedRelationships(ctx context.Context, clusterID int, detected []AutoRelationshipInput) error {
 	tx, err := d.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // Rollback is no-op if already committed
+
+	// Take a row-level lock on the cluster's row to serialize concurrent
+	// syncs targeting the same cluster. Other transactions that take this
+	// lock (or otherwise lock the row) block until this transaction
+	// commits or rolls back. A missing cluster yields pgx.ErrNoRows.
+	var lockedID int
+	err = tx.QueryRow(ctx,
+		`SELECT id FROM clusters WHERE id = $1 FOR UPDATE`,
+		clusterID,
+	).Scan(&lockedID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrClusterNotFound
+		}
+		return fmt.Errorf("failed to lock cluster row: %w", err)
+	}
 
 	_, err = tx.Exec(ctx,
 		`DELETE FROM cluster_node_relationships

--- a/server/src/internal/database/sync_auto_detected_relationships_test.go
+++ b/server/src/internal/database/sync_auto_detected_relationships_test.go
@@ -11,9 +11,12 @@ package database
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -547,5 +550,231 @@ func TestSyncAutoDetectedRelationships_CanceledContext(t *testing.T) {
 	}
 	if !hasRelationship(t, pool, clusterID, connA, connB, "streams_from", true) {
 		t.Fatalf("original auto edge was lost despite canceled context")
+	}
+}
+
+// TestSyncAutoDetectedRelationships_MissingClusterReturnsError verifies
+// that calling sync with a cluster id that does not exist in the
+// clusters table returns ErrClusterNotFound and makes no changes. The
+// SELECT ... FOR UPDATE on the clusters row produces pgx.ErrNoRows
+// which the function maps to the canonical ErrClusterNotFound sentinel.
+func TestSyncAutoDetectedRelationships_MissingClusterReturnsError(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+
+	const missingClusterID = 999999
+	err := ds.SyncAutoDetectedRelationships(ctx, missingClusterID,
+		[]AutoRelationshipInput{
+			{SourceConnectionID: connA, TargetConnectionID: connB, RelationshipType: "streams_from"},
+		})
+	if err == nil {
+		t.Fatalf("expected error for missing cluster, got nil")
+	}
+	if !errors.Is(err, ErrClusterNotFound) {
+		t.Fatalf("expected ErrClusterNotFound, got %v", err)
+	}
+
+	var rowCount int
+	if scanErr := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM cluster_node_relationships WHERE cluster_id = $1`,
+		missingClusterID,
+	).Scan(&rowCount); scanErr != nil {
+		t.Fatalf("count rows for missing cluster failed: %v", scanErr)
+	}
+	if rowCount != 0 {
+		t.Fatalf("expected 0 rows for missing cluster id, got %d", rowCount)
+	}
+}
+
+// TestSyncAutoDetectedRelationships_LockQueryFailure verifies that any
+// non-ErrNoRows failure on the SELECT ... FOR UPDATE that locks the
+// cluster row is surfaced as a wrapped "failed to lock cluster row"
+// error and not silently swallowed.
+func TestSyncAutoDetectedRelationships_LockQueryFailure(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+
+	// Drop the clusters table after the cluster id is captured so the
+	// SELECT ... FOR UPDATE inside SyncAutoDetectedRelationships fails
+	// with a missing-table error rather than ErrNoRows.
+	if _, err := pool.Exec(ctx, `DROP TABLE clusters CASCADE`); err != nil {
+		t.Fatalf("dropping clusters table failed: %v", err)
+	}
+
+	err := ds.SyncAutoDetectedRelationships(ctx, clusterID,
+		[]AutoRelationshipInput{
+			{SourceConnectionID: 1, TargetConnectionID: 2, RelationshipType: "streams_from"},
+		})
+	if err == nil {
+		t.Fatalf("expected error when clusters table is missing, got nil")
+	}
+	if errors.Is(err, ErrClusterNotFound) {
+		t.Fatalf("expected wrapped lock error, got ErrClusterNotFound")
+	}
+	if !strings.Contains(err.Error(), "failed to lock cluster row") {
+		t.Fatalf("expected lock-error wrap, got %v", err)
+	}
+}
+
+// TestSyncAutoDetectedRelationships_SerializesConcurrentSyncsForSameCluster
+// drives two goroutines that both call SyncAutoDetectedRelationships on
+// the same cluster with disjoint inputs. The SELECT ... FOR UPDATE
+// guarantees the second sync only runs after the first commits, so the
+// final auto-detected set must equal exactly one of the two inputs and
+// never the union of both.
+func TestSyncAutoDetectedRelationships_SerializesConcurrentSyncsForSameCluster(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+	connC := insertSyncTestConnection(t, pool, "node-c")
+	connD := insertSyncTestConnection(t, pool, "node-d")
+
+	inputOne := []AutoRelationshipInput{
+		{SourceConnectionID: connA, TargetConnectionID: connB, RelationshipType: "streams_from"},
+		{SourceConnectionID: connB, TargetConnectionID: connA, RelationshipType: "replicates_with"},
+	}
+	inputTwo := []AutoRelationshipInput{
+		{SourceConnectionID: connC, TargetConnectionID: connD, RelationshipType: "streams_from"},
+		{SourceConnectionID: connD, TargetConnectionID: connC, RelationshipType: "replicates_with"},
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make([]error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		errs[0] = ds.SyncAutoDetectedRelationships(ctx, clusterID, inputOne)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		errs[1] = ds.SyncAutoDetectedRelationships(ctx, clusterID, inputTwo)
+	}()
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d sync failed: %v", i, err)
+		}
+	}
+
+	got := countRelationships(t, pool, clusterID, true)
+	if got != len(inputOne) {
+		t.Fatalf("expected exactly %d auto rows (one input survives), got %d (union of both inputs would be %d)",
+			len(inputOne), got, len(inputOne)+len(inputTwo))
+	}
+
+	matchesOne := hasRelationship(t, pool, clusterID, connA, connB, "streams_from", true) &&
+		hasRelationship(t, pool, clusterID, connB, connA, "replicates_with", true)
+	matchesTwo := hasRelationship(t, pool, clusterID, connC, connD, "streams_from", true) &&
+		hasRelationship(t, pool, clusterID, connD, connC, "replicates_with", true)
+	if !(matchesOne || matchesTwo) {
+		t.Fatalf("final state does not match either input exactly")
+	}
+	if matchesOne && matchesTwo {
+		t.Fatalf("final state matched both inputs, indicating union (race not prevented)")
+	}
+}
+
+// TestSyncAutoDetectedRelationships_DoesNotBlockDifferentClusters
+// confirms that the cluster-row lock is row-scoped, not table-scoped.
+// One goroutine holds an explicit FOR UPDATE lock on cluster A's row in
+// a long-lived transaction; another goroutine syncs cluster B and must
+// complete promptly without waiting for the first transaction.
+func TestSyncAutoDetectedRelationships_DoesNotBlockDifferentClusters(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterA := insertSyncTestCluster(t, pool, "cluster-a")
+	clusterB := insertSyncTestCluster(t, pool, "cluster-b")
+	connOne := insertSyncTestConnection(t, pool, "node-1")
+	connTwo := insertSyncTestConnection(t, pool, "node-2")
+
+	// Hold cluster A's row lock in a separate goroutine so that the
+	// blocker tx remains open while the test syncs cluster B. The
+	// blocker signals readiness via `locked` and waits on `release`
+	// before committing.
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	blockerDone := make(chan error, 1)
+	go func() {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			blockerDone <- err
+			return
+		}
+		defer tx.Rollback(ctx) //nolint:errcheck
+		var id int
+		if err := tx.QueryRow(ctx,
+			`SELECT id FROM clusters WHERE id = $1 FOR UPDATE`,
+			clusterA,
+		).Scan(&id); err != nil {
+			blockerDone <- err
+			return
+		}
+		close(locked)
+		<-release
+		blockerDone <- tx.Commit(ctx)
+	}()
+
+	select {
+	case <-locked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blocker goroutine never acquired cluster A lock")
+	}
+
+	// While cluster A's row is locked, cluster B sync must proceed
+	// without waiting. Use a short timeout to detect any unintended
+	// blocking behavior; row-scoped locks should let this finish in
+	// well under a second on a healthy local Postgres.
+	syncCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	syncDone := make(chan error, 1)
+	go func() {
+		syncDone <- ds.SyncAutoDetectedRelationships(syncCtx, clusterB,
+			[]AutoRelationshipInput{
+				{SourceConnectionID: connOne, TargetConnectionID: connTwo, RelationshipType: "streams_from"},
+			})
+	}()
+
+	select {
+	case err := <-syncDone:
+		if err != nil {
+			close(release)
+			<-blockerDone
+			t.Fatalf("cluster B sync returned error while cluster A was locked: %v", err)
+		}
+	case <-time.After(4 * time.Second):
+		close(release)
+		<-blockerDone
+		t.Fatal("cluster B sync was blocked by cluster A row lock; row-scoped lock failed")
+	}
+
+	// Release the blocker and confirm it commits cleanly.
+	close(release)
+	if err := <-blockerDone; err != nil {
+		t.Fatalf("blocker tx returned error: %v", err)
+	}
+
+	if got := countRelationships(t, pool, clusterB, true); got != 1 {
+		t.Fatalf("expected 1 auto row in cluster B, got %d", got)
 	}
 }

--- a/server/src/internal/database/sync_auto_detected_relationships_test.go
+++ b/server/src/internal/database/sync_auto_detected_relationships_test.go
@@ -1,0 +1,551 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// syncAutoDetectedTestSchema creates the minimal subset of tables needed
+// to exercise SyncAutoDetectedRelationships. It mirrors the production
+// shape used by the collector schema for cluster_groups, clusters,
+// connections, and cluster_node_relationships, including the unique
+// constraint that the ON CONFLICT clause depends on.
+const syncAutoDetectedTestSchema = `
+DROP TABLE IF EXISTS cluster_node_relationships CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+DROP TABLE IF EXISTS clusters CASCADE;
+DROP TABLE IF EXISTS cluster_groups CASCADE;
+
+CREATE TABLE cluster_groups (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE clusters (
+    id SERIAL PRIMARY KEY,
+    group_id INTEGER REFERENCES cluster_groups(id) ON DELETE CASCADE,
+    auto_cluster_key VARCHAR(255) UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    replication_type VARCHAR(50),
+    dismissed BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    cluster_id INTEGER REFERENCES clusters(id) ON DELETE SET NULL,
+    membership_source VARCHAR(16) NOT NULL DEFAULT 'auto',
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE cluster_node_relationships (
+    id SERIAL PRIMARY KEY,
+    cluster_id INTEGER NOT NULL
+        REFERENCES clusters(id) ON DELETE CASCADE,
+    source_connection_id INTEGER NOT NULL
+        REFERENCES connections(id) ON DELETE CASCADE,
+    target_connection_id INTEGER NOT NULL
+        REFERENCES connections(id) ON DELETE CASCADE,
+    relationship_type VARCHAR(50) NOT NULL,
+    is_auto_detected BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_no_self_relationship
+        CHECK (source_connection_id != target_connection_id),
+    CONSTRAINT uq_relationship
+        UNIQUE (cluster_id, source_connection_id,
+                target_connection_id, relationship_type)
+);
+`
+
+const syncAutoDetectedTestTeardown = `
+DROP TABLE IF EXISTS cluster_node_relationships CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+DROP TABLE IF EXISTS clusters CASCADE;
+DROP TABLE IF EXISTS cluster_groups CASCADE;
+`
+
+// newSyncAutoDetectedTestDatastore wires up a *Datastore against the
+// TEST_AI_WORKBENCH_SERVER Postgres instance with only the tables
+// required to exercise SyncAutoDetectedRelationships. It returns a
+// cleanup function that drops the schema and closes the pool.
+func newSyncAutoDetectedTestDatastore(t *testing.T) (*Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, syncAutoDetectedTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create sync auto-detected test schema: %v", err)
+	}
+
+	ds := NewTestDatastore(pool)
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), syncAutoDetectedTestTeardown); err != nil {
+			t.Logf("sync auto-detected teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return ds, pool, cleanup
+}
+
+// insertSyncTestCluster inserts a cluster row and returns its id.
+func insertSyncTestCluster(t *testing.T, pool *pgxpool.Pool, name string) int {
+	t.Helper()
+	var id int
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO clusters (name) VALUES ($1) RETURNING id`,
+		name,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert cluster %q: %v", name, err)
+	}
+	return id
+}
+
+// insertSyncTestConnection inserts a connection row and returns its id.
+func insertSyncTestConnection(t *testing.T, pool *pgxpool.Pool, name string) int {
+	t.Helper()
+	var id int
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO connections (name) VALUES ($1) RETURNING id`,
+		name,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert connection %q: %v", name, err)
+	}
+	return id
+}
+
+// countRelationships returns the total relationship count for a cluster
+// matching the given is_auto_detected filter.
+func countRelationships(t *testing.T, pool *pgxpool.Pool, clusterID int, autoDetected bool) int {
+	t.Helper()
+	var count int
+	err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM cluster_node_relationships
+         WHERE cluster_id = $1 AND is_auto_detected = $2`,
+		clusterID, autoDetected,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("count relationships (cluster=%d, auto=%v): %v",
+			clusterID, autoDetected, err)
+	}
+	return count
+}
+
+// hasRelationship reports whether the given relationship row exists for
+// the cluster with the supplied is_auto_detected flag.
+func hasRelationship(t *testing.T, pool *pgxpool.Pool, clusterID, sourceID, targetID int, relType string, autoDetected bool) bool {
+	t.Helper()
+	var exists bool
+	err := pool.QueryRow(context.Background(),
+		`SELECT EXISTS(
+             SELECT 1 FROM cluster_node_relationships
+             WHERE cluster_id = $1
+               AND source_connection_id = $2
+               AND target_connection_id = $3
+               AND relationship_type = $4
+               AND is_auto_detected = $5
+         )`,
+		clusterID, sourceID, targetID, relType, autoDetected,
+	).Scan(&exists)
+	if err != nil {
+		t.Fatalf("hasRelationship: %v", err)
+	}
+	return exists
+}
+
+// insertAutoRelationship seeds an existing auto-detected relationship
+// directly via SQL so tests can verify it gets removed by sync.
+func insertAutoRelationship(t *testing.T, pool *pgxpool.Pool, clusterID, sourceID, targetID int, relType string, auto bool) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO cluster_node_relationships
+         (cluster_id, source_connection_id, target_connection_id,
+          relationship_type, is_auto_detected)
+         VALUES ($1, $2, $3, $4, $5)`,
+		clusterID, sourceID, targetID, relType, auto,
+	)
+	if err != nil {
+		t.Fatalf("insertAutoRelationship: %v", err)
+	}
+}
+
+// TestSyncAutoDetectedRelationships_ReplacesObsoleteRows is the
+// regression test for issue #152. When the topology changes (failover,
+// subscriber removal, new parent in a binary chain), the old
+// auto-detected rows must be removed and replaced with the new set in
+// a single transaction.
+func TestSyncAutoDetectedRelationships_ReplacesObsoleteRows(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+	connC := insertSyncTestConnection(t, pool, "node-c")
+
+	initial := []AutoRelationshipInput{
+		{SourceConnectionID: connA, TargetConnectionID: connB, RelationshipType: "streams_from"},
+		{SourceConnectionID: connB, TargetConnectionID: connA, RelationshipType: "replicates_with"},
+	}
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, initial); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	if got := countRelationships(t, pool, clusterID, true); got != 2 {
+		t.Fatalf("expected 2 auto rows after initial sync, got %d", got)
+	}
+
+	replacement := []AutoRelationshipInput{
+		{SourceConnectionID: connA, TargetConnectionID: connC, RelationshipType: "streams_from"},
+	}
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, replacement); err != nil {
+		t.Fatalf("replacement sync failed: %v", err)
+	}
+
+	if got := countRelationships(t, pool, clusterID, true); got != 1 {
+		t.Fatalf("expected 1 auto row after replacement, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterID, connA, connC, "streams_from", true) {
+		t.Fatalf("expected new edge connA->connC streams_from to exist")
+	}
+	if hasRelationship(t, pool, clusterID, connA, connB, "streams_from", true) {
+		t.Fatalf("obsolete edge connA->connB streams_from was not removed (issue #152)")
+	}
+	if hasRelationship(t, pool, clusterID, connB, connA, "replicates_with", true) {
+		t.Fatalf("obsolete edge connB->connA replicates_with was not removed (issue #152)")
+	}
+}
+
+// TestSyncAutoDetectedRelationships_PreservesManualRows verifies that
+// rows where is_auto_detected = FALSE are not touched by sync.
+func TestSyncAutoDetectedRelationships_PreservesManualRows(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+	connC := insertSyncTestConnection(t, pool, "node-c")
+
+	insertAutoRelationship(t, pool, clusterID, connA, connB, "streams_from", false)
+	insertAutoRelationship(t, pool, clusterID, connB, connC, "replicates_with", true)
+
+	if got := countRelationships(t, pool, clusterID, false); got != 1 {
+		t.Fatalf("expected 1 manual row before sync, got %d", got)
+	}
+
+	replacement := []AutoRelationshipInput{
+		{SourceConnectionID: connA, TargetConnectionID: connC, RelationshipType: "streams_from"},
+	}
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, replacement); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	if got := countRelationships(t, pool, clusterID, false); got != 1 {
+		t.Fatalf("manual rows were modified by sync: expected 1, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterID, connA, connB, "streams_from", false) {
+		t.Fatalf("manual relationship was removed by sync")
+	}
+	if got := countRelationships(t, pool, clusterID, true); got != 1 {
+		t.Fatalf("expected 1 auto row after sync, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterID, connA, connC, "streams_from", true) {
+		t.Fatalf("expected new auto edge to be inserted")
+	}
+}
+
+// TestSyncAutoDetectedRelationships_PreservesOtherClusters verifies
+// that auto-detected rows belonging to a different cluster are not
+// touched when syncing a given cluster.
+func TestSyncAutoDetectedRelationships_PreservesOtherClusters(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterA := insertSyncTestCluster(t, pool, "cluster-a")
+	clusterB := insertSyncTestCluster(t, pool, "cluster-b")
+	conn1 := insertSyncTestConnection(t, pool, "node-1")
+	conn2 := insertSyncTestConnection(t, pool, "node-2")
+
+	insertAutoRelationship(t, pool, clusterA, conn1, conn2, "streams_from", true)
+	insertAutoRelationship(t, pool, clusterB, conn2, conn1, "replicates_with", true)
+
+	replacement := []AutoRelationshipInput{
+		{SourceConnectionID: conn2, TargetConnectionID: conn1, RelationshipType: "streams_from"},
+	}
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterA, replacement); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	if got := countRelationships(t, pool, clusterB, true); got != 1 {
+		t.Fatalf("auto rows for cluster B were modified: expected 1, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterB, conn2, conn1, "replicates_with", true) {
+		t.Fatalf("auto edge for cluster B was removed by sync of cluster A")
+	}
+
+	if got := countRelationships(t, pool, clusterA, true); got != 1 {
+		t.Fatalf("expected 1 auto row in cluster A after sync, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterA, conn2, conn1, "streams_from", true) {
+		t.Fatalf("expected replacement edge in cluster A")
+	}
+	if hasRelationship(t, pool, clusterA, conn1, conn2, "streams_from", true) {
+		t.Fatalf("obsolete cluster A edge was not removed")
+	}
+}
+
+// TestSyncAutoDetectedRelationships_EmptyDetectedClearsAutoRows
+// verifies that calling sync with an empty slice removes every existing
+// auto-detected row for the target cluster (e.g. all replication links
+// disappeared) while leaving manual rows intact.
+func TestSyncAutoDetectedRelationships_EmptyDetectedClearsAutoRows(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+
+	insertAutoRelationship(t, pool, clusterID, connA, connB, "streams_from", true)
+	insertAutoRelationship(t, pool, clusterID, connB, connA, "replicates_with", true)
+	insertAutoRelationship(t, pool, clusterID, connA, connB, "subscribes_to", false)
+
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, nil); err != nil {
+		t.Fatalf("sync with nil slice failed: %v", err)
+	}
+
+	if got := countRelationships(t, pool, clusterID, true); got != 0 {
+		t.Fatalf("expected 0 auto rows after empty sync, got %d", got)
+	}
+	if got := countRelationships(t, pool, clusterID, false); got != 1 {
+		t.Fatalf("manual rows were affected by empty sync: expected 1, got %d", got)
+	}
+
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, []AutoRelationshipInput{}); err != nil {
+		t.Fatalf("sync with empty slice failed: %v", err)
+	}
+	if got := countRelationships(t, pool, clusterID, true); got != 0 {
+		t.Fatalf("expected 0 auto rows after empty-slice sync, got %d", got)
+	}
+}
+
+// TestSyncAutoDetectedRelationships_HandlesDuplicatesInInput verifies
+// that a duplicate inside the detected slice does not error and that
+// only one row is materialized per unique tuple.
+func TestSyncAutoDetectedRelationships_HandlesDuplicatesInInput(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+
+	dup := []AutoRelationshipInput{
+		{SourceConnectionID: connA, TargetConnectionID: connB, RelationshipType: "streams_from"},
+		{SourceConnectionID: connA, TargetConnectionID: connB, RelationshipType: "streams_from"},
+		{SourceConnectionID: connA, TargetConnectionID: connB, RelationshipType: "streams_from"},
+	}
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, dup); err != nil {
+		t.Fatalf("sync with duplicates failed: %v", err)
+	}
+
+	if got := countRelationships(t, pool, clusterID, true); got != 1 {
+		t.Fatalf("expected 1 auto row from duplicates, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterID, connA, connB, "streams_from", true) {
+		t.Fatalf("expected edge to be present")
+	}
+}
+
+// TestSyncAutoDetectedRelationships_RollsBackOnInsertFailure verifies
+// the transactional guarantee: if any insert fails (e.g. violates the
+// CHECK constraint that source != target), the prior delete is rolled
+// back and the previous auto-detected state survives intact.
+func TestSyncAutoDetectedRelationships_RollsBackOnInsertFailure(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+
+	initial := []AutoRelationshipInput{
+		{SourceConnectionID: connA, TargetConnectionID: connB, RelationshipType: "streams_from"},
+	}
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, initial); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+	if got := countRelationships(t, pool, clusterID, true); got != 1 {
+		t.Fatalf("expected 1 auto row after initial sync, got %d", got)
+	}
+
+	bad := []AutoRelationshipInput{
+		{SourceConnectionID: connB, TargetConnectionID: connA, RelationshipType: "streams_from"},
+		{SourceConnectionID: connA, TargetConnectionID: connA, RelationshipType: "streams_from"},
+	}
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, bad); err == nil {
+		t.Fatalf("expected error from self-relationship insert, got nil")
+	}
+
+	if got := countRelationships(t, pool, clusterID, true); got != 1 {
+		t.Fatalf("transaction did not roll back: expected 1 auto row, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterID, connA, connB, "streams_from", true) {
+		t.Fatalf("rollback lost the original auto edge")
+	}
+	if hasRelationship(t, pool, clusterID, connB, connA, "streams_from", true) {
+		t.Fatalf("partial insert from failed transaction was committed")
+	}
+}
+
+// TestSyncAutoDetectedRelationships_NoExistingRows verifies the empty
+// initial-state path: syncing into a cluster with no prior auto-detected
+// rows should simply insert the new set without error.
+func TestSyncAutoDetectedRelationships_NoExistingRows(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+
+	detected := []AutoRelationshipInput{
+		{SourceConnectionID: connA, TargetConnectionID: connB, RelationshipType: "streams_from"},
+		{SourceConnectionID: connB, TargetConnectionID: connA, RelationshipType: "replicates_with"},
+	}
+	if err := ds.SyncAutoDetectedRelationships(ctx, clusterID, detected); err != nil {
+		t.Fatalf("sync into empty cluster failed: %v", err)
+	}
+
+	if got := countRelationships(t, pool, clusterID, true); got != 2 {
+		t.Fatalf("expected 2 auto rows, got %d", got)
+	}
+}
+
+// TestSyncAutoDetectedRelationships_BeginFailure verifies that a
+// failure to begin the transaction is surfaced as an error and does
+// not leak a half-applied state.
+func TestSyncAutoDetectedRelationships_BeginFailure(t *testing.T) {
+	ds, _, cleanup := newSyncAutoDetectedTestDatastore(t)
+	cleanup()
+
+	ctx := context.Background()
+	err := ds.SyncAutoDetectedRelationships(ctx, 1, []AutoRelationshipInput{
+		{SourceConnectionID: 1, TargetConnectionID: 2, RelationshipType: "streams_from"},
+	})
+	if err == nil {
+		t.Fatalf("expected error from closed pool, got nil")
+	}
+	if !strings.Contains(err.Error(), "begin transaction") {
+		t.Fatalf("expected begin-transaction error, got %v", err)
+	}
+}
+
+// TestSyncAutoDetectedRelationships_DeleteFailure verifies that a
+// DELETE failure (here triggered by dropping the table after the test
+// schema is created) is surfaced as a wrapped error and the
+// transaction is rolled back.
+func TestSyncAutoDetectedRelationships_DeleteFailure(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+
+	if _, err := pool.Exec(ctx, `DROP TABLE cluster_node_relationships CASCADE`); err != nil {
+		t.Fatalf("dropping relationships table failed: %v", err)
+	}
+
+	err := ds.SyncAutoDetectedRelationships(ctx, clusterID, []AutoRelationshipInput{
+		{SourceConnectionID: 1, TargetConnectionID: 2, RelationshipType: "streams_from"},
+	})
+	if err == nil {
+		t.Fatalf("expected error when relationships table is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "delete existing auto-detected relationships") {
+		t.Fatalf("expected delete-error wrap, got %v", err)
+	}
+}
+
+// TestSyncAutoDetectedRelationships_CancelledContext verifies that a
+// cancelled context produces an error rather than a silent success or
+// a partial commit.
+func TestSyncAutoDetectedRelationships_CancelledContext(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+
+	insertAutoRelationship(t, pool, clusterID, connA, connB, "streams_from", true)
+
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	err := ds.SyncAutoDetectedRelationships(cancelCtx, clusterID,
+		[]AutoRelationshipInput{
+			{SourceConnectionID: connB, TargetConnectionID: connA, RelationshipType: "streams_from"},
+		})
+	if err == nil {
+		t.Fatalf("expected error from cancelled context, got nil")
+	}
+
+	if got := countRelationships(t, pool, clusterID, true); got != 1 {
+		t.Fatalf("cancelled sync left %d auto rows; expected the original 1", got)
+	}
+	if !hasRelationship(t, pool, clusterID, connA, connB, "streams_from", true) {
+		t.Fatalf("original auto edge was lost despite cancelled context")
+	}
+}

--- a/server/src/internal/database/sync_auto_detected_relationships_test.go
+++ b/server/src/internal/database/sync_auto_detected_relationships_test.go
@@ -684,7 +684,7 @@ func TestSyncAutoDetectedRelationships_SerializesConcurrentSyncsForSameCluster(t
 		hasRelationship(t, pool, clusterID, connB, connA, "replicates_with", true)
 	matchesTwo := hasRelationship(t, pool, clusterID, connC, connD, "streams_from", true) &&
 		hasRelationship(t, pool, clusterID, connD, connC, "replicates_with", true)
-	if !(matchesOne || matchesTwo) {
+	if !matchesOne && !matchesTwo {
 		t.Fatalf("final state does not match either input exactly")
 	}
 	if matchesOne && matchesTwo {

--- a/server/src/internal/database/sync_auto_detected_relationships_test.go
+++ b/server/src/internal/database/sync_auto_detected_relationships_test.go
@@ -518,10 +518,10 @@ func TestSyncAutoDetectedRelationships_DeleteFailure(t *testing.T) {
 	}
 }
 
-// TestSyncAutoDetectedRelationships_CancelledContext verifies that a
-// cancelled context produces an error rather than a silent success or
+// TestSyncAutoDetectedRelationships_CanceledContext verifies that a
+// canceled context produces an error rather than a silent success or
 // a partial commit.
-func TestSyncAutoDetectedRelationships_CancelledContext(t *testing.T) {
+func TestSyncAutoDetectedRelationships_CanceledContext(t *testing.T) {
 	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
 	defer cleanup()
 
@@ -539,13 +539,13 @@ func TestSyncAutoDetectedRelationships_CancelledContext(t *testing.T) {
 			{SourceConnectionID: connB, TargetConnectionID: connA, RelationshipType: "streams_from"},
 		})
 	if err == nil {
-		t.Fatalf("expected error from cancelled context, got nil")
+		t.Fatalf("expected error from canceled context, got nil")
 	}
 
 	if got := countRelationships(t, pool, clusterID, true); got != 1 {
-		t.Fatalf("cancelled sync left %d auto rows; expected the original 1", got)
+		t.Fatalf("canceled sync left %d auto rows; expected the original 1", got)
 	}
 	if !hasRelationship(t, pool, clusterID, connA, connB, "streams_from", true) {
-		t.Fatalf("original auto edge was lost despite cancelled context")
+		t.Fatalf("original auto edge was lost despite canceled context")
 	}
 }

--- a/server/src/internal/database/sync_relationships_from_topology_test.go
+++ b/server/src/internal/database/sync_relationships_from_topology_test.go
@@ -1,0 +1,246 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSyncRelationshipsFromTopology_EmptyDetectedClearsAutoRows is the
+// regression test for issue #152 follow-up: when a cluster's topology no
+// longer yields any edges (e.g. its last subscriber was removed or all
+// replication was torn down), the obsolete auto-detected rows for that
+// cluster must be cleared. Auto-detected rows for OTHER clusters and
+// manual rows on the same cluster must be left untouched.
+func TestSyncRelationshipsFromTopology_EmptyDetectedClearsAutoRows(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	clusterAID := insertSyncTestCluster(t, pool, "cluster-a")
+	clusterBID := insertSyncTestCluster(t, pool, "cluster-b")
+	connA1 := insertSyncTestConnection(t, pool, "a-node-1")
+	connA2 := insertSyncTestConnection(t, pool, "a-node-2")
+	connB1 := insertSyncTestConnection(t, pool, "b-node-1")
+	connB2 := insertSyncTestConnection(t, pool, "b-node-2")
+
+	// Pre-populate cluster A with two auto-detected rows and one manual
+	// row. After the empty-topology sync the auto rows must be gone but
+	// the manual row must remain.
+	insertAutoRelationship(t, pool, clusterAID, connA1, connA2, "streams_from", true)
+	insertAutoRelationship(t, pool, clusterAID, connA2, connA1, "replicates_with", true)
+	insertAutoRelationship(t, pool, clusterAID, connA1, connA2, "subscribes_to", false)
+
+	// Cluster B is NOT in the topology map passed to the function and
+	// must be untouched.
+	insertAutoRelationship(t, pool, clusterBID, connB1, connB2, "streams_from", true)
+	insertAutoRelationship(t, pool, clusterBID, connB2, connB1, "replicates_with", true)
+
+	// Build a topology that yields zero edges for cluster A: a logical
+	// cluster whose publisher has no Children. extractLogicalRelationships
+	// returns an empty slice for this shape, so SyncAutoDetectedRelationships
+	// is invoked with an empty detected slice.
+	autoKey := "auto-key-cluster-a"
+	autoDetectedClusters := map[string]TopologyCluster{
+		autoKey: {
+			ID:          "auto-cluster-a",
+			Name:        "cluster-a",
+			ClusterType: "logical",
+			Servers: []TopologyServerInfo{
+				{ID: connA1, Name: "a-node-1"},
+			},
+		},
+	}
+	clusterIDMap := map[string]int{autoKey: clusterAID}
+
+	ds.syncRelationshipsFromTopology(ctx, autoDetectedClusters, clusterIDMap)
+
+	if got := countRelationships(t, pool, clusterAID, true); got != 0 {
+		t.Fatalf("cluster A still has %d auto-detected rows after empty-topology sync; expected 0", got)
+	}
+	if got := countRelationships(t, pool, clusterAID, false); got != 1 {
+		t.Fatalf("cluster A manual row count changed: expected 1, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterAID, connA1, connA2, "subscribes_to", false) {
+		t.Fatalf("cluster A manual relationship was removed by empty-topology sync")
+	}
+
+	if got := countRelationships(t, pool, clusterBID, true); got != 2 {
+		t.Fatalf("cluster B auto rows were modified: expected 2, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterBID, connB1, connB2, "streams_from", true) {
+		t.Fatalf("cluster B auto edge B1->B2 streams_from was removed")
+	}
+	if !hasRelationship(t, pool, clusterBID, connB2, connB1, "replicates_with", true) {
+		t.Fatalf("cluster B auto edge B2->B1 replicates_with was removed")
+	}
+}
+
+// TestSyncRelationshipsFromTopology_SkipsUnmappedClusters verifies the
+// early-continue path: a topology entry whose auto-key is not present in
+// the cluster ID map (standalone server, failed upsert) does not trigger
+// a sync call and does not affect existing rows.
+func TestSyncRelationshipsFromTopology_SkipsUnmappedClusters(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "test-cluster")
+	connA := insertSyncTestConnection(t, pool, "node-a")
+	connB := insertSyncTestConnection(t, pool, "node-b")
+
+	insertAutoRelationship(t, pool, clusterID, connA, connB, "streams_from", true)
+
+	autoDetectedClusters := map[string]TopologyCluster{
+		"unmapped-key": {
+			ID:          "unmapped",
+			Name:        "unmapped",
+			ClusterType: "binary",
+			Servers: []TopologyServerInfo{
+				{ID: connA, Name: "a"},
+			},
+		},
+	}
+	// Empty map: no auto-key has a db cluster ID, so the function must
+	// skip every entry without touching the database.
+	clusterIDMap := map[string]int{}
+
+	ds.syncRelationshipsFromTopology(ctx, autoDetectedClusters, clusterIDMap)
+
+	if got := countRelationships(t, pool, clusterID, true); got != 1 {
+		t.Fatalf("unmapped cluster sync touched existing rows: got %d auto rows, expected 1", got)
+	}
+	if !hasRelationship(t, pool, clusterID, connA, connB, "streams_from", true) {
+		t.Fatalf("existing auto edge was removed despite unmapped topology")
+	}
+}
+
+// TestSyncRelationshipsFromTopology_BinaryClusterPopulatesEdges verifies
+// the happy path for a binary cluster: a primary with two standbys
+// produces two streams_from auto-detected rows in the database.
+func TestSyncRelationshipsFromTopology_BinaryClusterPopulatesEdges(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "binary-cluster")
+	primary := insertSyncTestConnection(t, pool, "primary")
+	standby1 := insertSyncTestConnection(t, pool, "standby-1")
+	standby2 := insertSyncTestConnection(t, pool, "standby-2")
+
+	autoKey := "binary-auto"
+	autoDetectedClusters := map[string]TopologyCluster{
+		autoKey: {
+			ID:          "binary-auto",
+			Name:        "binary-cluster",
+			ClusterType: "binary",
+			Servers: []TopologyServerInfo{
+				{
+					ID:   primary,
+					Name: "primary",
+					Children: []TopologyServerInfo{
+						{ID: standby1, Name: "standby-1"},
+						{ID: standby2, Name: "standby-2"},
+					},
+				},
+			},
+		},
+	}
+	clusterIDMap := map[string]int{autoKey: clusterID}
+
+	ds.syncRelationshipsFromTopology(ctx, autoDetectedClusters, clusterIDMap)
+
+	if got := countRelationships(t, pool, clusterID, true); got != 2 {
+		t.Fatalf("expected 2 auto-detected rows from binary topology, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterID, standby1, primary, "streams_from", true) {
+		t.Fatalf("expected standby1->primary streams_from edge")
+	}
+	if !hasRelationship(t, pool, clusterID, standby2, primary, "streams_from", true) {
+		t.Fatalf("expected standby2->primary streams_from edge")
+	}
+}
+
+// TestSyncRelationshipsFromTopology_SpockCluster verifies the spock
+// cluster path produces bidirectional replicates_with rows for every
+// pair of nodes.
+func TestSyncRelationshipsFromTopology_SpockCluster(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "spock-cluster")
+	n1 := insertSyncTestConnection(t, pool, "spock-1")
+	n2 := insertSyncTestConnection(t, pool, "spock-2")
+
+	autoKey := "spock-auto"
+	autoDetectedClusters := map[string]TopologyCluster{
+		autoKey: {
+			ID:          "spock-auto",
+			Name:        "spock-cluster",
+			ClusterType: "spock",
+			Servers: []TopologyServerInfo{
+				{ID: n1, Name: "spock-1"},
+				{ID: n2, Name: "spock-2"},
+			},
+		},
+	}
+	clusterIDMap := map[string]int{autoKey: clusterID}
+
+	ds.syncRelationshipsFromTopology(ctx, autoDetectedClusters, clusterIDMap)
+
+	if got := countRelationships(t, pool, clusterID, true); got != 2 {
+		t.Fatalf("expected 2 replicates_with rows for spock pair, got %d", got)
+	}
+	if !hasRelationship(t, pool, clusterID, n1, n2, "replicates_with", true) {
+		t.Fatalf("expected n1->n2 replicates_with edge")
+	}
+	if !hasRelationship(t, pool, clusterID, n2, n1, "replicates_with", true) {
+		t.Fatalf("expected n2->n1 replicates_with edge")
+	}
+}
+
+// TestSyncRelationshipsFromTopology_ServerClusterTypeProducesNoEdges
+// verifies that a non-replicating cluster type ("server") falls through
+// the switch with no edges and that any prior auto-detected rows for
+// the cluster are cleared (defensive: the case is unlikely in practice
+// but the function must not leak stale rows for it).
+func TestSyncRelationshipsFromTopology_ServerClusterTypeProducesNoEdges(t *testing.T) {
+	ds, pool, cleanup := newSyncAutoDetectedTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	clusterID := insertSyncTestCluster(t, pool, "lone-server")
+	connA := insertSyncTestConnection(t, pool, "a")
+	connB := insertSyncTestConnection(t, pool, "b")
+
+	insertAutoRelationship(t, pool, clusterID, connA, connB, "streams_from", true)
+
+	autoKey := "server-auto"
+	autoDetectedClusters := map[string]TopologyCluster{
+		autoKey: {
+			ID:          "server-auto",
+			Name:        "lone-server",
+			ClusterType: "server",
+			Servers: []TopologyServerInfo{
+				{ID: connA, Name: "a"},
+			},
+		},
+	}
+	clusterIDMap := map[string]int{autoKey: clusterID}
+
+	ds.syncRelationshipsFromTopology(ctx, autoDetectedClusters, clusterIDMap)
+
+	if got := countRelationships(t, pool, clusterID, true); got != 0 {
+		t.Fatalf("expected stale auto rows to be cleared for server cluster, got %d", got)
+	}
+}

--- a/server/src/internal/database/topology_autodetect.go
+++ b/server/src/internal/database/topology_autodetect.go
@@ -915,10 +915,8 @@ func (d *Datastore) syncRelationshipsFromTopology(ctx context.Context, autoDetec
 			detected = extractLogicalRelationships(cluster.Servers)
 		}
 
-		if len(detected) > 0 {
-			if err := d.SyncAutoDetectedRelationships(ctx, dbClusterID, detected); err != nil {
-				logger.Errorf("syncRelationshipsFromTopology: failed to sync relationships for cluster %q (id=%d): %v", autoKey, dbClusterID, err)
-			}
+		if err := d.SyncAutoDetectedRelationships(ctx, dbClusterID, detected); err != nil {
+			logger.Errorf("syncRelationshipsFromTopology: failed to sync relationships for cluster %q (id=%d): %v", autoKey, dbClusterID, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #152.

- `SyncAutoDetectedRelationships` now replaces the auto-detected
  relationship set for a cluster transactionally instead of
  append-only syncing. Within one transaction it deletes all existing
  `is_auto_detected = TRUE` rows for the cluster, inserts the freshly
  detected set, and commits; manual rows and auto-detected rows for
  other clusters are left untouched, and any failure rolls back the
  transaction so prior state is preserved.

- `syncRelationshipsFromTopology` no longer short-circuits on an empty
  detected slice. A cluster whose topology yields zero edges (last
  subscriber removed, replication dismantled) now has its obsolete
  auto-detected rows cleared.

## Why

Append-only sync left obsolete edges in `cluster_node_relationships`
after failover, subscriber removal, or a new parent in a binary
chain. Topology reads then surfaced impossible or duplicated edges.

## Test plan

- [x] `cd server/src && go test -race ./internal/database/...` passes.
- [x] `cd server && make coverage` passes; `SyncAutoDetectedRelationships`
      at 92.9%, `syncRelationshipsFromTopology` at 90.9%.
- [x] New tests in `sync_auto_detected_relationships_test.go` cover:
  replace-on-sync, manual rows preserved, other clusters preserved,
  empty input clears auto rows, duplicate input tolerated, rollback
  on insert failure, begin/delete failure paths, cancelled context.
- [x] New tests in `sync_relationships_from_topology_test.go` cover:
  empty topology clears auto rows, unmapped clusters skipped,
  unknown cluster type produces no edges.
- [x] Changelog entry added under Unreleased / Fixed.

https://claude.ai/code/session_01V9Vj5aac5YSMCCpr6pLUfH

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9Vj5aac5YSMCCpr6pLUfH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relationship syncing now atomically replaces a cluster’s auto-detected edges (delete-then-insert) while preserving manual relationships and other clusters’ auto-detected rows; operations run in a transaction and roll back on failure.

* **Tests**
  * Added comprehensive DB and topology tests for replacement semantics, empty/nil inputs, duplicates, transactional error handling, concurrency/locking, and multiple cluster topologies.

* **Documentation**
  * Changelog updated to describe the new syncing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->