### PR TITLE
fix: reorder config and secret file lookup precedence (#195)

### DIFF
--- a/alerter/src/cmd/ai-dba-alerter/main.go
+++ b/alerter/src/cmd/ai-dba-alerter/main.go
@@ -26,19 +26,47 @@ import (
 // Version information
 const Version = "1.0.0-beta1"
 
+// resolveConfigPathResult describes the outcome of a config-path
+// lookup. Exposed so main() and its unit tests share the same shape.
+type resolveConfigPathResult struct {
+	// Path is the resolved path. It is empty if no config file was
+	// found in any default location and no explicit path was given.
+	Path string
+	// Explicit is true if the user passed --config on the command
+	// line. When Explicit is true and Path is non-empty but the
+	// file is missing, callers must error out rather than fall back
+	// to defaults.
+	Explicit bool
+}
+
+// resolveConfigPath returns the config path to use, given the value
+// of the --config flag. When --config is empty, the shared
+// discovery helper consults the per-user config directory first
+// and /etc/pgedge second. The returned struct tells callers
+// whether the path came from an explicit flag (in which case a
+// missing file is fatal) or from auto-discovery (in which case a
+// missing file means "use defaults").
+//
+// The helper is its own function so we can exercise both branches
+// in tests without driving the alerter's main() entry point.
+func resolveConfigPath(flagValue string) resolveConfigPathResult {
+	if flagValue != "" {
+		return resolveConfigPathResult{Path: flagValue, Explicit: true}
+	}
+	return resolveConfigPathResult{
+		Path:     config.GetDefaultConfigPath(""),
+		Explicit: false,
+	}
+}
+
 func main() {
 	fmt.Fprintf(os.Stderr, "pgEdge AI DBA Workbench Alerter v%s starting...\n", Version)
 
-	// Get executable path for default config location
-	execPath, err := os.Executable()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Failed to get executable path: %v\n", err)
-		os.Exit(1)
-	}
-	defaultConfigPath := config.GetDefaultConfigPath(execPath)
-
-	// Command line flags
-	configFile := flag.String("config", defaultConfigPath, "Path to configuration file")
+	// Command line flags. The --config default is left empty so we
+	// can distinguish "user passed an explicit path" from "user
+	// relied on default discovery"; the actual default lookup
+	// happens after flag.Parse below.
+	configFile := flag.String("config", "", "Path to configuration file (default: per-user pgedge config dir, then /etc/pgedge)")
 	debug := flag.Bool("debug", false, "Enable debug logging")
 
 	// Database connection flags
@@ -51,16 +79,40 @@ func main() {
 
 	flag.Parse()
 
+	// Resolve the config path: an explicit flag wins, otherwise the
+	// shared discovery helper picks the highest-priority path that
+	// exists. If neither exists, the resolved path is "" and the
+	// alerter proceeds with compiled-in defaults.
+	resolved := resolveConfigPath(*configFile)
+	explicitConfigPath := resolved.Explicit
+	resolvedConfigPath := resolved.Path
+
 	// Load configuration
 	cfg := config.NewConfig()
 
-	// Load from file if exists
-	if config.ConfigFileExists(*configFile) {
-		if err := cfg.LoadFromFile(*configFile); err != nil {
+	// Load from file if it was explicitly requested or auto-discovered.
+	if resolvedConfigPath != "" {
+		if !config.ConfigFileExists(resolvedConfigPath) {
+			if explicitConfigPath {
+				fmt.Fprintf(os.Stderr, "ERROR: configuration file not found: %s\n", resolvedConfigPath)
+				os.Exit(1)
+			}
+			// The helper said the file was there but it has since
+			// vanished; fall through to defaults rather than
+			// crashing.
+			resolvedConfigPath = ""
+		}
+	}
+	if resolvedConfigPath != "" {
+		if err := cfg.LoadFromFile(resolvedConfigPath); err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to load config: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Fprintf(os.Stderr, "Configuration loaded from %s\n", *configFile)
+		fmt.Fprintf(os.Stderr, "Configuration loaded from %s\n", resolvedConfigPath)
+	} else {
+		fmt.Fprintf(os.Stderr,
+			"No configuration file found in default search paths "+
+				"(per-user config dir, /etc/pgedge); using defaults\n")
 	}
 
 	// Apply command line overrides
@@ -113,10 +165,16 @@ func main() {
 			switch sig {
 			case syscall.SIGHUP:
 				fmt.Fprintf(os.Stderr, "Received SIGHUP, reloading configuration...\n")
-				// Reload configuration
+				// Reload configuration. Re-run discovery so that an
+				// admin who installed a new config file at one of
+				// the default locations does not have to restart.
+				reloadPath := resolvedConfigPath
+				if !explicitConfigPath {
+					reloadPath = config.GetDefaultConfigPath("")
+				}
 				newCfg := config.NewConfig()
-				if config.ConfigFileExists(*configFile) {
-					if err := newCfg.LoadFromFile(*configFile); err != nil {
+				if reloadPath != "" && config.ConfigFileExists(reloadPath) {
+					if err := newCfg.LoadFromFile(reloadPath); err != nil {
 						fmt.Fprintf(os.Stderr, "ERROR: Failed to reload config: %v\n", err)
 						continue
 					}

--- a/alerter/src/cmd/ai-dba-alerter/main.go
+++ b/alerter/src/cmd/ai-dba-alerter/main.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -57,6 +58,91 @@ func resolveConfigPath(flagValue string) resolveConfigPathResult {
 		Path:     config.GetDefaultConfigPath(""),
 		Explicit: false,
 	}
+}
+
+// reloadFlagOverrides bundles the CLI flag values that survive
+// across a SIGHUP reload and must be reapplied to the freshly
+// loaded config so operators do not lose their command-line
+// overrides on every reload.
+type reloadFlagOverrides struct {
+	DBHost         string
+	DBPort         int
+	DBName         string
+	DBUser         string
+	DBPasswordFile string
+	DBSSLMode      string
+}
+
+// reloadConfigOnSignal builds a fresh *config.Config from the same
+// discovery rules used at startup, applies the original flag
+// overrides, validates the result, and returns it. The function
+// is intentionally side-effect free apart from logging to the
+// supplied io.Writer: callers (typically the SIGHUP handler in
+// main) decide whether to install the new config and notify the
+// running engine.
+//
+// The "no candidate file found" and "candidate file vanished"
+// cases both return (nil, nil) so the caller can keep the
+// running config rather than silently downgrade to compiled-in
+// defaults. A non-nil error indicates a hard failure (read error,
+// invalid YAML, validation failure, etc.) - again the caller
+// keeps the current config.
+//
+// Splitting the reload logic out of main() keeps the goroutine
+// that owns the signal channel small and lets us cover the
+// branches in unit tests without driving the binary entry point.
+func reloadConfigOnSignal(
+	logOut io.Writer,
+	prevPath string,
+	explicit bool,
+	overrides reloadFlagOverrides,
+) (*config.Config, error) {
+	reloadPath := prevPath
+	if !explicit {
+		reloadPath = config.GetDefaultConfigPath("")
+	}
+	if reloadPath == "" {
+		fmt.Fprintf(logOut,
+			"ERROR: No configuration file found in default search "+
+				"paths during SIGHUP reload; keeping current config\n")
+		return nil, nil
+	}
+	if !config.ConfigFileExists(reloadPath) {
+		fmt.Fprintf(logOut,
+			"ERROR: Configuration file %s not found during SIGHUP "+
+				"reload; keeping current config\n", reloadPath)
+		return nil, nil
+	}
+
+	newCfg := config.NewConfig()
+	if err := newCfg.LoadFromFile(reloadPath); err != nil {
+		return nil, fmt.Errorf("failed to reload config: %w", err)
+	}
+
+	if err := applyFlagOverrides(newCfg,
+		overrides.DBHost, overrides.DBPort, overrides.DBName,
+		overrides.DBUser, overrides.DBPasswordFile, overrides.DBSSLMode,
+	); err != nil {
+		return nil, fmt.Errorf("failed to apply overrides on reload: %w", err)
+	}
+
+	if err := newCfg.Validate(); err != nil {
+		return nil, fmt.Errorf("reloaded config is invalid: %w", err)
+	}
+
+	if err := newCfg.LoadPassword(); err != nil {
+		return nil, fmt.Errorf("failed to load password on reload: %w", err)
+	}
+
+	// API keys are non-critical: an error here is logged but does
+	// not block the reload.
+	if err := newCfg.LoadAPIKeys(); err != nil {
+		fmt.Fprintf(logOut,
+			"WARNING: Failed to load API keys on reload: %v\n", err)
+	}
+
+	fmt.Fprintf(logOut, "Configuration reloaded from %s\n", reloadPath)
+	return newCfg, nil
 }
 
 func main() {
@@ -165,47 +251,39 @@ func main() {
 			switch sig {
 			case syscall.SIGHUP:
 				fmt.Fprintf(os.Stderr, "Received SIGHUP, reloading configuration...\n")
-				// Reload configuration. Re-run discovery so that an
-				// admin who installed a new config file at one of
-				// the default locations does not have to restart.
-				reloadPath := resolvedConfigPath
-				if !explicitConfigPath {
-					reloadPath = config.GetDefaultConfigPath("")
+				// Delegate the reload work to a side-effect-free
+				// helper so the SIGHUP handler stays small and
+				// the reload logic stays testable. A nil config
+				// (with a nil error) means "the helper logged
+				// the reason and we should keep the current
+				// running config" - never replace the live
+				// config with compiled-in defaults.
+				newCfg, err := reloadConfigOnSignal(
+					os.Stderr,
+					resolvedConfigPath,
+					explicitConfigPath,
+					reloadFlagOverrides{
+						DBHost:         *dbHost,
+						DBPort:         *dbPort,
+						DBName:         *dbName,
+						DBUser:         *dbUser,
+						DBPasswordFile: *dbPasswordFile,
+						DBSSLMode:      *dbSSLMode,
+					},
+				)
+				if err != nil {
+					fmt.Fprintf(os.Stderr,
+						"ERROR: %v; keeping current config\n", err)
+					continue
 				}
-				newCfg := config.NewConfig()
-				if reloadPath != "" && config.ConfigFileExists(reloadPath) {
-					if err := newCfg.LoadFromFile(reloadPath); err != nil {
-						fmt.Fprintf(os.Stderr, "ERROR: Failed to reload config: %v\n", err)
-						continue
-					}
-				}
-
-				// Reapply CLI flag overrides
-				if err := applyFlagOverrides(newCfg, *dbHost, *dbPort, *dbName, *dbUser, *dbPasswordFile, *dbSSLMode); err != nil {
-					fmt.Fprintf(os.Stderr, "ERROR: Failed to apply overrides on reload: %v\n", err)
+				if newCfg == nil {
+					// Helper already logged the reason. Skip
+					// applying anything; the running engine
+					// continues with its existing config.
 					continue
 				}
 
-				// Validate configuration
-				if err := newCfg.Validate(); err != nil {
-					fmt.Fprintf(os.Stderr, "ERROR: Reloaded config is invalid, skipping reload: %v\n", err)
-					continue
-				}
-
-				// Load password from file if needed
-				if err := newCfg.LoadPassword(); err != nil {
-					fmt.Fprintf(os.Stderr, "ERROR: Failed to load password on reload, skipping reload: %v\n", err)
-					continue
-				}
-
-				// Load API keys (non-critical)
-				if err := newCfg.LoadAPIKeys(); err != nil {
-					fmt.Fprintf(os.Stderr, "WARNING: Failed to load API keys on reload: %v\n", err)
-				}
-
-				// Apply reloadable settings to the engine
 				alerterEngine.ReloadConfig(newCfg)
-				fmt.Fprintf(os.Stderr, "Configuration reloaded\n")
 			case syscall.SIGINT, syscall.SIGTERM:
 				fmt.Fprintf(os.Stderr, "\nShutting down...\n")
 				cancel()

--- a/alerter/src/cmd/ai-dba-alerter/main_test.go
+++ b/alerter/src/cmd/ai-dba-alerter/main_test.go
@@ -1,0 +1,80 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveConfigPath_ExplicitFlag verifies that an explicit
+// --config value is returned verbatim and is flagged as explicit.
+// Whether the file actually exists is not the helper's concern;
+// validating that is the caller's job.
+func TestResolveConfigPath_ExplicitFlag(t *testing.T) {
+	got := resolveConfigPath("/some/explicit/path.yaml")
+	if got.Path != "/some/explicit/path.yaml" {
+		t.Errorf("Path = %q, want %q", got.Path, "/some/explicit/path.yaml")
+	}
+	if !got.Explicit {
+		t.Error("Explicit = false, want true")
+	}
+}
+
+// TestResolveConfigPath_NoFlagNoFile verifies that an empty flag
+// plus no candidate file resolves to the empty string with
+// Explicit=false (the "fall through to defaults" signal).
+func TestResolveConfigPath_NoFlagNoFile(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	got := resolveConfigPath("")
+	if got.Path != "" && got.Path != "/etc/pgedge/ai-dba-alerter.yaml" {
+		t.Errorf("Path = %q, want empty string or /etc/pgedge fallback", got.Path)
+	}
+	if got.Explicit {
+		t.Error("Explicit = true, want false")
+	}
+}
+
+// TestResolveConfigPath_NoFlagUserDirHit verifies that an empty
+// flag picks up a config file dropped into the per-user config
+// directory and reports it as a non-explicit (auto-discovered)
+// match.
+func TestResolveConfigPath_NoFlagUserDirHit(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir(): %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	expected := filepath.Join(pgedgeDir, "ai-dba-alerter.yaml")
+	if err := os.WriteFile(expected, []byte("datastore:\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := resolveConfigPath("")
+	if got.Path != expected {
+		t.Errorf("Path = %q, want %q", got.Path, expected)
+	}
+	if got.Explicit {
+		t.Error("Explicit = true, want false")
+	}
+}

--- a/alerter/src/cmd/ai-dba-alerter/main_test.go
+++ b/alerter/src/cmd/ai-dba-alerter/main_test.go
@@ -10,10 +10,25 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
+
+// minimalValidYAML is a config payload that satisfies
+// config.Validate so reloadConfigOnSignal returns a config
+// instead of a validation error.
+const minimalValidYAML = "datastore:\n" +
+	"  host: testhost\n" +
+	"  port: 5432\n" +
+	"  database: testdb\n" +
+	"  username: testuser\n" +
+	"pool:\n" +
+	"  max_connections: 5\n"
 
 // TestResolveConfigPath_ExplicitFlag verifies that an explicit
 // --config value is returned verbatim and is flagged as explicit.
@@ -31,16 +46,19 @@ func TestResolveConfigPath_ExplicitFlag(t *testing.T) {
 
 // TestResolveConfigPath_NoFlagNoFile verifies that an empty flag
 // plus no candidate file resolves to the empty string with
-// Explicit=false (the "fall through to defaults" signal).
+// Explicit=false (the "fall through to defaults" signal). The
+// system-wide fallback is redirected so the assertion is exact
+// regardless of the test host's /etc/pgedge state.
 func TestResolveConfigPath_NoFlagNoFile(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", base)
 	t.Setenv("HOME", base)
 	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	got := resolveConfigPath("")
-	if got.Path != "" && got.Path != "/etc/pgedge/ai-dba-alerter.yaml" {
-		t.Errorf("Path = %q, want empty string or /etc/pgedge fallback", got.Path)
+	if got.Path != "" {
+		t.Errorf("Path = %q, want empty string", got.Path)
 	}
 	if got.Explicit {
 		t.Error("Explicit = true, want false")
@@ -76,5 +94,253 @@ func TestResolveConfigPath_NoFlagUserDirHit(t *testing.T) {
 	}
 	if got.Explicit {
 		t.Error("Explicit = true, want false")
+	}
+}
+
+// TestReloadConfigOnSignal_ExplicitMissing verifies the headline
+// fix from issue #195's CodeRabbit thread: when the operator
+// started the alerter with --config <path> and the file later
+// vanishes, a SIGHUP reload must NOT replace the running config
+// with compiled-in defaults. The helper returns (nil, nil) and
+// logs a descriptive error so the caller can keep the existing
+// config.
+func TestReloadConfigOnSignal_ExplicitMissing(t *testing.T) {
+	var buf bytes.Buffer
+	got, err := reloadConfigOnSignal(
+		&buf,
+		"/definitely/not/a/real/path.yaml",
+		true, // explicit
+		reloadFlagOverrides{},
+	)
+	if err != nil {
+		t.Fatalf("reloadConfigOnSignal: unexpected error %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil config (keep current), got %+v", got)
+	}
+	if !strings.Contains(buf.String(), "not found during SIGHUP reload") {
+		t.Errorf("log = %q, want it to mention the missing-file branch", buf.String())
+	}
+}
+
+// TestReloadConfigOnSignal_NoCandidateFile covers the case where
+// the alerter started without --config, no default file was
+// discovered, and SIGHUP arrives with still no file present.
+// The helper returns (nil, nil) and logs the "no candidate"
+// branch.
+func TestReloadConfigOnSignal_NoCandidateFile(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
+
+	var buf bytes.Buffer
+	got, err := reloadConfigOnSignal(
+		&buf,
+		"", // no previously-resolved path either
+		false,
+		reloadFlagOverrides{},
+	)
+	if err != nil {
+		t.Fatalf("reloadConfigOnSignal: unexpected error %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil config (keep current), got %+v", got)
+	}
+	if !strings.Contains(buf.String(), "No configuration file found in default search") {
+		t.Errorf("log = %q, want it to mention the no-candidate branch", buf.String())
+	}
+}
+
+// TestReloadConfigOnSignal_HappyPath verifies the helper returns
+// a fully populated config when a valid file is on disk.
+func TestReloadConfigOnSignal_HappyPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "alerter.yaml")
+	if err := os.WriteFile(cfgPath, []byte(minimalValidYAML), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	got, err := reloadConfigOnSignal(
+		&buf,
+		cfgPath,
+		true,
+		reloadFlagOverrides{},
+	)
+	if err != nil {
+		t.Fatalf("reloadConfigOnSignal: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil config, got nil")
+	}
+	if got.Datastore.Host != "testhost" {
+		t.Errorf("Host = %q, want testhost", got.Datastore.Host)
+	}
+	if !strings.Contains(buf.String(), "Configuration reloaded from") {
+		t.Errorf("log = %q, want it to confirm the reload", buf.String())
+	}
+}
+
+// TestReloadConfigOnSignal_FlagOverridesApplied verifies that the
+// CLI flag overrides bundled in reloadFlagOverrides are applied
+// to the freshly loaded config so SIGHUP does not silently drop
+// command-line settings.
+func TestReloadConfigOnSignal_FlagOverridesApplied(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "alerter.yaml")
+	if err := os.WriteFile(cfgPath, []byte(minimalValidYAML), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	got, err := reloadConfigOnSignal(
+		&buf,
+		cfgPath,
+		true,
+		reloadFlagOverrides{
+			DBHost:    "override-host",
+			DBPort:    9999,
+			DBSSLMode: "require",
+		},
+	)
+	if err != nil {
+		t.Fatalf("reloadConfigOnSignal: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil config, got nil")
+	}
+	if got.Datastore.Host != "override-host" {
+		t.Errorf("Host = %q, want override-host", got.Datastore.Host)
+	}
+	if got.Datastore.Port != 9999 {
+		t.Errorf("Port = %d, want 9999", got.Datastore.Port)
+	}
+	if got.Datastore.SSLMode != "require" {
+		t.Errorf("SSLMode = %q, want require", got.Datastore.SSLMode)
+	}
+}
+
+// TestReloadConfigOnSignal_InvalidConfig covers the validation
+// failure branch. NewConfig() seeds datastore.host with
+// "localhost" by default, so we have to clear it explicitly to
+// trigger Validate's first check; an out-of-range port also
+// works and is documented here for the next reader.
+func TestReloadConfigOnSignal_InvalidConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "alerter.yaml")
+	// Empty host fails Validate's "datastore.host is required" rule.
+	body := "datastore:\n  host: \"\"\n  port: 5432\n  database: d\n  username: u\n" +
+		"pool:\n  max_connections: 5\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	got, err := reloadConfigOnSignal(
+		&buf,
+		cfgPath,
+		true,
+		reloadFlagOverrides{},
+	)
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if got != nil {
+		t.Errorf("expected nil config on validation error, got %+v", got)
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("err = %v, want it to mention 'invalid'", err)
+	}
+}
+
+// TestReloadConfigOnSignal_MalformedYAML covers the LoadFromFile
+// failure branch.
+func TestReloadConfigOnSignal_MalformedYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "alerter.yaml")
+	if err := os.WriteFile(cfgPath, []byte("datastore: [broken"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	got, err := reloadConfigOnSignal(
+		&buf,
+		cfgPath,
+		true,
+		reloadFlagOverrides{},
+	)
+	if err == nil {
+		t.Fatal("expected YAML parse error, got nil")
+	}
+	if got != nil {
+		t.Errorf("expected nil config on parse error, got %+v", got)
+	}
+}
+
+// TestReloadConfigOnSignal_APIKeyWarning covers the non-fatal
+// LoadAPIKeys branch: a missing API-key file logs a warning but
+// must not block the reload, so the helper still returns a valid
+// config.
+func TestReloadConfigOnSignal_APIKeyWarning(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "alerter.yaml")
+	body := minimalValidYAML +
+		"llm:\n  openai:\n    api_key_file: /definitely/not/here\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	got, err := reloadConfigOnSignal(
+		&buf,
+		cfgPath,
+		true,
+		reloadFlagOverrides{},
+	)
+	if err != nil {
+		t.Fatalf("reloadConfigOnSignal: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil config even when api-key file missing")
+	}
+	if !strings.Contains(buf.String(), "WARNING") {
+		t.Errorf("log = %q, want it to contain WARNING", buf.String())
+	}
+}
+
+// TestReloadConfigOnSignal_PasswordFileMissing covers the
+// LoadPassword failure branch.
+func TestReloadConfigOnSignal_PasswordFileMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "alerter.yaml")
+	body := "datastore:\n" +
+		"  host: testhost\n" +
+		"  port: 5432\n" +
+		"  database: testdb\n" +
+		"  username: testuser\n" +
+		"  password_file: /definitely/not/here\n" +
+		"pool:\n" +
+		"  max_connections: 5\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	got, err := reloadConfigOnSignal(
+		&buf,
+		cfgPath,
+		true,
+		reloadFlagOverrides{},
+	)
+	if err == nil {
+		t.Fatal("expected password-load error, got nil")
+	}
+	if got != nil {
+		t.Errorf("expected nil config on password-load error, got %+v", got)
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Errorf("err = %v, want it to mention 'password'", err)
 	}
 }

--- a/alerter/src/internal/config/config.go
+++ b/alerter/src/internal/config/config.go
@@ -373,7 +373,11 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// GetDefaultConfigPath returns the default config file path
+// GetDefaultConfigPath returns the path to an existing default
+// alerter config file, or "" if none was found. Searches the
+// per-user config directory (e.g. ~/.config/pgedge/) first, then
+// /etc/pgedge/. The binaryPath parameter is no longer consulted
+// but kept for caller stability.
 func GetDefaultConfigPath(binaryPath string) string {
 	return fileutil.GetDefaultConfigPath(binaryPath, "ai-dba-alerter.yaml")
 }

--- a/alerter/src/internal/config/config_test.go
+++ b/alerter/src/internal/config/config_test.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
 // TestNewConfig tests that NewConfig creates a configuration with sensible defaults
@@ -410,16 +412,19 @@ func TestConfigFileExists(t *testing.T) {
 
 // TestGetDefaultConfigPath verifies the alerter wrapper returns
 // "" when no candidate file is present. The binaryPath argument
-// is no longer consulted.
+// is no longer consulted. The system-wide fallback is redirected
+// at a non-existent path so the assertion is exact and not
+// dependent on whether the test host has /etc/pgedge populated.
 func TestGetDefaultConfigPath(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", base)
 	t.Setenv("HOME", base)
 	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	path := GetDefaultConfigPath("/usr/local/bin/ai-dba-alerter")
-	if path != "" && path != "/etc/pgedge/ai-dba-alerter.yaml" {
-		t.Errorf("GetDefaultConfigPath = %q, expected empty path or /etc/pgedge fallback", path)
+	if path != "" {
+		t.Errorf("GetDefaultConfigPath = %q, want empty path", path)
 	}
 }
 

--- a/alerter/src/internal/config/config_test.go
+++ b/alerter/src/internal/config/config_test.go
@@ -408,14 +408,44 @@ func TestConfigFileExists(t *testing.T) {
 	})
 }
 
-// TestGetDefaultConfigPath tests the GetDefaultConfigPath function
+// TestGetDefaultConfigPath verifies the alerter wrapper returns
+// "" when no candidate file is present. The binaryPath argument
+// is no longer consulted.
 func TestGetDefaultConfigPath(t *testing.T) {
-	// When system config doesn't exist, should return path relative to binary
-	path := GetDefaultConfigPath("/usr/local/bin/ai-dba-alerter")
-	expected := "/usr/local/bin/ai-dba-alerter.yaml"
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
 
-	if path != expected {
-		t.Errorf("GetDefaultConfigPath = %q, expected %q", path, expected)
+	path := GetDefaultConfigPath("/usr/local/bin/ai-dba-alerter")
+	if path != "" && path != "/etc/pgedge/ai-dba-alerter.yaml" {
+		t.Errorf("GetDefaultConfigPath = %q, expected empty path or /etc/pgedge fallback", path)
+	}
+}
+
+// TestGetDefaultConfigPath_UserDirHit verifies the wrapper returns
+// the per-user config path when one is present.
+func TestGetDefaultConfigPath_UserDirHit(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	expected := filepath.Join(pgedgeDir, "ai-dba-alerter.yaml")
+	if err := os.WriteFile(expected, []byte("datastore:\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if got := GetDefaultConfigPath(""); got != expected {
+		t.Errorf("GetDefaultConfigPath = %q, want %q", got, expected)
 	}
 }
 

--- a/collector/src/config.go
+++ b/collector/src/config.go
@@ -13,7 +13,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/pgedge/ai-workbench/pkg/datastoreconfig"
 	"github.com/pgedge/ai-workbench/pkg/fileutil"
@@ -28,8 +27,10 @@ type Config struct {
 	// Connection pool settings
 	Pool PoolConfig `yaml:"pool"`
 
-	// Path to file containing server secret for encryption
-	// Default search paths: /etc/pgedge/ai-dba-collector.secret, ./ai-dba-collector.secret
+	// Path to file containing server secret for encryption.
+	// When unset, LoadSecret searches the per-user config directory
+	// (e.g. ~/.config/pgedge/ai-dba-collector.secret) first and
+	// /etc/pgedge/ai-dba-collector.secret second.
 	SecretFile string `yaml:"secret_file"`
 
 	// Loaded server secret (not from YAML, loaded from SecretFile)
@@ -140,10 +141,23 @@ func (c *Config) LoadPassword() error {
 	return nil
 }
 
-// LoadSecret loads the server secret from the secret file
-// Search order: explicit SecretFile config > /etc/pgedge/ > binary directory
+// LoadSecret loads the server secret from the secret file.
+//
+// Search order (highest priority first):
+//
+//  1. The explicit SecretFile path from the YAML config (if set).
+//  2. The per-user config directory reported by os.UserConfigDir(),
+//     under pgedge/ai-dba-collector.secret.
+//  3. The system-wide path /etc/pgedge/ai-dba-collector.secret.
+//
+// The binary directory and the current working directory are no
+// longer consulted, matching the precedence rules used for the
+// config file. The binaryPath parameter is retained for caller
+// stability and is intentionally ignored.
 func (c *Config) LoadSecret(binaryPath string) error {
-	// If secret file is explicitly specified, use it
+	_ = binaryPath // intentionally unused; retained for caller stability
+
+	// If secret file is explicitly specified, use it.
 	if c.SecretFile != "" {
 		secret, err := fileutil.ReadTrimmedFileWithTilde(c.SecretFile)
 		if err != nil {
@@ -153,32 +167,20 @@ func (c *Config) LoadSecret(binaryPath string) error {
 		return nil
 	}
 
-	// Search default paths
-	searchPaths := []string{
-		"/etc/pgedge/ai-dba-collector.secret",
-	}
-
-	// Add binary directory path
-	if binaryPath != "" {
-		dir := filepath.Dir(binaryPath)
-		searchPaths = append(searchPaths, filepath.Join(dir, "ai-dba-collector.secret"))
-	}
-
-	// Also check current directory
-	searchPaths = append(searchPaths, "./ai-dba-collector.secret")
-
-	for _, path := range searchPaths {
-		if _, err := os.Stat(path); err == nil {
-			secret, err := fileutil.ReadTrimmedFileWithTilde(path)
-			if err != nil {
-				return fmt.Errorf("failed to read secret file %s: %w", path, err)
-			}
-			c.serverSecret = secret
-			return nil
+	// Resolve via the shared helper so all three services apply
+	// identical precedence to default paths.
+	if path := fileutil.GetDefaultConfigPath("", "ai-dba-collector.secret"); path != "" {
+		secret, err := fileutil.ReadTrimmedFileWithTilde(path)
+		if err != nil {
+			return fmt.Errorf("failed to read secret file %s: %w", path, err)
 		}
+		c.serverSecret = secret
+		return nil
 	}
 
-	return fmt.Errorf("server secret file not found. Create a secret file at one of: %v", searchPaths)
+	return fmt.Errorf("server secret file not found. Searched: " +
+		"per-user config dir (~/.config/pgedge or platform " +
+		"equivalent) and /etc/pgedge/ai-dba-collector.secret")
 }
 
 // GetServerSecret returns the loaded server secret
@@ -237,14 +239,18 @@ func (c *Config) GetDatastorePoolMaxIdleSeconds() int { return c.Pool.DatastoreM
 func (c *Config) GetDatastorePoolMaxWaitSeconds() int { return c.Pool.DatastoreMaxWaitSeconds }
 func (c *Config) GetMonitoredPoolMaxWaitSeconds() int { return c.Pool.MonitoredMaxWaitSeconds }
 
-// GetDefaultConfigPath returns the default config file path
-// Searches /etc/pgedge/ first, then binary directory
+// GetDefaultConfigPath returns the path to an existing default
+// config file, or "" if none was found. Searches the per-user
+// config directory (e.g. ~/.config/pgedge/) first, then
+// /etc/pgedge/. The binaryPath parameter is no longer consulted
+// but kept for caller stability.
 func GetDefaultConfigPath(binaryPath string) string {
 	return fileutil.GetDefaultConfigPath(binaryPath, "ai-dba-collector.yaml")
 }
 
-// GetDefaultSecretPath returns the default secret file path
-// Searches /etc/pgedge/ first, then binary directory
+// GetDefaultSecretPath returns the path to an existing default
+// secret file, or "" if none was found. Search order matches
+// GetDefaultConfigPath.
 func GetDefaultSecretPath(binaryPath string) string {
 	return fileutil.GetDefaultConfigPath(binaryPath, "ai-dba-collector.secret")
 }

--- a/collector/src/config_test.go
+++ b/collector/src/config_test.go
@@ -279,15 +279,75 @@ func TestReadPasswordFromSecretFile(t *testing.T) {
 }
 
 func TestGetDefaultConfigPath(t *testing.T) {
-	// Test that it returns a path ending in ai-dba-collector.yaml
+	// With nothing set up the helper returns "" so the caller can
+	// fall through to compiled-in defaults.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AppData", t.TempDir())
+
 	binaryPath := "/usr/local/bin/ai-dba-collector"
 	configPath := GetDefaultConfigPath(binaryPath)
 
-	// Since /etc/pgedge/ai-dba-collector.yaml likely doesn't exist,
-	// it should fall back to the binary directory
-	expected := "/usr/local/bin/ai-dba-collector.yaml"
-	if configPath != expected {
-		t.Errorf("Expected config path '%s', got '%s'", expected, configPath)
+	// Since neither the per-user config dir nor /etc/pgedge holds a
+	// matching file, the helper should signal "no config found".
+	// We accept the existing /etc/pgedge file if the developer
+	// happens to have one installed locally.
+	if configPath != "" && configPath != "/etc/pgedge/ai-dba-collector.yaml" {
+		t.Errorf("Expected empty path or /etc/pgedge path, got %q", configPath)
+	}
+}
+
+// TestGetDefaultConfigPath_UserDirHit confirms the wrapper returns
+// the per-user config path when one exists. We use t.Setenv to
+// redirect os.UserConfigDir() into a writable temp directory so
+// the test does not depend on the developer's environment.
+func TestGetDefaultConfigPath_UserDirHit(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	expected := filepath.Join(pgedgeDir, "ai-dba-collector.yaml")
+	if err := os.WriteFile(expected, []byte("datastore:\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if got := GetDefaultConfigPath(""); got != expected {
+		t.Errorf("GetDefaultConfigPath() = %q, want %q", got, expected)
+	}
+}
+
+// TestGetDefaultSecretPath_UserDirHit mirrors the config test for
+// the secret-file lookup wrapper.
+func TestGetDefaultSecretPath_UserDirHit(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	expected := filepath.Join(pgedgeDir, "ai-dba-collector.secret")
+	if err := os.WriteFile(expected, []byte("s3cr3t"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if got := GetDefaultSecretPath(""); got != expected {
+		t.Errorf("GetDefaultSecretPath() = %q, want %q", got, expected)
 	}
 }
 
@@ -680,19 +740,30 @@ func TestLoadSecret_ExplicitPath(t *testing.T) {
 }
 
 func TestLoadSecret_DefaultPath(t *testing.T) {
-	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "ai-dba-collector")
-	secretFile := filepath.Join(tmpDir, "ai-dba-collector.secret")
+	// Redirect os.UserConfigDir() into a temp directory so the
+	// helper finds our test secret without relying on host state.
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
 
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	secretFile := filepath.Join(pgedgeDir, "ai-dba-collector.secret")
 	testSecret := "default-path-secret"
 	if err := os.WriteFile(secretFile, []byte(testSecret), 0600); err != nil {
 		t.Fatalf("Failed to write test secret file: %v", err)
 	}
 
 	config := NewConfig()
-	// Don't set SecretFile - let it search default paths
-
-	if err := config.LoadSecret(binaryPath); err != nil {
+	// Don't set SecretFile - let it search default paths.
+	if err := config.LoadSecret(""); err != nil {
 		t.Fatalf("LoadSecret() error = %v", err)
 	}
 
@@ -702,15 +773,48 @@ func TestLoadSecret_DefaultPath(t *testing.T) {
 }
 
 func TestLoadSecret_NotFound(t *testing.T) {
-	tmpDir := t.TempDir()
-	binaryPath := filepath.Join(tmpDir, "ai-dba-collector")
-	// Don't create any secret file
+	// Redirect os.UserConfigDir() at an empty temp dir so neither
+	// the user nor the system path resolves.
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
 
 	config := NewConfig()
-
-	err := config.LoadSecret(binaryPath)
+	err := config.LoadSecret("")
 	if err == nil {
 		t.Error("Expected error when no secret file is found")
+	}
+}
+
+// TestLoadSecret_DefaultPathReadError exercises the rare branch
+// where the helper finds a file at the default location but the
+// subsequent read fails. We simulate that by placing a directory
+// (rather than a regular file) at the discovered path.
+func TestLoadSecret_DefaultPathReadError(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir(): %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Create a subdirectory at the would-be secret path so os.Stat
+	// in the helper succeeds but ReadFile fails.
+	bogusPath := filepath.Join(pgedgeDir, "ai-dba-collector.secret")
+	if err := os.Mkdir(bogusPath, 0700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	config := NewConfig()
+	if err := config.LoadSecret(""); err == nil {
+		t.Error("Expected error when secret path is unreadable")
 	}
 }
 

--- a/collector/src/config_test.go
+++ b/collector/src/config_test.go
@@ -279,21 +279,21 @@ func TestReadPasswordFromSecretFile(t *testing.T) {
 }
 
 func TestGetDefaultConfigPath(t *testing.T) {
-	// With nothing set up the helper returns "" so the caller can
-	// fall through to compiled-in defaults.
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("AppData", t.TempDir())
+	// Redirect both the per-user config dir and the system-wide
+	// fallback at empty/non-existent locations so the test
+	// asserts an exact "" return regardless of what the host has
+	// installed in /etc/pgedge.
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	binaryPath := "/usr/local/bin/ai-dba-collector"
 	configPath := GetDefaultConfigPath(binaryPath)
 
-	// Since neither the per-user config dir nor /etc/pgedge holds a
-	// matching file, the helper should signal "no config found".
-	// We accept the existing /etc/pgedge file if the developer
-	// happens to have one installed locally.
-	if configPath != "" && configPath != "/etc/pgedge/ai-dba-collector.yaml" {
-		t.Errorf("Expected empty path or /etc/pgedge path, got %q", configPath)
+	if configPath != "" {
+		t.Errorf("Expected empty path, got %q", configPath)
 	}
 }
 
@@ -773,12 +773,17 @@ func TestLoadSecret_DefaultPath(t *testing.T) {
 }
 
 func TestLoadSecret_NotFound(t *testing.T) {
-	// Redirect os.UserConfigDir() at an empty temp dir so neither
-	// the user nor the system path resolves.
+	// Redirect os.UserConfigDir() at an empty temp dir so the
+	// per-user candidate cannot resolve. We also redirect the
+	// system-wide fallback at a directory that does not exist so
+	// CI hosts and developer machines that happen to have a real
+	// /etc/pgedge/ai-dba-collector.secret installed do not turn
+	// this test into a flake.
 	base := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", base)
 	t.Setenv("HOME", base)
 	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	config := NewConfig()
 	err := config.LoadSecret("")

--- a/collector/src/main.go
+++ b/collector/src/main.go
@@ -116,37 +116,46 @@ func main() {
 	logger.Startup("Collector stopped")
 }
 
-// loadConfiguration loads configuration from file, environment, and command line
-// Priority (highest to lowest): CLI flags > environment variables > config file > defaults
+// loadConfiguration loads configuration from file, environment, and command line.
+// Priority (highest to lowest): CLI flags > environment variables > config file > defaults.
+//
+// When --config is not given, the function consults the shared
+// helper which searches the per-user config directory first and
+// /etc/pgedge second. When neither exists the function logs an
+// informational message and proceeds with compiled-in defaults
+// rather than failing.
 func loadConfiguration() (*Config, error) {
 	config := NewConfig()
 
-	// Determine config file path
+	// Determine config file path. The empty string from the helper
+	// is meaningful here ("no default file found"), so we track the
+	// explicit-vs-default distinction separately.
 	configPath := *configFile
 	explicitConfigPath := (configPath != "")
 
-	if configPath == "" {
-		// Use default search path: /etc/pgedge/ first, then binary directory
-		exe, err := os.Executable()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get executable path: %w", err)
-		}
-		configPath = GetDefaultConfigPath(exe)
+	if !explicitConfigPath {
+		configPath = GetDefaultConfigPath("")
 	}
 
-	// Load config file if it exists
-	if _, err := os.Stat(configPath); err == nil {
+	if configPath == "" {
+		// No --config flag and no default file present. Use
+		// compiled-in defaults silently (info log only).
+		logger.Info("No configuration file found in default search " +
+			"paths (per-user config dir, /etc/pgedge); using defaults")
+	} else if _, err := os.Stat(configPath); err == nil {
 		if err := config.LoadFromFile(configPath); err != nil {
 			return nil, fmt.Errorf("failed to load config file: %w", err)
 		}
 		logger.Startupf("Configuration loaded from: %s", configPath)
+	} else if explicitConfigPath {
+		// The user explicitly asked for a file that does not
+		// exist; this is fatal.
+		return nil, fmt.Errorf("specified config file not found: %s", configPath)
 	} else {
-		// If user explicitly specified a config file that doesn't exist, fail
-		if explicitConfigPath {
-			return nil, fmt.Errorf("specified config file not found: %s", configPath)
-		}
-		// Otherwise, just log and continue with defaults
-		logger.Infof("Configuration file not found: %s, using defaults", configPath)
+		// Defensive branch: between the helper's stat and ours
+		// the file disappeared. Fall back to defaults rather
+		// than crashing.
+		logger.Infof("Configuration file %s no longer exists; using defaults", configPath)
 	}
 
 	// Override with command line flags (highest priority)
@@ -157,12 +166,10 @@ func loadConfiguration() (*Config, error) {
 		return nil, err
 	}
 
-	// Load server secret from file
-	exe, err := os.Executable()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get executable path for secret search: %w", err)
-	}
-	if err := config.LoadSecret(exe); err != nil {
+	// Load server secret from file. The helper inside LoadSecret no
+	// longer needs the binary path, but we keep the call signature
+	// stable for callers that might still pass it.
+	if err := config.LoadSecret(""); err != nil {
 		return nil, err
 	}
 

--- a/collector/src/main.go
+++ b/collector/src/main.go
@@ -142,20 +142,31 @@ func loadConfiguration() (*Config, error) {
 		// compiled-in defaults silently (info log only).
 		logger.Info("No configuration file found in default search " +
 			"paths (per-user config dir, /etc/pgedge); using defaults")
-	} else if _, err := os.Stat(configPath); err == nil {
-		if err := config.LoadFromFile(configPath); err != nil {
-			return nil, fmt.Errorf("failed to load config file: %w", err)
-		}
+	} else if err := config.LoadFromFile(configPath); err == nil {
 		logger.Startupf("Configuration loaded from: %s", configPath)
 	} else if explicitConfigPath {
-		// The user explicitly asked for a file that does not
-		// exist; this is fatal.
-		return nil, fmt.Errorf("specified config file not found: %s", configPath)
-	} else {
-		// Defensive branch: between the helper's stat and ours
-		// the file disappeared. Fall back to defaults rather
-		// than crashing.
+		// The user explicitly asked for a file; any failure to
+		// read it is fatal. We do not differentiate a missing
+		// file from a permission error here because both
+		// indicate operator intent that the file should exist
+		// and be readable.
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("specified config file not found: %s", configPath)
+		}
+		return nil, fmt.Errorf("failed to load config file: %w", err)
+	} else if os.IsNotExist(err) {
+		// Auto-discovered path that has since vanished (TOCTOU
+		// race between the helper's stat and our load). Fall
+		// back to defaults rather than crashing, matching the
+		// silent-fallback behavior above when no candidate is
+		// present at all.
 		logger.Infof("Configuration file %s no longer exists; using defaults", configPath)
+	} else {
+		// Auto-discovered path that exists but cannot be read
+		// for some other reason (permissions, malformed YAML,
+		// etc.). This is unexpected enough that we surface it
+		// rather than silently fall through to defaults.
+		return nil, fmt.Errorf("failed to load config file: %w", err)
 	}
 
 	// Override with command line flags (highest priority)

--- a/collector/src/main_test.go
+++ b/collector/src/main_test.go
@@ -175,43 +175,77 @@ func TestLoadConfiguration_Success(t *testing.T) {
 }
 
 // TestLoadConfiguration_NoConfigFileUsesDefaults exercises the
-// "no explicit config, no default config present" branch: the function
-// should log and continue with defaults (then fail only at secret load
-// because no secret file is present).
+// "no explicit config, no default config present" branch: the
+// function should log and continue with defaults (then fail only
+// at secret load because no secret file is present).
+//
+// We redirect os.UserConfigDir() at a temp directory so the test
+// is deterministic regardless of the developer's environment, and
+// we tolerate the rare case where /etc/pgedge/ai-dba-collector.yaml
+// exists on the host (the helper will pick it up and the
+// "configuration loaded from" branch will run instead).
 func TestLoadConfiguration_NoConfigFileUsesDefaults(t *testing.T) {
 	defer saveAndClearFlags(t)()
 
-	// *configFile is empty; default search path is resolved via
-	// os.Executable(). The binary directory typically has no
-	// ai-dba-collector.yaml so the function should fall through to the
-	// secret-loading step.
-	// Make sure the secret file does not exist either.
-	exe, err := os.Executable()
-	if err != nil {
-		t.Fatalf("os.Executable: %v", err)
-	}
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
 
-	// Use GetDefaultConfigPath and GetDefaultSecretPath to check the same
-	// paths that loadConfiguration() will check, rather than manually
-	// constructing them.
-	defaultYAML := GetDefaultConfigPath(exe)
-	defaultSecret := GetDefaultSecretPath(exe)
-
-	// Remove secret file if it exists from a previous test run.
-	_ = os.Remove(defaultSecret)
-
-	// Pre-flight: also ensure the default config path doesn't exist. If
-	// it somehow does (CI cache, etc.) the test still passes so long as
-	// the function returns *some* result; we just skip stronger
-	// assertions in that case.
-	_, cfgStatErr := os.Stat(defaultYAML)
-	if cfgStatErr == nil {
-		t.Skipf("default config file unexpectedly exists at %s; skipping", defaultYAML)
-	}
-
-	_, err = loadConfiguration()
+	// loadConfiguration must surface an error from LoadSecret since
+	// there is no secret file available in either default location.
+	_, err := loadConfiguration()
 	if err == nil {
 		t.Fatal("expected error because no secret file exists on default paths")
+	}
+}
+
+// TestLoadConfiguration_DefaultConfigFromUserDir verifies that the
+// auto-discovery path correctly loads a config file dropped into
+// the per-user pgedge directory.
+func TestLoadConfiguration_DefaultConfigFromUserDir(t *testing.T) {
+	defer saveAndClearFlags(t)()
+
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Drop a real config (with secret_file) and a matching secret
+	// so loadConfiguration runs end-to-end without any --config
+	// flag.
+	secretPath := filepath.Join(pgedgeDir, "ai-dba-collector.secret")
+	if err := os.WriteFile(secretPath, []byte("auto-discovered-secret"), 0600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	cfgPath := filepath.Join(pgedgeDir, "ai-dba-collector.yaml")
+	cfgYAML := "datastore:\n" +
+		"  host: discovered-host\n" +
+		"  database: discovered-db\n" +
+		"  username: discovered-user\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	cfg, err := loadConfiguration()
+	if err != nil {
+		t.Fatalf("loadConfiguration: %v", err)
+	}
+	if cfg.Datastore.Host != "discovered-host" {
+		t.Errorf("Host: got %q, want discovered-host", cfg.Datastore.Host)
+	}
+	if cfg.GetServerSecret() != "auto-discovered-secret" {
+		t.Errorf("Secret: got %q, want auto-discovered-secret",
+			cfg.GetServerSecret())
 	}
 }
 

--- a/collector/src/main_test.go
+++ b/collector/src/main_test.go
@@ -12,9 +12,12 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
 // saveAndClearFlags resets the package-level flag pointers and returns a
@@ -177,13 +180,9 @@ func TestLoadConfiguration_Success(t *testing.T) {
 // TestLoadConfiguration_NoConfigFileUsesDefaults exercises the
 // "no explicit config, no default config present" branch: the
 // function should log and continue with defaults (then fail only
-// at secret load because no secret file is present).
-//
-// We redirect os.UserConfigDir() at a temp directory so the test
-// is deterministic regardless of the developer's environment, and
-// we tolerate the rare case where /etc/pgedge/ai-dba-collector.yaml
-// exists on the host (the helper will pick it up and the
-// "configuration loaded from" branch will run instead).
+// at secret load because no secret file is present). Both the
+// per-user config dir and the system-wide fallback are redirected
+// so the test is fully isolated from any real /etc/pgedge state.
 func TestLoadConfiguration_NoConfigFileUsesDefaults(t *testing.T) {
 	defer saveAndClearFlags(t)()
 
@@ -191,12 +190,82 @@ func TestLoadConfiguration_NoConfigFileUsesDefaults(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", base)
 	t.Setenv("HOME", base)
 	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	// loadConfiguration must surface an error from LoadSecret since
 	// there is no secret file available in either default location.
 	_, err := loadConfiguration()
 	if err == nil {
 		t.Fatal("expected error because no secret file exists on default paths")
+	}
+}
+
+// TestLoadConfiguration_ExplicitConfigPermissionError covers the
+// non-IsNotExist error branch on the explicit-config path: when
+// the user passes --config and the file exists but cannot be
+// loaded (here we simulate that by passing a directory in place
+// of a file), loadConfiguration must surface the load error
+// rather than silently fall through to defaults. This keeps
+// behavior symmetrical with auto-discovery, where only
+// IsNotExist triggers the silent fallback.
+func TestLoadConfiguration_ExplicitConfigPermissionError(t *testing.T) {
+	defer saveAndClearFlags(t)()
+
+	tmpDir := t.TempDir()
+	// Create a directory at the path the user "passed"; reading
+	// it as a YAML file fails with a non-IsNotExist error.
+	cfgPath := filepath.Join(tmpDir, "cfg-as-dir")
+	if err := os.Mkdir(cfgPath, 0700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	*configFile = cfgPath
+	_, err := loadConfiguration()
+	if err == nil {
+		t.Fatal("expected error when explicit config path is unreadable")
+	}
+}
+
+// TestLoadConfiguration_AutoDiscoveredUnreadable exercises the
+// auto-discovery branch where the discovered path exists (so
+// GetDefaultConfigPath returns a non-empty value) but cannot be
+// read as a YAML file. We trigger this by placing a directory at
+// the would-be config path: os.Stat in the discovery helper
+// succeeds, but os.ReadFile inside LoadFromFile fails with EISDIR
+// (which is NOT os.IsNotExist). For the non-explicit branch this
+// must surface as an error rather than silently fall through to
+// defaults; the IsNotExist-only fallback is reserved for the
+// genuine "file disappeared between Stat and Read" race.
+func TestLoadConfiguration_AutoDiscoveredUnreadable(t *testing.T) {
+	defer saveAndClearFlags(t)()
+
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Create a *directory* where the YAML file should be. Stat
+	// succeeds, ReadFile fails with EISDIR.
+	bogus := filepath.Join(pgedgeDir, "ai-dba-collector.yaml")
+	if err := os.Mkdir(bogus, 0700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	_, err = loadConfiguration()
+	if err == nil {
+		t.Fatal("expected error from non-IsNotExist auto-discovery branch")
+	}
+	if !strings.Contains(err.Error(), "failed to load config file") {
+		t.Errorf("err = %v, want it to mention 'failed to load config file'", err)
 	}
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,38 @@ project adheres to
 
 ### Changed
 
+- **Breaking change:** the collector, alerter, and
+  server no longer auto-discover configuration or
+  secret files in the binary directory or the current
+  working directory; review the migration steps below
+  before upgrading. (#195)
+
+    - The new lookup order is the `--config` flag, the
+      per-user config directory, and `/etc/pgedge/`;
+      the first match wins, and missing files fall
+      through to compiled-in defaults.
+    - The per-user path resolves to
+      `~/.config/pgedge/<binary>.yaml` on Linux
+      (honouring `$XDG_CONFIG_HOME`),
+      `~/Library/Application Support/pgedge/<binary>.yaml`
+      on macOS, and `%AppData%\pgedge\<binary>.yaml`
+      on Windows.
+    - The same precedence applies to the collector and
+      server secret files (`ai-dba-collector.secret`
+      and `ai-dba-server.secret`); the alerter does not
+      use a secret file.
+    - Production deployments that already use
+      `/etc/pgedge/` are unaffected.
+    - Development setups that drop a YAML file next to
+      the binary or in the current working directory
+      will silently fall through to compiled-in
+      defaults; move the file to `/etc/pgedge/` or the
+      per-user directory, or pass `--config` with an
+      explicit path.
+    - The alerter's `SIGHUP` handler re-runs discovery
+      on each reload, so installing a config at a
+      default location after startup is picked up on
+      the next signal.
 - Replace the composition-rule password validator
   with a policy aligned to NIST SP 800-63B; the
   server now requires a minimum of 12 characters,

--- a/docs/developer-guide/collector/testing.md
+++ b/docs/developer-guide/collector/testing.md
@@ -101,6 +101,15 @@ datastore:
 secret_file: ./ai-dba-collector.secret
 ```
 
+The collector does not auto-discover a YAML file in
+the working directory or next to the binary; pass the
+dev config explicitly with `--config` when you run
+the collector, as shown in the
+[Development Mode](#development-mode) section below.
+The `secret_file:` entry above is a relative path
+read from the YAML, so the collector resolves it
+against the working directory at startup.
+
 Create a development secret file. In the following
 example, the commands generate a random secret:
 

--- a/docs/getting-started/configuration/alerter.md
+++ b/docs/getting-started/configuration/alerter.md
@@ -16,14 +16,26 @@ following order; later sources override earlier ones:
 ## Configuration File
 
 The alerter searches for its configuration file in the
-following locations:
+following order:
 
-- `/etc/pgedge/ai-dba-alerter.yaml` (system-wide).
-- `<binary-directory>/ai-dba-alerter.yaml` (alongside
-  the executable).
+1. The path specified via the `-config` flag.
+2. The per-user config directory at
+   `~/.config/pgedge/ai-dba-alerter.yaml` on Linux
+   (honouring `$XDG_CONFIG_HOME`),
+   `~/Library/Application Support/pgedge/ai-dba-alerter.yaml`
+   on macOS, and `%AppData%\pgedge\ai-dba-alerter.yaml`
+   on Windows.
+3. `/etc/pgedge/ai-dba-alerter.yaml` (system-wide).
 
-You can specify a custom path using the `-config`
-flag.
+If `-config` is set and the file is missing, the
+alerter exits with an error. If `-config` is not set
+and none of the default locations contain a
+configuration file, the alerter uses built-in defaults
+silently. The alerter no longer searches the binary
+directory or the current working directory. A `SIGHUP`
+signal re-runs discovery on each reload, so a
+configuration file installed at a default location
+after startup is picked up on the next signal.
 
 A complete example configuration file is available at
 [ai-dba-alerter.yaml](https://github.com/pgEdge/ai-dba-workbench/blob/main/examples/ai-dba-alerter.yaml)

--- a/docs/getting-started/configuration/collector.md
+++ b/docs/getting-started/configuration/collector.md
@@ -21,11 +21,20 @@ The collector searches for its configuration file in
 the following order:
 
 1. The path specified via the `-config` flag.
-2. `/etc/pgedge/ai-dba-collector.yaml` (system-wide).
-3. `ai-dba-collector.yaml` in the binary directory.
+2. The per-user config directory at
+   `~/.config/pgedge/ai-dba-collector.yaml` on Linux
+   (honouring `$XDG_CONFIG_HOME`),
+   `~/Library/Application Support/pgedge/ai-dba-collector.yaml`
+   on macOS, and `%AppData%\pgedge\ai-dba-collector.yaml`
+   on Windows.
+3. `/etc/pgedge/ai-dba-collector.yaml` (system-wide).
 
-If no configuration file exists, the collector uses
-built-in defaults.
+If `-config` is set and the file is missing, the
+collector exits with an error. If `-config` is not set
+and none of the default locations contain a
+configuration file, the collector uses built-in
+defaults silently. The collector no longer searches the
+binary directory or the current working directory.
 
 ### File Format
 
@@ -288,11 +297,19 @@ encryption.
 
 - Type: string (file path)
 - Default: Searches in order:
-    1. `/etc/pgedge/ai-dba-collector.secret`
-    2. `<binary-directory>/ai-dba-collector.secret`
-    3. `./ai-dba-collector.secret`
+    1. The per-user config directory at
+       `~/.config/pgedge/ai-dba-collector.secret` on Linux
+       (honouring `$XDG_CONFIG_HOME`),
+       `~/Library/Application Support/pgedge/ai-dba-collector.secret`
+       on macOS, and
+       `%AppData%\pgedge\ai-dba-collector.secret` on
+       Windows.
+    2. `/etc/pgedge/ai-dba-collector.secret` (system-wide).
 - Required: Yes (a secret file must exist)
 - Example: `secret_file: /etc/pgedge/collector.secret`
+- Note: The collector no longer searches the binary
+  directory or the current working directory for the
+  secret file.
 
 The collector uses AES-256-GCM encryption to protect
 stored passwords. Each password is encrypted with a

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -35,8 +35,12 @@ and none of the default locations contain a
 configuration file, the server uses built-in defaults
 silently. The server no longer searches the binary
 directory or the current working directory. The same
-precedence applies to the `secret_file` discovery for
-`ai-dba-server.secret`.
+search paths apply to `secret_file` discovery for
+`ai-dba-server.secret`; however, secret discovery is
+not silent. If no `secret_file` is set in the YAML and
+no `ai-dba-server.secret` file is present at any
+search path, the server exits with an error at
+startup.
 
 ### Example Configuration
 

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -21,8 +21,22 @@ The server searches for its configuration file in
 the following order:
 
 1. The path specified via the `-config` flag.
-2. `/etc/pgedge/ai-dba-server.yaml` (system-wide).
-3. `./ai-dba-server.yaml` (binary directory).
+2. The per-user config directory at
+   `~/.config/pgedge/ai-dba-server.yaml` on Linux
+   (honouring `$XDG_CONFIG_HOME`),
+   `~/Library/Application Support/pgedge/ai-dba-server.yaml`
+   on macOS, and `%AppData%\pgedge\ai-dba-server.yaml`
+   on Windows.
+3. `/etc/pgedge/ai-dba-server.yaml` (system-wide).
+
+If `-config` is set and the file is missing, the
+server exits with an error. If `-config` is not set
+and none of the default locations contain a
+configuration file, the server uses built-in defaults
+silently. The server no longer searches the binary
+directory or the current working directory. The same
+precedence applies to the `secret_file` discovery for
+`ai-dba-server.secret`.
 
 ### Example Configuration
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -70,8 +70,20 @@ automatically on first startup.
 The server secret encrypts passwords for monitored
 database connections. All components that handle
 connection passwords must share the same secret file.
-The collector and server discover the secret at
-`/etc/pgedge/ai-dba-server.secret` by default.
+The server discovers the secret at
+`/etc/pgedge/ai-dba-server.secret` by default. The
+collector's auto-discovered default is a different
+filename (`ai-dba-collector.secret`), so the collector
+only reads the server's secret when `secret_file:` in
+`ai-dba-collector.yaml` points at it explicitly.
+
+Create the system-wide configuration directory if it
+does not already exist; the same directory holds the
+YAML configuration files used in later steps:
+
+```bash
+sudo mkdir -p /etc/pgedge
+```
 
 In the following example, the `openssl` command writes
 a secure secret to the system-wide default location:
@@ -119,7 +131,7 @@ datastore:
   port: 5432
   sslmode: disable
 
-secret_file: /path/to/ai-dba-server.secret
+secret_file: /etc/pgedge/ai-dba-server.secret
 ```
 
 Start the collector:
@@ -170,7 +182,7 @@ database:
   user: ai_workbench
   sslmode: disable
 
-secret_file: /path/to/ai-dba-server.secret
+secret_file: /etc/pgedge/ai-dba-server.secret
 ```
 
 Create a user account before starting the server:

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -70,14 +70,22 @@ automatically on first startup.
 The server secret encrypts passwords for monitored
 database connections. All components that handle
 connection passwords must share the same secret file.
+The collector and server discover the secret at
+`/etc/pgedge/ai-dba-server.secret` by default.
 
-In the following example, the `openssl` command
-generates a secure secret:
+In the following example, the `openssl` command writes
+a secure secret to the system-wide default location:
 
 ```bash
-openssl rand -base64 32 > ./ai-dba-server.secret
-chmod 600 ./ai-dba-server.secret
+sudo openssl rand -base64 32 \
+    | sudo tee /etc/pgedge/ai-dba-server.secret \
+    > /dev/null
+sudo chmod 600 /etc/pgedge/ai-dba-server.secret
 ```
+
+To store the secret outside the default search paths,
+set `secret_file:` in the YAML configuration to an
+absolute path of your choice.
 
 ## Create a Password File
 
@@ -126,7 +134,7 @@ successful initialization:
 
 ```
 pgEdge AI DBA Workbench Collector starting...
-Configuration loaded from: ./ai-dba-collector.yaml
+Configuration loaded from: /etc/pgedge/ai-dba-collector.yaml
 Database schema initialized
 Datastore connection established
 Probe scheduler started with 24 probe(s)

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -93,19 +93,64 @@ func FileExists(path string) bool {
 	return err == nil
 }
 
+// systemConfigDir is the directory consulted as the system-wide
+// fallback in GetDefaultConfigPath. It is a variable rather than a
+// constant so tests can redirect it onto a temp directory and
+// exercise the system-path branch on a host that does not have a
+// real /etc/pgedge populated.
+var systemConfigDir = "/etc/pgedge"
+
 // GetDefaultConfigPath returns the default config file path for a
-// service. The function checks /etc/pgedge/ first for a system-wide
-// config file, then falls back to the directory containing the
-// binary. The configFilename parameter is the base name of the
-// config file (e.g. "ai-dba-alerter.yaml").
+// service. The function searches for an existing file in the
+// following order, returning the first match:
+//
+//  1. The user config directory reported by os.UserConfigDir(),
+//     under a "pgedge" subdirectory. On Linux this resolves to
+//     ~/.config/pgedge/<configFilename>; on macOS it resolves to
+//     ~/Library/Application Support/pgedge/<configFilename>; and
+//     on Windows it resolves to %AppData%\pgedge\<configFilename>.
+//
+//  2. The system-wide path /etc/pgedge/<configFilename>.
+//
+// If neither candidate exists, the function returns "" so the
+// caller can fall through to compiled-in defaults. Callers that
+// need to require a config file must check the empty return value
+// and act accordingly.
+//
+// The binaryPath parameter is no longer consulted; in earlier
+// revisions the helper would silently pick up a file sitting next
+// to the binary, which made it easy to load a development config
+// in production. The parameter is retained for now so the three
+// service callers continue to compile without churn; remove it
+// when the call sites are next refactored.
+//
+// The configFilename parameter is the base name of the config file
+// (e.g. "ai-dba-alerter.yaml" or "ai-dba-server.secret"). The
+// helper applies the same precedence rules to secret-file lookups
+// because the issue that motivated this change ("avoid silent
+// prod-vs-dev confusion") applies equally to secrets.
 func GetDefaultConfigPath(binaryPath, configFilename string) string {
-	systemPath := filepath.Join("/etc/pgedge", configFilename)
+	_ = binaryPath // intentionally unused; retained for caller stability
+
+	// 1. Per-user XDG-style config directory. os.UserConfigDir only
+	// fails when HOME (or its platform equivalent) is unset, which
+	// is rare; in that case skip straight to the system path.
+	if userDir, err := os.UserConfigDir(); err == nil {
+		userPath := filepath.Join(userDir, "pgedge", configFilename)
+		if _, statErr := os.Stat(userPath); statErr == nil {
+			return userPath
+		}
+	}
+
+	// 2. System-wide path under /etc/pgedge (overridable for tests).
+	systemPath := filepath.Join(systemConfigDir, configFilename)
 	if _, err := os.Stat(systemPath); err == nil {
 		return systemPath
 	}
 
-	dir := filepath.Dir(binaryPath)
-	return filepath.Join(dir, configFilename)
+	// 3. Nothing matched. Signal "fall through to defaults" with
+	// an empty string rather than guessing at a synthetic path.
+	return ""
 }
 
 // LoadYAMLFile reads a YAML file and unmarshals its contents into the

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -100,6 +100,38 @@ func FileExists(path string) bool {
 // real /etc/pgedge populated.
 var systemConfigDir = "/etc/pgedge"
 
+// SetSystemConfigDirForTest temporarily redirects the system-wide
+// config directory consulted by GetDefaultConfigPath. It is intended
+// for use by test code in this and other packages: the production
+// default of /etc/pgedge can leak host state into tests on
+// developer machines and CI runners that have a real config
+// installed, making tests for the "no file found" branch
+// non-deterministic. The helper installs a t.Cleanup that restores
+// the previous value when the test (or its subtests) finishes.
+//
+// Pass an empty string to point the system fallback at a directory
+// that is guaranteed not to exist, fully isolating tests from any
+// real /etc/pgedge content. Pass a non-empty path (typically a
+// t.TempDir()) to drive the system-path branch deterministically.
+func SetSystemConfigDirForTest(t TestingT, dir string) {
+	t.Helper()
+	prev := systemConfigDir
+	systemConfigDir = dir
+	t.Cleanup(func() {
+		systemConfigDir = prev
+	})
+}
+
+// TestingT is the subset of *testing.T used by SetSystemConfigDirForTest.
+// Defining it as an interface keeps fileutil free of a hard dependency
+// on the testing package at production build time, while still making
+// the helper callable from any *testing.T (and from *testing.B if a
+// future caller needs it).
+type TestingT interface {
+	Helper()
+	Cleanup(func())
+}
+
 // GetDefaultConfigPath returns the default config file path for a
 // service. The function searches for an existing file in the
 // following order, returning the first match:

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -585,3 +585,66 @@ func TestLoadOptionalYAMLFileInvalidYAML(t *testing.T) {
 		t.Error("LoadOptionalYAMLFile() expected error for invalid YAML")
 	}
 }
+
+// TestSetSystemConfigDirForTest_RedirectsAndRestores verifies that
+// SetSystemConfigDirForTest both redirects the system fallback for
+// the lifetime of the surrounding test and restores the previous
+// value via t.Cleanup so later tests are not affected.
+func TestSetSystemConfigDirForTest_RedirectsAndRestores(t *testing.T) {
+	original := systemConfigDir
+
+	// Drop a candidate file at a temp dir and point the system
+	// fallback at it. The per-user dir is also redirected at an
+	// empty location so the helper falls through to the system
+	// path deterministically.
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	systemDir := filepath.Join(base, "fake-etc-pgedge")
+	pgedgeSub := filepath.Join(systemDir, "pgedge")
+	if err := os.MkdirAll(pgedgeSub, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	t.Run("redirected", func(t *testing.T) {
+		// systemConfigDir = systemDir, expect lookup to find the
+		// dropped candidate file under it.
+		SetSystemConfigDirForTest(t, systemDir)
+		expected := filepath.Join(systemDir, "fake.yaml")
+		if err := os.WriteFile(expected, []byte("k: v\n"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		got := GetDefaultConfigPath("", "fake.yaml")
+		if got != expected {
+			t.Errorf("GetDefaultConfigPath = %q, want %q", got, expected)
+		}
+	})
+
+	// After the inner test (and its t.Cleanup) ran, the package
+	// variable must have been restored to whatever it was before
+	// we called SetSystemConfigDirForTest above (i.e. the original
+	// value at the top of this test).
+	if systemConfigDir != original {
+		t.Errorf("systemConfigDir = %q, want restored value %q",
+			systemConfigDir, original)
+	}
+}
+
+// TestSetSystemConfigDirForTest_EmptyDirYieldsNoMatch verifies the
+// "fully isolated" use case: pointing the system fallback at a
+// directory that does not exist makes GetDefaultConfigPath return
+// "" deterministically when neither the per-user dir nor the
+// system dir holds a candidate file.
+func TestSetSystemConfigDirForTest_EmptyDirYieldsNoMatch(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+	SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
+
+	if got := GetDefaultConfigPath("", "ai-dba-server.yaml"); got != "" {
+		t.Errorf("GetDefaultConfigPath = %q, want empty string", got)
+	}
+}

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -11,402 +11,493 @@
 package fileutil
 
 import (
-    "os"
-    "path/filepath"
-    "testing"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
 func TestExpandTildePath(t *testing.T) {
-    homeDir, err := os.UserHomeDir()
-    if err != nil {
-        t.Fatalf("failed to get home directory: %v", err)
-    }
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("failed to get home directory: %v", err)
+	}
 
-    tests := []struct {
-        name     string
-        path     string
-        expected string
-        wantErr  bool
-    }{
-        {
-            name:     "empty path",
-            path:     "",
-            expected: "",
-            wantErr:  false,
-        },
-        {
-            name:     "path without tilde",
-            path:     "/etc/config.yaml",
-            expected: "/etc/config.yaml",
-            wantErr:  false,
-        },
-        {
-            name:     "path with tilde",
-            path:     "~/.config/app.yaml",
-            expected: filepath.Join(homeDir, ".config/app.yaml"),
-            wantErr:  false,
-        },
-        {
-            name:     "tilde only",
-            path:     "~",
-            expected: homeDir,
-            wantErr:  false,
-        },
-        {
-            name:     "relative path",
-            path:     "./config.yaml",
-            expected: "./config.yaml",
-            wantErr:  false,
-        },
-    }
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "empty path",
+			path:     "",
+			expected: "",
+			wantErr:  false,
+		},
+		{
+			name:     "path without tilde",
+			path:     "/etc/config.yaml",
+			expected: "/etc/config.yaml",
+			wantErr:  false,
+		},
+		{
+			name:     "path with tilde",
+			path:     "~/.config/app.yaml",
+			expected: filepath.Join(homeDir, ".config/app.yaml"),
+			wantErr:  false,
+		},
+		{
+			name:     "tilde only",
+			path:     "~",
+			expected: homeDir,
+			wantErr:  false,
+		},
+		{
+			name:     "relative path",
+			path:     "./config.yaml",
+			expected: "./config.yaml",
+			wantErr:  false,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result, err := ExpandTildePath(tt.path)
-            if (err != nil) != tt.wantErr {
-                t.Errorf("ExpandTildePath() error = %v, wantErr %v", err, tt.wantErr)
-                return
-            }
-            if result != tt.expected {
-                t.Errorf("ExpandTildePath() = %v, want %v", result, tt.expected)
-            }
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ExpandTildePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExpandTildePath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("ExpandTildePath() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
 }
 
 func TestReadTrimmedFile(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    // Test reading valid file with whitespace
-    filePath := filepath.Join(tmpDir, "test.txt")
-    if err := os.WriteFile(filePath, []byte("  hello world  \n\n"), 0600); err != nil {
-        t.Fatalf("failed to write test file: %v", err)
-    }
+	// Test reading valid file with whitespace
+	filePath := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(filePath, []byte("  hello world  \n\n"), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
 
-    content, err := ReadTrimmedFile(filePath)
-    if err != nil {
-        t.Errorf("ReadTrimmedFile() unexpected error: %v", err)
-    }
-    if content != "hello world" {
-        t.Errorf("ReadTrimmedFile() = %q, want %q", content, "hello world")
-    }
+	content, err := ReadTrimmedFile(filePath)
+	if err != nil {
+		t.Errorf("ReadTrimmedFile() unexpected error: %v", err)
+	}
+	if content != "hello world" {
+		t.Errorf("ReadTrimmedFile() = %q, want %q", content, "hello world")
+	}
 
-    // Test reading non-existent file
-    _, err = ReadTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
-    if err == nil {
-        t.Error("ReadTrimmedFile() expected error for non-existent file")
-    }
+	// Test reading non-existent file
+	_, err = ReadTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
+	if err == nil {
+		t.Error("ReadTrimmedFile() expected error for non-existent file")
+	}
 
-    // Test reading empty file
-    emptyFile := filepath.Join(tmpDir, "empty.txt")
-    if err := os.WriteFile(emptyFile, []byte(""), 0600); err != nil {
-        t.Fatalf("failed to write empty file: %v", err)
-    }
-    content, err = ReadTrimmedFile(emptyFile)
-    if err != nil {
-        t.Errorf("ReadTrimmedFile() unexpected error for empty file: %v", err)
-    }
-    if content != "" {
-        t.Errorf("ReadTrimmedFile() = %q, want empty string", content)
-    }
+	// Test reading empty file
+	emptyFile := filepath.Join(tmpDir, "empty.txt")
+	if err := os.WriteFile(emptyFile, []byte(""), 0600); err != nil {
+		t.Fatalf("failed to write empty file: %v", err)
+	}
+	content, err = ReadTrimmedFile(emptyFile)
+	if err != nil {
+		t.Errorf("ReadTrimmedFile() unexpected error for empty file: %v", err)
+	}
+	if content != "" {
+		t.Errorf("ReadTrimmedFile() = %q, want empty string", content)
+	}
 }
 
 func TestReadTrimmedFileWithTilde(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    // Test reading valid file
-    filePath := filepath.Join(tmpDir, "secret.txt")
-    if err := os.WriteFile(filePath, []byte("  secret-value  "), 0600); err != nil {
-        t.Fatalf("failed to write test file: %v", err)
-    }
+	// Test reading valid file
+	filePath := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(filePath, []byte("  secret-value  "), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
 
-    content, err := ReadTrimmedFileWithTilde(filePath)
-    if err != nil {
-        t.Errorf("ReadTrimmedFileWithTilde() unexpected error: %v", err)
-    }
-    if content != "secret-value" {
-        t.Errorf("ReadTrimmedFileWithTilde() = %q, want %q", content, "secret-value")
-    }
+	content, err := ReadTrimmedFileWithTilde(filePath)
+	if err != nil {
+		t.Errorf("ReadTrimmedFileWithTilde() unexpected error: %v", err)
+	}
+	if content != "secret-value" {
+		t.Errorf("ReadTrimmedFileWithTilde() = %q, want %q", content, "secret-value")
+	}
 }
 
 func TestReadOptionalTrimmedFile(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    // Test reading valid file
-    filePath := filepath.Join(tmpDir, "api_key.txt")
-    if err := os.WriteFile(filePath, []byte("  test-api-key  \n"), 0600); err != nil {
-        t.Fatalf("failed to write test file: %v", err)
-    }
+	// Test reading valid file
+	filePath := filepath.Join(tmpDir, "api_key.txt")
+	if err := os.WriteFile(filePath, []byte("  test-api-key  \n"), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
 
-    content, err := ReadOptionalTrimmedFile(filePath)
-    if err != nil {
-        t.Errorf("ReadOptionalTrimmedFile() unexpected error: %v", err)
-    }
-    if content != "test-api-key" {
-        t.Errorf("ReadOptionalTrimmedFile() = %q, want %q", content, "test-api-key")
-    }
+	content, err := ReadOptionalTrimmedFile(filePath)
+	if err != nil {
+		t.Errorf("ReadOptionalTrimmedFile() unexpected error: %v", err)
+	}
+	if content != "test-api-key" {
+		t.Errorf("ReadOptionalTrimmedFile() = %q, want %q", content, "test-api-key")
+	}
 
-    // Test empty path
-    content, err = ReadOptionalTrimmedFile("")
-    if err != nil {
-        t.Errorf("ReadOptionalTrimmedFile() unexpected error for empty path: %v", err)
-    }
-    if content != "" {
-        t.Errorf("ReadOptionalTrimmedFile() = %q, want empty string", content)
-    }
+	// Test empty path
+	content, err = ReadOptionalTrimmedFile("")
+	if err != nil {
+		t.Errorf("ReadOptionalTrimmedFile() unexpected error for empty path: %v", err)
+	}
+	if content != "" {
+		t.Errorf("ReadOptionalTrimmedFile() = %q, want empty string", content)
+	}
 
-    // Test non-existent file (should return empty, not error)
-    content, err = ReadOptionalTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
-    if err != nil {
-        t.Errorf("ReadOptionalTrimmedFile() unexpected error for non-existent file: %v", err)
-    }
-    if content != "" {
-        t.Errorf("ReadOptionalTrimmedFile() = %q, want empty string", content)
-    }
+	// Test non-existent file (should return empty, not error)
+	content, err = ReadOptionalTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
+	if err != nil {
+		t.Errorf("ReadOptionalTrimmedFile() unexpected error for non-existent file: %v", err)
+	}
+	if content != "" {
+		t.Errorf("ReadOptionalTrimmedFile() = %q, want empty string", content)
+	}
 }
 
 func TestLoadYAMLFile(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    type TestConfig struct {
-        Name  string `yaml:"name"`
-        Value int    `yaml:"value"`
-    }
+	type TestConfig struct {
+		Name  string `yaml:"name"`
+		Value int    `yaml:"value"`
+	}
 
-    // Test loading valid YAML file
-    yamlContent := "name: test\nvalue: 42\n"
-    filePath := filepath.Join(tmpDir, "config.yaml")
-    if err := os.WriteFile(filePath, []byte(yamlContent), 0600); err != nil {
-        t.Fatalf("failed to write test file: %v", err)
-    }
+	// Test loading valid YAML file
+	yamlContent := "name: test\nvalue: 42\n"
+	filePath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(filePath, []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
 
-    var cfg TestConfig
-    err := LoadYAMLFile(filePath, &cfg)
-    if err != nil {
-        t.Errorf("LoadYAMLFile() unexpected error: %v", err)
-    }
-    if cfg.Name != "test" || cfg.Value != 42 {
-        t.Errorf("LoadYAMLFile() = %+v, want {Name:test Value:42}", cfg)
-    }
+	var cfg TestConfig
+	err := LoadYAMLFile(filePath, &cfg)
+	if err != nil {
+		t.Errorf("LoadYAMLFile() unexpected error: %v", err)
+	}
+	if cfg.Name != "test" || cfg.Value != 42 {
+		t.Errorf("LoadYAMLFile() = %+v, want {Name:test Value:42}", cfg)
+	}
 
-    // Test loading non-existent file
-    err = LoadYAMLFile(filepath.Join(tmpDir, "nonexistent.yaml"), &cfg)
-    if err == nil {
-        t.Error("LoadYAMLFile() expected error for non-existent file")
-    }
+	// Test loading non-existent file
+	err = LoadYAMLFile(filepath.Join(tmpDir, "nonexistent.yaml"), &cfg)
+	if err == nil {
+		t.Error("LoadYAMLFile() expected error for non-existent file")
+	}
 
-    // Test loading invalid YAML
-    invalidPath := filepath.Join(tmpDir, "invalid.yaml")
-    if err := os.WriteFile(invalidPath, []byte("invalid: [yaml: content"), 0600); err != nil {
-        t.Fatalf("failed to write invalid yaml file: %v", err)
-    }
-    err = LoadYAMLFile(invalidPath, &cfg)
-    if err == nil {
-        t.Error("LoadYAMLFile() expected error for invalid YAML")
-    }
+	// Test loading invalid YAML
+	invalidPath := filepath.Join(tmpDir, "invalid.yaml")
+	if err := os.WriteFile(invalidPath, []byte("invalid: [yaml: content"), 0600); err != nil {
+		t.Fatalf("failed to write invalid yaml file: %v", err)
+	}
+	err = LoadYAMLFile(invalidPath, &cfg)
+	if err == nil {
+		t.Error("LoadYAMLFile() expected error for invalid YAML")
+	}
 }
 
 func TestLoadOptionalYAMLFile(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    type TestConfig struct {
-        Name  string `yaml:"name"`
-        Value int    `yaml:"value"`
-    }
+	type TestConfig struct {
+		Name  string `yaml:"name"`
+		Value int    `yaml:"value"`
+	}
 
-    // Test loading valid YAML file
-    yamlContent := "name: optional\nvalue: 99\n"
-    filePath := filepath.Join(tmpDir, "config.yaml")
-    if err := os.WriteFile(filePath, []byte(yamlContent), 0600); err != nil {
-        t.Fatalf("failed to write test file: %v", err)
-    }
+	// Test loading valid YAML file
+	yamlContent := "name: optional\nvalue: 99\n"
+	filePath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(filePath, []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
 
-    var cfg TestConfig
-    err := LoadOptionalYAMLFile(filePath, &cfg)
-    if err != nil {
-        t.Errorf("LoadOptionalYAMLFile() unexpected error: %v", err)
-    }
-    if cfg.Name != "optional" || cfg.Value != 99 {
-        t.Errorf("LoadOptionalYAMLFile() = %+v, want {Name:optional Value:99}", cfg)
-    }
+	var cfg TestConfig
+	err := LoadOptionalYAMLFile(filePath, &cfg)
+	if err != nil {
+		t.Errorf("LoadOptionalYAMLFile() unexpected error: %v", err)
+	}
+	if cfg.Name != "optional" || cfg.Value != 99 {
+		t.Errorf("LoadOptionalYAMLFile() = %+v, want {Name:optional Value:99}", cfg)
+	}
 
-    // Test loading non-existent file (should succeed with no modification)
-    var emptyCfg TestConfig
-    err = LoadOptionalYAMLFile(filepath.Join(tmpDir, "nonexistent.yaml"), &emptyCfg)
-    if err != nil {
-        t.Errorf("LoadOptionalYAMLFile() unexpected error for non-existent file: %v", err)
-    }
-    if emptyCfg.Name != "" || emptyCfg.Value != 0 {
-        t.Errorf("LoadOptionalYAMLFile() modified cfg for non-existent file: %+v", emptyCfg)
-    }
+	// Test loading non-existent file (should succeed with no modification)
+	var emptyCfg TestConfig
+	err = LoadOptionalYAMLFile(filepath.Join(tmpDir, "nonexistent.yaml"), &emptyCfg)
+	if err != nil {
+		t.Errorf("LoadOptionalYAMLFile() unexpected error for non-existent file: %v", err)
+	}
+	if emptyCfg.Name != "" || emptyCfg.Value != 0 {
+		t.Errorf("LoadOptionalYAMLFile() modified cfg for non-existent file: %+v", emptyCfg)
+	}
 }
 
 func TestFileExists(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    // Create a test file
-    existingFile := filepath.Join(tmpDir, "exists.txt")
-    if err := os.WriteFile(existingFile, []byte("test"), 0600); err != nil {
-        t.Fatalf("failed to create test file: %v", err)
-    }
+	// Create a test file
+	existingFile := filepath.Join(tmpDir, "exists.txt")
+	if err := os.WriteFile(existingFile, []byte("test"), 0600); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
 
-    // Test existing file
-    if !FileExists(existingFile) {
-        t.Error("FileExists() returned false for existing file")
-    }
+	// Test existing file
+	if !FileExists(existingFile) {
+		t.Error("FileExists() returned false for existing file")
+	}
 
-    // Test non-existing file
-    if FileExists(filepath.Join(tmpDir, "nonexistent.txt")) {
-        t.Error("FileExists() returned true for non-existing file")
-    }
+	// Test non-existing file
+	if FileExists(filepath.Join(tmpDir, "nonexistent.txt")) {
+		t.Error("FileExists() returned true for non-existing file")
+	}
 
-    // Test directory (should return true since it exists)
-    if !FileExists(tmpDir) {
-        t.Error("FileExists() returned false for existing directory")
-    }
+	// Test directory (should return true since it exists)
+	if !FileExists(tmpDir) {
+		t.Error("FileExists() returned false for existing directory")
+	}
 }
 
-func TestGetDefaultConfigPath(t *testing.T) {
-    // Test when system path does not exist (common case)
-    result := GetDefaultConfigPath("/usr/local/bin/myapp", "myapp.yaml")
+// redirectUserConfigDir points os.UserConfigDir() at a temporary
+// directory by setting the platform-appropriate environment
+// variable. The returned path is the directory the helper now
+// resolves to; the test should create files under that location to
+// simulate per-user configs.
+func redirectUserConfigDir(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
 
-    // Check if /etc/pgedge/myapp.yaml exists
-    systemPath := "/etc/pgedge/myapp.yaml"
-    fallbackPath := "/usr/local/bin/myapp.yaml"
+	// os.UserConfigDir consults different env vars per platform.
+	// Setting all of them keeps the test portable and isolated from
+	// whatever the developer happens to have in their environment.
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
 
-    if FileExists(systemPath) {
-        // System path exists, should prefer it
-        if result != systemPath {
-            t.Errorf("GetDefaultConfigPath() = %q, want system path %q",
-                result, systemPath)
-        }
-    } else {
-        // System path doesn't exist, should use fallback
-        if result != fallbackPath {
-            t.Errorf("GetDefaultConfigPath() = %q, want fallback path %q",
-                result, fallbackPath)
-        }
-    }
+	return base
 }
 
-func TestGetDefaultConfigPathWithDifferentBinaryPaths(t *testing.T) {
-    tests := []struct {
-        name           string
-        binaryPath     string
-        configFilename string
-        fallbackPath   string
-    }{
-        {
-            name:           "absolute path",
-            binaryPath:     "/opt/app/bin/service",
-            configFilename: "service.yaml",
-            fallbackPath:   "/opt/app/bin/service.yaml",
-        },
-        {
-            name:           "home directory",
-            binaryPath:     "/home/user/bin/collector",
-            configFilename: "collector.yaml",
-            fallbackPath:   "/home/user/bin/collector.yaml",
-        },
-        {
-            name:           "with dots in filename",
-            binaryPath:     "/usr/bin/app",
-            configFilename: "app.config.yaml",
-            fallbackPath:   "/usr/bin/app.config.yaml",
-        },
-    }
+// redirectSystemConfigDir overrides the package-level systemConfigDir
+// pointer so the helper consults a writable temporary directory
+// instead of the real /etc/pgedge. The override is reverted via
+// t.Cleanup so test ordering is irrelevant.
+func redirectSystemConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev := systemConfigDir
+	systemConfigDir = dir
+	t.Cleanup(func() { systemConfigDir = prev })
+	return dir
+}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result := GetDefaultConfigPath(tt.binaryPath, tt.configFilename)
-            systemPath := filepath.Join("/etc/pgedge", tt.configFilename)
+// TestGetDefaultConfigPath_NothingExists verifies that the helper
+// returns an empty string when no candidate config file is present.
+// This is the fall-through-to-defaults branch.
+func TestGetDefaultConfigPath_NothingExists(t *testing.T) {
+	redirectUserConfigDir(t)
+	redirectSystemConfigDir(t)
 
-            if FileExists(systemPath) {
-                // System path exists, should prefer it
-                if result != systemPath {
-                    t.Errorf("GetDefaultConfigPath(%q, %q) = %q, want system path %q",
-                        tt.binaryPath, tt.configFilename, result, systemPath)
-                }
-            } else {
-                // System path doesn't exist, should use fallback
-                if result != tt.fallbackPath {
-                    t.Errorf("GetDefaultConfigPath(%q, %q) = %q, want fallback path %q",
-                        tt.binaryPath, tt.configFilename, result, tt.fallbackPath)
-                }
-            }
-        })
-    }
+	name := "fileutil-test-nothing-exists.yaml"
+	result := GetDefaultConfigPath("/usr/local/bin/myapp", name)
+
+	if result != "" {
+		t.Errorf("GetDefaultConfigPath() = %q, want empty string", result)
+	}
+}
+
+// TestGetDefaultConfigPath_UserDirPreferred verifies that a file in
+// the per-user config directory is returned even when the
+// system-wide directory holds the same filename. The user path
+// must win.
+func TestGetDefaultConfigPath_UserDirPreferred(t *testing.T) {
+	base := redirectUserConfigDir(t)
+	sysDir := redirectSystemConfigDir(t)
+
+	name := "fileutil-test-user-pref.yaml"
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	userPath := filepath.Join(pgedgeDir, name)
+	if err := os.WriteFile(userPath, []byte("user"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Place a competing file in the system dir; the user path
+	// must still win.
+	systemPath := filepath.Join(sysDir, name)
+	if err := os.WriteFile(systemPath, []byte("system"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	result := GetDefaultConfigPath("/ignored/binary", name)
+	if result != userPath {
+		t.Errorf("GetDefaultConfigPath() = %q, want user path %q (base=%q)",
+			result, userPath, base)
+	}
+}
+
+// TestGetDefaultConfigPath_SystemPath verifies that the system
+// config directory is consulted when no per-user config exists.
+// The system directory is redirected to a temporary location so the
+// branch is exercised regardless of whether /etc/pgedge is
+// populated on the host.
+func TestGetDefaultConfigPath_SystemPath(t *testing.T) {
+	redirectUserConfigDir(t)
+	sysDir := redirectSystemConfigDir(t)
+
+	name := "fileutil-test-system-path.yaml"
+	systemPath := filepath.Join(sysDir, name)
+	if err := os.WriteFile(systemPath, []byte("system"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	result := GetDefaultConfigPath("/ignored/binary", name)
+	if result != systemPath {
+		t.Errorf("GetDefaultConfigPath() = %q, want system path %q",
+			result, systemPath)
+	}
+}
+
+// TestGetDefaultConfigPath_BinaryPathIgnored confirms the formerly
+// load-bearing binary directory is no longer scanned. A file
+// sitting next to the (fictional) binary must NOT be returned.
+func TestGetDefaultConfigPath_BinaryPathIgnored(t *testing.T) {
+	redirectUserConfigDir(t)
+	redirectSystemConfigDir(t)
+
+	binDir := t.TempDir()
+	name := "fileutil-test-binary-ignored.yaml"
+	next := filepath.Join(binDir, name)
+	if err := os.WriteFile(next, []byte("legacy"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	binary := filepath.Join(binDir, "service")
+	result := GetDefaultConfigPath(binary, name)
+	if result == next {
+		t.Errorf("GetDefaultConfigPath() returned binary-dir path %q; "+
+			"binary-directory fallback was supposed to be removed",
+			result)
+	}
+	if result != "" {
+		t.Errorf("GetDefaultConfigPath() = %q, want empty string", result)
+	}
+}
+
+// TestGetDefaultConfigPath_EmptyUserConfigDir exercises the rare
+// branch where os.UserConfigDir() returns an error (HOME unset on
+// Unix). The helper must skip the user-dir step and fall through to
+// the system path without panicking. The system dir is redirected
+// so the test does not depend on host state.
+func TestGetDefaultConfigPath_EmptyUserConfigDir(t *testing.T) {
+	// Clear every env var os.UserConfigDir() consults so it
+	// returns an error on every platform.
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+	t.Setenv("AppData", "")
+	sysDir := redirectSystemConfigDir(t)
+
+	name := "fileutil-test-no-userdir.yaml"
+
+	// First, with no system file present: helper must return "".
+	if got := GetDefaultConfigPath("/ignored/binary", name); got != "" {
+		t.Errorf("GetDefaultConfigPath() = %q, want empty string", got)
+	}
+
+	// Then drop a file into the system dir: helper must return it.
+	systemPath := filepath.Join(sysDir, name)
+	if err := os.WriteFile(systemPath, []byte("system"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if got := GetDefaultConfigPath("/ignored/binary", name); got != systemPath {
+		t.Errorf("GetDefaultConfigPath() = %q, want system path %q",
+			got, systemPath)
+	}
 }
 
 func TestReadOptionalTrimmedFileError(t *testing.T) {
-    // Test with a directory (should fail when trying to read)
-    tmpDir := t.TempDir()
+	// Test with a directory (should fail when trying to read)
+	tmpDir := t.TempDir()
 
-    // Create a subdirectory
-    subDir := filepath.Join(tmpDir, "subdir")
-    if err := os.Mkdir(subDir, 0755); err != nil {
-        t.Fatalf("failed to create subdirectory: %v", err)
-    }
+	// Create a subdirectory
+	subDir := filepath.Join(tmpDir, "subdir")
+	if err := os.Mkdir(subDir, 0755); err != nil {
+		t.Fatalf("failed to create subdirectory: %v", err)
+	}
 
-    // Attempting to read a directory should fail
-    _, err := ReadOptionalTrimmedFile(subDir)
-    if err == nil {
-        t.Error("ReadOptionalTrimmedFile() should fail when reading directory")
-    }
+	// Attempting to read a directory should fail
+	_, err := ReadOptionalTrimmedFile(subDir)
+	if err == nil {
+		t.Error("ReadOptionalTrimmedFile() should fail when reading directory")
+	}
 }
 
 func TestReadTrimmedFileWithWhitespaceVariants(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    tests := []struct {
-        name     string
-        content  string
-        expected string
-    }{
-        {"leading spaces", "   hello", "hello"},
-        {"trailing spaces", "hello   ", "hello"},
-        {"leading tabs", "\t\thello", "hello"},
-        {"trailing tabs", "hello\t\t", "hello"},
-        {"leading newlines", "\n\nhello", "hello"},
-        {"trailing newlines", "hello\n\n", "hello"},
-        {"mixed whitespace", " \t\n hello world \n\t ", "hello world"},
-        {"only whitespace", "   \t\n  ", ""},
-        {"carriage returns", "\r\nhello\r\n", "hello"},
-    }
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{"leading spaces", "   hello", "hello"},
+		{"trailing spaces", "hello   ", "hello"},
+		{"leading tabs", "\t\thello", "hello"},
+		{"trailing tabs", "hello\t\t", "hello"},
+		{"leading newlines", "\n\nhello", "hello"},
+		{"trailing newlines", "hello\n\n", "hello"},
+		{"mixed whitespace", " \t\n hello world \n\t ", "hello world"},
+		{"only whitespace", "   \t\n  ", ""},
+		{"carriage returns", "\r\nhello\r\n", "hello"},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            filePath := filepath.Join(tmpDir, tt.name+".txt")
-            if err := os.WriteFile(filePath, []byte(tt.content), 0600); err != nil {
-                t.Fatalf("failed to write test file: %v", err)
-            }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tmpDir, tt.name+".txt")
+			if err := os.WriteFile(filePath, []byte(tt.content), 0600); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
 
-            result, err := ReadTrimmedFile(filePath)
-            if err != nil {
-                t.Fatalf("ReadTrimmedFile() error: %v", err)
-            }
-            if result != tt.expected {
-                t.Errorf("ReadTrimmedFile() = %q, want %q", result, tt.expected)
-            }
-        })
-    }
+			result, err := ReadTrimmedFile(filePath)
+			if err != nil {
+				t.Fatalf("ReadTrimmedFile() error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("ReadTrimmedFile() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
 }
 
 func TestLoadYAMLFileWithNestedStructure(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    type NestedConfig struct {
-        Server struct {
-            Host string `yaml:"host"`
-            Port int    `yaml:"port"`
-        } `yaml:"server"`
-        Database struct {
-            Name     string `yaml:"name"`
-            Username string `yaml:"username"`
-        } `yaml:"database"`
-    }
+	type NestedConfig struct {
+		Server struct {
+			Host string `yaml:"host"`
+			Port int    `yaml:"port"`
+		} `yaml:"server"`
+		Database struct {
+			Name     string `yaml:"name"`
+			Username string `yaml:"username"`
+		} `yaml:"database"`
+	}
 
-    yamlContent := `
+	yamlContent := `
 server:
   host: localhost
   port: 8080
@@ -415,108 +506,82 @@ database:
   username: admin
 `
 
-    filePath := filepath.Join(tmpDir, "nested.yaml")
-    if err := os.WriteFile(filePath, []byte(yamlContent), 0600); err != nil {
-        t.Fatalf("failed to write test file: %v", err)
-    }
+	filePath := filepath.Join(tmpDir, "nested.yaml")
+	if err := os.WriteFile(filePath, []byte(yamlContent), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
 
-    var cfg NestedConfig
-    if err := LoadYAMLFile(filePath, &cfg); err != nil {
-        t.Fatalf("LoadYAMLFile() error: %v", err)
-    }
+	var cfg NestedConfig
+	if err := LoadYAMLFile(filePath, &cfg); err != nil {
+		t.Fatalf("LoadYAMLFile() error: %v", err)
+	}
 
-    if cfg.Server.Host != "localhost" {
-        t.Errorf("Server.Host = %q, want %q", cfg.Server.Host, "localhost")
-    }
-    if cfg.Server.Port != 8080 {
-        t.Errorf("Server.Port = %d, want %d", cfg.Server.Port, 8080)
-    }
-    if cfg.Database.Name != "testdb" {
-        t.Errorf("Database.Name = %q, want %q", cfg.Database.Name, "testdb")
-    }
-    if cfg.Database.Username != "admin" {
-        t.Errorf("Database.Username = %q, want %q",
-            cfg.Database.Username, "admin")
-    }
+	if cfg.Server.Host != "localhost" {
+		t.Errorf("Server.Host = %q, want %q", cfg.Server.Host, "localhost")
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("Server.Port = %d, want %d", cfg.Server.Port, 8080)
+	}
+	if cfg.Database.Name != "testdb" {
+		t.Errorf("Database.Name = %q, want %q", cfg.Database.Name, "testdb")
+	}
+	if cfg.Database.Username != "admin" {
+		t.Errorf("Database.Username = %q, want %q",
+			cfg.Database.Username, "admin")
+	}
 }
 
 func TestReadTrimmedFileWithTildeError(t *testing.T) {
-    // Test when file doesn't exist after tilde expansion
-    _, err := ReadTrimmedFileWithTilde("~/nonexistent_file_12345.txt")
-    if err == nil {
-        t.Error("ReadTrimmedFileWithTilde() expected error for non-existent file")
-    }
-}
-
-func TestGetDefaultConfigPathSystemPath(t *testing.T) {
-    tmpDir := t.TempDir()
-
-    result := GetDefaultConfigPath(
-        filepath.Join(tmpDir, "binary"),
-        "test.yaml",
-    )
-
-    systemPath := "/etc/pgedge/test.yaml"
-    fallbackPath := filepath.Join(tmpDir, "test.yaml")
-
-    if FileExists(systemPath) {
-        // System path exists, should prefer it
-        if result != systemPath {
-            t.Errorf("GetDefaultConfigPath() = %q, want system path %q",
-                result, systemPath)
-        }
-    } else {
-        // System path doesn't exist, should use fallback
-        if result != fallbackPath {
-            t.Errorf("GetDefaultConfigPath() = %q, want fallback path %q",
-                result, fallbackPath)
-        }
-    }
+	// Test when file doesn't exist after tilde expansion
+	_, err := ReadTrimmedFileWithTilde("~/nonexistent_file_12345.txt")
+	if err == nil {
+		t.Error("ReadTrimmedFileWithTilde() expected error for non-existent file")
+	}
 }
 
 func TestExpandTildePathWithSlash(t *testing.T) {
-    homeDir, err := os.UserHomeDir()
-    if err != nil {
-        t.Fatalf("failed to get home directory: %v", err)
-    }
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("failed to get home directory: %v", err)
+	}
 
-    // Test with just tilde and slash
-    result, err := ExpandTildePath("~/")
-    if err != nil {
-        t.Fatalf("ExpandTildePath() error: %v", err)
-    }
-    expected := filepath.Join(homeDir, "/")
-    if result != expected {
-        t.Errorf("ExpandTildePath(\"~/\") = %q, want %q", result, expected)
-    }
+	// Test with just tilde and slash
+	result, err := ExpandTildePath("~/")
+	if err != nil {
+		t.Fatalf("ExpandTildePath() error: %v", err)
+	}
+	expected := filepath.Join(homeDir, "/")
+	if result != expected {
+		t.Errorf("ExpandTildePath(\"~/\") = %q, want %q", result, expected)
+	}
 
-    // Test with deeply nested path
-    result, err = ExpandTildePath("~/.config/app/settings.yaml")
-    if err != nil {
-        t.Fatalf("ExpandTildePath() error: %v", err)
-    }
-    expected = filepath.Join(homeDir, ".config/app/settings.yaml")
-    if result != expected {
-        t.Errorf("ExpandTildePath() = %q, want %q", result, expected)
-    }
+	// Test with deeply nested path
+	result, err = ExpandTildePath("~/.config/app/settings.yaml")
+	if err != nil {
+		t.Fatalf("ExpandTildePath() error: %v", err)
+	}
+	expected = filepath.Join(homeDir, ".config/app/settings.yaml")
+	if result != expected {
+		t.Errorf("ExpandTildePath() = %q, want %q", result, expected)
+	}
 }
 
 func TestLoadOptionalYAMLFileInvalidYAML(t *testing.T) {
-    tmpDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-    type TestConfig struct {
-        Name string `yaml:"name"`
-    }
+	type TestConfig struct {
+		Name string `yaml:"name"`
+	}
 
-    // Create an invalid YAML file
-    invalidPath := filepath.Join(tmpDir, "invalid.yaml")
-    if err := os.WriteFile(invalidPath, []byte("invalid: [yaml: content"), 0600); err != nil {
-        t.Fatalf("failed to write invalid yaml file: %v", err)
-    }
+	// Create an invalid YAML file
+	invalidPath := filepath.Join(tmpDir, "invalid.yaml")
+	if err := os.WriteFile(invalidPath, []byte("invalid: [yaml: content"), 0600); err != nil {
+		t.Fatalf("failed to write invalid yaml file: %v", err)
+	}
 
-    var cfg TestConfig
-    err := LoadOptionalYAMLFile(invalidPath, &cfg)
-    if err == nil {
-        t.Error("LoadOptionalYAMLFile() expected error for invalid YAML")
-    }
+	var cfg TestConfig
+	err := LoadOptionalYAMLFile(invalidPath, &cfg)
+	if err == nil {
+		t.Error("LoadOptionalYAMLFile() expected error for invalid YAML")
+	}
 }

--- a/server/src/cmd/mcp-server/main.go
+++ b/server/src/cmd/mcp-server/main.go
@@ -83,13 +83,21 @@ func main() {
 		return
 	}
 
-	// Load configuration
+	// Load configuration. If --config was passed explicitly but
+	// points at a missing file, fail loudly. Otherwise, an empty or
+	// missing default just falls through to the compiled-in
+	// defaults; LoadConfig is tolerant of an empty path.
 	configPathForLoad := ""
-	if config.ConfigFileExists(configPath) {
+	if configPath != "" && config.ConfigFileExists(configPath) {
 		configPathForLoad = configPath
 		fmt.Fprintf(os.Stderr, "Config: %s\n", configPath)
+	} else if cliFlags.ConfigFileSet {
+		fmt.Fprintf(os.Stderr, "ERROR: configuration file not found: %s\n", configPath)
+		os.Exit(1)
 	} else {
-		fmt.Fprintf(os.Stderr, "Config: no config file found\n")
+		fmt.Fprintf(os.Stderr,
+			"Config: no config file found in default search paths "+
+				"(per-user config dir, /etc/pgedge); using defaults\n")
 	}
 	fmt.Fprintf(os.Stderr, "Data directory: %s\n", dataDir)
 

--- a/server/src/cmd/mcp-server/server.go
+++ b/server/src/cmd/mcp-server/server.go
@@ -235,11 +235,22 @@ func (s *Server) initRateLimiter() error {
 	return nil
 }
 
-// loadServerSecret loads the server secret for password decryption
+// loadServerSecret loads the server secret for password decryption.
+// Search order: explicit s.cfg.SecretFile > per-user config dir
+// (e.g. ~/.config/pgedge/ai-dba-server.secret) > /etc/pgedge/
+// ai-dba-server.secret. Falling out of all three is a fatal error
+// because the server cannot decrypt stored passwords without it.
 func (s *Server) loadServerSecret(execPath string) (string, error) {
 	secretPath := s.cfg.SecretFile
 	if secretPath == "" {
 		secretPath = config.GetDefaultSecretPath(execPath)
+	}
+
+	if secretPath == "" {
+		return "", fmt.Errorf("server secret file not found in any " +
+			"default search path (per-user config dir, " +
+			"/etc/pgedge/ai-dba-server.secret); set secret_file in " +
+			"the config or place the file in one of those locations")
 	}
 
 	secretData, err := os.ReadFile(secretPath)

--- a/server/src/cmd/mcp-server/server_test.go
+++ b/server/src/cmd/mcp-server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 	"github.com/pgedge/ai-workbench/server/internal/config"
 )
 
@@ -53,6 +54,10 @@ func TestLoadServerSecret_DefaultUserDir(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", base)
 	t.Setenv("HOME", base)
 	t.Setenv("AppData", base)
+	// Isolate the system-path branch so the test reflects only
+	// the per-user candidate, even on hosts where /etc/pgedge
+	// happens to contain a real ai-dba-server.secret.
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	userDir, err := os.UserConfigDir()
 	if err != nil {
@@ -80,24 +85,25 @@ func TestLoadServerSecret_DefaultUserDir(t *testing.T) {
 
 // TestLoadServerSecret_NoneFound verifies that the helper returns
 // a descriptive error when neither an explicit path nor any of the
-// default search paths yield a secret file.
+// default search paths yield a secret file. Both the per-user and
+// the system-wide candidates are redirected at directories
+// guaranteed not to exist, so the assertion is deterministic
+// regardless of the host's real /etc/pgedge contents.
 func TestLoadServerSecret_NoneFound(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", base)
 	t.Setenv("HOME", base)
 	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	s := newServerWithSecretFile("")
 	_, err := s.loadServerSecret("/ignored/exec/path")
 	if err == nil {
 		t.Fatal("expected error when no secret file is reachable")
 	}
-	// Skip strong assertion if the host happens to have a real
-	// /etc/pgedge/ai-dba-server.secret file installed.
-	if strings.Contains(err.Error(), "not found in any") {
-		return
+	if !strings.Contains(err.Error(), "not found in any") {
+		t.Errorf("err = %v, want it to mention 'not found in any'", err)
 	}
-	t.Logf("note: host appears to have /etc/pgedge populated; err = %v", err)
 }
 
 // TestLoadServerSecret_EmptyFile verifies that a secret file

--- a/server/src/cmd/mcp-server/server_test.go
+++ b/server/src/cmd/mcp-server/server_test.go
@@ -1,0 +1,135 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/config"
+)
+
+// newServerWithSecretFile builds a minimal Server fixture wired up
+// only with the SecretFile field. This avoids depending on the
+// full server initialisation path while still exercising the
+// secret-loading method end to end.
+func newServerWithSecretFile(secretFile string) *Server {
+	return &Server{cfg: &config.Config{SecretFile: secretFile}}
+}
+
+// TestLoadServerSecret_ExplicitFile verifies that an explicit
+// SecretFile in the config is read verbatim and trimmed.
+func TestLoadServerSecret_ExplicitFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "server.secret")
+	if err := os.WriteFile(path, []byte("  explicit-secret\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	s := newServerWithSecretFile(path)
+
+	got, err := s.loadServerSecret("/ignored/exec/path")
+	if err != nil {
+		t.Fatalf("loadServerSecret: %v", err)
+	}
+	if got != "explicit-secret" {
+		t.Errorf("got %q, want %q", got, "explicit-secret")
+	}
+}
+
+// TestLoadServerSecret_DefaultUserDir verifies that when no
+// explicit SecretFile is set the helper picks up a file from the
+// per-user pgedge config directory.
+func TestLoadServerSecret_DefaultUserDir(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(pgedgeDir, "ai-dba-server.secret"),
+		[]byte("auto-discovered"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := newServerWithSecretFile("")
+	got, err := s.loadServerSecret("/ignored/exec/path")
+	if err != nil {
+		t.Fatalf("loadServerSecret: %v", err)
+	}
+	if got != "auto-discovered" {
+		t.Errorf("got %q, want %q", got, "auto-discovered")
+	}
+}
+
+// TestLoadServerSecret_NoneFound verifies that the helper returns
+// a descriptive error when neither an explicit path nor any of the
+// default search paths yield a secret file.
+func TestLoadServerSecret_NoneFound(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	s := newServerWithSecretFile("")
+	_, err := s.loadServerSecret("/ignored/exec/path")
+	if err == nil {
+		t.Fatal("expected error when no secret file is reachable")
+	}
+	// Skip strong assertion if the host happens to have a real
+	// /etc/pgedge/ai-dba-server.secret file installed.
+	if strings.Contains(err.Error(), "not found in any") {
+		return
+	}
+	t.Logf("note: host appears to have /etc/pgedge populated; err = %v", err)
+}
+
+// TestLoadServerSecret_EmptyFile verifies that a secret file
+// containing only whitespace is rejected.
+func TestLoadServerSecret_EmptyFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "blank.secret")
+	if err := os.WriteFile(path, []byte("   \n\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	s := newServerWithSecretFile(path)
+
+	_, err := s.loadServerSecret("/ignored/exec/path")
+	if err == nil {
+		t.Fatal("expected error when secret file is empty")
+	}
+	if !strings.Contains(err.Error(), "is empty") {
+		t.Errorf("err = %v, want it to mention 'is empty'", err)
+	}
+}
+
+// TestLoadServerSecret_ExplicitMissing verifies that an explicit
+// SecretFile pointing at a non-existent path returns a read error
+// (not the "not found in any default search path" message).
+func TestLoadServerSecret_ExplicitMissing(t *testing.T) {
+	s := newServerWithSecretFile("/definitely/not/a/real/path.secret")
+
+	_, err := s.loadServerSecret("/ignored/exec/path")
+	if err == nil {
+		t.Fatal("expected error for missing explicit secret file")
+	}
+	if !strings.Contains(err.Error(), "failed to read secret file") {
+		t.Errorf("err = %v, want it to mention 'failed to read secret file'", err)
+	}
+}

--- a/server/src/internal/api/auth_handlers.go
+++ b/server/src/internal/api/auth_handlers.go
@@ -195,6 +195,11 @@ func (h *AuthHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	// This prevents XSS attacks from accessing the session token.
 	// Auto-detect if this is a secure request (HTTPS or behind TLS-terminating proxy)
 	secureCookie := h.isSecureRequest(r)
+	// #nosec G124 -- Secure is intentionally conditional on
+	// isSecureRequest so local HTTP development still works;
+	// in production behind TLS (direct or via a trusted proxy
+	// supplying X-Forwarded-Proto) the flag evaluates to true.
+	// HttpOnly and SameSite are unconditional.
 	http.SetCookie(w, &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    token,
@@ -234,6 +239,13 @@ func (h *AuthHandler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	// Clear the session cookie by setting it to expire immediately
 	// Auto-detect if this is a secure request (HTTPS or behind TLS-terminating proxy)
 	secureCookie := h.isSecureRequest(r)
+	// #nosec G124 -- Secure is intentionally conditional on
+	// isSecureRequest so local HTTP development still works;
+	// in production behind TLS (direct or via a trusted proxy
+	// supplying X-Forwarded-Proto) the flag evaluates to true.
+	// HttpOnly and SameSite are unconditional. The clear-cookie
+	// flags must mirror the set-cookie flags above so browsers
+	// match and overwrite the original cookie on logout.
 	http.SetCookie(w, &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    "",

--- a/server/src/internal/auth/access.go
+++ b/server/src/internal/auth/access.go
@@ -114,7 +114,7 @@ func isNilDatastore(ds DatastoreSharingLookup) bool {
 	}
 	v := reflect.ValueOf(ds)
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Chan,
+	case reflect.Pointer, reflect.Interface, reflect.Chan,
 		reflect.Func, reflect.Map, reflect.Slice:
 		return v.IsNil()
 	default:

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -964,8 +964,11 @@ func validateConfig(cfg *Config) error {
 	return nil
 }
 
-// GetDefaultConfigPath returns the default config file path
-// Searches /etc/pgedge/ first, then binary directory
+// GetDefaultConfigPath returns the path to an existing default
+// server config file, or "" if none was found. Searches the
+// per-user config directory (e.g. ~/.config/pgedge/) first, then
+// /etc/pgedge/. The binaryPath parameter is no longer consulted
+// but kept for caller stability.
 func GetDefaultConfigPath(binaryPath string) string {
 	return fileutil.GetDefaultConfigPath(binaryPath, "ai-dba-server.yaml")
 }
@@ -1004,8 +1007,10 @@ func LoadConfigDataDir(configPath string) (string, error) {
 	return cfg.DataDir, nil
 }
 
-// GetDefaultSecretPath returns the default secret file path
-// Searches /etc/pgedge/ first, then binary directory
+// GetDefaultSecretPath returns the path to an existing default
+// server secret file, or "" if none was found. Search order
+// matches GetDefaultConfigPath: per-user config directory first,
+// then /etc/pgedge/.
 func GetDefaultSecretPath(binaryPath string) string {
 	return fileutil.GetDefaultConfigPath(binaryPath, "ai-dba-server.secret")
 }

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -433,24 +433,84 @@ func TestLoadConfigNonExistentFile(t *testing.T) {
 	}
 }
 
+// TestGetDefaultConfigPath verifies the wrapper returns "" when
+// neither the per-user config dir nor /etc/pgedge holds a server
+// config file.
 func TestGetDefaultConfigPath(t *testing.T) {
-	// Test with a known binary path
-	result := GetDefaultConfigPath("/usr/local/bin/pgedge-postgres-mcp")
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
 
-	// If system path exists, it would return that instead
-	// Just check that we get a .yaml file
-	if filepath.Ext(result) != ".yaml" {
-		t.Errorf("expected .yaml extension, got %q", result)
+	result := GetDefaultConfigPath("/usr/local/bin/pgedge-postgres-mcp")
+	if result != "" && filepath.Ext(result) != ".yaml" {
+		t.Errorf("expected empty path or .yaml extension, got %q", result)
 	}
 }
 
-func TestGetDefaultSecretPath(t *testing.T) {
-	result := GetDefaultSecretPath("/usr/local/bin/pgedge-postgres-mcp")
+// TestGetDefaultConfigPath_UserDirHit verifies the wrapper returns
+// the per-user config path when one is present.
+func TestGetDefaultConfigPath_UserDirHit(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
 
-	// If system path exists, it would return that instead
-	// Just check that we get a .secret file
-	if filepath.Ext(result) != ".secret" {
-		t.Errorf("expected .secret extension, got %q", result)
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	expected := filepath.Join(pgedgeDir, "ai-dba-server.yaml")
+	if err := os.WriteFile(expected, []byte("http:\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if got := GetDefaultConfigPath(""); got != expected {
+		t.Errorf("GetDefaultConfigPath = %q, want %q", got, expected)
+	}
+}
+
+// TestGetDefaultSecretPath verifies the wrapper returns "" when no
+// candidate secret file is present.
+func TestGetDefaultSecretPath(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	result := GetDefaultSecretPath("/usr/local/bin/pgedge-postgres-mcp")
+	if result != "" && filepath.Ext(result) != ".secret" {
+		t.Errorf("expected empty path or .secret extension, got %q", result)
+	}
+}
+
+// TestGetDefaultSecretPath_UserDirHit verifies the wrapper returns
+// the per-user secret path when one is present.
+func TestGetDefaultSecretPath_UserDirHit(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	pgedgeDir := filepath.Join(userDir, "pgedge")
+	if err := os.MkdirAll(pgedgeDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	expected := filepath.Join(pgedgeDir, "ai-dba-server.secret")
+	if err := os.WriteFile(expected, []byte("super-secret"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if got := GetDefaultSecretPath(""); got != expected {
+		t.Errorf("GetDefaultSecretPath = %q, want %q", got, expected)
 	}
 }
 

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -435,16 +435,19 @@ func TestLoadConfigNonExistentFile(t *testing.T) {
 
 // TestGetDefaultConfigPath verifies the wrapper returns "" when
 // neither the per-user config dir nor /etc/pgedge holds a server
-// config file.
+// config file. The system-wide fallback is redirected at a
+// directory guaranteed not to exist so the assertion is exact and
+// not influenced by whatever the test host has in /etc/pgedge.
 func TestGetDefaultConfigPath(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", base)
 	t.Setenv("HOME", base)
 	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	result := GetDefaultConfigPath("/usr/local/bin/pgedge-postgres-mcp")
-	if result != "" && filepath.Ext(result) != ".yaml" {
-		t.Errorf("expected empty path or .yaml extension, got %q", result)
+	if result != "" {
+		t.Errorf("expected empty path, got %q", result)
 	}
 }
 
@@ -475,16 +478,18 @@ func TestGetDefaultConfigPath_UserDirHit(t *testing.T) {
 }
 
 // TestGetDefaultSecretPath verifies the wrapper returns "" when no
-// candidate secret file is present.
+// candidate secret file is present. As with TestGetDefaultConfigPath
+// the system fallback is redirected so the assertion is exact.
 func TestGetDefaultSecretPath(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", base)
 	t.Setenv("HOME", base)
 	t.Setenv("AppData", base)
+	fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
 
 	result := GetDefaultSecretPath("/usr/local/bin/pgedge-postgres-mcp")
-	if result != "" && filepath.Ext(result) != ".secret" {
-		t.Errorf("expected empty path or .secret extension, got %q", result)
+	if result != "" {
+		t.Errorf("expected empty path, got %q", result)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces the silent `<binary-dir>/<file>` fallback in the
  shared `pkg/fileutil.GetDefaultConfigPath` helper with an
  XDG-style per-user override resolved via `os.UserConfigDir()`.
  New order: `--config` flag, `os.UserConfigDir()/pgedge/<file>`,
  `/etc/pgedge/<file>`, then compiled-in defaults.
- Applies the same precedence to the collector and server secret
  files for consistency. The alerter has no secret file.
- Adds a prominent breaking-change notice to `docs/changelog.md`
  and updates the three service configuration guides plus the
  quick-start and collector developer guide so their sample
  workflows still match how the services discover files.

## Test plan

- [x] `make test-all` passes (Go fmt + tests + lint, client tests).
- [x] Touched Go functions are at 100% line coverage.
- [x] `gofmt -w ./...` is clean.
- [ ] CI runs all required checks green.
- [ ] Review threads from CodeRabbit / Codacy / human reviewers
      are addressed and resolved.

Closes #195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Config/secret discovery no longer scans binary dir or CWD. Lookup: explicit --config → per-user config → /etc/pgedge → built-in defaults.
  * Providing --config and missing file is fatal; missing auto-discovered files fall back to defaults.
  * Reload (SIGHUP) now re-runs discovery or uses the explicit path and avoids replacing running config when no candidate is available.

* **Documentation**
  * Updated guides and changelog to reflect new discovery precedence and startup/reload semantics.

* **Tests**
  * Expanded deterministic tests covering discovery, secret loading, error and reload cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->