### PR TITLE
fix(client): wrap Ask Ellie markdown tables in horizontal scroll container

### DIFF
--- a/client/src/components/ChatPanel/ChatMessage.tsx
+++ b/client/src/components/ChatPanel/ChatMessage.tsx
@@ -266,10 +266,31 @@ const getMdBlockquoteSx = (theme: Theme) => ({
     fontStyle: 'italic',
 });
 
-const getMdTableSx = (theme: Theme) => ({
+// Wrapper around <table> that turns wide markdown tables into horizontally
+// scrollable regions instead of letting them clip at the right edge of the
+// chat bubble. Vertical overflow stays visible so tall tables still grow
+// the bubble naturally. Combined with getMdTableSx (width: 'auto', minWidth:
+// '100%') narrow tables look identical to the previous full-width layout.
+const getMdTableContainerSx = () => ({
+    display: 'block',
     width: '100%',
-    borderCollapse: 'collapse',
+    maxWidth: '100%',
+    overflowX: 'auto',
+    overflowY: 'visible',
+    // Smooth momentum scrolling on iOS / iPadOS Safari.
+    WebkitOverflowScrolling: 'touch',
     my: 1,
+});
+
+const getMdTableSx = (theme: Theme) => ({
+    // The wrapper provides horizontal scrolling; the table itself sizes to
+    // its widest row and only stretches to fill the bubble (minWidth: 100%)
+    // when its natural width is smaller than the container.
+    width: 'auto',
+    minWidth: '100%',
+    borderCollapse: 'collapse',
+    // Spacing lives on the container so the scrollbar tracks with the table.
+    my: 0,
     fontSize: '1.125rem',
     '& th, & td': {
         border: '1px solid',
@@ -450,9 +471,19 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message, mode }) => {
                     {children}
                 </Box>
             ),
+            // Wrap the rendered <table> in a horizontally scrollable
+            // container. Without this the table inherits the bubble's
+            // ~92% maxWidth and clips its right-side columns; MCP tool
+            // payloads (alerts, query rows, etc.) are routinely wider
+            // than the chat panel.
             table: ({ children }: { children?: React.ReactNode }) => (
-                <Box component="table" sx={getMdTableSx(theme)}>
-                    {children}
+                <Box
+                    data-testid="chat-table-container"
+                    sx={getMdTableContainerSx()}
+                >
+                    <Box component="table" sx={getMdTableSx(theme)}>
+                        {children}
+                    </Box>
                 </Box>
             ),
         }),

--- a/client/src/components/ChatPanel/__tests__/ChatMessage.test.tsx
+++ b/client/src/components/ChatPanel/__tests__/ChatMessage.test.tsx
@@ -320,4 +320,100 @@ describe('ChatMessage', () => {
             expect(screen.getByText('SELECT')).toBeInTheDocument();
         });
     });
+
+    // Regression coverage for issue #185. Wide markdown tables produced by
+    // MCP tools (get_alert_history, get_alert_rules, query_datastore, ...)
+    // used to overflow the narrow chat bubble and clip the right-side
+    // columns. Each table must now sit inside a horizontally scrollable
+    // wrapper so the bubble width stays unchanged but wide tables scroll.
+    describe('markdown tables (issue #185)', () => {
+        // A 6-column table is wider than the ~414px (92% of 450px) the
+        // assistant bubble offers, so it exercises the scroll behaviour.
+        const wideTable = [
+            '| col_a | col_b | col_c | col_d | col_e | col_f |',
+            '|-------|-------|-------|-------|-------|-------|',
+            '| 1 | 2 | 3 | 4 | 5 | 6 |',
+            '| 7 | 8 | 9 | 10 | 11 | 12 |',
+        ].join('\n');
+
+        it('wraps tables in a horizontally scrollable container', () => {
+            const message: ChatMessageData = {
+                role: 'assistant',
+                content: wideTable,
+            };
+            renderWithTheme(<ChatMessage message={message} mode="dark" />);
+
+            const wrapper = screen.getByTestId('chat-table-container');
+            expect(wrapper).toBeInTheDocument();
+
+            // The wrapper must allow horizontal overflow but not introduce
+            // its own vertical scrollbar (tall tables grow the bubble).
+            const styles = window.getComputedStyle(wrapper);
+            expect(styles.overflowX).toBe('auto');
+            expect(styles.overflowY).toBe('visible');
+            expect(styles.maxWidth).toBe('100%');
+        });
+
+        it('renders the table element inside the scroll wrapper', () => {
+            const message: ChatMessageData = {
+                role: 'assistant',
+                content: wideTable,
+            };
+            renderWithTheme(<ChatMessage message={message} mode="dark" />);
+
+            const wrapper = screen.getByTestId('chat-table-container');
+            const table = wrapper.querySelector('table');
+            expect(table).not.toBeNull();
+            // The table is no longer forced to width: 100% — the wrapper
+            // owns the constraint. MUI/emotion generates a class on the
+            // table; the corresponding stylesheet sets minWidth: 100% so
+            // narrow tables still fill the bubble. jsdom doesn't always
+            // resolve emotion-injected CSS to computed styles, so assert
+            // the contract by checking the table has a class and lives
+            // inside the scroll wrapper rather than the previous fixed
+            // width: 100% layout. The companion wrapper test verifies the
+            // overflow behaviour, which is the critical part of the fix.
+            expect(table?.className).toMatch(/css-/);
+            expect(table?.parentElement).toBe(wrapper);
+        });
+
+        it('preserves header and body cell content inside the table', () => {
+            const message: ChatMessageData = {
+                role: 'assistant',
+                content: wideTable,
+            };
+            renderWithTheme(<ChatMessage message={message} mode="dark" />);
+
+            // Header cells render as <th> from remark-gfm.
+            expect(screen.getByText('col_a')).toBeInTheDocument();
+            expect(screen.getByText('col_f')).toBeInTheDocument();
+            // A body cell from the right-most column proves the right
+            // edge is not clipped from the DOM (even when visually
+            // hidden by overflow it must still be present).
+            expect(screen.getByText('12')).toBeInTheDocument();
+        });
+
+        it('still renders surrounding markdown around a table', () => {
+            const message: ChatMessageData = {
+                role: 'assistant',
+                content: [
+                    '## Recent alerts',
+                    '',
+                    'Here are the rows:',
+                    '',
+                    wideTable,
+                    '',
+                    '- More info follows',
+                ].join('\n'),
+            };
+            renderWithTheme(<ChatMessage message={message} mode="dark" />);
+
+            // Heading, paragraph, table wrapper, and list item all coexist.
+            expect(screen.getByText('Recent alerts')).toBeInTheDocument();
+            expect(screen.getByText('Here are the rows:')).toBeInTheDocument();
+            expect(screen.getByTestId('chat-table-container'))
+                .toBeInTheDocument();
+            expect(screen.getByText('More info follows')).toBeInTheDocument();
+        });
+    });
 });

--- a/client/src/components/shared/MarkdownContent.tsx
+++ b/client/src/components/shared/MarkdownContent.tsx
@@ -42,6 +42,7 @@ import {
     getLinkSx,
     getBlockquoteSx,
     getTableSx,
+    getTableContainerSx,
 } from './markdownStyles';
 
 // ---------------------------------------------------------------------------
@@ -246,9 +247,17 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
                 {children}
             </Box>
         ),
+        // Wrap the table in a horizontally scrollable container so wide
+        // tables (returned by MCP tools, large queries, etc.) scroll within
+        // the parent surface instead of clipping at the right edge.
         table: ({ children }) => (
-            <Box component="table" sx={getTableSx(theme)}>
-                {children}
+            <Box
+                data-testid="markdown-table-container"
+                sx={getTableContainerSx()}
+            >
+                <Box component="table" sx={getTableSx(theme)}>
+                    {children}
+                </Box>
             </Box>
         ),
     }), [isDark, theme, connectionId, databaseName, serverName, connectionMap]);

--- a/client/src/components/shared/MarkdownExports.ts
+++ b/client/src/components/shared/MarkdownExports.ts
@@ -44,6 +44,7 @@ export {
     getLinkSx,
     getBlockquoteSx,
     getTableSx,
+    getTableContainerSx,
     getCodeBlockButtonGroupSx,
     getCopyButtonSx,
     getRunButtonSx,

--- a/client/src/components/shared/__tests__/MarkdownContent.test.tsx
+++ b/client/src/components/shared/__tests__/MarkdownContent.test.tsx
@@ -1,0 +1,100 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Focused regression coverage for the issue #185 fix. The full
+// MarkdownContent component renders an extensive set of markdown features
+// (code blocks, runnable SQL, connection selectors, link sanitisation, ...)
+// that already have integration coverage through the dialogs that mount
+// it. This file pins down the specific behaviour added by the issue #185
+// fix: every rendered markdown <table> sits inside a horizontally
+// scrollable wrapper so wide MCP-tool tables no longer clip the right
+// side of the surrounding surface.
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MarkdownContent } from '../MarkdownContent';
+import { renderWithTheme } from '../../../test/renderWithTheme';
+
+// MarkdownContent imports several heavy children (RunnableCodeBlock,
+// ConnectionSelectorCodeBlock, AnalysisSkeleton) that pull in API
+// utilities. None of them are exercised by a markdown payload that only
+// contains text and a table, so we mock them defensively to keep the
+// test surface tight and the test deterministic.
+vi.mock('../RunnableCodeBlock', () => ({
+    default: () => <div data-testid="runnable-code-block" />,
+    // The named QueryState/QueryResponse type re-exports are not used at
+    // runtime and only matter for TypeScript; vi.mock returns undefined
+    // for them which is fine.
+}));
+
+vi.mock('../ConnectionSelectorCodeBlock', () => ({
+    default: () => <div data-testid="connection-selector" />,
+}));
+
+vi.mock('../AnalysisSkeleton', () => ({
+    default: () => <div data-testid="analysis-skeleton" />,
+}));
+
+vi.mock('../CopyCodeButton', () => ({
+    default: () => <button type="button">copy</button>,
+}));
+
+const TABLE_MARKDOWN = [
+    '| col_a | col_b | col_c | col_d | col_e |',
+    '|-------|-------|-------|-------|-------|',
+    '| 1 | 2 | 3 | 4 | 5 |',
+    '| 6 | 7 | 8 | 9 | 10 |',
+].join('\n');
+
+describe('MarkdownContent table overflow (issue #185)', () => {
+    it('wraps markdown tables in a horizontally scrollable container', () => {
+        renderWithTheme(
+            <MarkdownContent content={TABLE_MARKDOWN} isDark={false} />,
+        );
+
+        const wrapper = screen.getByTestId('markdown-table-container');
+        expect(wrapper).toBeInTheDocument();
+
+        // Wide tables must scroll horizontally inside the surface, not
+        // overflow it. Vertical overflow stays visible so tall tables
+        // keep growing the surrounding container.
+        const styles = window.getComputedStyle(wrapper);
+        expect(styles.overflowX).toBe('auto');
+        expect(styles.overflowY).toBe('visible');
+        expect(styles.maxWidth).toBe('100%');
+    });
+
+    it('places the rendered table inside the scroll wrapper', () => {
+        renderWithTheme(
+            <MarkdownContent content={TABLE_MARKDOWN} isDark={false} />,
+        );
+
+        const wrapper = screen.getByTestId('markdown-table-container');
+        const table = wrapper.querySelector('table');
+        expect(table).not.toBeNull();
+        // Confirm the cells are still part of the DOM — the previous
+        // `width: 100%` rule could squash columns but never dropped
+        // cells; this guards against future regressions from the new
+        // `width: auto` layout.
+        expect(screen.getByText('col_a')).toBeInTheDocument();
+        expect(screen.getByText('col_e')).toBeInTheDocument();
+        expect(screen.getByText('10')).toBeInTheDocument();
+    });
+
+    it('renders nothing when content is empty', () => {
+        // The early-return branch in MarkdownContent. Worth pinning down
+        // so the touched module retains its existing safety net.
+        const { container } = renderWithTheme(
+            <MarkdownContent content="" isDark={false} />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+});

--- a/client/src/components/shared/markdownStyles.ts
+++ b/client/src/components/shared/markdownStyles.ts
@@ -160,10 +160,36 @@ export const getBlockquoteSx = (theme: Theme) => ({
     fontStyle: 'italic',
 });
 
-export const getTableSx = (theme: Theme) => ({
+// Wrapper around <table> that lets wide tables scroll horizontally instead
+// of overflowing the parent (chat bubble, dialog body, etc.). The wrapper
+// must NOT introduce vertical scrolling: tall tables still grow the parent
+// as before.
+//
+// Together with getTableSx (width: 'auto', minWidth: '100%'), narrow tables
+// still fill the container exactly like before; only tables wider than the
+// container produce a horizontal scrollbar.
+export const getTableContainerSx = () => ({
+    display: 'block',
     width: '100%',
-    borderCollapse: 'collapse',
+    maxWidth: '100%',
+    overflowX: 'auto',
+    overflowY: 'visible',
+    // Smooth momentum scrolling on iOS / iPadOS Safari.
+    WebkitOverflowScrolling: 'touch',
     my: 1.5,
+});
+
+export const getTableSx = (theme: Theme) => ({
+    // Let the table grow to fit its widest row. minWidth: '100%' keeps narrow
+    // tables flush with the container (so a 2-column table still spans the
+    // bubble), while wider tables overflow the parent and trigger the
+    // horizontal scrollbar provided by getTableContainerSx.
+    width: 'auto',
+    minWidth: '100%',
+    borderCollapse: 'collapse',
+    // No vertical margin here; the wrapper (getTableContainerSx) owns spacing
+    // so the scroll affordance and the table stay visually grouped.
+    my: 0,
     fontSize: '1rem',
     '& th, & td': {
         border: '1px solid',

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -132,6 +132,16 @@ project adheres to
 
 ### Fixed
 
+- Fix wide markdown tables overflowing and clipping the
+  right-side columns inside the Ask Ellie chat panel;
+  tables returned by MCP tools such as
+  `get_alert_history`, `get_alert_rules`, and
+  `query_datastore` now sit inside a horizontally
+  scrollable wrapper, so narrow tables still fill the
+  bubble while wide tables scroll within it instead of
+  spilling outside. The shared `MarkdownContent`
+  helper used by other dialogs received the same
+  treatment. (#185)
 - Fix the web client rendering a blank screen on every
   navigation when the LLM proxy was enabled with a
   reasoning model that returns a structured `summary`


### PR DESCRIPTION
## Summary

- MCP tool responses such as `get_alert_history`, `get_alert_rules`, and
  `query_datastore` render markdown tables that were forced to
  `width: 100%` inside the ~414px Ask Ellie bubble. With the message
  list set to `overflow-x: hidden`, right-side columns were squashed
  past their content width and clipped, becoming unreadable
  ([screenshots in issue](https://github.com/pgEdge/ai-dba-workbench/issues/185)).
- Tables now sit inside a `Box` with `overflow-x: auto` and the table
  itself is `width: auto; min-width: 100%`. Narrow tables still fill
  the bubble exactly as before; wide tables grow to natural width and
  scroll horizontally inside the bubble.
- The shared `MarkdownContent` helper used by other dialogs received
  the same treatment, plus a new `getTableContainerSx` styling helper
  in `markdownStyles.ts` so the wrapper contract lives in one place.

## Test plan

- [x] `cd client && npm run lint` — 0 errors
- [x] `cd client && npm test -- --run` — 2706 tests pass (added 7 new
  tests covering the scroll wrapper)
- [x] `cd client && make coverage` — `ChatMessage.tsx` 97.33%,
  `markdownStyles.ts` 100%
- [x] `make test-all` from repo root — all suites pass
- [ ] Manual verification in the running web client: open Ask Ellie,
  ask "Show me the alert history" and "What are the alert rules?",
  confirm the rendered table scrolls horizontally inside the bubble
  rather than clipping

Closes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of wide markdown tables that were being clipped on the right side in chat messages and content dialogs. Tables now scroll horizontally instead.

* **Tests**
  * Added regression tests for wide table rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->