### PR TITLE
fix(client): stop Ask Ellie loop when user has no MCP privileges

### DIFF
--- a/client/src/hooks/chat/__tests__/chatAgenticLoop.test.ts
+++ b/client/src/hooks/chat/__tests__/chatAgenticLoop.test.ts
@@ -14,6 +14,8 @@ import {
     type AgenticLoopParams,
     type FetchFunction,
     ITERATION_LIMIT_MESSAGE,
+    NO_MCP_PRIVILEGES_MESSAGE,
+    UNKNOWN_TOOL_MESSAGE,
 } from '../chatAgenticLoop';
 import type { APIMessage, ToolDefinition } from '../chatTypes';
 import type { LLMResponse, ToolCallResponse } from '../../../types/llm';
@@ -424,7 +426,11 @@ describe('chatAgenticLoop', () => {
                 expect(result.finalMessage.content).toBe('Done');
             });
 
-            it('handles tool with missing name', async () => {
+            it('bails out when tool_use omits name', async () => {
+                // A tool_use without a name cannot match any entry in
+                // availableTools, so the loop bails out with the
+                // unknown-tool message rather than attempting an
+                // unnamed call (the old behaviour). See issue #188.
                 const mockFetch = createMockFetch(
                     [
                         {
@@ -449,12 +455,11 @@ describe('chatAgenticLoop', () => {
 
                 const result = await runAgenticLoop(params);
 
-                // Should use 'unknown' as tool name
-                const activity = result.finalMessage.activity;
-                if (!activity) {
-                    throw new Error('expected activity');
-                }
-                expect(activity[0].name).toBe('unknown');
+                expect(result.finalMessage.isError).toBe(true);
+                expect(result.finalMessage.content).toBe(
+                    UNKNOWN_TOOL_MESSAGE,
+                );
+                expect(result.finalMessage.activity).toBeUndefined();
             });
 
             it('handles tool response with no content', async () => {
@@ -861,6 +866,160 @@ describe('chatAgenticLoop', () => {
 
                 const lastCall = onToolActivity.mock.calls[onToolActivity.mock.calls.length - 1][0];
                 expect(lastCall[0].status).toBe('error');
+            });
+        });
+
+        // ---------------------------------------------------------------
+        // Unknown-tool bail-out (issue #188)
+        //
+        // Defensive guard: if the LLM proposes only tool calls that
+        // are not in availableTools, exit with a single, clear error
+        // rather than feeding "Tool execution failed" results back to
+        // the LLM N times.
+        // ---------------------------------------------------------------
+
+        describe('unknown-tool bail-out', () => {
+            it('bails out when LLM calls a tool not in availableTools', async () => {
+                const mockFetch = createMockFetch([
+                    createToolUseResponse([
+                        {
+                            id: 'tool-1',
+                            name: 'forbidden_tool',
+                            input: {},
+                        },
+                    ]),
+                    createTextResponse('Should not reach here'),
+                ]);
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.isError).toBe(true);
+                expect(result.finalMessage.content).toBe(
+                    UNKNOWN_TOOL_MESSAGE,
+                );
+            });
+
+            it('does not call /mcp/tools/call for unknown tools', async () => {
+                const mockFetch = createMockFetch([
+                    createToolUseResponse([
+                        {
+                            id: 'tool-1',
+                            name: 'forbidden_tool',
+                            input: {},
+                        },
+                    ]),
+                ]);
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                await runAgenticLoop(params);
+
+                const toolCalls = (
+                    mockFetch as ReturnType<typeof vi.fn>
+                ).mock.calls.filter(c => c[0] === '/api/v1/mcp/tools/call');
+                expect(toolCalls).toHaveLength(0);
+            });
+
+            it('exits in a single LLM iteration', async () => {
+                // The loop must not keep calling the LLM after
+                // detecting unknown tools. Provide only one LLM
+                // response; if the loop iterates past it, the test
+                // helper would supply an empty fallback response.
+                const mockFetch = createMockFetch([
+                    createToolUseResponse([
+                        { id: 't1', name: 'unknown_a', input: {} },
+                        { id: 't2', name: 'unknown_b', input: {} },
+                    ]),
+                ]);
+                const params = createLoopParams({
+                    maxIterations: 50,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                const llmCalls = (
+                    mockFetch as ReturnType<typeof vi.fn>
+                ).mock.calls.filter(c => c[0] === '/api/v1/llm/chat');
+                expect(llmCalls).toHaveLength(1);
+                expect(result.finalMessage.content).toBe(
+                    UNKNOWN_TOOL_MESSAGE,
+                );
+            });
+
+            it('does not bail out when at least one tool is known', async () => {
+                // If the LLM proposes a mix of known and unknown
+                // tools, the loop should proceed normally; the
+                // unknown call falls through to /mcp/tools/call and
+                // the server returns its own error. This preserves
+                // existing behaviour for partial mismatches.
+                const mockFetch = createMockFetch(
+                    [
+                        createToolUseResponse([
+                            { id: 't1', name: 'list_connections', input: {} },
+                            { id: 't2', name: 'forbidden_tool', input: {} },
+                        ]),
+                        createTextResponse('Done'),
+                    ],
+                    new Map([
+                        [
+                            'list_connections',
+                            createToolCallResponse('OK'),
+                        ],
+                        [
+                            'forbidden_tool',
+                            createToolCallResponse('Denied', true),
+                        ],
+                    ]),
+                );
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.content).toBe('Done');
+                expect(result.finalMessage.isError).toBeUndefined();
+                expect(result.finalMessage.activity).toHaveLength(2);
+            });
+
+            it('appends the bail-out message to API history', async () => {
+                const mockFetch = createMockFetch([
+                    createToolUseResponse([
+                        {
+                            id: 'tool-1',
+                            name: 'forbidden_tool',
+                            input: {},
+                        },
+                    ]),
+                ]);
+                const params = createLoopParams({
+                    apiMessages: [{ role: 'user', content: 'Hi' }],
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                const last =
+                    result.updatedApiMessages[
+                        result.updatedApiMessages.length - 1
+                    ];
+                expect(last.role).toBe('assistant');
+                expect(last.content).toBe(UNKNOWN_TOOL_MESSAGE);
+            });
+        });
+
+        // ---------------------------------------------------------------
+        // Module-level constants exposed for the orchestrator (issue #188)
+        // ---------------------------------------------------------------
+
+        describe('exported constants', () => {
+            it('exports a non-empty NO_MCP_PRIVILEGES_MESSAGE', () => {
+                expect(NO_MCP_PRIVILEGES_MESSAGE.length).toBeGreaterThan(0);
+                expect(NO_MCP_PRIVILEGES_MESSAGE).toContain('permission');
+            });
+
+            it('exports a non-empty UNKNOWN_TOOL_MESSAGE', () => {
+                expect(UNKNOWN_TOOL_MESSAGE.length).toBeGreaterThan(0);
+                expect(UNKNOWN_TOOL_MESSAGE).toContain('tools');
             });
         });
     });

--- a/client/src/hooks/chat/__tests__/useChat.test.ts
+++ b/client/src/hooks/chat/__tests__/useChat.test.ts
@@ -29,6 +29,17 @@ const mockToAPIMessages = vi.fn();
 
 vi.mock('../chatAgenticLoop', () => ({
     runAgenticLoop: (...args: unknown[]) => mockRunAgenticLoop(...args),
+    NO_MCP_PRIVILEGES_MESSAGE:
+        "You don't have permission to use any of the tools I need to " +
+        'answer questions like this. Ask your administrator to grant ' +
+        'you the relevant MCP privileges and try again.',
+    UNKNOWN_TOOL_MESSAGE:
+        'The model attempted to call tools that are not available to ' +
+        'you. This usually means your account lacks the necessary MCP ' +
+        'privileges. Please contact your administrator.',
+    ITERATION_LIMIT_MESSAGE:
+        'I was unable to complete the request within the allowed ' +
+        'number of steps. Please try rephrasing your question.',
 }));
 
 vi.mock('../chatCompaction', () => ({
@@ -127,9 +138,26 @@ describe('useChat', () => {
             ],
         });
 
+        // Default tools fetch returns a non-empty tool list. This
+        // mirrors a privileged user and keeps the agentic loop active
+        // for the existing tests; tests that need to exercise the
+        // no-privileges short-circuit override this mock explicitly.
         mockApiFetch.mockResolvedValue({
             ok: true,
-            json: () => Promise.resolve({ tools: [] }),
+            json: () =>
+                Promise.resolve({
+                    tools: [
+                        {
+                            name: 'list_connections',
+                            description: 'List database connections',
+                            inputSchema: {
+                                type: 'object',
+                                properties: {},
+                                required: [],
+                            },
+                        },
+                    ],
+                }),
         });
     });
 
@@ -203,9 +231,24 @@ describe('useChat', () => {
 
             const { result } = renderHook(() => useChat());
 
+            // Wait for the initial tools fetch so sendMessage no
+            // longer needs to await it; without this, the hook
+            // suspends at `await toolsFetchRef.current` before ever
+            // invoking runAgenticLoop and resolveLoop never gets set.
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith(
+                    '/api/v1/mcp/tools',
+                );
+            });
+
             let sendPromise: Promise<void>;
-            act(() => {
+            await act(async () => {
                 sendPromise = result.current.sendMessage('Hello');
+                // Allow microtasks to flush so sendMessage proceeds
+                // past the toolsFetchRef await and reaches the
+                // runAgenticLoop call that captures resolveLoop.
+                await Promise.resolve();
+                await Promise.resolve();
             });
 
             // isLoading should be true while waiting
@@ -742,6 +785,124 @@ describe('useChat', () => {
 
             // Should still be functional with default tools
             expect(result.current.error).toBeNull();
+        });
+    });
+
+    // -------------------------------------------------------------------
+    // No-MCP-privileges short-circuit (issue #188)
+    //
+    // When the server returns an empty tools list (the user has zero
+    // MCP privileges), sendMessage must skip the agentic loop and
+    // surface a clear permission-denied message rather than spinning
+    // up to maxIterations LLM calls that all fail with "Access
+    // denied".
+    // -------------------------------------------------------------------
+
+    describe('no MCP privileges short-circuit', () => {
+        beforeEach(() => {
+            // Server returns an empty tool list, simulating a user
+            // with no MCP privileges. The fetch is OK so the empty
+            // list is authoritative (not a transient failure).
+            mockApiFetch.mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ tools: [] }),
+            } as Response);
+        });
+
+        it('does not call runAgenticLoop when tool list is empty', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith(
+                    '/api/v1/mcp/tools',
+                );
+            });
+
+            await act(async () => {
+                await result.current.sendMessage('Show me alert history');
+            });
+
+            expect(mockRunAgenticLoop).not.toHaveBeenCalled();
+        });
+
+        it('renders a permission-denied assistant message', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith(
+                    '/api/v1/mcp/tools',
+                );
+            });
+
+            await act(async () => {
+                await result.current.sendMessage('Show me alert history');
+            });
+
+            await waitFor(() => {
+                expect(result.current.messages.length).toBe(2);
+            });
+
+            const assistant = result.current.messages[1];
+            expect(assistant.role).toBe('assistant');
+            expect(assistant.isError).toBe(true);
+            expect(assistant.content).toContain("don't have permission");
+            expect(assistant.content).toContain('administrator');
+        });
+
+        it('clears the loading state after short-circuit', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith(
+                    '/api/v1/mcp/tools',
+                );
+            });
+
+            await act(async () => {
+                await result.current.sendMessage('Hello');
+            });
+
+            await waitFor(() => {
+                expect(result.current.isLoading).toBe(false);
+            });
+            expect(result.current.activeTools).toEqual([]);
+        });
+
+        it('still records input in history when short-circuiting', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith(
+                    '/api/v1/mcp/tools',
+                );
+            });
+
+            await act(async () => {
+                await result.current.sendMessage('Test input');
+            });
+
+            expect(mockSaveInputHistory).toHaveBeenCalled();
+        });
+
+        it('appends user message before the denial reply', async () => {
+            const { result } = renderHook(() => useChat());
+
+            await waitFor(() => {
+                expect(mockApiFetch).toHaveBeenCalledWith(
+                    '/api/v1/mcp/tools',
+                );
+            });
+
+            await act(async () => {
+                await result.current.sendMessage('Hello there');
+            });
+
+            await waitFor(() => {
+                expect(result.current.messages.length).toBe(2);
+            });
+            expect(result.current.messages[0].role).toBe('user');
+            expect(result.current.messages[0].content).toBe('Hello there');
+            expect(result.current.messages[1].role).toBe('assistant');
         });
     });
 });

--- a/client/src/hooks/chat/chatAgenticLoop.ts
+++ b/client/src/hooks/chat/chatAgenticLoop.ts
@@ -73,6 +73,30 @@ export const ITERATION_LIMIT_MESSAGE =
     'steps. Please try rephrasing your question.';
 
 /**
+ * Error message rendered when the user has no MCP tool privileges.
+ *
+ * The chat short-circuits before invoking the agentic loop when the
+ * server reports an empty tool list. Without this guard, the LLM would
+ * keep proposing tool calls that all fail with "Access denied", causing
+ * the loop to spin until `maxIterations` is exhausted. See issue #188.
+ */
+export const NO_MCP_PRIVILEGES_MESSAGE =
+    "You don't have permission to use any of the tools I need to answer " +
+    'questions like this. Ask your administrator to grant you the ' +
+    'relevant MCP privileges and try again.';
+
+/**
+ * Error message returned when the LLM proposes a tool call that is not
+ * in the available tool list. This guards against drift between the
+ * system prompt (which mentions tools by name) and the RBAC-filtered
+ * tool list the user is actually permitted to call.
+ */
+export const UNKNOWN_TOOL_MESSAGE =
+    'The model attempted to call tools that are not available to you. ' +
+    'This usually means your account lacks the necessary MCP ' +
+    'privileges. Please contact your administrator.';
+
+/**
  * Run the agentic LLM tool-use loop.
  *
  * This function calls the LLM with the current message history. If the
@@ -137,6 +161,41 @@ export async function runAgenticLoop(
             data.content?.filter(c => c.type === 'tool_use') || [];
         const textBlocks =
             data.content?.filter(c => c.type === 'text') || [];
+
+        // Defensive check: if the LLM proposes only tool calls that are
+        // not in the available tool list, bail out rather than feeding
+        // back N "unknown tool" errors. This typically indicates the
+        // user lacks MCP privileges for the tools the model is reaching
+        // for (the system prompt mentions all tools by name; RBAC may
+        // filter them out of `availableTools`). See issue #188.
+        if (toolUses.length > 0) {
+            const availableNames = new Set(
+                availableTools.map(t => t.name),
+            );
+            const allUnknown = toolUses.every(
+                t => !availableNames.has(t.name ?? ''),
+            );
+            if (allUnknown) {
+                const finalMessage: ChatMessageData = {
+                    role: 'assistant',
+                    content: UNKNOWN_TOOL_MESSAGE,
+                    timestamp: new Date().toISOString(),
+                    isError: true,
+                    activity:
+                        collectedActivity.length > 0
+                            ? [...collectedActivity]
+                            : undefined,
+                };
+                currentMessages = [
+                    ...currentMessages,
+                    { role: 'assistant', content: UNKNOWN_TOOL_MESSAGE },
+                ];
+                return {
+                    finalMessage,
+                    updatedApiMessages: currentMessages,
+                };
+            }
+        }
 
         if (toolUses.length === 0) {
             // No tool calls - extract final text response

--- a/client/src/hooks/chat/useChat.ts
+++ b/client/src/hooks/chat/useChat.ts
@@ -30,7 +30,10 @@ import {
     updateConversation,
     fetchConversation,
 } from './chatConversation';
-import { runAgenticLoop } from './chatAgenticLoop';
+import {
+    NO_MCP_PRIVILEGES_MESSAGE,
+    runAgenticLoop,
+} from './chatAgenticLoop';
 import { logger } from '../../utils/logger';
 
 // Re-export types that consuming modules import from this hook.
@@ -101,11 +104,30 @@ export function useChat(): UseChatReturn {
     // Ref to track visible messages within the sendMessage closure
     // without depending on the `messages` state value.
     const visibleMessagesRef = useRef<ChatMessageData[]>([]);
+    // Ref mirroring the latest `availableTools` value. Reading the
+    // tool list through a ref inside sendMessage eliminates the
+    // closure-staleness race where a fast user could click send
+    // between the tools fetch starting and the resulting setState
+    // committing — without the ref, sendMessage would observe the
+    // hardcoded CHAT_TOOLS fallback and skip the empty-list short
+    // circuit even when the user has zero MCP privileges (issue
+    // #188).
+    const availableToolsRef = useRef<ToolDefinition[]>(CHAT_TOOLS);
+    // Ref to the in-flight tools fetch promise. sendMessage awaits
+    // this before reading availableToolsRef so it always observes
+    // the authoritative tool list rather than the initial fallback.
+    const toolsFetchRef = useRef<Promise<void> | null>(null);
 
     // Keep the visible messages ref in sync with React state.
     useEffect(() => {
         visibleMessagesRef.current = messages;
     }, [messages]);
+
+    // Keep the tools ref in sync with React state so async closures
+    // (sendMessage in particular) always read the latest list.
+    useEffect(() => {
+        availableToolsRef.current = availableTools;
+    }, [availableTools]);
 
     /**
      * Keep the conversation id ref in sync with React state so
@@ -116,39 +138,51 @@ export function useChat(): UseChatReturn {
         setCurrentConversationId(id);
     }, []);
 
-    // Fetch available tools from the server on mount
+    // Fetch available tools from the server on mount.
+    //
+    // The server returns the RBAC-filtered tool list for the current
+    // user. Trust that list verbatim, including empty arrays: a user
+    // with zero MCP privileges legitimately has no tools available,
+    // and treating an empty list as "fall back to the hardcoded
+    // defaults" causes the agentic loop to send tools the user is not
+    // allowed to call, triggering the infinite "Access denied" loop
+    // described in issue #188. We only fall back to CHAT_TOOLS when
+    // the fetch itself fails (network error / non-OK response).
     useEffect(() => {
-        const fetchTools = async () => {
+        const fetchTools = async (): Promise<void> => {
             try {
                 const response = await apiFetch('/api/v1/mcp/tools');
                 if (response.ok) {
                     const data = await response.json();
                     const tools = data.tools || [];
-                    if (tools.length > 0) {
-                        setAvailableTools(
-                            tools.map(
-                                (t: {
-                                    name: string;
-                                    description: string;
-                                    inputSchema: Record<
-                                        string,
-                                        unknown
-                                    >;
-                                }) => ({
-                                    name: t.name,
-                                    description: t.description,
-                                    inputSchema: t.inputSchema,
-                                }),
-                            ),
-                        );
-                    }
+                    const mapped: ToolDefinition[] = tools.map(
+                        (t: {
+                            name: string;
+                            description: string;
+                            inputSchema: Record<string, unknown>;
+                        }) => ({
+                            name: t.name,
+                            description: t.description,
+                            inputSchema: t.inputSchema,
+                        }),
+                    );
+                    // Update the ref synchronously alongside the
+                    // state update so that any sendMessage call
+                    // awaiting toolsFetchRef sees the resolved list
+                    // immediately on its next read, regardless of
+                    // whether React has flushed the state update.
+                    availableToolsRef.current = mapped;
+                    setAvailableTools(mapped);
                 }
             } catch {
                 // Fall back to hardcoded CHAT_TOOLS (already the
-                // initial state)
+                // initial state). This preserves chat functionality
+                // when the tools endpoint is transiently unreachable.
             }
         };
-        void fetchTools();
+        // Track the in-flight fetch so sendMessage can await it
+        // and avoid the closure-staleness race described above.
+        toolsFetchRef.current = fetchTools();
     }, []);
 
     // ---------------------------------------------------------------
@@ -209,12 +243,70 @@ export function useChat(): UseChatReturn {
                 userAPIMessage,
             ];
 
+            // Wait for the initial tools fetch to settle before
+            // reading the tool list. Without this, a fast user (or a
+            // synchronous test runner) can invoke sendMessage between
+            // the fetch starting and setAvailableTools committing,
+            // causing the closure to observe the hardcoded CHAT_TOOLS
+            // fallback and bypass the empty-list short circuit even
+            // when the server reported zero tools — see issue #188.
+            if (toolsFetchRef.current) {
+                try {
+                    await toolsFetchRef.current;
+                } catch {
+                    // Fetch errors are already handled inside the
+                    // useEffect; the ref still holds the resolved
+                    // (or fallback) tool list.
+                }
+            }
+
+            // Read the authoritative tool list from the ref. The ref
+            // is updated synchronously alongside setAvailableTools so
+            // it reflects the latest list immediately, even if React
+            // has not yet flushed the state update.
+            const currentTools = availableToolsRef.current;
+
+            // Short-circuit when the user has no MCP tool privileges.
+            // Without this guard the agentic loop would invoke the LLM
+            // with an empty tool list (or, worse, with the hardcoded
+            // fallback tools the user is forbidden from calling), and
+            // every proposed call would fail with "Access denied". The
+            // loop would then spin until `maxIterations` is exhausted
+            // — see issue #188. Render a clear permission message and
+            // skip the loop entirely.
+            if (currentTools.length === 0) {
+                const deniedMessage: ChatMessageData = {
+                    role: 'assistant',
+                    content: NO_MCP_PRIVILEGES_MESSAGE,
+                    timestamp: new Date().toISOString(),
+                    isError: true,
+                };
+                setMessages(prev => {
+                    const updated = [...prev, deniedMessage];
+                    visibleMessagesRef.current = updated;
+                    return updated;
+                });
+                apiMessagesRef.current = [
+                    ...apiMessagesRef.current,
+                    {
+                        role: 'assistant',
+                        content: NO_MCP_PRIVILEGES_MESSAGE,
+                    },
+                ];
+                setIsLoading(false);
+                setActiveTools([]);
+                if (abortControllerRef.current === abortController) {
+                    abortControllerRef.current = null;
+                }
+                return;
+            }
+
             try {
-                // Run the agentic loop
+                // Run the agentic loop with the resolved tool list.
                 const { finalMessage, updatedApiMessages } =
                     await runAgenticLoop({
                         apiMessages: apiMessagesRef.current,
-                        availableTools,
+                        availableTools: currentTools,
                         systemPrompt: SYSTEM_PROMPT,
                         maxIterations,
                         abortSignal: abortController.signal,
@@ -293,7 +385,10 @@ export function useChat(): UseChatReturn {
                 }
             }
         },
-        [availableTools, maxIterations, syncConversationId],
+        // The tool list is read through availableToolsRef rather than
+        // captured via closure, so availableTools is intentionally not
+        // a dependency here.
+        [maxIterations, syncConversationId],
     );
 
     // ---------------------------------------------------------------

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -132,6 +132,11 @@ project adheres to
 
 ### Fixed
 
+- Fix Ask Ellie entering a long retry loop ("Joining the
+  relations..." / "Validating query") when the signed-in
+  user has no MCP privileges; the chat now surfaces a
+  clear permission-denied message immediately instead of
+  cycling through planning steps. (#188)
 - Fix wide markdown tables overflowing and clipping the
   right-side columns inside the Ask Ellie chat panel;
   tables returned by MCP tools such as


### PR DESCRIPTION
## Summary

- Trust the server's filtered MCP tool list verbatim. The client previously kept its hardcoded `CHAT_TOOLS` fallback whenever the server returned `[]`, so a no-privileges user fed the LLM 12 tool definitions, every call was denied by RBAC, and the agentic loop iterated up to `maxIterations` while `ThinkingIndicator` cycled status phrases.
- Short-circuit `useChat.sendMessage` with a clear permission-denied message when `availableTools` is empty.
- Await the in-flight tools fetch via a ref so `sendMessage` cannot read a stale tool list.
- Add a defensive bail-out in `runAgenticLoop` when every `tool_use` block references a name not present in `availableTools` — protects partial-privilege users from LLM hallucination of forbidden tools.

## Test plan

- [x] `make test-all` from repo root: Go suites + 2718 client tests pass.
- [x] Vitest coverage on touched files: `chatAgenticLoop.ts` 100%, `useChat.ts` 96.21% lines (both above the 90% floor).
- [x] Lint clean for the modified files; pre-existing warnings unchanged.
- [x] Typecheck unchanged from `main`.
- [ ] Manual smoke: log in as a user with no MCP privileges, open Ask Ellie, send a query → permission-denied message, no loop.

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed behavior when users lack MCP privileges: Ask Ellie now immediately displays a clear permission-denied message instead of entering lengthy retry cycles.
  * Fixed handling of unknown or unavailable tool proposals: the system now exits gracefully with an error message when proposed tools are not accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->