### PR TITLE
Add Spock exception and conflict alerts (#200)

### DIFF
--- a/alerter/src/internal/database/metric_registry.go
+++ b/alerter/src/internal/database/metric_registry.go
@@ -310,11 +310,21 @@ var metricRegistry = map[string]metricQueryConfig{
 	// so the latest-sample count equals the live rolling-window count.
 	// Counting only the latest sample (rather than across multiple samples)
 	// avoids double-counting rows captured by overlapping cycles.
+	//
+	// The latest CTE constrains MAX(collected_at) to samples within the past
+	// 5 minutes. Without the cutoff a stale-but-still-present sample (for
+	// example, the source-side rolling window has drained but the probe
+	// short-circuits Store on the empty result) keeps the alert active long
+	// after the underlying condition resolves. Five minutes spans five
+	// default 60-second probe cycles, which is enough headroom to absorb a
+	// missed cycle without flapping but short enough that the alert clears
+	// promptly when source rows age out of the rolling window.
 	"spock_exception_log.recent_count": {
 		latestSQL: `
 			WITH latest AS (
 				SELECT connection_id, MAX(collected_at) AS collected_at
 				  FROM metrics.spock_exception_log
+				 WHERE collected_at > NOW() - INTERVAL '5 minutes'
 				 GROUP BY connection_id
 			)
 			SELECT s.connection_id,
@@ -345,11 +355,17 @@ var metricRegistry = map[string]metricQueryConfig{
 	// against the metrics.spock_resolutions table. The collector applies the
 	// same rolling 15-minute source-side window to spock.resolutions, so the
 	// latest-sample count equals the live rolling-window count.
+	//
+	// As with spock_exception_log.recent_count the latest CTE constrains
+	// MAX(collected_at) to samples within the past 5 minutes so a stale
+	// non-empty sample cannot keep an otherwise-resolved alert active after
+	// the source-side rolling window has drained.
 	"spock_resolutions.recent_count": {
 		latestSQL: `
 			WITH latest AS (
 				SELECT connection_id, MAX(collected_at) AS collected_at
 				  FROM metrics.spock_resolutions
+				 WHERE collected_at > NOW() - INTERVAL '5 minutes'
 				 GROUP BY connection_id
 			)
 			SELECT s.connection_id,

--- a/alerter/src/internal/database/metric_registry.go
+++ b/alerter/src/internal/database/metric_registry.go
@@ -231,6 +231,151 @@ var metricRegistry = map[string]metricQueryConfig{
 		historicalScan: historicalScanBasic,
 	},
 
+	// pg_replication_slots.inactive_count counts replication slots that
+	// have active=false in the latest metrics.pg_replication_slots sample
+	// for each connection. The COUNT(*) FILTER aggregate yields zero when
+	// every slot is active (the alert clears) and the inactive count when
+	// any slot has dropped its WAL receiver.
+	"pg_replication_slots.inactive_count": {
+		latestSQL: `
+			WITH latest AS (
+				SELECT connection_id, MAX(collected_at) AS collected_at
+				  FROM metrics.pg_replication_slots
+				 GROUP BY connection_id
+			)
+			SELECT s.connection_id,
+			       COUNT(*) FILTER (WHERE NOT s.active)::float AS value,
+			       l.collected_at
+			  FROM metrics.pg_replication_slots s
+			  JOIN latest l
+			    ON s.connection_id = l.connection_id
+			   AND s.collected_at  = l.collected_at
+			 GROUP BY s.connection_id, l.collected_at
+		`,
+		historicalSQL: `
+			SELECT s.connection_id,
+			       NULL::text AS database_name,
+			       COUNT(*) FILTER (WHERE NOT s.active)::float AS value,
+			       s.collected_at
+			  FROM metrics.pg_replication_slots s
+			  JOIN connections c ON c.id = s.connection_id
+			 WHERE s.collected_at > NOW() - INTERVAL '1 day' * $1
+			 GROUP BY s.connection_id, s.collected_at
+			 ORDER BY s.connection_id, s.collected_at
+		`,
+		scan:           scanBasic,
+		historicalScan: historicalScanBasic,
+	},
+
+	// pg_replication_slots.max_retained_bytes returns the maximum
+	// retained_bytes across all replication slots in the latest sample
+	// for each connection. retained_bytes is NUMERIC in the source table
+	// to handle WAL retention values larger than int64; the cast to float
+	// is safe for the threshold ranges the operator-facing alert rules
+	// configure (1 GiB warning, 10 GiB critical).
+	"pg_replication_slots.max_retained_bytes": {
+		latestSQL: `
+			WITH latest AS (
+				SELECT connection_id, MAX(collected_at) AS collected_at
+				  FROM metrics.pg_replication_slots
+				 GROUP BY connection_id
+			)
+			SELECT s.connection_id,
+			       COALESCE(MAX(s.retained_bytes), 0)::float AS value,
+			       l.collected_at
+			  FROM metrics.pg_replication_slots s
+			  JOIN latest l
+			    ON s.connection_id = l.connection_id
+			   AND s.collected_at  = l.collected_at
+			 GROUP BY s.connection_id, l.collected_at
+		`,
+		historicalSQL: `
+			SELECT s.connection_id,
+			       NULL::text AS database_name,
+			       COALESCE(MAX(s.retained_bytes), 0)::float AS value,
+			       s.collected_at
+			  FROM metrics.pg_replication_slots s
+			  JOIN connections c ON c.id = s.connection_id
+			 WHERE s.collected_at > NOW() - INTERVAL '1 day' * $1
+			 GROUP BY s.connection_id, s.collected_at
+			 ORDER BY s.connection_id, s.collected_at
+		`,
+		scan:           scanBasic,
+		historicalScan: historicalScanBasic,
+	},
+
+	// spock_exception_log.recent_count counts rows in the latest
+	// metrics.spock_exception_log sample for each connection. The collector
+	// re-evaluates a rolling 15-minute source-side window every probe cycle,
+	// so the latest-sample count equals the live rolling-window count.
+	// Counting only the latest sample (rather than across multiple samples)
+	// avoids double-counting rows captured by overlapping cycles.
+	"spock_exception_log.recent_count": {
+		latestSQL: `
+			WITH latest AS (
+				SELECT connection_id, MAX(collected_at) AS collected_at
+				  FROM metrics.spock_exception_log
+				 GROUP BY connection_id
+			)
+			SELECT s.connection_id,
+			       COUNT(*)::float AS value,
+			       l.collected_at
+			  FROM metrics.spock_exception_log s
+			  JOIN latest l
+			    ON s.connection_id = l.connection_id
+			   AND s.collected_at  = l.collected_at
+			 GROUP BY s.connection_id, l.collected_at
+		`,
+		historicalSQL: `
+			SELECT s.connection_id,
+			       NULL::text AS database_name,
+			       COUNT(*)::float AS value,
+			       s.collected_at
+			  FROM metrics.spock_exception_log s
+			  JOIN connections c ON c.id = s.connection_id
+			 WHERE s.collected_at > NOW() - INTERVAL '1 day' * $1
+			 GROUP BY s.connection_id, s.collected_at
+			 ORDER BY s.connection_id, s.collected_at
+		`,
+		scan:           scanBasic,
+		historicalScan: historicalScanBasic,
+	},
+
+	// spock_resolutions.recent_count mirrors spock_exception_log.recent_count
+	// against the metrics.spock_resolutions table. The collector applies the
+	// same rolling 15-minute source-side window to spock.resolutions, so the
+	// latest-sample count equals the live rolling-window count.
+	"spock_resolutions.recent_count": {
+		latestSQL: `
+			WITH latest AS (
+				SELECT connection_id, MAX(collected_at) AS collected_at
+				  FROM metrics.spock_resolutions
+				 GROUP BY connection_id
+			)
+			SELECT s.connection_id,
+			       COUNT(*)::float AS value,
+			       l.collected_at
+			  FROM metrics.spock_resolutions s
+			  JOIN latest l
+			    ON s.connection_id = l.connection_id
+			   AND s.collected_at  = l.collected_at
+			 GROUP BY s.connection_id, l.collected_at
+		`,
+		historicalSQL: `
+			SELECT s.connection_id,
+			       NULL::text AS database_name,
+			       COUNT(*)::float AS value,
+			       s.collected_at
+			  FROM metrics.spock_resolutions s
+			  JOIN connections c ON c.id = s.connection_id
+			 WHERE s.collected_at > NOW() - INTERVAL '1 day' * $1
+			 GROUP BY s.connection_id, s.collected_at
+			 ORDER BY s.connection_id, s.collected_at
+		`,
+		scan:           scanBasic,
+		historicalScan: historicalScanBasic,
+	},
+
 	"pg_stat_replication.standby_disconnected": {
 		latestSQL: `
 			WITH recent_standby AS (

--- a/alerter/src/internal/database/metric_registry_integration_test.go
+++ b/alerter/src/internal/database/metric_registry_integration_test.go
@@ -84,7 +84,7 @@ DROP TABLE IF EXISTS connections CASCADE;
 // newMetricRegistryTestDatastore returns a Datastore backed by the
 // integration-test database referenced by TEST_AI_WORKBENCH_SERVER. The test
 // is skipped when the variable is unset (or SKIP_DB_TESTS is set), matching
-// the behaviour of the other integration tests in this package. The returned
+// the behavior of the other integration tests in this package. The returned
 // cleanup function tears down the schema and closes the pool.
 func newMetricRegistryTestDatastore(t *testing.T) (*Datastore, *pgxpool.Pool, func()) {
 	t.Helper()

--- a/alerter/src/internal/database/metric_registry_integration_test.go
+++ b/alerter/src/internal/database/metric_registry_integration_test.go
@@ -45,23 +45,25 @@ CREATE SCHEMA metrics;
 
 CREATE TABLE metrics.spock_exception_log (
     connection_id INTEGER NOT NULL,
+    database_name TEXT NOT NULL,
     collected_at TIMESTAMPTZ NOT NULL,
     remote_origin OID NOT NULL,
     remote_commit_ts TIMESTAMPTZ NOT NULL,
     command_counter INTEGER NOT NULL,
     retry_errored_at TIMESTAMPTZ NOT NULL,
     remote_xid BIGINT NOT NULL,
-    PRIMARY KEY (connection_id, collected_at, remote_origin,
+    PRIMARY KEY (connection_id, database_name, collected_at, remote_origin,
                  remote_commit_ts, command_counter, retry_errored_at)
 );
 
 CREATE TABLE metrics.spock_resolutions (
     connection_id INTEGER NOT NULL,
+    database_name TEXT NOT NULL,
     collected_at TIMESTAMPTZ NOT NULL,
     id INTEGER NOT NULL,
     node_name NAME NOT NULL,
     log_time TIMESTAMPTZ NOT NULL,
-    PRIMARY KEY (connection_id, collected_at, id, node_name)
+    PRIMARY KEY (connection_id, database_name, collected_at, id, node_name)
 );
 
 CREATE TABLE metrics.pg_replication_slots (
@@ -134,10 +136,10 @@ func insertSpockExceptionRow(t *testing.T, pool *pgxpool.Pool, connID int,
 
 	if _, err := pool.Exec(context.Background(), `
 		INSERT INTO metrics.spock_exception_log (
-		    connection_id, collected_at, remote_origin, remote_commit_ts,
-		    command_counter, retry_errored_at, remote_xid
+		    connection_id, database_name, collected_at, remote_origin,
+		    remote_commit_ts, command_counter, retry_errored_at, remote_xid
 		) VALUES (
-		    $1, $2, 12345, $2, $3, $2, 999
+		    $1, 'app', $2, 12345, $2, $3, $2, 999
 		)
 	`, connID, collectedAt, commandCounter); err != nil {
 		t.Fatalf("Failed to insert spock_exception_log row: %v", err)
@@ -152,9 +154,9 @@ func insertSpockResolutionRow(t *testing.T, pool *pgxpool.Pool, connID int,
 
 	if _, err := pool.Exec(context.Background(), `
 		INSERT INTO metrics.spock_resolutions (
-		    connection_id, collected_at, id, node_name, log_time
+		    connection_id, database_name, collected_at, id, node_name, log_time
 		) VALUES (
-		    $1, $2, $3, 'node-a', $2
+		    $1, 'app', $2, $3, 'node-a', $2
 		)
 	`, connID, collectedAt, id); err != nil {
 		t.Fatalf("Failed to insert spock_resolutions row: %v", err)

--- a/alerter/src/internal/database/metric_registry_integration_test.go
+++ b/alerter/src/internal/database/metric_registry_integration_test.go
@@ -12,6 +12,7 @@ package database
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -254,6 +255,85 @@ func TestMetricRegistry_SpockResolutionsRecentCount(t *testing.T) {
 	got := findValueForConnection(t, results, connID)
 	if got != 2 {
 		t.Errorf("spock_resolutions.recent_count = %v; want 2 (latest sample only)", got)
+	}
+}
+
+// TestMetricRegistry_SpockExceptionLogRecentCount_StaleSampleExcluded
+// proves the freshness cutoff on the latest CTE: a sample older than
+// the 5-minute cutoff must not keep the metric reporting a non-zero
+// value after the rolling source-side window has drained.
+//
+// The probe short-circuits Store when Execute returns no rows, so a
+// stale non-empty sample can otherwise persist as the latest-recorded
+// state long after the underlying condition has resolved. The
+// freshness cutoff in the latest CTE is what causes the alert to
+// auto-clear in that situation.
+//
+// Seed a single row at now() - 6 minutes (outside the 5-minute cutoff)
+// and assert the metric returns no row for that connection.
+// GetLatestMetricValues returns "no data found for metric" when the
+// underlying query yields zero rows; that is the expected outcome
+// when every sample lies outside the cutoff.
+func TestMetricRegistry_SpockExceptionLogRecentCount_StaleSampleExcluded(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "spock-exception-stale")
+	stale := time.Now().UTC().Add(-6 * time.Minute)
+	insertSpockExceptionRow(t, pool, connID, stale, 1)
+
+	results, err := ds.GetLatestMetricValues(ctx, "spock_exception_log.recent_count")
+	if err == nil {
+		// If GetLatestMetricValues returns rows the cutoff did not
+		// apply; surface a precise diagnostic before failing.
+		for _, mv := range results {
+			if mv.ConnectionID == connID {
+				t.Errorf("spock_exception_log.recent_count returned a "+
+					"value for connection %d after the only sample "+
+					"aged out of the 5-minute cutoff: got %v",
+					connID, mv.Value)
+			}
+		}
+		return
+	}
+
+	// "no data found" is the expected error path when every sample
+	// for every connection is outside the cutoff. Any other error
+	// indicates a real failure in the registry SQL.
+	if !strings.Contains(err.Error(), "no data found") {
+		t.Fatalf("unexpected error from GetLatestMetricValues: %v", err)
+	}
+}
+
+// TestMetricRegistry_SpockResolutionsRecentCount_StaleSampleExcluded
+// mirrors the exception_log freshness assertion for the resolutions
+// table. The cutoff is what allows the high/critical resolutions
+// alerts to auto-clear once Spock stops auto-resolving conflicts.
+func TestMetricRegistry_SpockResolutionsRecentCount_StaleSampleExcluded(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "spock-resolutions-stale")
+	stale := time.Now().UTC().Add(-6 * time.Minute)
+	insertSpockResolutionRow(t, pool, connID, stale, 1)
+
+	results, err := ds.GetLatestMetricValues(ctx, "spock_resolutions.recent_count")
+	if err == nil {
+		for _, mv := range results {
+			if mv.ConnectionID == connID {
+				t.Errorf("spock_resolutions.recent_count returned a "+
+					"value for connection %d after the only sample "+
+					"aged out of the 5-minute cutoff: got %v",
+					connID, mv.Value)
+			}
+		}
+		return
+	}
+
+	if !strings.Contains(err.Error(), "no data found") {
+		t.Fatalf("unexpected error from GetLatestMetricValues: %v", err)
 	}
 }
 

--- a/alerter/src/internal/database/metric_registry_integration_test.go
+++ b/alerter/src/internal/database/metric_registry_integration_test.go
@@ -12,7 +12,6 @@ package database
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -269,40 +268,55 @@ func TestMetricRegistry_SpockResolutionsRecentCount(t *testing.T) {
 // freshness cutoff in the latest CTE is what causes the alert to
 // auto-clear in that situation.
 //
-// Seed a single row at now() - 6 minutes (outside the 5-minute cutoff)
-// and assert the metric returns no row for that connection.
-// GetLatestMetricValues returns "no data found for metric" when the
-// underlying query yields zero rows; that is the expected outcome
-// when every sample lies outside the cutoff.
+// To exercise the success path of GetLatestMetricValues without the
+// no-data sentinel error masking a real bug, seed two connections:
+// the "stale" connection at now() - 6 minutes (outside the 5-minute
+// cutoff) and a "fresh" connection at now() - 1 minute (inside the
+// cutoff). The query must therefore return exactly one row -- for
+// the fresh connection -- with no entry for the stale connection.
+// Any returned error fails the test outright.
 func TestMetricRegistry_SpockExceptionLogRecentCount_StaleSampleExcluded(t *testing.T) {
 	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
 	defer cleanup()
 
 	ctx := context.Background()
-	connID := insertConnection(t, pool, "spock-exception-stale")
+	staleConnID := insertConnection(t, pool, "spock-exception-stale")
+	freshConnID := insertConnection(t, pool, "spock-exception-fresh")
+
 	stale := time.Now().UTC().Add(-6 * time.Minute)
-	insertSpockExceptionRow(t, pool, connID, stale, 1)
+	fresh := time.Now().UTC().Add(-1 * time.Minute)
+	insertSpockExceptionRow(t, pool, staleConnID, stale, 1)
+	insertSpockExceptionRow(t, pool, freshConnID, fresh, 1)
 
 	results, err := ds.GetLatestMetricValues(ctx, "spock_exception_log.recent_count")
-	if err == nil {
-		// If GetLatestMetricValues returns rows the cutoff did not
-		// apply; surface a precise diagnostic before failing.
-		for _, mv := range results {
-			if mv.ConnectionID == connID {
-				t.Errorf("spock_exception_log.recent_count returned a "+
-					"value for connection %d after the only sample "+
-					"aged out of the 5-minute cutoff: got %v",
-					connID, mv.Value)
-			}
-		}
-		return
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(spock_exception_log.recent_count) "+
+			"returned unexpected error: %v", err)
 	}
 
-	// "no data found" is the expected error path when every sample
-	// for every connection is outside the cutoff. Any other error
-	// indicates a real failure in the registry SQL.
-	if !strings.Contains(err.Error(), "no data found") {
-		t.Fatalf("unexpected error from GetLatestMetricValues: %v", err)
+	// The fresh connection must be present and the stale connection must
+	// be absent. Iterating once lets us assert both properties with
+	// targeted diagnostics.
+	var sawFresh bool
+	for _, mv := range results {
+		switch mv.ConnectionID {
+		case staleConnID:
+			t.Errorf("spock_exception_log.recent_count returned a value "+
+				"for stale connection %d whose only sample (at %s) was "+
+				"outside the 5-minute freshness cutoff: got value %v",
+				staleConnID, stale.Format(time.RFC3339), mv.Value)
+		case freshConnID:
+			sawFresh = true
+		default:
+			t.Errorf("spock_exception_log.recent_count returned an "+
+				"unexpected connection_id=%d (value %v); only the fresh "+
+				"connection (%d) should appear in the result set",
+				mv.ConnectionID, mv.Value, freshConnID)
+		}
+	}
+	if !sawFresh {
+		t.Errorf("spock_exception_log.recent_count did not return the "+
+			"fresh connection %d; results=%+v", freshConnID, results)
 	}
 }
 
@@ -310,30 +324,51 @@ func TestMetricRegistry_SpockExceptionLogRecentCount_StaleSampleExcluded(t *test
 // mirrors the exception_log freshness assertion for the resolutions
 // table. The cutoff is what allows the high/critical resolutions
 // alerts to auto-clear once Spock stops auto-resolving conflicts.
+//
+// As with the exception_log variant, a second "fresh" connection is
+// seeded so the query returns a non-empty result set. The assertions
+// then explicitly check that the stale connection is excluded and the
+// fresh connection is included, eliminating any silent-pass gap when
+// results happen to be empty.
 func TestMetricRegistry_SpockResolutionsRecentCount_StaleSampleExcluded(t *testing.T) {
 	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
 	defer cleanup()
 
 	ctx := context.Background()
-	connID := insertConnection(t, pool, "spock-resolutions-stale")
+	staleConnID := insertConnection(t, pool, "spock-resolutions-stale")
+	freshConnID := insertConnection(t, pool, "spock-resolutions-fresh")
+
 	stale := time.Now().UTC().Add(-6 * time.Minute)
-	insertSpockResolutionRow(t, pool, connID, stale, 1)
+	fresh := time.Now().UTC().Add(-1 * time.Minute)
+	insertSpockResolutionRow(t, pool, staleConnID, stale, 1)
+	insertSpockResolutionRow(t, pool, freshConnID, fresh, 1)
 
 	results, err := ds.GetLatestMetricValues(ctx, "spock_resolutions.recent_count")
-	if err == nil {
-		for _, mv := range results {
-			if mv.ConnectionID == connID {
-				t.Errorf("spock_resolutions.recent_count returned a "+
-					"value for connection %d after the only sample "+
-					"aged out of the 5-minute cutoff: got %v",
-					connID, mv.Value)
-			}
-		}
-		return
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(spock_resolutions.recent_count) "+
+			"returned unexpected error: %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "no data found") {
-		t.Fatalf("unexpected error from GetLatestMetricValues: %v", err)
+	var sawFresh bool
+	for _, mv := range results {
+		switch mv.ConnectionID {
+		case staleConnID:
+			t.Errorf("spock_resolutions.recent_count returned a value "+
+				"for stale connection %d whose only sample (at %s) was "+
+				"outside the 5-minute freshness cutoff: got value %v",
+				staleConnID, stale.Format(time.RFC3339), mv.Value)
+		case freshConnID:
+			sawFresh = true
+		default:
+			t.Errorf("spock_resolutions.recent_count returned an "+
+				"unexpected connection_id=%d (value %v); only the fresh "+
+				"connection (%d) should appear in the result set",
+				mv.ConnectionID, mv.Value, freshConnID)
+		}
+	}
+	if !sawFresh {
+		t.Errorf("spock_resolutions.recent_count did not return the "+
+			"fresh connection %d; results=%+v", freshConnID, results)
 	}
 }
 

--- a/alerter/src/internal/database/metric_registry_integration_test.go
+++ b/alerter/src/internal/database/metric_registry_integration_test.go
@@ -1,0 +1,315 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// metricRegistryTestSchema creates the minimal subset of tables required to
+// exercise the four new metric_registry entries added for the Spock exception,
+// Spock resolution, and replication slot retention/inactivity alerts.
+//
+// The schema mirrors the production v3 collector schema for the columns the
+// metric registry queries actually read; columns that are never referenced
+// by these queries (for example the JSONB tuple snapshots in
+// spock_exception_log) are omitted to keep the test focused.
+//
+// The metrics.* tables intentionally do not declare a foreign key to the
+// connections table here because GetLatestMetricValues does not join through
+// the connections table; the tests instead seed connections directly so the
+// realistic primary key still applies.
+const metricRegistryTestSchema = `
+DROP SCHEMA IF EXISTS metrics CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE SCHEMA metrics;
+
+CREATE TABLE metrics.spock_exception_log (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    remote_origin OID NOT NULL,
+    remote_commit_ts TIMESTAMPTZ NOT NULL,
+    command_counter INTEGER NOT NULL,
+    retry_errored_at TIMESTAMPTZ NOT NULL,
+    remote_xid BIGINT NOT NULL,
+    PRIMARY KEY (connection_id, collected_at, remote_origin,
+                 remote_commit_ts, command_counter, retry_errored_at)
+);
+
+CREATE TABLE metrics.spock_resolutions (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    id INTEGER NOT NULL,
+    node_name NAME NOT NULL,
+    log_time TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (connection_id, collected_at, id, node_name)
+);
+
+CREATE TABLE metrics.pg_replication_slots (
+    connection_id INTEGER NOT NULL,
+    slot_name TEXT NOT NULL,
+    active BOOLEAN,
+    retained_bytes NUMERIC,
+    collected_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (connection_id, collected_at, slot_name)
+);
+`
+
+// metricRegistryTestTeardown drops every object the schema creates so a
+// subsequent test run starts from a clean slate.
+const metricRegistryTestTeardown = `
+DROP SCHEMA IF EXISTS metrics CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+`
+
+// newMetricRegistryTestDatastore returns a Datastore backed by the
+// integration-test database referenced by TEST_AI_WORKBENCH_SERVER. The test
+// is skipped when the variable is unset (or SKIP_DB_TESTS is set), matching
+// the behaviour of the other integration tests in this package. The returned
+// cleanup function tears down the schema and closes the pool.
+func newMetricRegistryTestDatastore(t *testing.T) (*Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping metric registry integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, metricRegistryTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create metric registry test schema: %v", err)
+	}
+
+	ds := &Datastore{pool: pool, config: nil}
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), metricRegistryTestTeardown); err != nil {
+			t.Logf("metric registry teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return ds, pool, cleanup
+}
+
+// insertSpockExceptionRow writes a single metrics.spock_exception_log row.
+// command_counter is used as the unique discriminator inside a sample so a
+// caller can stack several rows with the same collected_at without violating
+// the composite primary key.
+func insertSpockExceptionRow(t *testing.T, pool *pgxpool.Pool, connID int,
+	collectedAt time.Time, commandCounter int) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO metrics.spock_exception_log (
+		    connection_id, collected_at, remote_origin, remote_commit_ts,
+		    command_counter, retry_errored_at, remote_xid
+		) VALUES (
+		    $1, $2, 12345, $2, $3, $2, 999
+		)
+	`, connID, collectedAt, commandCounter); err != nil {
+		t.Fatalf("Failed to insert spock_exception_log row: %v", err)
+	}
+}
+
+// insertSpockResolutionRow writes a single metrics.spock_resolutions row.
+// id is used as the unique discriminator inside a sample.
+func insertSpockResolutionRow(t *testing.T, pool *pgxpool.Pool, connID int,
+	collectedAt time.Time, id int) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO metrics.spock_resolutions (
+		    connection_id, collected_at, id, node_name, log_time
+		) VALUES (
+		    $1, $2, $3, 'node-a', $2
+		)
+	`, connID, collectedAt, id); err != nil {
+		t.Fatalf("Failed to insert spock_resolutions row: %v", err)
+	}
+}
+
+// insertReplicationSlotRow writes a single metrics.pg_replication_slots row.
+func insertReplicationSlotRow(t *testing.T, pool *pgxpool.Pool, connID int,
+	collectedAt time.Time, slotName string, active bool, retainedBytes int64) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO metrics.pg_replication_slots (
+		    connection_id, slot_name, active, retained_bytes, collected_at
+		) VALUES (
+		    $1, $2, $3, $4, $5
+		)
+	`, connID, slotName, active, retainedBytes, collectedAt); err != nil {
+		t.Fatalf("Failed to insert pg_replication_slots row: %v", err)
+	}
+}
+
+// findValueForConnection returns the scanned value for the given connection
+// id, failing the test if the result set does not contain that connection.
+func findValueForConnection(t *testing.T, results []MetricValue, connID int) float64 {
+	t.Helper()
+
+	for _, mv := range results {
+		if mv.ConnectionID == connID {
+			return mv.Value
+		}
+	}
+	t.Fatalf("no metric value returned for connection_id=%d (got %+v)",
+		connID, results)
+	return 0
+}
+
+// TestMetricRegistry_SpockExceptionLogRecentCount verifies that the
+// spock_exception_log.recent_count metric returns COUNT(*) of the latest
+// sample only — older samples must not contribute to the count.
+//
+// Three rows are seeded across two distinct collected_at samples (one row in
+// the older sample, two rows in the newer sample). The latest-sample count
+// must therefore be 2.
+func TestMetricRegistry_SpockExceptionLogRecentCount(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "spock-exception-test")
+	older := time.Now().UTC().Add(-10 * time.Minute)
+	newer := time.Now().UTC().Add(-1 * time.Minute)
+
+	// Older sample: one row.
+	insertSpockExceptionRow(t, pool, connID, older, 1)
+	// Newer sample: two rows. Distinct command_counter values keep them
+	// from colliding on the composite primary key.
+	insertSpockExceptionRow(t, pool, connID, newer, 1)
+	insertSpockExceptionRow(t, pool, connID, newer, 2)
+
+	results, err := ds.GetLatestMetricValues(ctx, "spock_exception_log.recent_count")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(spock_exception_log.recent_count) failed: %v", err)
+	}
+
+	got := findValueForConnection(t, results, connID)
+	if got != 2 {
+		t.Errorf("spock_exception_log.recent_count = %v; want 2 (latest sample only)", got)
+	}
+}
+
+// TestMetricRegistry_SpockResolutionsRecentCount verifies that the
+// spock_resolutions.recent_count metric returns COUNT(*) of the latest
+// sample only.
+func TestMetricRegistry_SpockResolutionsRecentCount(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "spock-resolutions-test")
+	older := time.Now().UTC().Add(-10 * time.Minute)
+	newer := time.Now().UTC().Add(-1 * time.Minute)
+
+	// Older sample: one row.
+	insertSpockResolutionRow(t, pool, connID, older, 1)
+	// Newer sample: two rows.
+	insertSpockResolutionRow(t, pool, connID, newer, 1)
+	insertSpockResolutionRow(t, pool, connID, newer, 2)
+
+	results, err := ds.GetLatestMetricValues(ctx, "spock_resolutions.recent_count")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(spock_resolutions.recent_count) failed: %v", err)
+	}
+
+	got := findValueForConnection(t, results, connID)
+	if got != 2 {
+		t.Errorf("spock_resolutions.recent_count = %v; want 2 (latest sample only)", got)
+	}
+}
+
+// TestMetricRegistry_PgReplicationSlotsInactiveCount verifies that the
+// pg_replication_slots.inactive_count metric returns the number of slots in
+// the latest sample whose active column is FALSE.
+//
+// Three slots are seeded in a single sample: two inactive, one active. The
+// expected value is 2.
+func TestMetricRegistry_PgReplicationSlotsInactiveCount(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "slot-inactive-test")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_a", false, 100)
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_b", false, 200)
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_c", true, 300)
+
+	results, err := ds.GetLatestMetricValues(ctx, "pg_replication_slots.inactive_count")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(pg_replication_slots.inactive_count) failed: %v", err)
+	}
+
+	got := findValueForConnection(t, results, connID)
+	if got != 2 {
+		t.Errorf("pg_replication_slots.inactive_count = %v; want 2", got)
+	}
+}
+
+// TestMetricRegistry_PgReplicationSlotsMaxRetainedBytes verifies that the
+// pg_replication_slots.max_retained_bytes metric returns the maximum
+// retained_bytes value across slots in the latest sample.
+//
+// Three slots are seeded with retained_bytes 100, 5_000_000_000, and 200.
+// The expected maximum is 5_000_000_000 (a value larger than int32 to
+// confirm the NUMERIC/float round-trip preserves it).
+func TestMetricRegistry_PgReplicationSlotsMaxRetainedBytes(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "slot-retained-test")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_a", true, 100)
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_b", true, 5_000_000_000)
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_c", true, 200)
+
+	results, err := ds.GetLatestMetricValues(ctx, "pg_replication_slots.max_retained_bytes")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(pg_replication_slots.max_retained_bytes) failed: %v", err)
+	}
+
+	got := findValueForConnection(t, results, connID)
+	if got != 5_000_000_000 {
+		t.Errorf("pg_replication_slots.max_retained_bytes = %v; want 5000000000", got)
+	}
+}

--- a/alerter/src/internal/engine/engine_thresholds_integration_test.go
+++ b/alerter/src/internal/engine/engine_thresholds_integration_test.go
@@ -185,23 +185,25 @@ CREATE SCHEMA metrics;
 
 CREATE TABLE metrics.spock_exception_log (
     connection_id INTEGER NOT NULL,
+    database_name TEXT NOT NULL,
     collected_at TIMESTAMPTZ NOT NULL,
     remote_origin OID NOT NULL,
     remote_commit_ts TIMESTAMPTZ NOT NULL,
     command_counter INTEGER NOT NULL,
     retry_errored_at TIMESTAMPTZ NOT NULL,
     remote_xid BIGINT NOT NULL,
-    PRIMARY KEY (connection_id, collected_at, remote_origin,
+    PRIMARY KEY (connection_id, database_name, collected_at, remote_origin,
                  remote_commit_ts, command_counter, retry_errored_at)
 );
 
 CREATE TABLE metrics.spock_resolutions (
     connection_id INTEGER NOT NULL,
+    database_name TEXT NOT NULL,
     collected_at TIMESTAMPTZ NOT NULL,
     id INTEGER NOT NULL,
     node_name NAME NOT NULL,
     log_time TIMESTAMPTZ NOT NULL,
-    PRIMARY KEY (connection_id, collected_at, id, node_name)
+    PRIMARY KEY (connection_id, database_name, collected_at, id, node_name)
 );
 
 CREATE TABLE metrics.pg_replication_slots (
@@ -393,9 +395,9 @@ func insertSpockExceptionRow(t *testing.T, pool *pgxpool.Pool, connID int,
 
 	if _, err := pool.Exec(context.Background(), `
 		INSERT INTO metrics.spock_exception_log (
-		    connection_id, collected_at, remote_origin, remote_commit_ts,
-		    command_counter, retry_errored_at, remote_xid
-		) VALUES ($1, $2, 12345, $2, $3, $2, 999)
+		    connection_id, database_name, collected_at, remote_origin,
+		    remote_commit_ts, command_counter, retry_errored_at, remote_xid
+		) VALUES ($1, 'app', $2, 12345, $2, $3, $2, 999)
 	`, connID, collectedAt, commandCounter); err != nil {
 		t.Fatalf("Failed to insert spock_exception_log row: %v", err)
 	}
@@ -408,8 +410,8 @@ func insertSpockResolutionRow(t *testing.T, pool *pgxpool.Pool, connID int,
 
 	if _, err := pool.Exec(context.Background(), `
 		INSERT INTO metrics.spock_resolutions (
-		    connection_id, collected_at, id, node_name, log_time
-		) VALUES ($1, $2, $3, 'node-a', $2)
+		    connection_id, database_name, collected_at, id, node_name, log_time
+		) VALUES ($1, 'app', $2, $3, 'node-a', $2)
 	`, connID, collectedAt, id); err != nil {
 		t.Fatalf("Failed to insert spock_resolutions row: %v", err)
 	}

--- a/alerter/src/internal/engine/engine_thresholds_integration_test.go
+++ b/alerter/src/internal/engine/engine_thresholds_integration_test.go
@@ -700,3 +700,87 @@ func TestEngine_ReplicationSlotRetentionHigh_FireAndClear(t *testing.T) {
 
 	assertAlertCleared(t, ds, pool, rules["replication_slot_retention_high"], connID, alert.ID)
 }
+
+// TestEngine_SpockRecentExceptionsPresent_StaleSampleAutoClears proves that
+// the freshness cutoff in spock_exception_log.recent_count's latest CTE
+// auto-clears the alert when the most recent sample ages past 5 minutes.
+//
+// This models the production scenario where the source-side rolling window
+// drains: the probe's Execute returns no rows for several cycles, Store
+// short-circuits without writing anything, and the latest sample for the
+// connection ages out of the cutoff. The clean-resolved-alerts pass must
+// then transition the alert to status='cleared' even though the row that
+// caused the alert is still present in the table.
+//
+// The test fires the alert with a fresh row, ages the sample by rewriting
+// collected_at to 6 minutes ago (just outside the cutoff), and asserts the
+// alert clears. Rewriting collected_at is more deterministic than waiting
+// real time to elapse and exercises exactly the staleness-driven clear
+// path the cutoff was added to enable.
+func TestEngine_SpockRecentExceptionsPresent_StaleSampleAutoClears(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	rules := seedSpockBuiltInRules(t, pool)
+	disableAllRulesExcept(t, pool, "spock_recent_exceptions_present")
+
+	connID := insertTestConnection(t, pool, "spock-exceptions-stale-conn")
+	fresh := time.Now().UTC().Add(-1 * time.Minute)
+	insertSpockExceptionRow(t, pool, connID, fresh, 1)
+
+	engine.evaluateThresholds(ctx)
+
+	alert := assertAlertFired(t, ds, rules["spock_recent_exceptions_present"], connID, "warning")
+
+	// Age the only row past the 5-minute freshness cutoff. The probe
+	// short-circuits Store on empty results so a real probe never writes a
+	// fresher row in this scenario; rewriting collected_at simulates the
+	// passage of time without flaking on real-clock waits.
+	stale := time.Now().UTC().Add(-6 * time.Minute)
+	if _, err := pool.Exec(ctx, `
+		UPDATE metrics.spock_exception_log
+		   SET collected_at = $1
+		 WHERE connection_id = $2
+	`, stale, connID); err != nil {
+		t.Fatalf("Failed to age spock_exception_log row: %v", err)
+	}
+
+	engine.cleanResolvedAlerts(ctx)
+
+	assertAlertCleared(t, ds, pool, rules["spock_recent_exceptions_present"], connID, alert.ID)
+}
+
+// TestEngine_SpockRecentResolutionsPresent_StaleSampleAutoClears mirrors the
+// exception_log auto-clear test for the resolutions table. The freshness
+// cutoff applies symmetrically to both Spock recent_count metrics so a
+// drained source-side window clears the resolutions alert too.
+func TestEngine_SpockRecentResolutionsPresent_StaleSampleAutoClears(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	rules := seedSpockBuiltInRules(t, pool)
+	disableAllRulesExcept(t, pool, "spock_recent_resolutions_present")
+
+	connID := insertTestConnection(t, pool, "spock-resolutions-stale-conn")
+	fresh := time.Now().UTC().Add(-1 * time.Minute)
+	insertSpockResolutionRow(t, pool, connID, fresh, 1)
+
+	engine.evaluateThresholds(ctx)
+
+	alert := assertAlertFired(t, ds, rules["spock_recent_resolutions_present"], connID, "warning")
+
+	stale := time.Now().UTC().Add(-6 * time.Minute)
+	if _, err := pool.Exec(ctx, `
+		UPDATE metrics.spock_resolutions
+		   SET collected_at = $1
+		 WHERE connection_id = $2
+	`, stale, connID); err != nil {
+		t.Fatalf("Failed to age spock_resolutions row: %v", err)
+	}
+
+	engine.cleanResolvedAlerts(ctx)
+
+	assertAlertCleared(t, ds, pool, rules["spock_recent_resolutions_present"], connID, alert.ID)
+}

--- a/alerter/src/internal/engine/engine_thresholds_integration_test.go
+++ b/alerter/src/internal/engine/engine_thresholds_integration_test.go
@@ -1,0 +1,700 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package engine
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgedge/ai-workbench/alerter/internal/database"
+)
+
+// engineSpockTestSchema extends the alerter integration test schema with the
+// metrics.* tables required to drive the six built-in Spock and replication
+// slot alert rules end-to-end. The columns mirror the production v3 collector
+// schema for the fields the registry queries actually read; columns the
+// queries never reference are omitted.
+//
+// The metrics.* tables intentionally do not declare a foreign key to
+// connections; production behavior allows brief orphan rows after a
+// connection is deleted, and the metric queries do not join through the
+// connections table for these particular metrics.
+const engineSpockTestSchema = `
+DROP TABLE IF EXISTS alert_acknowledgments CASCADE;
+DROP TABLE IF EXISTS alerts CASCADE;
+DROP TABLE IF EXISTS alert_thresholds CASCADE;
+DROP TABLE IF EXISTS alert_rules CASCADE;
+DROP TABLE IF EXISTS blackouts CASCADE;
+DROP TABLE IF EXISTS alerter_settings CASCADE;
+DROP TABLE IF EXISTS probe_availability CASCADE;
+DROP TABLE IF EXISTS probe_configs CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+DROP TABLE IF EXISTS cluster_groups CASCADE;
+DROP TABLE IF EXISTS clusters CASCADE;
+DROP SCHEMA IF EXISTS metrics CASCADE;
+
+CREATE TABLE cluster_groups (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE clusters (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    group_id INTEGER REFERENCES cluster_groups(id) ON DELETE SET NULL
+);
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    is_monitored BOOLEAN NOT NULL DEFAULT TRUE,
+    connection_error TEXT,
+    cluster_id INTEGER REFERENCES clusters(id) ON DELETE SET NULL
+);
+
+CREATE TABLE alerter_settings (
+    id INTEGER PRIMARY KEY DEFAULT 1,
+    retention_days INTEGER NOT NULL DEFAULT 30,
+    default_anomaly_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    default_anomaly_sensitivity REAL NOT NULL DEFAULT 3.0,
+    baseline_refresh_interval_mins INTEGER NOT NULL DEFAULT 60,
+    correlation_window_seconds INTEGER NOT NULL DEFAULT 300,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE alert_rules (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    category VARCHAR(100) NOT NULL DEFAULT 'general',
+    metric_name VARCHAR(255) NOT NULL,
+    default_operator VARCHAR(10) NOT NULL DEFAULT '>',
+    default_threshold REAL NOT NULL DEFAULT 0,
+    default_severity VARCHAR(20) NOT NULL DEFAULT 'warning',
+    default_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    required_extension VARCHAR(100),
+    is_built_in BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE alert_thresholds (
+    id BIGSERIAL PRIMARY KEY,
+    rule_id BIGINT NOT NULL REFERENCES alert_rules(id) ON DELETE CASCADE,
+    scope VARCHAR(20) NOT NULL DEFAULT 'server',
+    connection_id INTEGER REFERENCES connections(id) ON DELETE CASCADE,
+    cluster_id INTEGER REFERENCES clusters(id) ON DELETE CASCADE,
+    group_id INTEGER REFERENCES cluster_groups(id) ON DELETE CASCADE,
+    database_name VARCHAR(255),
+    operator VARCHAR(10) NOT NULL,
+    threshold REAL NOT NULL,
+    severity VARCHAR(20) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE alerts (
+    id BIGSERIAL PRIMARY KEY,
+    alert_type TEXT NOT NULL CHECK (alert_type IN ('threshold', 'anomaly', 'connection')),
+    rule_id BIGINT REFERENCES alert_rules(id) ON DELETE SET NULL,
+    connection_id INTEGER NOT NULL REFERENCES connections(id) ON DELETE CASCADE,
+    database_name TEXT,
+    probe_name TEXT,
+    object_name TEXT,
+    metric_name TEXT,
+    metric_value REAL,
+    threshold_value REAL,
+    operator TEXT,
+    severity TEXT NOT NULL CHECK (severity IN ('info', 'warning', 'critical')),
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    correlation_id TEXT,
+    status TEXT NOT NULL CHECK (status IN ('active', 'cleared', 'acknowledged')),
+    triggered_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    cleared_at TIMESTAMPTZ,
+    last_updated TIMESTAMPTZ,
+    last_reevaluated_at TIMESTAMPTZ,
+    reevaluation_count INTEGER NOT NULL DEFAULT 0,
+    anomaly_score REAL,
+    anomaly_details JSONB,
+    ai_analysis TEXT,
+    ai_analysis_metric_value REAL
+);
+
+CREATE TABLE alert_acknowledgments (
+    id BIGSERIAL PRIMARY KEY,
+    alert_id BIGINT NOT NULL REFERENCES alerts(id) ON DELETE CASCADE,
+    acknowledged_by TEXT NOT NULL,
+    acknowledged_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    acknowledge_type TEXT NOT NULL CHECK (acknowledge_type IN ('acknowledge', 'dismiss', 'false_positive')),
+    message TEXT NOT NULL DEFAULT '',
+    false_positive BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE blackouts (
+    id BIGSERIAL PRIMARY KEY,
+    scope VARCHAR(20) NOT NULL DEFAULT 'server',
+    connection_id INTEGER REFERENCES connections(id) ON DELETE CASCADE,
+    cluster_id INTEGER REFERENCES clusters(id) ON DELETE CASCADE,
+    group_id INTEGER REFERENCES cluster_groups(id) ON DELETE CASCADE,
+    database_name TEXT,
+    reason TEXT NOT NULL DEFAULT '',
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT 'system',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO alerter_settings (id, retention_days, default_anomaly_enabled, default_anomaly_sensitivity,
+    baseline_refresh_interval_mins, correlation_window_seconds)
+VALUES (1, 30, true, 3.0, 60, 300);
+
+-- Empty probe_availability and probe_configs tables let evaluateMetricStaleness
+-- run cleanly during the threshold evaluator. The columns mirror the production
+-- collector schema; rows are never inserted by these tests so the staleness
+-- query simply returns no entries.
+CREATE TABLE probe_availability (
+    connection_id INTEGER NOT NULL,
+    probe_name TEXT NOT NULL,
+    is_available BOOLEAN NOT NULL DEFAULT TRUE,
+    last_collected TIMESTAMPTZ,
+    PRIMARY KEY (connection_id, probe_name)
+);
+
+CREATE TABLE probe_configs (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    connection_id INTEGER,
+    is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    collection_interval_seconds INTEGER NOT NULL DEFAULT 60
+);
+
+CREATE SCHEMA metrics;
+
+CREATE TABLE metrics.spock_exception_log (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    remote_origin OID NOT NULL,
+    remote_commit_ts TIMESTAMPTZ NOT NULL,
+    command_counter INTEGER NOT NULL,
+    retry_errored_at TIMESTAMPTZ NOT NULL,
+    remote_xid BIGINT NOT NULL,
+    PRIMARY KEY (connection_id, collected_at, remote_origin,
+                 remote_commit_ts, command_counter, retry_errored_at)
+);
+
+CREATE TABLE metrics.spock_resolutions (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    id INTEGER NOT NULL,
+    node_name NAME NOT NULL,
+    log_time TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (connection_id, collected_at, id, node_name)
+);
+
+CREATE TABLE metrics.pg_replication_slots (
+    connection_id INTEGER NOT NULL,
+    slot_name TEXT NOT NULL,
+    active BOOLEAN,
+    retained_bytes NUMERIC,
+    collected_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (connection_id, collected_at, slot_name)
+);
+`
+
+// engineSpockTestTeardown drops every object the schema creates so a
+// subsequent test run starts from a clean slate.
+const engineSpockTestTeardown = `
+DROP SCHEMA IF EXISTS metrics CASCADE;
+DROP TABLE IF EXISTS alert_acknowledgments CASCADE;
+DROP TABLE IF EXISTS alerts CASCADE;
+DROP TABLE IF EXISTS alert_thresholds CASCADE;
+DROP TABLE IF EXISTS alert_rules CASCADE;
+DROP TABLE IF EXISTS blackouts CASCADE;
+DROP TABLE IF EXISTS alerter_settings CASCADE;
+DROP TABLE IF EXISTS probe_availability CASCADE;
+DROP TABLE IF EXISTS probe_configs CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+DROP TABLE IF EXISTS clusters CASCADE;
+DROP TABLE IF EXISTS cluster_groups CASCADE;
+`
+
+// newEngineSpockTestEnv creates a test environment with the extended schema
+// (alerter tables plus the metrics.* tables required by the Spock and slot
+// alert rules) and returns the engine, datastore, pool, and cleanup function.
+// The test is skipped when the integration database is unavailable.
+//
+// The engine is constructed with nil config and no notification manager so it
+// can run evaluateThresholds and cleanResolvedAlerts without touching LLM or
+// notification infrastructure.
+func newEngineSpockTestEnv(t *testing.T) (*Engine, *database.Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping engine spock integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, engineSpockTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create engine spock test schema: %v", err)
+	}
+
+	ds := database.NewTestDatastore(pool)
+
+	// Construct an Engine with nil config; the threshold evaluation code path
+	// reads no config values, and queueNotification is a no-op when the
+	// notification pool is nil. NewEngine is invoked with a nil config so the
+	// LLM providers, notification manager, and notification worker pool stay
+	// uninitialized.
+	engine := NewEngine(nil, ds, false)
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), engineSpockTestTeardown); err != nil {
+			t.Logf("engine spock teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return engine, ds, pool, cleanup
+}
+
+// seedSpockBuiltInRules inserts the six new built-in alert rules added by the
+// collector v3 migration. The alerter integration test datastore is
+// independent of the collector datastore; in production the collector seeds
+// these rows into the same database, but in tests we need to seed them
+// directly. The threshold values, operators, and severities mirror the
+// constants in collector/src/database/schema.go for the v3 alert_rules seed.
+//
+// Returned map keys are the rule names; values are the inserted rule IDs.
+func seedSpockBuiltInRules(t *testing.T, pool *pgxpool.Pool) map[string]int64 {
+	t.Helper()
+
+	rules := []struct {
+		name        string
+		description string
+		category    string
+		metric      string
+		threshold   float64
+		severity    string
+	}{
+		{
+			name:        "spock_recent_exceptions_present",
+			description: "At least one Spock exception was logged in the last 15 minutes.",
+			category:    "replication",
+			metric:      "spock_exception_log.recent_count",
+			threshold:   1,
+			severity:    "warning",
+		},
+		{
+			name:        "spock_recent_exceptions_high",
+			description: "Ten or more Spock exceptions were logged in the last 15 minutes.",
+			category:    "replication",
+			metric:      "spock_exception_log.recent_count",
+			threshold:   10,
+			severity:    "critical",
+		},
+		{
+			name:        "spock_recent_resolutions_present",
+			description: "At least one Spock conflict resolution occurred in the last 15 minutes.",
+			category:    "replication",
+			metric:      "spock_resolutions.recent_count",
+			threshold:   1,
+			severity:    "warning",
+		},
+		{
+			name:        "spock_recent_resolutions_high",
+			description: "Twenty-five or more Spock conflict resolutions occurred in the last 15 minutes.",
+			category:    "replication",
+			metric:      "spock_resolutions.recent_count",
+			threshold:   25,
+			severity:    "critical",
+		},
+		{
+			name:        "replication_slot_retention_warn",
+			description: "A replication slot is retaining at least 1 GiB of WAL.",
+			category:    "replication",
+			metric:      "pg_replication_slots.max_retained_bytes",
+			threshold:   1073741824,
+			severity:    "warning",
+		},
+		{
+			name:        "replication_slot_retention_high",
+			description: "A replication slot is retaining at least 10 GiB of WAL.",
+			category:    "replication",
+			metric:      "pg_replication_slots.max_retained_bytes",
+			threshold:   10737418240,
+			severity:    "critical",
+		},
+	}
+
+	ids := make(map[string]int64, len(rules))
+	for _, r := range rules {
+		var id int64
+		err := pool.QueryRow(context.Background(), `
+			INSERT INTO alert_rules (name, description, category, metric_name,
+			    default_operator, default_threshold, default_severity,
+			    default_enabled, is_built_in)
+			VALUES ($1, $2, $3, $4, '>=', $5, $6, TRUE, TRUE)
+			RETURNING id
+		`, r.name, r.description, r.category, r.metric, r.threshold, r.severity).Scan(&id)
+		if err != nil {
+			t.Fatalf("Failed to seed built-in rule %q: %v", r.name, err)
+		}
+		ids[r.name] = id
+	}
+	return ids
+}
+
+// disableAllRulesExcept disables every alert_rule whose name is not in keep.
+// This isolates a single rule for evaluation so unrelated rules cannot fire
+// alerts on the same connection during a fire/clear assertion.
+func disableAllRulesExcept(t *testing.T, pool *pgxpool.Pool, keep ...string) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE alert_rules SET default_enabled = FALSE WHERE name <> ALL($1)`,
+		keep); err != nil {
+		t.Fatalf("Failed to disable other rules: %v", err)
+	}
+}
+
+// insertSpockExceptionRow writes a single metrics.spock_exception_log row
+// for the engine integration tests. command_counter discriminates rows that
+// share a (connection_id, collected_at) key.
+func insertSpockExceptionRow(t *testing.T, pool *pgxpool.Pool, connID int,
+	collectedAt time.Time, commandCounter int) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO metrics.spock_exception_log (
+		    connection_id, collected_at, remote_origin, remote_commit_ts,
+		    command_counter, retry_errored_at, remote_xid
+		) VALUES ($1, $2, 12345, $2, $3, $2, 999)
+	`, connID, collectedAt, commandCounter); err != nil {
+		t.Fatalf("Failed to insert spock_exception_log row: %v", err)
+	}
+}
+
+// insertSpockResolutionRow writes a single metrics.spock_resolutions row.
+func insertSpockResolutionRow(t *testing.T, pool *pgxpool.Pool, connID int,
+	collectedAt time.Time, id int) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO metrics.spock_resolutions (
+		    connection_id, collected_at, id, node_name, log_time
+		) VALUES ($1, $2, $3, 'node-a', $2)
+	`, connID, collectedAt, id); err != nil {
+		t.Fatalf("Failed to insert spock_resolutions row: %v", err)
+	}
+}
+
+// insertReplicationSlotRow writes a single metrics.pg_replication_slots row.
+func insertReplicationSlotRow(t *testing.T, pool *pgxpool.Pool, connID int,
+	collectedAt time.Time, slotName string, active bool, retainedBytes int64) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO metrics.pg_replication_slots (
+		    connection_id, slot_name, active, retained_bytes, collected_at
+		) VALUES ($1, $2, $3, $4, $5)
+	`, connID, slotName, active, retainedBytes, collectedAt); err != nil {
+		t.Fatalf("Failed to insert pg_replication_slots row: %v", err)
+	}
+}
+
+// truncateSpockExceptionLog removes every row for the given connection so the
+// metric query returns no rows for that connection (i.e., the metric drops
+// out of latest-sample results entirely). cleanResolvedAlerts treats the
+// missing entry as a resolved condition and clears the alert.
+func truncateSpockExceptionLog(t *testing.T, pool *pgxpool.Pool, connID int) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(),
+		`DELETE FROM metrics.spock_exception_log WHERE connection_id = $1`,
+		connID); err != nil {
+		t.Fatalf("Failed to truncate spock_exception_log for conn %d: %v", connID, err)
+	}
+}
+
+// truncateSpockResolutions mirrors truncateSpockExceptionLog for the
+// spock_resolutions table.
+func truncateSpockResolutions(t *testing.T, pool *pgxpool.Pool, connID int) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(),
+		`DELETE FROM metrics.spock_resolutions WHERE connection_id = $1`,
+		connID); err != nil {
+		t.Fatalf("Failed to truncate spock_resolutions for conn %d: %v", connID, err)
+	}
+}
+
+// truncateReplicationSlots removes every row for the given connection so the
+// metric query for max_retained_bytes returns no rows; cleanResolvedAlerts
+// then clears any active retention alert. This deliberately models the
+// "all slots disappeared" path; for the alternative "slots still exist but
+// retention dropped" path tests can rewrite a newer sample with smaller
+// retained_bytes values instead.
+func truncateReplicationSlots(t *testing.T, pool *pgxpool.Pool, connID int) {
+	t.Helper()
+
+	if _, err := pool.Exec(context.Background(),
+		`DELETE FROM metrics.pg_replication_slots WHERE connection_id = $1`,
+		connID); err != nil {
+		t.Fatalf("Failed to truncate pg_replication_slots for conn %d: %v", connID, err)
+	}
+}
+
+// activeAlertForRule looks up the active threshold alert for the given rule
+// and connection, returning nil when none exists. This is a thin convenience
+// over GetActiveThresholdAlert that fails the test on query errors so callers
+// can write linear assertions.
+func activeAlertForRule(t *testing.T, ds *database.Datastore, ruleID int64, connID int) *database.Alert {
+	t.Helper()
+
+	alert, err := ds.GetActiveThresholdAlert(context.Background(), ruleID, connID, nil)
+	if err != nil {
+		t.Fatalf("GetActiveThresholdAlert(rule=%d, conn=%d) failed: %v", ruleID, connID, err)
+	}
+	return alert
+}
+
+// assertAlertFired asserts that an active alert exists for the given rule
+// and connection with the expected severity. Returns the alert so callers
+// can inspect additional fields.
+func assertAlertFired(t *testing.T, ds *database.Datastore, ruleID int64, connID int, wantSeverity string) *database.Alert {
+	t.Helper()
+
+	alert := activeAlertForRule(t, ds, ruleID, connID)
+	if alert == nil {
+		t.Fatalf("expected active alert for rule %d on connection %d, found none", ruleID, connID)
+	}
+	if alert.Severity != wantSeverity {
+		t.Errorf("alert severity = %q; want %q", alert.Severity, wantSeverity)
+	}
+	if alert.Status != "active" {
+		t.Errorf("alert status = %q; want \"active\"", alert.Status)
+	}
+	return alert
+}
+
+// assertAlertCleared asserts that no active alert exists for the given rule
+// and connection, and that the previously fired alert (identified by id) was
+// transitioned to status='cleared'.
+func assertAlertCleared(t *testing.T, ds *database.Datastore, pool *pgxpool.Pool, ruleID int64, connID int, alertID int64) {
+	t.Helper()
+
+	if alert := activeAlertForRule(t, ds, ruleID, connID); alert != nil {
+		t.Fatalf("expected no active alert for rule %d on connection %d, found id=%d status=%q",
+			ruleID, connID, alert.ID, alert.Status)
+	}
+
+	var status string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT status FROM alerts WHERE id = $1`, alertID).Scan(&status); err != nil {
+		t.Fatalf("Failed to read alert %d status: %v", alertID, err)
+	}
+	if status != "cleared" {
+		t.Errorf("alert %d status = %q; want \"cleared\"", alertID, status)
+	}
+}
+
+// TestEngine_SpockRecentExceptionsPresent_FireAndClear exercises the warning
+// rule that fires when the latest sample of metrics.spock_exception_log holds
+// at least one row. The test seeds a single row to drive the metric to 1,
+// runs the threshold evaluator, asserts a warning alert fired, then deletes
+// every row for the connection and runs the cleaner; the alert must clear.
+func TestEngine_SpockRecentExceptionsPresent_FireAndClear(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	rules := seedSpockBuiltInRules(t, pool)
+	disableAllRulesExcept(t, pool, "spock_recent_exceptions_present")
+
+	connID := insertTestConnection(t, pool, "spock-exceptions-present-conn")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+	insertSpockExceptionRow(t, pool, connID, sample, 1)
+
+	engine.evaluateThresholds(ctx)
+
+	alert := assertAlertFired(t, ds, rules["spock_recent_exceptions_present"], connID, "warning")
+
+	// Drive the metric below the threshold by removing every row for this
+	// connection. cleanResolvedAlerts iterates active threshold alerts and
+	// re-queries the metric; an empty result clears the alert.
+	truncateSpockExceptionLog(t, pool, connID)
+	engine.cleanResolvedAlerts(ctx)
+
+	assertAlertCleared(t, ds, pool, rules["spock_recent_exceptions_present"], connID, alert.ID)
+}
+
+// TestEngine_SpockRecentExceptionsHigh_FireAndClear exercises the critical
+// rule that fires when the latest sample of metrics.spock_exception_log holds
+// ten or more rows. Ten rows drive the metric to exactly the threshold and
+// the rule's '>=' operator means the value violates it.
+func TestEngine_SpockRecentExceptionsHigh_FireAndClear(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	rules := seedSpockBuiltInRules(t, pool)
+	disableAllRulesExcept(t, pool, "spock_recent_exceptions_high")
+
+	connID := insertTestConnection(t, pool, "spock-exceptions-high-conn")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+	for i := 1; i <= 10; i++ {
+		insertSpockExceptionRow(t, pool, connID, sample, i)
+	}
+
+	engine.evaluateThresholds(ctx)
+
+	alert := assertAlertFired(t, ds, rules["spock_recent_exceptions_high"], connID, "critical")
+
+	truncateSpockExceptionLog(t, pool, connID)
+	engine.cleanResolvedAlerts(ctx)
+
+	assertAlertCleared(t, ds, pool, rules["spock_recent_exceptions_high"], connID, alert.ID)
+}
+
+// TestEngine_SpockRecentResolutionsPresent_FireAndClear exercises the warning
+// rule for spock_resolutions.recent_count >= 1.
+func TestEngine_SpockRecentResolutionsPresent_FireAndClear(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	rules := seedSpockBuiltInRules(t, pool)
+	disableAllRulesExcept(t, pool, "spock_recent_resolutions_present")
+
+	connID := insertTestConnection(t, pool, "spock-resolutions-present-conn")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+	insertSpockResolutionRow(t, pool, connID, sample, 1)
+
+	engine.evaluateThresholds(ctx)
+
+	alert := assertAlertFired(t, ds, rules["spock_recent_resolutions_present"], connID, "warning")
+
+	truncateSpockResolutions(t, pool, connID)
+	engine.cleanResolvedAlerts(ctx)
+
+	assertAlertCleared(t, ds, pool, rules["spock_recent_resolutions_present"], connID, alert.ID)
+}
+
+// TestEngine_SpockRecentResolutionsHigh_FireAndClear exercises the critical
+// rule for spock_resolutions.recent_count >= 25.
+func TestEngine_SpockRecentResolutionsHigh_FireAndClear(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	rules := seedSpockBuiltInRules(t, pool)
+	disableAllRulesExcept(t, pool, "spock_recent_resolutions_high")
+
+	connID := insertTestConnection(t, pool, "spock-resolutions-high-conn")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+	for i := 1; i <= 25; i++ {
+		insertSpockResolutionRow(t, pool, connID, sample, i)
+	}
+
+	engine.evaluateThresholds(ctx)
+
+	alert := assertAlertFired(t, ds, rules["spock_recent_resolutions_high"], connID, "critical")
+
+	truncateSpockResolutions(t, pool, connID)
+	engine.cleanResolvedAlerts(ctx)
+
+	assertAlertCleared(t, ds, pool, rules["spock_recent_resolutions_high"], connID, alert.ID)
+}
+
+// TestEngine_ReplicationSlotRetentionWarn_FireAndClear exercises the warning
+// rule for pg_replication_slots.max_retained_bytes >= 1 GiB.
+//
+// The fire phase seeds one slot retaining 2 GiB; the clear phase rewrites the
+// sample so every slot retains 0 bytes (a smaller, newer sample), driving
+// max_retained_bytes to 0 below the 1 GiB threshold. This exercises the
+// "metric still reports but value resolved" branch of cleanResolvedAlerts
+// rather than the "metric disappeared" branch.
+func TestEngine_ReplicationSlotRetentionWarn_FireAndClear(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	rules := seedSpockBuiltInRules(t, pool)
+	disableAllRulesExcept(t, pool, "replication_slot_retention_warn")
+
+	connID := insertTestConnection(t, pool, "slot-retention-warn-conn")
+	const twoGiB = int64(2) * 1024 * 1024 * 1024
+	fireSample := time.Now().UTC().Add(-2 * time.Minute)
+	insertReplicationSlotRow(t, pool, connID, fireSample, "slot_a", true, twoGiB)
+
+	engine.evaluateThresholds(ctx)
+
+	alert := assertAlertFired(t, ds, rules["replication_slot_retention_warn"], connID, "warning")
+
+	// Replace the latest sample with one that has zero retained bytes. The
+	// new sample wins MAX(collected_at) so the registry query reports 0,
+	// well below the 1 GiB threshold.
+	clearSample := time.Now().UTC()
+	insertReplicationSlotRow(t, pool, connID, clearSample, "slot_a", true, 0)
+	engine.cleanResolvedAlerts(ctx)
+
+	assertAlertCleared(t, ds, pool, rules["replication_slot_retention_warn"], connID, alert.ID)
+}
+
+// TestEngine_ReplicationSlotRetentionHigh_FireAndClear exercises the critical
+// rule for pg_replication_slots.max_retained_bytes >= 10 GiB.
+//
+// The clear phase deletes every slot row for the connection so the metric
+// returns no rows for this connection_id; cleanResolvedAlerts treats that as
+// a resolved condition and clears the alert. This complements the warn-rule
+// test which exercises the "value dropped" path; together they cover both
+// branches of cleanResolvedAlerts for the slot-retention metric.
+func TestEngine_ReplicationSlotRetentionHigh_FireAndClear(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	rules := seedSpockBuiltInRules(t, pool)
+	disableAllRulesExcept(t, pool, "replication_slot_retention_high")
+
+	connID := insertTestConnection(t, pool, "slot-retention-high-conn")
+	const fifteenGiB = int64(15) * 1024 * 1024 * 1024
+	fireSample := time.Now().UTC().Add(-1 * time.Minute)
+	insertReplicationSlotRow(t, pool, connID, fireSample, "slot_a", true, fifteenGiB)
+
+	engine.evaluateThresholds(ctx)
+
+	alert := assertAlertFired(t, ds, rules["replication_slot_retention_high"], connID, "critical")
+
+	truncateReplicationSlots(t, pool, connID)
+	engine.cleanResolvedAlerts(ctx)
+
+	assertAlertCleared(t, ds, pool, rules["replication_slot_retention_high"], connID, alert.ID)
+}

--- a/collector/src/database/migration_v3_test.go
+++ b/collector/src/database/migration_v3_test.go
@@ -111,9 +111,13 @@ func TestMigrationV3_SpockMetricsTablesExist(t *testing.T) {
 		}
 	}
 
-	// Verify a representative subset of the documented column shapes.
+	// Verify a representative subset of the documented column shapes,
+	// including the database_name discriminator added so rows from
+	// different databases on the same monitored connection cannot
+	// collide on the composite primary key.
 	exceptionColumns := map[string]string{
 		"connection_id":    "integer",
+		"database_name":    "text",
 		"collected_at":     "timestamp with time zone",
 		"remote_origin":    "oid",
 		"remote_commit_ts": "timestamp with time zone",
@@ -129,6 +133,7 @@ func TestMigrationV3_SpockMetricsTablesExist(t *testing.T) {
 
 	resolutionColumns := map[string]string{
 		"connection_id":    "integer",
+		"database_name":    "text",
 		"collected_at":     "timestamp with time zone",
 		"id":               "integer",
 		"node_name":        "name",
@@ -140,6 +145,70 @@ func TestMigrationV3_SpockMetricsTablesExist(t *testing.T) {
 		"remote_timestamp": "timestamp with time zone",
 	}
 	assertColumnTypes(t, pool, "spock_resolutions", resolutionColumns)
+
+	// database_name must participate in the composite primary key so a
+	// monitored connection running Spock in two databases keeps the
+	// per-database identity columns from colliding (notably
+	// spock.resolutions.id, which is a per-database sequence).
+	assertNotNullColumn(t, pool, "spock_exception_log", "database_name")
+	assertNotNullColumn(t, pool, "spock_resolutions", "database_name")
+	assertPrimaryKeyContains(t, pool, "spock_exception_log", "database_name")
+	assertPrimaryKeyContains(t, pool, "spock_resolutions", "database_name")
+}
+
+// assertNotNullColumn fails the test if the named column is nullable.
+// The Spock metrics tables require database_name to be NOT NULL so
+// every row carries a usable discriminator into the composite key.
+func assertNotNullColumn(t *testing.T, pool *pgxpool.Pool, table, column string) {
+	t.Helper()
+	ctx := context.Background()
+	var isNullable string
+	err := pool.QueryRow(ctx, `
+		SELECT is_nullable
+		FROM information_schema.columns
+		WHERE table_schema = 'metrics'
+		  AND table_name = $1
+		  AND column_name = $2
+	`, table, column).Scan(&isNullable)
+	if err != nil {
+		t.Errorf("metrics.%s column %q lookup failed: %v", table, column, err)
+		return
+	}
+	if isNullable != "NO" {
+		t.Errorf("metrics.%s.%s is_nullable = %q, want \"NO\"",
+			table, column, isNullable)
+	}
+}
+
+// assertPrimaryKeyContains fails the test if the named column is not
+// part of the primary key for the given metrics table.
+func assertPrimaryKeyContains(t *testing.T, pool *pgxpool.Pool, table, column string) {
+	t.Helper()
+	ctx := context.Background()
+	var contains bool
+	err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			JOIN pg_index i ON i.indrelid = c.oid AND i.indisprimary
+			JOIN pg_attribute a
+			  ON a.attrelid = c.oid
+			 AND a.attnum = ANY (i.indkey)
+			WHERE n.nspname = 'metrics'
+			  AND c.relname = $1
+			  AND a.attname = $2
+		)
+	`, table, column).Scan(&contains)
+	if err != nil {
+		t.Errorf("metrics.%s primary key lookup for %q failed: %v",
+			table, column, err)
+		return
+	}
+	if !contains {
+		t.Errorf("metrics.%s primary key does not include %q",
+			table, column)
+	}
 }
 
 // assertColumnTypes asserts that each column in the given metrics table

--- a/collector/src/database/migration_v3_test.go
+++ b/collector/src/database/migration_v3_test.go
@@ -1,0 +1,414 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestMigrationV3_SpockMetricsTablesExist verifies that the v3 migration
+// creates metrics.spock_exception_log and metrics.spock_resolutions as
+// partitioned tables keyed on collected_at.
+//
+// The fixture migrates a fresh test database to the latest schema version
+// then asserts the tables are present, partitioned, and own the documented
+// per-connection foreign key.
+func TestMigrationV3_SpockMetricsTablesExist(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("Failed to migrate: %v", err)
+	}
+
+	// Both metrics tables must exist and be partitioned by collected_at.
+	for _, table := range []string{"spock_exception_log", "spock_resolutions"} {
+		var exists bool
+		err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_tables
+				WHERE schemaname = 'metrics'
+				  AND tablename = $1
+			)
+		`, table).Scan(&exists)
+		if err != nil {
+			t.Fatalf("failed to check existence of metrics.%s: %v", table, err)
+		}
+		if !exists {
+			t.Errorf("metrics.%s was not created", table)
+			continue
+		}
+
+		var isPartitioned bool
+		err = pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_class c
+				JOIN pg_namespace n ON n.oid = c.relnamespace
+				WHERE n.nspname = 'metrics'
+				  AND c.relname = $1
+				  AND c.relkind = 'p'
+			)
+		`, table).Scan(&isPartitioned)
+		if err != nil {
+			t.Fatalf("failed to check partitioning of metrics.%s: %v", table, err)
+		}
+		if !isPartitioned {
+			t.Errorf("metrics.%s is not partitioned", table)
+		}
+
+		// The partition key should be (collected_at). We verify by reading
+		// pg_partitioned_table.
+		var partKey string
+		err = pool.QueryRow(ctx, `
+			SELECT pg_get_partkeydef(c.oid)
+			FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname = 'metrics'
+			  AND c.relname = $1
+		`, table).Scan(&partKey)
+		if err != nil {
+			t.Fatalf("failed to read partition key for metrics.%s: %v", table, err)
+		}
+		if partKey != "RANGE (collected_at)" {
+			t.Errorf("metrics.%s partition key = %q, want RANGE (collected_at)", table, partKey)
+		}
+
+		// The conn-time index documented in the design must exist.
+		expectedIndex := "idx_" + table + "_conn_time"
+		var idxExists bool
+		err = pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_indexes
+				WHERE schemaname = 'metrics'
+				  AND tablename = $1
+				  AND indexname = $2
+			)
+		`, table, expectedIndex).Scan(&idxExists)
+		if err != nil {
+			t.Fatalf("failed to check index %s: %v", expectedIndex, err)
+		}
+		if !idxExists {
+			t.Errorf("expected index %s on metrics.%s, but it was not created", expectedIndex, table)
+		}
+	}
+
+	// Verify a representative subset of the documented column shapes.
+	exceptionColumns := map[string]string{
+		"connection_id":    "integer",
+		"collected_at":     "timestamp with time zone",
+		"remote_origin":    "oid",
+		"remote_commit_ts": "timestamp with time zone",
+		"command_counter":  "integer",
+		"retry_errored_at": "timestamp with time zone",
+		"remote_xid":       "bigint",
+		"local_tup":        "jsonb",
+		"remote_old_tup":   "jsonb",
+		"remote_new_tup":   "jsonb",
+		"error_message":    "text",
+	}
+	assertColumnTypes(t, pool, "spock_exception_log", exceptionColumns)
+
+	resolutionColumns := map[string]string{
+		"connection_id":    "integer",
+		"collected_at":     "timestamp with time zone",
+		"id":               "integer",
+		"node_name":        "name",
+		"log_time":         "timestamp with time zone",
+		"local_tuple":      "text",
+		"local_xid":        "text",
+		"remote_xid":       "text",
+		"remote_lsn":       "text",
+		"remote_timestamp": "timestamp with time zone",
+	}
+	assertColumnTypes(t, pool, "spock_resolutions", resolutionColumns)
+}
+
+// assertColumnTypes asserts that each column in the given metrics table
+// matches the expected information_schema data_type. It logs a clear
+// failure for each missing or mistyped column.
+func assertColumnTypes(t *testing.T, pool *pgxpool.Pool, table string, expected map[string]string) {
+	t.Helper()
+	ctx := context.Background()
+	for col, wantType := range expected {
+		var gotType string
+		err := pool.QueryRow(ctx, `
+			SELECT data_type
+			FROM information_schema.columns
+			WHERE table_schema = 'metrics'
+			  AND table_name = $1
+			  AND column_name = $2
+		`, table, col).Scan(&gotType)
+		if err != nil {
+			t.Errorf("metrics.%s column %q lookup failed: %v", table, col, err)
+			continue
+		}
+		if gotType != wantType {
+			t.Errorf("metrics.%s.%s data_type = %q, want %q", table, col, gotType, wantType)
+		}
+	}
+}
+
+// TestMigrationV3_SpockProbeConfigsSeeded verifies the migration seeds the
+// two new global probe_configs rows with the documented defaults.
+func TestMigrationV3_SpockProbeConfigsSeeded(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("Failed to migrate: %v", err)
+	}
+
+	expected := []struct {
+		name     string
+		interval int
+		retain   int
+	}{
+		{"spock_exception_log", 60, 7},
+		{"spock_resolutions", 60, 7},
+	}
+
+	for _, want := range expected {
+		var (
+			gotConnNull bool
+			gotEnabled  bool
+			gotInterval int
+			gotRetain   int
+			gotDesc     string
+		)
+		err := pool.QueryRow(ctx, `
+			SELECT connection_id IS NULL,
+			       is_enabled,
+			       collection_interval_seconds,
+			       retention_days,
+			       description
+			FROM probe_configs
+			WHERE name = $1
+		`, want.name).Scan(&gotConnNull, &gotEnabled, &gotInterval, &gotRetain, &gotDesc)
+		if err != nil {
+			t.Errorf("probe_configs row for %s missing: %v", want.name, err)
+			continue
+		}
+		if !gotConnNull {
+			t.Errorf("probe_configs.%s: connection_id should be NULL", want.name)
+		}
+		if !gotEnabled {
+			t.Errorf("probe_configs.%s: is_enabled should be TRUE", want.name)
+		}
+		if gotInterval != want.interval {
+			t.Errorf("probe_configs.%s: collection_interval_seconds = %d, want %d",
+				want.name, gotInterval, want.interval)
+		}
+		if gotRetain != want.retain {
+			t.Errorf("probe_configs.%s: retention_days = %d, want %d",
+				want.name, gotRetain, want.retain)
+		}
+		if gotDesc == "" {
+			t.Errorf("probe_configs.%s: description must not be empty", want.name)
+		}
+	}
+}
+
+// TestMigrationV3_SpockAlertRulesSeeded verifies the migration seeds the
+// six new built-in alert rules with the thresholds and severities
+// documented in the design.
+func TestMigrationV3_SpockAlertRulesSeeded(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("Failed to migrate: %v", err)
+	}
+
+	type ruleSpec struct {
+		name              string
+		category          string
+		metricName        string
+		operator          string
+		threshold         float64
+		severity          string
+		requiredExtension *string
+	}
+	spock := "spock"
+	rules := []ruleSpec{
+		{"spock_recent_exceptions_present", "replication", "spock_exception_log.recent_count", ">=", 1, "warning", &spock},
+		{"spock_recent_exceptions_high", "replication", "spock_exception_log.recent_count", ">=", 10, "critical", &spock},
+		{"spock_recent_resolutions_present", "replication", "spock_resolutions.recent_count", ">=", 1, "warning", &spock},
+		{"spock_recent_resolutions_high", "replication", "spock_resolutions.recent_count", ">=", 25, "critical", &spock},
+		{"replication_slot_retention_warn", "replication", "pg_replication_slots.max_retained_bytes", ">=", 1073741824, "warning", nil},
+		{"replication_slot_retention_high", "replication", "pg_replication_slots.max_retained_bytes", ">=", 10737418240, "critical", nil},
+	}
+
+	for _, want := range rules {
+		var (
+			gotCategory  string
+			gotMetric    string
+			gotOperator  string
+			gotThreshold float64
+			gotSeverity  string
+			gotEnabled   bool
+			gotBuiltIn   bool
+			gotReqExtPtr *string
+		)
+		err := pool.QueryRow(ctx, `
+			SELECT category,
+			       metric_name,
+			       default_operator,
+			       default_threshold,
+			       default_severity,
+			       default_enabled,
+			       is_built_in,
+			       required_extension
+			FROM alert_rules
+			WHERE name = $1
+		`, want.name).Scan(&gotCategory, &gotMetric, &gotOperator, &gotThreshold,
+			&gotSeverity, &gotEnabled, &gotBuiltIn, &gotReqExtPtr)
+		if err != nil {
+			t.Errorf("alert_rules row %q missing: %v", want.name, err)
+			continue
+		}
+		if gotCategory != want.category {
+			t.Errorf("%s: category = %q, want %q", want.name, gotCategory, want.category)
+		}
+		if gotMetric != want.metricName {
+			t.Errorf("%s: metric_name = %q, want %q", want.name, gotMetric, want.metricName)
+		}
+		if gotOperator != want.operator {
+			t.Errorf("%s: default_operator = %q, want %q", want.name, gotOperator, want.operator)
+		}
+		if gotThreshold != want.threshold {
+			t.Errorf("%s: default_threshold = %v, want %v", want.name, gotThreshold, want.threshold)
+		}
+		if gotSeverity != want.severity {
+			t.Errorf("%s: default_severity = %q, want %q", want.name, gotSeverity, want.severity)
+		}
+		if !gotEnabled {
+			t.Errorf("%s: default_enabled must be TRUE", want.name)
+		}
+		if !gotBuiltIn {
+			t.Errorf("%s: is_built_in must be TRUE", want.name)
+		}
+		switch {
+		case want.requiredExtension == nil && gotReqExtPtr != nil:
+			t.Errorf("%s: required_extension = %q, want NULL", want.name, *gotReqExtPtr)
+		case want.requiredExtension != nil && gotReqExtPtr == nil:
+			t.Errorf("%s: required_extension is NULL, want %q", want.name, *want.requiredExtension)
+		case want.requiredExtension != nil && gotReqExtPtr != nil && *want.requiredExtension != *gotReqExtPtr:
+			t.Errorf("%s: required_extension = %q, want %q", want.name,
+				*gotReqExtPtr, *want.requiredExtension)
+		}
+	}
+}
+
+// TestMigrationV3_Idempotent verifies running Migrate twice does not error
+// and yields the same schema_version row count after the second pass.
+func TestMigrationV3_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("first Migrate failed: %v", err)
+	}
+
+	var firstMax int
+	if err := pool.QueryRow(ctx, `SELECT MAX(version) FROM schema_version`).Scan(&firstMax); err != nil {
+		t.Fatalf("failed to read schema_version after first migrate: %v", err)
+	}
+
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("second Migrate failed: %v", err)
+	}
+
+	var secondMax int
+	if err := pool.QueryRow(ctx, `SELECT MAX(version) FROM schema_version`).Scan(&secondMax); err != nil {
+		t.Fatalf("failed to read schema_version after second migrate: %v", err)
+	}
+
+	if firstMax != secondMax {
+		t.Errorf("schema_version max changed across runs: first=%d second=%d", firstMax, secondMax)
+	}
+
+	// V3 must be present in both runs.
+	var v3Count int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM schema_version WHERE version = 3`).Scan(&v3Count); err != nil {
+		t.Fatalf("failed to count v3 rows in schema_version: %v", err)
+	}
+	if v3Count != 1 {
+		t.Errorf("expected exactly one schema_version row for v3, got %d", v3Count)
+	}
+
+	// Re-running must not duplicate seed rows.
+	for _, ruleName := range []string{
+		"spock_recent_exceptions_present",
+		"spock_recent_exceptions_high",
+		"spock_recent_resolutions_present",
+		"spock_recent_resolutions_high",
+		"replication_slot_retention_warn",
+		"replication_slot_retention_high",
+	} {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT COUNT(*) FROM alert_rules WHERE name = $1`, ruleName).Scan(&n); err != nil {
+			t.Fatalf("failed to count alert_rules row %s: %v", ruleName, err)
+		}
+		if n != 1 {
+			t.Errorf("alert_rules %s: expected 1 row after idempotent migrate, got %d", ruleName, n)
+		}
+	}
+	for _, probeName := range []string{"spock_exception_log", "spock_resolutions"} {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT COUNT(*) FROM probe_configs WHERE name = $1`, probeName).Scan(&n); err != nil {
+			t.Fatalf("failed to count probe_configs row %s: %v", probeName, err)
+		}
+		if n != 1 {
+			t.Errorf("probe_configs %s: expected 1 row after idempotent migrate, got %d", probeName, n)
+		}
+	}
+}

--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -2612,12 +2612,20 @@ func (sm *SchemaManager) registerMigrations() {
 			// metrics.spock_exception_log
 			//
 			// Captures rows pulled from spock.exception_log within a rolling
-			// 15-minute source-side window. Composite primary key matches
-			// the source-side identity columns prefixed with collector keys
-			// so re-collected rows from a still-open window slot in cleanly.
+			// 15-minute source-side window. The composite primary key prefixes
+			// the natural Spock identity columns with collector keys
+			// (connection_id, database_name, collected_at) so re-collected
+			// rows from a still-open window slot in cleanly. database_name is
+			// part of the key because the probe is database-scoped: when Spock
+			// is installed in more than one database on the same monitored
+			// connection, the probe writes one set of rows per database and
+			// the natural Spock keys (remote_origin, remote_commit_ts,
+			// command_counter, retry_errored_at) collide across databases
+			// without the database_name discriminator.
 			_, err := tx.Exec(ctx, `
 				CREATE TABLE IF NOT EXISTS metrics.spock_exception_log (
 					connection_id INTEGER NOT NULL,
+					database_name TEXT NOT NULL,
 					collected_at TIMESTAMPTZ NOT NULL,
 					remote_origin OID NOT NULL,
 					remote_commit_ts TIMESTAMPTZ NOT NULL,
@@ -2635,11 +2643,13 @@ func (sm *SchemaManager) registerMigrations() {
 					ddl_statement TEXT,
 					ddl_user TEXT,
 					error_message TEXT,
-					PRIMARY KEY (connection_id, collected_at, remote_origin, remote_commit_ts, command_counter, retry_errored_at)
+					PRIMARY KEY (connection_id, database_name, collected_at, remote_origin, remote_commit_ts, command_counter, retry_errored_at)
 				) PARTITION BY RANGE (collected_at);
 
 				COMMENT ON TABLE metrics.spock_exception_log IS
 					'Rolling 15-minute snapshots of rows from the Spock extension''s exception_log catalog';
+				COMMENT ON COLUMN metrics.spock_exception_log.database_name IS
+					'Source database the row was collected from; included in the primary key to disambiguate rows when Spock is installed in multiple databases on the same monitored connection';
 
 				ALTER TABLE metrics.spock_exception_log
 					DROP CONSTRAINT IF EXISTS fk_spock_exception_log_connection_id;
@@ -2659,9 +2669,15 @@ func (sm *SchemaManager) registerMigrations() {
 			// Captures rows pulled from spock.resolutions within a rolling
 			// 15-minute source-side window. xid and pg_lsn columns are stored
 			// as TEXT so they round-trip cleanly via the standard COPY path.
+			// database_name is part of the primary key because the per-
+			// database resolutions.id sequence is independent across
+			// databases; without the discriminator two rows with the same id
+			// collected from different databases on the same monitored
+			// connection would collide on the composite key.
 			_, err = tx.Exec(ctx, `
 				CREATE TABLE IF NOT EXISTS metrics.spock_resolutions (
 					connection_id INTEGER NOT NULL,
+					database_name TEXT NOT NULL,
 					collected_at TIMESTAMPTZ NOT NULL,
 					id INTEGER NOT NULL,
 					node_name NAME NOT NULL,
@@ -2679,11 +2695,13 @@ func (sm *SchemaManager) registerMigrations() {
 					remote_xid TEXT,
 					remote_timestamp TIMESTAMPTZ,
 					remote_lsn TEXT,
-					PRIMARY KEY (connection_id, collected_at, id, node_name)
+					PRIMARY KEY (connection_id, database_name, collected_at, id, node_name)
 				) PARTITION BY RANGE (collected_at);
 
 				COMMENT ON TABLE metrics.spock_resolutions IS
 					'Rolling 15-minute snapshots of rows from the Spock extension''s resolutions catalog';
+				COMMENT ON COLUMN metrics.spock_resolutions.database_name IS
+					'Source database the row was collected from; included in the primary key to disambiguate rows because the spock.resolutions.id sequence is per-database, not per-connection';
 
 				ALTER TABLE metrics.spock_resolutions
 					DROP CONSTRAINT IF EXISTS fk_spock_resolutions_connection_id;

--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -2700,7 +2700,7 @@ func (sm *SchemaManager) registerMigrations() {
 
 			// Seed global probe_configs for the two new probes. ON CONFLICT
 			// DO NOTHING preserves any operator override that may already
-			// exist (matching the v1 seed's behaviour).
+			// exist (matching the v1 seed's behavior).
 			_, err = tx.Exec(ctx, `
 				INSERT INTO probe_configs (connection_id, is_enabled, name, description, collection_interval_seconds, retention_days)
 				VALUES

--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -2597,6 +2597,149 @@ func (sm *SchemaManager) registerMigrations() {
 		},
 	})
 
+	// Migration #3: Add Spock exception_log and resolutions metrics tables,
+	// seed the matching probe_configs rows, and seed six new built-in alert
+	// rules covering Spock recent-count thresholds and replication-slot WAL
+	// retention warn/critical tiers. The migration is forward-only and
+	// idempotent: CREATE TABLE IF NOT EXISTS for the metrics tables and
+	// ON CONFLICT DO NOTHING on the seed rows.
+	sm.migrations = append(sm.migrations, Migration{
+		Version:     3,
+		Description: "Add Spock metrics tables and seed Spock/slot retention alert rules",
+		Up: func(tx pgx.Tx) error {
+			ctx := context.Background()
+
+			// metrics.spock_exception_log
+			//
+			// Captures rows pulled from spock.exception_log within a rolling
+			// 15-minute source-side window. Composite primary key matches
+			// the source-side identity columns prefixed with collector keys
+			// so re-collected rows from a still-open window slot in cleanly.
+			_, err := tx.Exec(ctx, `
+				CREATE TABLE IF NOT EXISTS metrics.spock_exception_log (
+					connection_id INTEGER NOT NULL,
+					collected_at TIMESTAMPTZ NOT NULL,
+					remote_origin OID NOT NULL,
+					remote_commit_ts TIMESTAMPTZ NOT NULL,
+					command_counter INTEGER NOT NULL,
+					retry_errored_at TIMESTAMPTZ NOT NULL,
+					remote_xid BIGINT NOT NULL,
+					local_origin OID,
+					local_commit_ts TIMESTAMPTZ,
+					table_schema TEXT,
+					table_name TEXT,
+					operation TEXT,
+					local_tup JSONB,
+					remote_old_tup JSONB,
+					remote_new_tup JSONB,
+					ddl_statement TEXT,
+					ddl_user TEXT,
+					error_message TEXT,
+					PRIMARY KEY (connection_id, collected_at, remote_origin, remote_commit_ts, command_counter, retry_errored_at)
+				) PARTITION BY RANGE (collected_at);
+
+				COMMENT ON TABLE metrics.spock_exception_log IS
+					'Rolling 15-minute snapshots of rows from the Spock extension''s exception_log catalog';
+
+				ALTER TABLE metrics.spock_exception_log
+					DROP CONSTRAINT IF EXISTS fk_spock_exception_log_connection_id;
+				ALTER TABLE metrics.spock_exception_log
+					ADD CONSTRAINT fk_spock_exception_log_connection_id
+					FOREIGN KEY (connection_id) REFERENCES connections(id) ON DELETE CASCADE;
+
+				CREATE INDEX IF NOT EXISTS idx_spock_exception_log_conn_time
+					ON metrics.spock_exception_log(connection_id, collected_at DESC);
+			`)
+			if err != nil {
+				return fmt.Errorf("failed to create metrics.spock_exception_log: %w", err)
+			}
+
+			// metrics.spock_resolutions
+			//
+			// Captures rows pulled from spock.resolutions within a rolling
+			// 15-minute source-side window. xid and pg_lsn columns are stored
+			// as TEXT so they round-trip cleanly via the standard COPY path.
+			_, err = tx.Exec(ctx, `
+				CREATE TABLE IF NOT EXISTS metrics.spock_resolutions (
+					connection_id INTEGER NOT NULL,
+					collected_at TIMESTAMPTZ NOT NULL,
+					id INTEGER NOT NULL,
+					node_name NAME NOT NULL,
+					log_time TIMESTAMPTZ NOT NULL,
+					relname TEXT,
+					idxname TEXT,
+					conflict_type TEXT,
+					conflict_resolution TEXT,
+					local_origin INTEGER,
+					local_tuple TEXT,
+					local_xid TEXT,
+					local_timestamp TIMESTAMPTZ,
+					remote_origin INTEGER,
+					remote_tuple TEXT,
+					remote_xid TEXT,
+					remote_timestamp TIMESTAMPTZ,
+					remote_lsn TEXT,
+					PRIMARY KEY (connection_id, collected_at, id, node_name)
+				) PARTITION BY RANGE (collected_at);
+
+				COMMENT ON TABLE metrics.spock_resolutions IS
+					'Rolling 15-minute snapshots of rows from the Spock extension''s resolutions catalog';
+
+				ALTER TABLE metrics.spock_resolutions
+					DROP CONSTRAINT IF EXISTS fk_spock_resolutions_connection_id;
+				ALTER TABLE metrics.spock_resolutions
+					ADD CONSTRAINT fk_spock_resolutions_connection_id
+					FOREIGN KEY (connection_id) REFERENCES connections(id) ON DELETE CASCADE;
+
+				CREATE INDEX IF NOT EXISTS idx_spock_resolutions_conn_time
+					ON metrics.spock_resolutions(connection_id, collected_at DESC);
+			`)
+			if err != nil {
+				return fmt.Errorf("failed to create metrics.spock_resolutions: %w", err)
+			}
+
+			// Seed global probe_configs for the two new probes. ON CONFLICT
+			// DO NOTHING preserves any operator override that may already
+			// exist (matching the v1 seed's behaviour).
+			_, err = tx.Exec(ctx, `
+				INSERT INTO probe_configs (connection_id, is_enabled, name, description, collection_interval_seconds, retention_days)
+				VALUES
+					(NULL, TRUE, 'spock_exception_log', 'Captures rows added to spock.exception_log in a rolling 15-minute window', 60, 7),
+					(NULL, TRUE, 'spock_resolutions', 'Captures rows added to spock.resolutions in a rolling 15-minute window', 60, 7)
+				ON CONFLICT DO NOTHING;
+			`)
+			if err != nil {
+				return fmt.Errorf("failed to seed Spock probe_configs: %w", err)
+			}
+
+			// Seed built-in alert rules. ON CONFLICT (name) DO NOTHING
+			// preserves operator overrides on previously seeded rules.
+			// The two slot-retention rules carry required_extension = NULL
+			// because slot retention applies to every PostgreSQL deployment.
+			_, err = tx.Exec(ctx, `
+				INSERT INTO alert_rules (name, description, category, metric_name, metric_unit, default_operator, default_threshold, default_severity, default_enabled, required_extension, is_built_in)
+				VALUES
+					-- Spock exception_log content rules.
+					('spock_recent_exceptions_present', 'Spock has logged at least one exception in the last 15 minutes', 'replication', 'spock_exception_log.recent_count', 'exceptions', '>=', 1, 'warning', TRUE, 'spock', TRUE),
+					('spock_recent_exceptions_high', 'Spock has logged a high number of exceptions in the last 15 minutes', 'replication', 'spock_exception_log.recent_count', 'exceptions', '>=', 10, 'critical', TRUE, 'spock', TRUE),
+
+					-- Spock resolutions content rules.
+					('spock_recent_resolutions_present', 'Spock has auto-resolved at least one conflict in the last 15 minutes', 'replication', 'spock_resolutions.recent_count', 'resolutions', '>=', 1, 'warning', TRUE, 'spock', TRUE),
+					('spock_recent_resolutions_high', 'Spock has auto-resolved a high number of conflicts in the last 15 minutes', 'replication', 'spock_resolutions.recent_count', 'resolutions', '>=', 25, 'critical', TRUE, 'spock', TRUE),
+
+					-- Replication slot WAL retention tiers.
+					('replication_slot_retention_warn', 'A replication slot is retaining more than 1 GiB of WAL', 'replication', 'pg_replication_slots.max_retained_bytes', 'bytes', '>=', 1073741824, 'warning', TRUE, NULL, TRUE),
+					('replication_slot_retention_high', 'A replication slot is retaining more than 10 GiB of WAL', 'replication', 'pg_replication_slots.max_retained_bytes', 'bytes', '>=', 10737418240, 'critical', TRUE, NULL, TRUE)
+				ON CONFLICT (name) DO NOTHING;
+			`)
+			if err != nil {
+				return fmt.Errorf("failed to seed Spock and slot retention alert rules: %w", err)
+			}
+
+			return nil
+		},
+	})
+
 }
 
 // Migrate applies all pending migrations

--- a/collector/src/database/schema_test.go
+++ b/collector/src/database/schema_test.go
@@ -283,7 +283,7 @@ func TestNewSchemaManager(t *testing.T) {
 	}
 
 	// Verify all migrations are registered
-	expectedVersions := []int{1, 2}
+	expectedVersions := []int{1, 2, 3}
 	if len(sm.migrations) != len(expectedVersions) {
 		t.Fatalf("Expected %d migrations, got %d", len(expectedVersions), len(sm.migrations))
 	}
@@ -995,6 +995,8 @@ func TestZZZ_FullSchemaForInspection(t *testing.T) {
 		"pg_stat_wal",
 		"pg_stat_replication",
 		"pg_replication_slots",
+		"spock_exception_log",
+		"spock_resolutions",
 		"pg_stat_subscription",
 		"pg_stat_recovery_prefetch",
 		"pg_stat_io",

--- a/collector/src/probes/constants.go
+++ b/collector/src/probes/constants.go
@@ -39,6 +39,8 @@ const (
 	ProbeNamePgStatUserFunctions     = "pg_stat_user_functions"
 	ProbeNamePgStatStatements        = "pg_stat_statements"
 	ProbeNamePgExtension             = "pg_extension"
+	ProbeNameSpockExceptionLog       = "spock_exception_log"
+	ProbeNameSpockResolutions        = "spock_resolutions"
 )
 
 // Probe names - System Stats Extension probes (server-scoped, require system_stats extension)

--- a/collector/src/probes/integration_helpers_test.go
+++ b/collector/src/probes/integration_helpers_test.go
@@ -722,6 +722,32 @@ func applyMetricsSchema(ctx context.Context, pool *pgxpool.Pool) error {
 			error_message TEXT
 		) PARTITION BY RANGE (collected_at)`,
 
+		// metrics.spock_resolutions mirrors the v3 migration column
+		// list, including the TEXT representation of xid and pg_lsn
+		// values that the probe casts on the source side. The probe's
+		// Store path appends to this parent table; child partitions
+		// are created on demand by EnsurePartition during the test.
+		`CREATE TABLE IF NOT EXISTS metrics.spock_resolutions (
+			connection_id INTEGER NOT NULL,
+			collected_at TIMESTAMPTZ NOT NULL,
+			id INTEGER NOT NULL,
+			node_name NAME NOT NULL,
+			log_time TIMESTAMPTZ NOT NULL,
+			relname TEXT,
+			idxname TEXT,
+			conflict_type TEXT,
+			conflict_resolution TEXT,
+			local_origin INTEGER,
+			local_tuple TEXT,
+			local_xid TEXT,
+			local_timestamp TIMESTAMPTZ,
+			remote_origin INTEGER,
+			remote_tuple TEXT,
+			remote_xid TEXT,
+			remote_timestamp TIMESTAMPTZ,
+			remote_lsn TEXT
+		) PARTITION BY RANGE (collected_at)`,
+
 		// pg_stat_statements is a real extension and is enabled in
 		// the CI environment via shared_preload_libraries. We try
 		// to install it; if the server was not started with the

--- a/collector/src/probes/integration_helpers_test.go
+++ b/collector/src/probes/integration_helpers_test.go
@@ -698,6 +698,30 @@ func applyMetricsSchema(ctx context.Context, pool *pgxpool.Pool) error {
 			stats_reset TIMESTAMPTZ
 		) PARTITION BY RANGE (collected_at)`,
 
+		// Spock probe target tables. Mirrors the v3 migration column
+		// shape so the probe Store paths can write rows without
+		// schema drift in unit/integration tests.
+		`CREATE TABLE IF NOT EXISTS metrics.spock_exception_log (
+			connection_id INTEGER NOT NULL,
+			collected_at TIMESTAMPTZ NOT NULL,
+			remote_origin OID,
+			remote_commit_ts TIMESTAMPTZ,
+			command_counter INTEGER,
+			retry_errored_at TIMESTAMPTZ,
+			remote_xid BIGINT,
+			local_origin OID,
+			local_commit_ts TIMESTAMPTZ,
+			table_schema TEXT,
+			table_name TEXT,
+			operation TEXT,
+			local_tup JSONB,
+			remote_old_tup JSONB,
+			remote_new_tup JSONB,
+			ddl_statement TEXT,
+			ddl_user TEXT,
+			error_message TEXT
+		) PARTITION BY RANGE (collected_at)`,
+
 		// pg_stat_statements is a real extension and is enabled in
 		// the CI environment via shared_preload_libraries. We try
 		// to install it; if the server was not started with the

--- a/collector/src/probes/integration_helpers_test.go
+++ b/collector/src/probes/integration_helpers_test.go
@@ -700,9 +700,13 @@ func applyMetricsSchema(ctx context.Context, pool *pgxpool.Pool) error {
 
 		// Spock probe target tables. Mirrors the v3 migration column
 		// shape so the probe Store paths can write rows without
-		// schema drift in unit/integration tests.
+		// schema drift in unit/integration tests. database_name is
+		// NOT NULL here just like in the v3 migration: the probe's
+		// Store path always supplies a value sourced from the
+		// scheduler-injected "_database_name" key.
 		`CREATE TABLE IF NOT EXISTS metrics.spock_exception_log (
 			connection_id INTEGER NOT NULL,
+			database_name TEXT NOT NULL,
 			collected_at TIMESTAMPTZ NOT NULL,
 			remote_origin OID,
 			remote_commit_ts TIMESTAMPTZ,
@@ -729,6 +733,7 @@ func applyMetricsSchema(ctx context.Context, pool *pgxpool.Pool) error {
 		// are created on demand by EnsurePartition during the test.
 		`CREATE TABLE IF NOT EXISTS metrics.spock_resolutions (
 			connection_id INTEGER NOT NULL,
+			database_name TEXT NOT NULL,
 			collected_at TIMESTAMPTZ NOT NULL,
 			id INTEGER NOT NULL,
 			node_name NAME NOT NULL,

--- a/collector/src/probes/spock_exception_log_probe.go
+++ b/collector/src/probes/spock_exception_log_probe.go
@@ -1,0 +1,164 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package probes
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/collector/src/utils"
+)
+
+// SpockExceptionLogProbe captures rows added to spock.exception_log in a
+// rolling 15-minute source-side window. The probe is database-scoped so it
+// runs once per monitored database connection; pgEdge clusters typically
+// register Spock in a single application database, but this scoping lets us
+// pick up exception rows from any database that has the extension loaded
+// without depending on cluster-level configuration.
+//
+// The probe short-circuits cleanly on databases where Spock is not
+// installed: Execute returns (nil, nil) so the scheduler treats the
+// collection as a successful no-op rather than retrying on every cycle.
+type SpockExceptionLogProbe struct {
+	BaseMetricsProbe
+}
+
+// NewSpockExceptionLogProbe constructs a SpockExceptionLogProbe with the
+// supplied configuration. databaseScoped is set to true so the scheduler
+// iterates over each user database when invoking the probe.
+func NewSpockExceptionLogProbe(config *ProbeConfig) *SpockExceptionLogProbe {
+	return &SpockExceptionLogProbe{
+		BaseMetricsProbe: BaseMetricsProbe{
+			config:         config,
+			databaseScoped: true,
+		},
+	}
+}
+
+// GetExtensionName advertises the Spock dependency to the scheduler so the
+// "extension missing" reason can be surfaced in operator-facing tooling.
+// This satisfies the ExtensionProbe interface defined in base.go.
+func (p *SpockExceptionLogProbe) GetExtensionName() string {
+	return "spock"
+}
+
+// GetQuery returns the SQL executed against the monitored database. The
+// rolling 15-minute window is anchored on retry_errored_at because that is
+// the column Spock advances when an apply attempt fails; collected_at on
+// the destination side is recorded separately by Store.
+//
+// The column list mirrors metrics.spock_exception_log so Store can pass the
+// row maps straight through without reshaping. local_tup, remote_old_tup,
+// and remote_new_tup are JSONB on both sides, so pgx scans them into Go
+// values that the COPY/INSERT path serializes back to JSONB transparently.
+func (p *SpockExceptionLogProbe) GetQuery() string {
+	return `
+		SELECT remote_origin,
+		       remote_commit_ts,
+		       command_counter,
+		       retry_errored_at,
+		       remote_xid,
+		       local_origin,
+		       local_commit_ts,
+		       table_schema,
+		       table_name,
+		       operation,
+		       local_tup,
+		       remote_old_tup,
+		       remote_new_tup,
+		       ddl_statement,
+		       ddl_user,
+		       error_message
+		  FROM spock.exception_log
+		 WHERE retry_errored_at > now() - interval '15 minutes'
+	`
+}
+
+// Execute runs the rolling-window query against the monitored database
+// after first verifying that the Spock extension is installed. On
+// databases without Spock the call returns (nil, nil) without touching
+// the catalog — the CheckExtensionExists helper caches the negative
+// result so the existence query only hits the catalog once per
+// connection lifetime.
+func (p *SpockExceptionLogProbe) Execute(ctx context.Context, connectionName string, monitoredConn *pgxpool.Conn, pgVersion int) ([]map[string]any, error) {
+	exists, err := CheckExtensionExists(ctx, connectionName, monitoredConn, "spock")
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+
+	query := WrapQuery(ProbeNameSpockExceptionLog, p.GetQuery())
+	rows, err := monitoredConn.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute spock_exception_log query: %w", err)
+	}
+	defer rows.Close()
+
+	return utils.ScanRowsToMaps(rows)
+}
+
+// Store writes the captured rows to metrics.spock_exception_log. Empty
+// metric slices short-circuit before any datastore work so the scheduler
+// can call Store unconditionally after Execute.
+//
+// The column order matches the v3 migration (collector/src/database/
+// schema.go) and the surface contract documented on GetQuery; do not
+// reorder or rename columns without updating both call sites.
+func (p *SpockExceptionLogProbe) Store(ctx context.Context, datastoreConn *pgxpool.Conn, connectionID int, timestamp time.Time, metrics []map[string]any) error {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	if err := p.EnsurePartition(ctx, datastoreConn, timestamp); err != nil {
+		return fmt.Errorf("failed to ensure partition: %w", err)
+	}
+
+	columns := []string{
+		"connection_id", "collected_at",
+		"remote_origin", "remote_commit_ts", "command_counter",
+		"retry_errored_at", "remote_xid", "local_origin",
+		"local_commit_ts", "table_schema", "table_name", "operation",
+		"local_tup", "remote_old_tup", "remote_new_tup",
+		"ddl_statement", "ddl_user", "error_message",
+	}
+
+	values := make([][]any, 0, len(metrics))
+	for _, m := range metrics {
+		values = append(values, []any{
+			connectionID,
+			timestamp,
+			m["remote_origin"],
+			m["remote_commit_ts"],
+			m["command_counter"],
+			m["retry_errored_at"],
+			m["remote_xid"],
+			m["local_origin"],
+			m["local_commit_ts"],
+			m["table_schema"],
+			m["table_name"],
+			m["operation"],
+			m["local_tup"],
+			m["remote_old_tup"],
+			m["remote_new_tup"],
+			m["ddl_statement"],
+			m["ddl_user"],
+			m["error_message"],
+		})
+	}
+
+	if err := StoreMetrics(ctx, datastoreConn, p.GetTableName(), columns, values); err != nil {
+		return fmt.Errorf("failed to store spock_exception_log metrics: %w", err)
+	}
+	return nil
+}

--- a/collector/src/probes/spock_exception_log_probe.go
+++ b/collector/src/probes/spock_exception_log_probe.go
@@ -115,6 +115,12 @@ func (p *SpockExceptionLogProbe) Execute(ctx context.Context, connectionName str
 // The column order matches the v3 migration (collector/src/database/
 // schema.go) and the surface contract documented on GetQuery; do not
 // reorder or rename columns without updating both call sites.
+//
+// database_name is sourced from the per-row "_database_name" key the
+// scheduler injects on every database-scoped probe. The value is part
+// of the destination primary key because the probe runs once per
+// monitored database and the Spock identity columns can collide across
+// databases on the same monitored connection.
 func (p *SpockExceptionLogProbe) Store(ctx context.Context, datastoreConn *pgxpool.Conn, connectionID int, timestamp time.Time, metrics []map[string]any) error {
 	if len(metrics) == 0 {
 		return nil
@@ -125,7 +131,7 @@ func (p *SpockExceptionLogProbe) Store(ctx context.Context, datastoreConn *pgxpo
 	}
 
 	columns := []string{
-		"connection_id", "collected_at",
+		"connection_id", "database_name", "collected_at",
 		"remote_origin", "remote_commit_ts", "command_counter",
 		"retry_errored_at", "remote_xid", "local_origin",
 		"local_commit_ts", "table_schema", "table_name", "operation",
@@ -135,8 +141,13 @@ func (p *SpockExceptionLogProbe) Store(ctx context.Context, datastoreConn *pgxpo
 
 	values := make([][]any, 0, len(metrics))
 	for _, m := range metrics {
+		databaseName, ok := m["_database_name"]
+		if !ok {
+			return fmt.Errorf("database_name not found in metrics for spock_exception_log; scheduler must inject _database_name on database-scoped probes")
+		}
 		values = append(values, []any{
 			connectionID,
+			databaseName,
 			timestamp,
 			m["remote_origin"],
 			m["remote_commit_ts"],

--- a/collector/src/probes/spock_exception_log_probe_test.go
+++ b/collector/src/probes/spock_exception_log_probe_test.go
@@ -87,13 +87,23 @@ func TestSpockExceptionLogProbe_StoreEmpty(t *testing.T) {
 // raising an error or attempting to query a missing catalog. This
 // branch is hit on every collection cycle for non-Spock databases
 // and must not log noise or churn the connection pool.
+//
+// The test is skipped when Spock is already installed on the host
+// integration database; the integration pool is created fresh per
+// process today, but the guard keeps this test correct on hosts where
+// Spock is part of the base image.
 func TestSpockExceptionLogProbe_ExecuteWhenSpockAbsent(t *testing.T) {
 	pool := requireIntegrationPool(t)
 	conn := acquireConn(t, pool)
+	ctx := context.Background()
 	pgVersion := detectPgVersion(t, conn)
 
+	if spockAlreadyInstalled(t, ctx, conn) {
+		t.Skip("spock extension already installed; cannot exercise " +
+			"the spock-absent branch")
+	}
+
 	p := newSpockExceptionLogProbeForTest()
-	ctx := context.Background()
 
 	metrics, err := p.Execute(ctx, "no-spock", conn, pgVersion)
 	if err != nil {

--- a/collector/src/probes/spock_exception_log_probe_test.go
+++ b/collector/src/probes/spock_exception_log_probe_test.go
@@ -105,3 +105,218 @@ func TestSpockExceptionLogProbe_ExecuteWhenSpockAbsent(t *testing.T) {
 			len(metrics))
 	}
 }
+
+// TestSpockExceptionLogProbe_GetExtensionName documents the
+// extension dependency advertised to the scheduler so operator-
+// facing reasons ("Spock not installed") stay in sync with the
+// runtime guard inside Execute.
+func TestSpockExceptionLogProbe_GetExtensionName(t *testing.T) {
+	p := newSpockExceptionLogProbeForTest()
+	if got := p.GetExtensionName(); got != "spock" {
+		t.Errorf("GetExtensionName() = %q, want %q", got, "spock")
+	}
+}
+
+// TestSpockExceptionLogProbe_ExecuteWithStubSpock drives the Spock-
+// installed branch of Execute by registering a stub spock extension
+// and creating a minimal spock.exception_log table that matches the
+// columns the probe selects. With the schema in place Execute should
+// succeed and return an empty (non-nil) slice when no rows fall
+// inside the rolling 15-minute window. We then insert a single row
+// and verify it round-trips through Execute and Store.
+func TestSpockExceptionLogProbe_ExecuteWithStubSpock(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	ctx := context.Background()
+	pgVersion := detectPgVersion(t, conn)
+
+	if spockAlreadyInstalled(t, ctx, conn) {
+		t.Skip("spock extension already installed; this test " +
+			"creates a stub spock and would otherwise need to " +
+			"destroy a real one to clean up")
+	}
+
+	stmts := []string{
+		`CREATE SCHEMA IF NOT EXISTS spock`,
+		`CREATE TABLE IF NOT EXISTS spock.exception_log (
+			remote_origin OID NOT NULL,
+			remote_commit_ts TIMESTAMPTZ NOT NULL,
+			command_counter INTEGER NOT NULL,
+			retry_errored_at TIMESTAMPTZ NOT NULL,
+			remote_xid BIGINT NOT NULL,
+			local_origin OID,
+			local_commit_ts TIMESTAMPTZ,
+			table_schema TEXT,
+			table_name TEXT,
+			operation TEXT,
+			local_tup JSONB,
+			remote_old_tup JSONB,
+			remote_new_tup JSONB,
+			ddl_statement TEXT,
+			ddl_user TEXT,
+			error_message TEXT
+		)`,
+		`INSERT INTO pg_extension (oid, extname, extowner,
+			extnamespace, extrelocatable, extversion,
+			extconfig, extcondition)
+			SELECT (SELECT MAX(oid::oid::int)
+				FROM pg_extension) + 1, 'spock', 10,
+				(SELECT oid FROM pg_namespace
+					WHERE nspname='spock'),
+				TRUE, '1.0', NULL, NULL
+			WHERE NOT EXISTS (SELECT 1 FROM pg_extension
+				WHERE extname='spock')`,
+	}
+	for _, s := range stmts {
+		if _, err := conn.Exec(ctx, s); err != nil {
+			t.Fatalf("setup spock stub: %v\n%s", err, s)
+		}
+	}
+	t.Cleanup(func() {
+		if _, err := conn.Exec(ctx,
+			"DELETE FROM pg_extension "+
+				"WHERE extname='spock'"); err != nil {
+			t.Logf("cleanup pg_extension spock row: %v", err)
+		}
+		if _, err := conn.Exec(ctx,
+			"DROP SCHEMA spock CASCADE"); err != nil {
+			t.Logf("cleanup spock schema: %v", err)
+		}
+	})
+
+	p := newSpockExceptionLogProbeForTest()
+
+	// Empty-window case: no rows yet, but the query and scan path
+	// must succeed and return a non-error result.
+	metrics, err := p.Execute(ctx, "with-spock", conn, pgVersion)
+	if err != nil {
+		t.Fatalf("Execute (empty window): %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Errorf("Execute (empty window) returned %d metrics, "+
+			"want 0", len(metrics))
+	}
+
+	// Insert a synthetic row that falls inside the 15-minute window.
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO spock.exception_log (
+			remote_origin, remote_commit_ts, command_counter,
+			retry_errored_at, remote_xid, local_origin,
+			local_commit_ts, table_schema, table_name, operation,
+			local_tup, remote_old_tup, remote_new_tup,
+			ddl_statement, ddl_user, error_message)
+		VALUES (
+			16384, now(), 1, now(), 12345, 16385,
+			now(), 'public', 't1', 'INSERT',
+			'{"a":1}'::jsonb, NULL, '{"a":2}'::jsonb,
+			NULL, NULL, 'apply failed: dup key')
+	`); err != nil {
+		t.Fatalf("insert exception_log row: %v", err)
+	}
+
+	metrics, err = p.Execute(ctx, "with-spock", conn, pgVersion)
+	if err != nil {
+		t.Fatalf("Execute (one row): %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("Execute returned %d rows, want 1", len(metrics))
+	}
+	if got := metrics[0]["error_message"]; got !=
+		"apply failed: dup key" {
+		t.Errorf("error_message = %v, want %q",
+			got, "apply failed: dup key")
+	}
+
+	// Store the row to metrics.spock_exception_log to exercise the
+	// happy path of the COPY/INSERT pipeline. The integration
+	// helper schema includes this table so partition creation and
+	// the column ordering above are both verified end-to-end.
+	if err := p.Store(ctx, conn, 1, time.Now().UTC(),
+		metrics); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	// Confirm at least one row landed in the destination table.
+	var stored int
+	if err := conn.QueryRow(ctx, `
+		SELECT COUNT(*) FROM metrics.spock_exception_log
+		 WHERE connection_id = 1
+	`).Scan(&stored); err != nil {
+		t.Fatalf("count stored rows: %v", err)
+	}
+	if stored != 1 {
+		t.Errorf("metrics.spock_exception_log count = %d, want 1",
+			stored)
+	}
+}
+
+// TestSpockExceptionLogProbe_ExecuteCheckExtensionError exercises the
+// CheckExtensionExists error branch by passing a connection that has
+// already been released. pgxpool returns an error for any query
+// attempted on a released connection; the probe must wrap and
+// return that error rather than swallowing it.
+func TestSpockExceptionLogProbe_ExecuteCheckExtensionError(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	ctx := context.Background()
+	pgVersion := detectPgVersion(t, conn)
+
+	// Force the underlying *pgx.Conn into a state that fails the
+	// next query. Cancelling the context is the cheapest way to
+	// guarantee QueryRow returns an error without disturbing the
+	// shared pool.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	p := newSpockExceptionLogProbeForTest()
+	if _, err := p.Execute(cancelCtx, "cancelled", conn,
+		pgVersion); err == nil {
+		t.Fatal("Execute with cancelled context: expected error, " +
+			"got nil")
+	}
+}
+
+// TestSpockExceptionLogProbe_StoreEnsurePartitionError drives the
+// EnsurePartition error branch of Store by passing a cancelled
+// context with a real datastore connection. EnsurePartition issues
+// SQL through the connection, which fails immediately when the
+// context is already cancelled, causing Store to surface the wrapped
+// "failed to ensure partition" error.
+func TestSpockExceptionLogProbe_StoreEnsurePartitionError(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	metrics := []map[string]any{
+		{
+			"remote_origin":    uint32(1),
+			"remote_commit_ts": time.Now(),
+			"command_counter":  1,
+			"retry_errored_at": time.Now(),
+			"remote_xid":       int64(1),
+			"local_origin":     nil,
+			"local_commit_ts":  nil,
+			"table_schema":     "public",
+			"table_name":       "t",
+			"operation":        "INSERT",
+			"local_tup":        nil,
+			"remote_old_tup":   nil,
+			"remote_new_tup":   nil,
+			"ddl_statement":    nil,
+			"ddl_user":         nil,
+			"error_message":    "boom",
+		},
+	}
+
+	p := newSpockExceptionLogProbeForTest()
+	err := p.Store(cancelCtx, conn, 1, time.Now(), metrics)
+	if err == nil {
+		t.Fatal("Store(cancelled ctx) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to ensure partition") {
+		t.Errorf("Store error = %q; want it to mention "+
+			"'failed to ensure partition'", err.Error())
+	}
+}

--- a/collector/src/probes/spock_exception_log_probe_test.go
+++ b/collector/src/probes/spock_exception_log_probe_test.go
@@ -1,0 +1,107 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package probes
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newSpockExceptionLogProbeForTest constructs a probe with a minimal,
+// deterministic configuration suitable for unit and integration tests.
+// The returned probe is database-scoped, matching production behaviour.
+func newSpockExceptionLogProbeForTest() *SpockExceptionLogProbe {
+	return NewSpockExceptionLogProbe(&ProbeConfig{
+		Name:                      ProbeNameSpockExceptionLog,
+		CollectionIntervalSeconds: 60,
+		RetentionDays:             7,
+		IsEnabled:                 true,
+	})
+}
+
+// TestSpockExceptionLogProbe_Surface verifies the probe's static
+// metadata: name, table name, scope, and that GetQuery returns SQL
+// that targets spock.exception_log over the rolling 15-minute window
+// described in the design spec.
+func TestSpockExceptionLogProbe_Surface(t *testing.T) {
+	p := newSpockExceptionLogProbeForTest()
+
+	if got := p.GetName(); got != ProbeNameSpockExceptionLog {
+		t.Errorf("GetName() = %q, want %q",
+			got, ProbeNameSpockExceptionLog)
+	}
+	if got := p.GetTableName(); got != ProbeNameSpockExceptionLog {
+		t.Errorf("GetTableName() = %q, want %q",
+			got, ProbeNameSpockExceptionLog)
+	}
+	if !p.IsDatabaseScoped() {
+		t.Error("IsDatabaseScoped() = false, want true " +
+			"(spock_exception_log is a per-database catalog)")
+	}
+
+	q := p.GetQuery()
+	for _, s := range []string{
+		"spock.exception_log",
+		"retry_errored_at",
+		"remote_origin",
+		"error_message",
+		"interval '15 minutes'",
+	} {
+		if !strings.Contains(q, s) {
+			t.Errorf("GetQuery missing substring %q; query was:\n%s",
+				s, q)
+		}
+	}
+}
+
+// TestSpockExceptionLogProbe_StoreEmpty asserts that Store returns
+// nil with a nil/empty metrics slice and never touches the
+// datastore connection. This is the no-op fast path that lets the
+// scheduler call Store unconditionally even when Execute returned
+// nothing (e.g. Spock not installed, or no exceptions in the window).
+func TestSpockExceptionLogProbe_StoreEmpty(t *testing.T) {
+	p := newSpockExceptionLogProbeForTest()
+	if err := p.Store(context.Background(), nil, 1, time.Now(),
+		nil); err != nil {
+		t.Errorf("Store(nil) = %v, want nil", err)
+	}
+	// Empty slice should also be a no-op.
+	if err := p.Store(context.Background(), nil, 1, time.Now(),
+		[]map[string]any{}); err != nil {
+		t.Errorf("Store([]) = %v, want nil", err)
+	}
+}
+
+// TestSpockExceptionLogProbe_ExecuteWhenSpockAbsent verifies the
+// graceful-skip behaviour: when the Spock extension is not installed
+// in the connected database, Execute returns (nil, nil) rather than
+// raising an error or attempting to query a missing catalog. This
+// branch is hit on every collection cycle for non-Spock databases
+// and must not log noise or churn the connection pool.
+func TestSpockExceptionLogProbe_ExecuteWhenSpockAbsent(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	pgVersion := detectPgVersion(t, conn)
+
+	p := newSpockExceptionLogProbeForTest()
+	ctx := context.Background()
+
+	metrics, err := p.Execute(ctx, "no-spock", conn, pgVersion)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if metrics != nil {
+		t.Errorf("Execute() returned %d metrics; want nil "+
+			"(integration database has no Spock extension)",
+			len(metrics))
+	}
+}

--- a/collector/src/probes/spock_exception_log_probe_test.go
+++ b/collector/src/probes/spock_exception_log_probe_test.go
@@ -227,6 +227,13 @@ func TestSpockExceptionLogProbe_ExecuteWithStubSpock(t *testing.T) {
 			got, "apply failed: dup key")
 	}
 
+	// The scheduler injects _database_name on every row before
+	// Store is called. Mirror that here so Store can populate the
+	// destination database_name column without errors.
+	for i := range metrics {
+		metrics[i]["_database_name"] = "stub-db"
+	}
+
 	// Store the row to metrics.spock_exception_log to exercise the
 	// happy path of the COPY/INSERT pipeline. The integration
 	// helper schema includes this table so partition creation and

--- a/collector/src/probes/spock_exception_log_probe_test.go
+++ b/collector/src/probes/spock_exception_log_probe_test.go
@@ -146,6 +146,19 @@ func TestSpockExceptionLogProbe_ExecuteWithStubSpock(t *testing.T) {
 			"destroy a real one to clean up")
 	}
 
+	// Track whether this test created the spock schema. If a stale
+	// schema exists from a previous crashed run (or a future setup
+	// step pre-creates it for unrelated reasons) the cleanup must
+	// leave it alone rather than drop a structure it does not own.
+	var createdSchema bool
+	if err := conn.QueryRow(ctx, `
+		SELECT NOT EXISTS (
+			SELECT 1 FROM pg_namespace WHERE nspname = 'spock'
+		)
+	`).Scan(&createdSchema); err != nil {
+		t.Fatalf("check spock schema existence: %v", err)
+	}
+
 	stmts := []string{
 		`CREATE SCHEMA IF NOT EXISTS spock`,
 		`CREATE TABLE IF NOT EXISTS spock.exception_log (
@@ -187,6 +200,18 @@ func TestSpockExceptionLogProbe_ExecuteWithStubSpock(t *testing.T) {
 			"DELETE FROM pg_extension "+
 				"WHERE extname='spock'"); err != nil {
 			t.Logf("cleanup pg_extension spock row: %v", err)
+		}
+		if !createdSchema {
+			// The schema was already there; leave it alone so a
+			// crashed previous run or unrelated test fixture does
+			// not lose its structure to this cleanup. In that
+			// situation we still drop the table the test created
+			// so subsequent runs find a clean schema.
+			if _, err := conn.Exec(ctx,
+				"DROP TABLE IF EXISTS spock.exception_log"); err != nil {
+				t.Logf("cleanup spock.exception_log table: %v", err)
+			}
+			return
 		}
 		if _, err := conn.Exec(ctx,
 			"DROP SCHEMA spock CASCADE"); err != nil {

--- a/collector/src/probes/spock_exception_log_probe_test.go
+++ b/collector/src/probes/spock_exception_log_probe_test.go
@@ -318,6 +318,50 @@ func TestSpockExceptionLogProbe_ExecuteCheckExtensionError(t *testing.T) {
 	}
 }
 
+// TestSpockExceptionLogProbe_StoreMissingDatabaseName drives the
+// guard that surfaces a clear error when the scheduler-injected
+// _database_name key is missing from a metric row. database_name is
+// part of the destination primary key, so a missing value is a
+// programming error in the scheduler rather than a runtime data
+// condition the probe can recover from.
+func TestSpockExceptionLogProbe_StoreMissingDatabaseName(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+
+	metrics := []map[string]any{
+		{
+			// _database_name deliberately omitted so Store hits the
+			// guarded error path before issuing any SQL.
+			"remote_origin":    uint32(1),
+			"remote_commit_ts": time.Now(),
+			"command_counter":  1,
+			"retry_errored_at": time.Now(),
+			"remote_xid":       int64(1),
+			"local_origin":     nil,
+			"local_commit_ts":  nil,
+			"table_schema":     "public",
+			"table_name":       "t",
+			"operation":        "INSERT",
+			"local_tup":        nil,
+			"remote_old_tup":   nil,
+			"remote_new_tup":   nil,
+			"ddl_statement":    nil,
+			"ddl_user":         nil,
+			"error_message":    "boom",
+		},
+	}
+
+	p := newSpockExceptionLogProbeForTest()
+	err := p.Store(context.Background(), conn, 1, time.Now(), metrics)
+	if err == nil {
+		t.Fatal("Store(no _database_name) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "database_name not found") {
+		t.Errorf("Store error = %q; want it to mention "+
+			"'database_name not found'", err.Error())
+	}
+}
+
 // TestSpockExceptionLogProbe_StoreEnsurePartitionError drives the
 // EnsurePartition error branch of Store by passing a canceled
 // context with a real datastore connection. EnsurePartition issues

--- a/collector/src/probes/spock_exception_log_probe_test.go
+++ b/collector/src/probes/spock_exception_log_probe_test.go
@@ -18,7 +18,7 @@ import (
 
 // newSpockExceptionLogProbeForTest constructs a probe with a minimal,
 // deterministic configuration suitable for unit and integration tests.
-// The returned probe is database-scoped, matching production behaviour.
+// The returned probe is database-scoped, matching production behavior.
 func newSpockExceptionLogProbeForTest() *SpockExceptionLogProbe {
 	return NewSpockExceptionLogProbe(&ProbeConfig{
 		Name:                      ProbeNameSpockExceptionLog,
@@ -82,7 +82,7 @@ func TestSpockExceptionLogProbe_StoreEmpty(t *testing.T) {
 }
 
 // TestSpockExceptionLogProbe_ExecuteWhenSpockAbsent verifies the
-// graceful-skip behaviour: when the Spock extension is not installed
+// graceful-skip behavior: when the Spock extension is not installed
 // in the connected database, Execute returns (nil, nil) rather than
 // raising an error or attempting to query a missing catalog. This
 // branch is hit on every collection cycle for non-Spock databases
@@ -262,25 +262,25 @@ func TestSpockExceptionLogProbe_ExecuteCheckExtensionError(t *testing.T) {
 	pgVersion := detectPgVersion(t, conn)
 
 	// Force the underlying *pgx.Conn into a state that fails the
-	// next query. Cancelling the context is the cheapest way to
+	// next query. Canceling the context is the cheapest way to
 	// guarantee QueryRow returns an error without disturbing the
 	// shared pool.
 	cancelCtx, cancel := context.WithCancel(ctx)
 	cancel()
 
 	p := newSpockExceptionLogProbeForTest()
-	if _, err := p.Execute(cancelCtx, "cancelled", conn,
+	if _, err := p.Execute(cancelCtx, "canceled", conn,
 		pgVersion); err == nil {
-		t.Fatal("Execute with cancelled context: expected error, " +
+		t.Fatal("Execute with canceled context: expected error, " +
 			"got nil")
 	}
 }
 
 // TestSpockExceptionLogProbe_StoreEnsurePartitionError drives the
-// EnsurePartition error branch of Store by passing a cancelled
+// EnsurePartition error branch of Store by passing a canceled
 // context with a real datastore connection. EnsurePartition issues
 // SQL through the connection, which fails immediately when the
-// context is already cancelled, causing Store to surface the wrapped
+// context is already canceled, causing Store to surface the wrapped
 // "failed to ensure partition" error.
 func TestSpockExceptionLogProbe_StoreEnsurePartitionError(t *testing.T) {
 	pool := requireIntegrationPool(t)
@@ -313,7 +313,7 @@ func TestSpockExceptionLogProbe_StoreEnsurePartitionError(t *testing.T) {
 	p := newSpockExceptionLogProbeForTest()
 	err := p.Store(cancelCtx, conn, 1, time.Now(), metrics)
 	if err == nil {
-		t.Fatal("Store(cancelled ctx) expected error, got nil")
+		t.Fatal("Store(canceled ctx) expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "failed to ensure partition") {
 		t.Errorf("Store error = %q; want it to mention "+

--- a/collector/src/probes/spock_resolutions_probe.go
+++ b/collector/src/probes/spock_resolutions_probe.go
@@ -121,6 +121,13 @@ func (p *SpockResolutionsProbe) Execute(ctx context.Context, connectionName stri
 // pg_lsn values arrive as Go strings (already cast to text on the
 // source side) and land in TEXT columns on the destination, avoiding
 // any pgx type negotiation in the COPY path.
+//
+// database_name is sourced from the per-row "_database_name" key the
+// scheduler injects on every database-scoped probe. The value is part
+// of the destination primary key because the spock.resolutions.id
+// sequence is per-database, so two rows with the same id collected
+// from different databases on the same monitored connection would
+// otherwise collide on the composite key.
 func (p *SpockResolutionsProbe) Store(ctx context.Context, datastoreConn *pgxpool.Conn, connectionID int, timestamp time.Time, metrics []map[string]any) error {
 	if len(metrics) == 0 {
 		return nil
@@ -131,7 +138,7 @@ func (p *SpockResolutionsProbe) Store(ctx context.Context, datastoreConn *pgxpoo
 	}
 
 	columns := []string{
-		"connection_id", "collected_at",
+		"connection_id", "database_name", "collected_at",
 		"id", "node_name", "log_time", "relname", "idxname",
 		"conflict_type", "conflict_resolution",
 		"local_origin", "local_tuple", "local_xid", "local_timestamp",
@@ -141,8 +148,13 @@ func (p *SpockResolutionsProbe) Store(ctx context.Context, datastoreConn *pgxpoo
 
 	values := make([][]any, 0, len(metrics))
 	for _, m := range metrics {
+		databaseName, ok := m["_database_name"]
+		if !ok {
+			return fmt.Errorf("database_name not found in metrics for spock_resolutions; scheduler must inject _database_name on database-scoped probes")
+		}
 		values = append(values, []any{
 			connectionID,
+			databaseName,
 			timestamp,
 			m["id"],
 			m["node_name"],

--- a/collector/src/probes/spock_resolutions_probe.go
+++ b/collector/src/probes/spock_resolutions_probe.go
@@ -1,0 +1,170 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package probes
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/collector/src/utils"
+)
+
+// SpockResolutionsProbe captures rows added to spock.resolutions in a
+// rolling 15-minute source-side window. The probe is database-scoped so
+// it runs once per monitored database connection; pgEdge clusters
+// typically register Spock in a single application database, but this
+// scoping lets us pick up resolution rows from any database that has the
+// extension loaded without depending on cluster-level configuration.
+//
+// The probe short-circuits cleanly on databases where Spock is not
+// installed: Execute returns (nil, nil) so the scheduler treats the
+// collection as a successful no-op rather than retrying on every cycle.
+type SpockResolutionsProbe struct {
+	BaseMetricsProbe
+}
+
+// NewSpockResolutionsProbe constructs a SpockResolutionsProbe with the
+// supplied configuration. databaseScoped is set to true so the
+// scheduler iterates over each user database when invoking the probe.
+func NewSpockResolutionsProbe(config *ProbeConfig) *SpockResolutionsProbe {
+	return &SpockResolutionsProbe{
+		BaseMetricsProbe: BaseMetricsProbe{
+			config:         config,
+			databaseScoped: true,
+		},
+	}
+}
+
+// GetExtensionName advertises the Spock dependency to the scheduler so
+// the "extension missing" reason can be surfaced in operator-facing
+// tooling. This satisfies the ExtensionProbe interface defined in
+// base.go.
+func (p *SpockResolutionsProbe) GetExtensionName() string {
+	return "spock"
+}
+
+// GetQuery returns the SQL executed against the monitored database.
+// The rolling 15-minute window is anchored on log_time because that is
+// the column Spock advances when a conflict is auto-resolved on the
+// receiving node; collected_at on the destination side is recorded
+// separately by Store.
+//
+// xid and pg_lsn values are projected through ::text casts so pgx scans
+// them into Go strings rather than the dedicated PostgreSQL types,
+// matching the TEXT columns used by metrics.spock_resolutions on the
+// datastore side. The column list mirrors the v3 migration so Store
+// can pass row maps straight through without reshaping.
+func (p *SpockResolutionsProbe) GetQuery() string {
+	return `
+		SELECT id,
+		       node_name,
+		       log_time,
+		       relname,
+		       idxname,
+		       conflict_type,
+		       conflict_resolution,
+		       local_origin,
+		       local_tuple,
+		       local_xid::text  AS local_xid,
+		       local_timestamp,
+		       remote_origin,
+		       remote_tuple,
+		       remote_xid::text AS remote_xid,
+		       remote_timestamp,
+		       remote_lsn::text AS remote_lsn
+		  FROM spock.resolutions
+		 WHERE log_time > now() - interval '15 minutes'
+	`
+}
+
+// Execute runs the rolling-window query against the monitored database
+// after first verifying that the Spock extension is installed. On
+// databases without Spock the call returns (nil, nil) without touching
+// the catalog further; the CheckExtensionExists helper caches the
+// negative result so the existence query only hits the catalog once
+// per connection lifetime.
+func (p *SpockResolutionsProbe) Execute(ctx context.Context, connectionName string, monitoredConn *pgxpool.Conn, pgVersion int) ([]map[string]any, error) {
+	exists, err := CheckExtensionExists(ctx, connectionName, monitoredConn, "spock")
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+
+	query := WrapQuery(ProbeNameSpockResolutions, p.GetQuery())
+	rows, err := monitoredConn.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute spock_resolutions query: %w", err)
+	}
+	defer rows.Close()
+
+	return utils.ScanRowsToMaps(rows)
+}
+
+// Store writes the captured rows to metrics.spock_resolutions. Empty
+// metric slices short-circuit before any datastore work so the
+// scheduler can call Store unconditionally after Execute.
+//
+// The column order matches the v3 migration (collector/src/database/
+// schema.go) and the surface contract documented on GetQuery; do not
+// reorder or rename columns without updating both call sites. xid and
+// pg_lsn values arrive as Go strings (already cast to text on the
+// source side) and land in TEXT columns on the destination, avoiding
+// any pgx type negotiation in the COPY path.
+func (p *SpockResolutionsProbe) Store(ctx context.Context, datastoreConn *pgxpool.Conn, connectionID int, timestamp time.Time, metrics []map[string]any) error {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	if err := p.EnsurePartition(ctx, datastoreConn, timestamp); err != nil {
+		return fmt.Errorf("failed to ensure partition: %w", err)
+	}
+
+	columns := []string{
+		"connection_id", "collected_at",
+		"id", "node_name", "log_time", "relname", "idxname",
+		"conflict_type", "conflict_resolution",
+		"local_origin", "local_tuple", "local_xid", "local_timestamp",
+		"remote_origin", "remote_tuple", "remote_xid", "remote_timestamp",
+		"remote_lsn",
+	}
+
+	values := make([][]any, 0, len(metrics))
+	for _, m := range metrics {
+		values = append(values, []any{
+			connectionID,
+			timestamp,
+			m["id"],
+			m["node_name"],
+			m["log_time"],
+			m["relname"],
+			m["idxname"],
+			m["conflict_type"],
+			m["conflict_resolution"],
+			m["local_origin"],
+			m["local_tuple"],
+			m["local_xid"],
+			m["local_timestamp"],
+			m["remote_origin"],
+			m["remote_tuple"],
+			m["remote_xid"],
+			m["remote_timestamp"],
+			m["remote_lsn"],
+		})
+	}
+
+	if err := StoreMetrics(ctx, datastoreConn, p.GetTableName(), columns, values); err != nil {
+		return fmt.Errorf("failed to store spock_resolutions metrics: %w", err)
+	}
+	return nil
+}

--- a/collector/src/probes/spock_resolutions_probe_test.go
+++ b/collector/src/probes/spock_resolutions_probe_test.go
@@ -348,6 +348,51 @@ func TestSpockResolutionsProbe_ExecuteCheckExtensionError(t *testing.T) {
 	}
 }
 
+// TestSpockResolutionsProbe_StoreMissingDatabaseName drives the
+// guard that surfaces a clear error when the scheduler-injected
+// _database_name key is missing from a metric row. database_name is
+// part of the destination primary key (the spock.resolutions.id
+// sequence is per-database, so the discriminator is essential), and
+// a missing value is a programming error in the scheduler rather
+// than a runtime data condition the probe can recover from.
+func TestSpockResolutionsProbe_StoreMissingDatabaseName(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+
+	metrics := []map[string]any{
+		{
+			// _database_name deliberately omitted so Store hits the
+			// guarded error path before issuing any SQL.
+			"id":                  1,
+			"node_name":           "n1",
+			"log_time":            time.Now(),
+			"relname":             "public.t",
+			"idxname":             "t_pkey",
+			"conflict_type":       "update_update",
+			"conflict_resolution": "keep_local",
+			"local_origin":        int32(16384),
+			"local_tuple":         "a=1",
+			"local_xid":           "12345",
+			"local_timestamp":     time.Now(),
+			"remote_origin":       int32(16385),
+			"remote_tuple":        "a=2",
+			"remote_xid":          "12346",
+			"remote_timestamp":    time.Now(),
+			"remote_lsn":          "0/16B6300",
+		},
+	}
+
+	p := newSpockResolutionsProbeForTest()
+	err := p.Store(context.Background(), conn, 1, time.Now(), metrics)
+	if err == nil {
+		t.Fatal("Store(no _database_name) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "database_name not found") {
+		t.Errorf("Store error = %q; want it to mention "+
+			"'database_name not found'", err.Error())
+	}
+}
+
 // TestSpockResolutionsProbe_StoreEnsurePartitionError drives the
 // EnsurePartition error branch of Store by passing a canceled
 // context with a real datastore connection. EnsurePartition issues

--- a/collector/src/probes/spock_resolutions_probe_test.go
+++ b/collector/src/probes/spock_resolutions_probe_test.go
@@ -154,6 +154,19 @@ func TestSpockResolutionsProbe_ExecuteWithStubSpock(t *testing.T) {
 			"destroy a real one to clean up")
 	}
 
+	// Track whether this test created the spock schema. If a stale
+	// schema exists from a previous crashed run (or a future setup
+	// step pre-creates it for unrelated reasons) the cleanup must
+	// leave it alone rather than drop a structure it does not own.
+	var createdSchema bool
+	if err := conn.QueryRow(ctx, `
+		SELECT NOT EXISTS (
+			SELECT 1 FROM pg_namespace WHERE nspname = 'spock'
+		)
+	`).Scan(&createdSchema); err != nil {
+		t.Fatalf("check spock schema existence: %v", err)
+	}
+
 	stmts := []string{
 		`CREATE SCHEMA IF NOT EXISTS spock`,
 		`CREATE TABLE IF NOT EXISTS spock.resolutions (
@@ -195,6 +208,18 @@ func TestSpockResolutionsProbe_ExecuteWithStubSpock(t *testing.T) {
 			"DELETE FROM pg_extension "+
 				"WHERE extname='spock'"); err != nil {
 			t.Logf("cleanup pg_extension spock row: %v", err)
+		}
+		if !createdSchema {
+			// The schema was already there; leave it alone so a
+			// crashed previous run or unrelated test fixture does
+			// not lose its structure to this cleanup. In that
+			// situation we still drop the table the test created
+			// so subsequent runs find a clean schema.
+			if _, err := conn.Exec(ctx,
+				"DROP TABLE IF EXISTS spock.resolutions"); err != nil {
+				t.Logf("cleanup spock.resolutions table: %v", err)
+			}
+			return
 		}
 		if _, err := conn.Exec(ctx,
 			"DROP SCHEMA spock CASCADE"); err != nil {

--- a/collector/src/probes/spock_resolutions_probe_test.go
+++ b/collector/src/probes/spock_resolutions_probe_test.go
@@ -1,0 +1,352 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package probes
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newSpockResolutionsProbeForTest constructs a probe with a minimal,
+// deterministic configuration suitable for unit and integration tests.
+// The returned probe is database-scoped, matching production behaviour.
+// Mirrors newSpockExceptionLogProbeForTest for symmetry.
+func newSpockResolutionsProbeForTest() *SpockResolutionsProbe {
+	return NewSpockResolutionsProbe(&ProbeConfig{
+		Name:                      ProbeNameSpockResolutions,
+		CollectionIntervalSeconds: 60,
+		RetentionDays:             7,
+		IsEnabled:                 true,
+	})
+}
+
+// TestSpockResolutionsProbe_Surface verifies the probe's static
+// metadata: name, table name, scope, and that GetQuery returns SQL
+// that targets spock.resolutions over the rolling 15-minute window
+// described in the design spec. The query must surface the columns
+// the alerter relies on (log_time, conflict_type, conflict_resolution)
+// and the rolling-window predicate.
+func TestSpockResolutionsProbe_Surface(t *testing.T) {
+	p := newSpockResolutionsProbeForTest()
+
+	if got := p.GetName(); got != ProbeNameSpockResolutions {
+		t.Errorf("GetName() = %q, want %q",
+			got, ProbeNameSpockResolutions)
+	}
+	if got := p.GetTableName(); got != ProbeNameSpockResolutions {
+		t.Errorf("GetTableName() = %q, want %q",
+			got, ProbeNameSpockResolutions)
+	}
+	if !p.IsDatabaseScoped() {
+		t.Error("IsDatabaseScoped() = false, want true " +
+			"(spock_resolutions is a per-database catalog)")
+	}
+
+	q := p.GetQuery()
+	for _, s := range []string{
+		"spock.resolutions",
+		"log_time",
+		"conflict_type",
+		"conflict_resolution",
+		"interval '15 minutes'",
+	} {
+		if !strings.Contains(q, s) {
+			t.Errorf("GetQuery missing substring %q; query was:\n%s",
+				s, q)
+		}
+	}
+}
+
+// TestSpockResolutionsProbe_StoreEmpty asserts that Store returns
+// nil with a nil/empty metrics slice and never touches the
+// datastore connection. This is the no-op fast path that lets the
+// scheduler call Store unconditionally even when Execute returned
+// nothing (e.g. Spock not installed, or no resolutions in the window).
+func TestSpockResolutionsProbe_StoreEmpty(t *testing.T) {
+	p := newSpockResolutionsProbeForTest()
+	if err := p.Store(context.Background(), nil, 1, time.Now(),
+		nil); err != nil {
+		t.Errorf("Store(nil) = %v, want nil", err)
+	}
+	// Empty slice should also be a no-op.
+	if err := p.Store(context.Background(), nil, 1, time.Now(),
+		[]map[string]any{}); err != nil {
+		t.Errorf("Store([]) = %v, want nil", err)
+	}
+}
+
+// TestSpockResolutionsProbe_ExecuteWhenSpockAbsent verifies the
+// graceful-skip behaviour: when the Spock extension is not installed
+// in the connected database, Execute returns (nil, nil) rather than
+// raising an error or attempting to query a missing catalog. This
+// branch is hit on every collection cycle for non-Spock databases
+// and must not log noise or churn the connection pool.
+func TestSpockResolutionsProbe_ExecuteWhenSpockAbsent(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	pgVersion := detectPgVersion(t, conn)
+
+	p := newSpockResolutionsProbeForTest()
+	ctx := context.Background()
+
+	metrics, err := p.Execute(ctx, "no-spock", conn, pgVersion)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if metrics != nil {
+		t.Errorf("Execute() returned %d metrics; want nil "+
+			"(integration database has no Spock extension)",
+			len(metrics))
+	}
+}
+
+// TestSpockResolutionsProbe_GetExtensionName documents the
+// extension dependency advertised to the scheduler so operator-
+// facing reasons ("Spock not installed") stay in sync with the
+// runtime guard inside Execute.
+func TestSpockResolutionsProbe_GetExtensionName(t *testing.T) {
+	p := newSpockResolutionsProbeForTest()
+	if got := p.GetExtensionName(); got != "spock" {
+		t.Errorf("GetExtensionName() = %q, want %q", got, "spock")
+	}
+}
+
+// TestSpockResolutionsProbe_ExecuteWithStubSpock drives the Spock-
+// installed branch of Execute by registering a stub spock extension
+// and creating a minimal spock.resolutions table that matches the
+// columns the probe selects. With the schema in place Execute should
+// succeed and return an empty (non-nil) slice when no rows fall
+// inside the rolling 15-minute window. We then insert a single row
+// and verify it round-trips through Execute and Store.
+//
+// xid columns in the source table use TEXT here (rather than the
+// catalog's xid type) because the probe casts xid::text in its query;
+// using TEXT in the stub keeps the round-trip free of pgx-side type
+// negotiation while still validating the column ordering.
+func TestSpockResolutionsProbe_ExecuteWithStubSpock(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	ctx := context.Background()
+	pgVersion := detectPgVersion(t, conn)
+
+	if spockAlreadyInstalled(t, ctx, conn) {
+		t.Skip("spock extension already installed; this test " +
+			"creates a stub spock and would otherwise need to " +
+			"destroy a real one to clean up")
+	}
+
+	stmts := []string{
+		`CREATE SCHEMA IF NOT EXISTS spock`,
+		`CREATE TABLE IF NOT EXISTS spock.resolutions (
+			id INTEGER NOT NULL,
+			node_name NAME NOT NULL,
+			log_time TIMESTAMPTZ NOT NULL,
+			relname TEXT,
+			idxname TEXT,
+			conflict_type TEXT,
+			conflict_resolution TEXT,
+			local_origin INTEGER,
+			local_tuple TEXT,
+			local_xid XID,
+			local_timestamp TIMESTAMPTZ,
+			remote_origin INTEGER,
+			remote_tuple TEXT,
+			remote_xid XID,
+			remote_timestamp TIMESTAMPTZ,
+			remote_lsn PG_LSN
+		)`,
+		`INSERT INTO pg_extension (oid, extname, extowner,
+			extnamespace, extrelocatable, extversion,
+			extconfig, extcondition)
+			SELECT (SELECT MAX(oid::oid::int)
+				FROM pg_extension) + 1, 'spock', 10,
+				(SELECT oid FROM pg_namespace
+					WHERE nspname='spock'),
+				TRUE, '1.0', NULL, NULL
+			WHERE NOT EXISTS (SELECT 1 FROM pg_extension
+				WHERE extname='spock')`,
+	}
+	for _, s := range stmts {
+		if _, err := conn.Exec(ctx, s); err != nil {
+			t.Fatalf("setup spock stub: %v\n%s", err, s)
+		}
+	}
+	t.Cleanup(func() {
+		if _, err := conn.Exec(ctx,
+			"DELETE FROM pg_extension "+
+				"WHERE extname='spock'"); err != nil {
+			t.Logf("cleanup pg_extension spock row: %v", err)
+		}
+		if _, err := conn.Exec(ctx,
+			"DROP SCHEMA spock CASCADE"); err != nil {
+			t.Logf("cleanup spock schema: %v", err)
+		}
+	})
+
+	p := newSpockResolutionsProbeForTest()
+
+	// Empty-window case: no rows yet, but the query and scan path
+	// must succeed and return a non-error result.
+	metrics, err := p.Execute(ctx, "with-spock", conn, pgVersion)
+	if err != nil {
+		t.Fatalf("Execute (empty window): %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Errorf("Execute (empty window) returned %d metrics, "+
+			"want 0", len(metrics))
+	}
+
+	// Insert a synthetic row that falls inside the 15-minute window.
+	// xid and pg_lsn values use the cast-friendly literal forms so the
+	// probe's xid::text / pg_lsn::text projections produce stable text
+	// representations.
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO spock.resolutions (
+			id, node_name, log_time,
+			relname, idxname,
+			conflict_type, conflict_resolution,
+			local_origin, local_tuple, local_xid, local_timestamp,
+			remote_origin, remote_tuple, remote_xid, remote_timestamp,
+			remote_lsn)
+		VALUES (
+			1, 'n1', now(),
+			'public.t', 't_pkey',
+			'update_update', 'keep_local',
+			16384, 'a=1', '12345'::xid, now(),
+			16385, 'a=2', '12346'::xid, now(),
+			'0/16B6300'::pg_lsn)
+	`); err != nil {
+		t.Fatalf("insert resolutions row: %v", err)
+	}
+
+	metrics, err = p.Execute(ctx, "with-spock", conn, pgVersion)
+	if err != nil {
+		t.Fatalf("Execute (one row): %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("Execute returned %d rows, want 1", len(metrics))
+	}
+	if got := metrics[0]["conflict_type"]; got != "update_update" {
+		t.Errorf("conflict_type = %v, want %q",
+			got, "update_update")
+	}
+	if got := metrics[0]["conflict_resolution"]; got != "keep_local" {
+		t.Errorf("conflict_resolution = %v, want %q",
+			got, "keep_local")
+	}
+	// xid and pg_lsn must arrive as text after the explicit cast so
+	// the COPY/INSERT pipeline can write them into the destination
+	// TEXT columns without further coercion.
+	if got, ok := metrics[0]["local_xid"].(string); !ok ||
+		got != "12345" {
+		t.Errorf("local_xid = %v (%T), want \"12345\" (string)",
+			metrics[0]["local_xid"], metrics[0]["local_xid"])
+	}
+	if got, ok := metrics[0]["remote_lsn"].(string); !ok ||
+		got != "0/16B6300" {
+		t.Errorf("remote_lsn = %v (%T), want \"0/16B6300\" (string)",
+			metrics[0]["remote_lsn"], metrics[0]["remote_lsn"])
+	}
+
+	// Store the row to metrics.spock_resolutions to exercise the
+	// happy path of the COPY/INSERT pipeline. The integration helper
+	// schema includes this table so partition creation and the
+	// column ordering above are both verified end-to-end.
+	if err := p.Store(ctx, conn, 1, time.Now().UTC(),
+		metrics); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	// Confirm at least one row landed in the destination table.
+	var stored int
+	if err := conn.QueryRow(ctx, `
+		SELECT COUNT(*) FROM metrics.spock_resolutions
+		 WHERE connection_id = 1
+	`).Scan(&stored); err != nil {
+		t.Fatalf("count stored rows: %v", err)
+	}
+	if stored != 1 {
+		t.Errorf("metrics.spock_resolutions count = %d, want 1",
+			stored)
+	}
+}
+
+// TestSpockResolutionsProbe_ExecuteCheckExtensionError exercises the
+// CheckExtensionExists error branch by passing a cancelled context.
+// pgxpool returns an error for any query attempted with a cancelled
+// context; the probe must wrap and return that error rather than
+// swallowing it.
+func TestSpockResolutionsProbe_ExecuteCheckExtensionError(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	ctx := context.Background()
+	pgVersion := detectPgVersion(t, conn)
+
+	// Force the underlying *pgx.Conn into a state that fails the
+	// next query. Cancelling the context is the cheapest way to
+	// guarantee QueryRow returns an error without disturbing the
+	// shared pool.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	p := newSpockResolutionsProbeForTest()
+	if _, err := p.Execute(cancelCtx, "cancelled", conn,
+		pgVersion); err == nil {
+		t.Fatal("Execute with cancelled context: expected error, " +
+			"got nil")
+	}
+}
+
+// TestSpockResolutionsProbe_StoreEnsurePartitionError drives the
+// EnsurePartition error branch of Store by passing a cancelled
+// context with a real datastore connection. EnsurePartition issues
+// SQL through the connection, which fails immediately when the
+// context is already cancelled, causing Store to surface the wrapped
+// "failed to ensure partition" error.
+func TestSpockResolutionsProbe_StoreEnsurePartitionError(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	metrics := []map[string]any{
+		{
+			"id":                  1,
+			"node_name":           "n1",
+			"log_time":            time.Now(),
+			"relname":             "public.t",
+			"idxname":             "t_pkey",
+			"conflict_type":       "update_update",
+			"conflict_resolution": "keep_local",
+			"local_origin":        int32(16384),
+			"local_tuple":         "a=1",
+			"local_xid":           "12345",
+			"local_timestamp":     time.Now(),
+			"remote_origin":       int32(16385),
+			"remote_tuple":        "a=2",
+			"remote_xid":          "12346",
+			"remote_timestamp":    time.Now(),
+			"remote_lsn":          "0/16B6300",
+		},
+	}
+
+	p := newSpockResolutionsProbeForTest()
+	err := p.Store(cancelCtx, conn, 1, time.Now(), metrics)
+	if err == nil {
+		t.Fatal("Store(cancelled ctx) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to ensure partition") {
+		t.Errorf("Store error = %q; want it to mention "+
+			"'failed to ensure partition'", err.Error())
+	}
+}

--- a/collector/src/probes/spock_resolutions_probe_test.go
+++ b/collector/src/probes/spock_resolutions_probe_test.go
@@ -257,6 +257,13 @@ func TestSpockResolutionsProbe_ExecuteWithStubSpock(t *testing.T) {
 			metrics[0]["remote_lsn"], metrics[0]["remote_lsn"])
 	}
 
+	// The scheduler injects _database_name on every row before
+	// Store is called. Mirror that here so Store can populate the
+	// destination database_name column without errors.
+	for i := range metrics {
+		metrics[i]["_database_name"] = "stub-db"
+	}
+
 	// Store the row to metrics.spock_resolutions to exercise the
 	// happy path of the COPY/INSERT pipeline. The integration helper
 	// schema includes this table so partition creation and the

--- a/collector/src/probes/spock_resolutions_probe_test.go
+++ b/collector/src/probes/spock_resolutions_probe_test.go
@@ -90,13 +90,23 @@ func TestSpockResolutionsProbe_StoreEmpty(t *testing.T) {
 // raising an error or attempting to query a missing catalog. This
 // branch is hit on every collection cycle for non-Spock databases
 // and must not log noise or churn the connection pool.
+//
+// The test is skipped when Spock is already installed on the host
+// integration database; the integration pool is created fresh per
+// process today, but the guard keeps this test correct on hosts where
+// Spock is part of the base image.
 func TestSpockResolutionsProbe_ExecuteWhenSpockAbsent(t *testing.T) {
 	pool := requireIntegrationPool(t)
 	conn := acquireConn(t, pool)
+	ctx := context.Background()
 	pgVersion := detectPgVersion(t, conn)
 
+	if spockAlreadyInstalled(t, ctx, conn) {
+		t.Skip("spock extension already installed; cannot exercise " +
+			"the spock-absent branch")
+	}
+
 	p := newSpockResolutionsProbeForTest()
-	ctx := context.Background()
 
 	metrics, err := p.Execute(ctx, "no-spock", conn, pgVersion)
 	if err != nil {

--- a/collector/src/probes/spock_resolutions_probe_test.go
+++ b/collector/src/probes/spock_resolutions_probe_test.go
@@ -18,7 +18,7 @@ import (
 
 // newSpockResolutionsProbeForTest constructs a probe with a minimal,
 // deterministic configuration suitable for unit and integration tests.
-// The returned probe is database-scoped, matching production behaviour.
+// The returned probe is database-scoped, matching production behavior.
 // Mirrors newSpockExceptionLogProbeForTest for symmetry.
 func newSpockResolutionsProbeForTest() *SpockResolutionsProbe {
 	return NewSpockResolutionsProbe(&ProbeConfig{
@@ -85,7 +85,7 @@ func TestSpockResolutionsProbe_StoreEmpty(t *testing.T) {
 }
 
 // TestSpockResolutionsProbe_ExecuteWhenSpockAbsent verifies the
-// graceful-skip behaviour: when the Spock extension is not installed
+// graceful-skip behavior: when the Spock extension is not installed
 // in the connected database, Execute returns (nil, nil) rather than
 // raising an error or attempting to query a missing catalog. This
 // branch is hit on every collection cycle for non-Spock databases
@@ -281,8 +281,8 @@ func TestSpockResolutionsProbe_ExecuteWithStubSpock(t *testing.T) {
 }
 
 // TestSpockResolutionsProbe_ExecuteCheckExtensionError exercises the
-// CheckExtensionExists error branch by passing a cancelled context.
-// pgxpool returns an error for any query attempted with a cancelled
+// CheckExtensionExists error branch by passing a canceled context.
+// pgxpool returns an error for any query attempted with a canceled
 // context; the probe must wrap and return that error rather than
 // swallowing it.
 func TestSpockResolutionsProbe_ExecuteCheckExtensionError(t *testing.T) {
@@ -292,25 +292,25 @@ func TestSpockResolutionsProbe_ExecuteCheckExtensionError(t *testing.T) {
 	pgVersion := detectPgVersion(t, conn)
 
 	// Force the underlying *pgx.Conn into a state that fails the
-	// next query. Cancelling the context is the cheapest way to
+	// next query. Canceling the context is the cheapest way to
 	// guarantee QueryRow returns an error without disturbing the
 	// shared pool.
 	cancelCtx, cancel := context.WithCancel(ctx)
 	cancel()
 
 	p := newSpockResolutionsProbeForTest()
-	if _, err := p.Execute(cancelCtx, "cancelled", conn,
+	if _, err := p.Execute(cancelCtx, "canceled", conn,
 		pgVersion); err == nil {
-		t.Fatal("Execute with cancelled context: expected error, " +
+		t.Fatal("Execute with canceled context: expected error, " +
 			"got nil")
 	}
 }
 
 // TestSpockResolutionsProbe_StoreEnsurePartitionError drives the
-// EnsurePartition error branch of Store by passing a cancelled
+// EnsurePartition error branch of Store by passing a canceled
 // context with a real datastore connection. EnsurePartition issues
 // SQL through the connection, which fails immediately when the
-// context is already cancelled, causing Store to surface the wrapped
+// context is already canceled, causing Store to surface the wrapped
 // "failed to ensure partition" error.
 func TestSpockResolutionsProbe_StoreEnsurePartitionError(t *testing.T) {
 	pool := requireIntegrationPool(t)
@@ -343,7 +343,7 @@ func TestSpockResolutionsProbe_StoreEnsurePartitionError(t *testing.T) {
 	p := newSpockResolutionsProbeForTest()
 	err := p.Store(cancelCtx, conn, 1, time.Now(), metrics)
 	if err == nil {
-		t.Fatal("Store(cancelled ctx) expected error, got nil")
+		t.Fatal("Store(canceled ctx) expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "failed to ensure partition") {
 		t.Errorf("Store error = %q; want it to mention "+

--- a/collector/src/scheduler/scheduler.go
+++ b/collector/src/scheduler/scheduler.go
@@ -811,6 +811,10 @@ func (ps *ProbeScheduler) createProbe(config *probes.ProbeConfig) probes.Metrics
 		return probes.NewPgStatStatementsProbe(config)
 	case probes.ProbeNamePgExtension:
 		return probes.NewPgExtensionProbe(config)
+	case probes.ProbeNameSpockExceptionLog:
+		return probes.NewSpockExceptionLogProbe(config)
+	case probes.ProbeNameSpockResolutions:
+		return probes.NewSpockResolutionsProbe(config)
 	// System Stats Extension probes (server-scoped)
 	case probes.ProbeNamePgSysOsInfo:
 		return probes.NewPgSysOsInfoProbe(config)

--- a/collector/src/scheduler/scheduler_test.go
+++ b/collector/src/scheduler/scheduler_test.go
@@ -118,6 +118,8 @@ func TestCreateProbe_AllKnownNames(t *testing.T) {
 		probes.ProbeNamePgStatUserFunctions,
 		probes.ProbeNamePgStatStatements,
 		probes.ProbeNamePgExtension,
+		probes.ProbeNameSpockExceptionLog,
+		probes.ProbeNameSpockResolutions,
 		probes.ProbeNamePgSysOsInfo,
 		probes.ProbeNamePgSysCPUInfo,
 		probes.ProbeNamePgSysCPUUsageInfo,

--- a/docs/admin-guide/alert-rules.md
+++ b/docs/admin-guide/alert-rules.md
@@ -3,7 +3,7 @@
 Alert rules define the conditions that trigger
 threshold-based alerts. Each rule specifies a metric to
 monitor, a comparison operator, and a threshold value.
-The alerter includes 24 built-in rules and supports
+The alerter includes 30 built-in rules and supports
 custom rules.
 
 ## Rule Structure
@@ -58,14 +58,66 @@ categories:
 
 - Connection rules monitor database connections and
   session state.
-- Replication rules monitor replication lag and slot
-  status.
+- Replication rules monitor replication lag, slot
+  status, Spock exceptions, and Spock conflict
+  resolutions.
 - Performance rules monitor query performance and
   locking.
 - Storage rules monitor disk usage and table
   maintenance.
 - System rules monitor CPU, memory, and system
   resources.
+
+## Replication Rules
+
+The replication category includes built-in rules that
+monitor Spock exception activity, Spock conflict
+auto-resolutions, and replication-slot WAL retention.
+The Spock rules require the `spock` extension on the
+monitored database; the slot retention rules apply to
+every PostgreSQL deployment.
+
+The Spock recent-count rules read from the
+`spock_exception_log` and `spock_resolutions` probe
+tables, both of which capture a rolling 15-minute
+window. The alerter clears each Spock alert
+automatically as the corresponding rows age out of the
+window and the recent count returns below the
+threshold.
+
+The following bullets describe the built-in
+replication rules added for Spock and slot retention
+monitoring:
+
+- `spock_recent_exceptions_present` fires at warning
+  severity when `spock_exception_log.recent_count` is
+  greater than or equal to 1; the rule requires the
+  `spock` extension.
+- `spock_recent_exceptions_high` fires at critical
+  severity when `spock_exception_log.recent_count` is
+  greater than or equal to 10; the rule requires the
+  `spock` extension.
+- `spock_recent_resolutions_present` fires at warning
+  severity when `spock_resolutions.recent_count` is
+  greater than or equal to 1; the rule requires the
+  `spock` extension.
+- `spock_recent_resolutions_high` fires at critical
+  severity when `spock_resolutions.recent_count` is
+  greater than or equal to 25; the rule requires the
+  `spock` extension.
+- `replication_slot_retention_warn` fires at warning
+  severity when `pg_replication_slots.max_retained_bytes`
+  is greater than or equal to 1073741824 (1 GiB); the
+  rule has no extension requirement.
+- `replication_slot_retention_high` fires at critical
+  severity when `pg_replication_slots.max_retained_bytes`
+  is greater than or equal to 10737418240 (10 GiB); the
+  rule has no extension requirement.
+
+The slot retention rules evaluate the maximum retained
+WAL across all replication slots on a server; the
+alerter fires a rule when any single slot retains more
+WAL than the threshold permits.
 
 ## Hierarchical Overrides
 

--- a/docs/admin-guide/probes.md
+++ b/docs/admin-guide/probes.md
@@ -48,6 +48,8 @@ execute once per monitored connection:
   configuration (change-tracked).
 - `pg_node_role` detects the node role for cluster
   topologies.
+- `pg_connectivity` monitors database connectivity and
+  measures connection response time.
 - `pg_database` collects the database catalog with
   XID wraparound indicators.
 
@@ -79,6 +81,33 @@ server:
 - `spock_resolutions` collects rows added to
   `spock.resolutions` in a rolling 15-minute window
   and targets Spock v5 or later.
+
+### System Statistics Probes
+
+System statistics probes collect host-level metrics
+through the `system_stats` extension and execute once
+per monitored connection:
+
+- `pg_sys_os_info` collects operating system
+  identification and version information.
+- `pg_sys_cpu_info` collects CPU model, vendor, and
+  configuration information.
+- `pg_sys_cpu_usage_info` collects CPU utilisation
+  statistics across all cores.
+- `pg_sys_memory_info` collects total, used, and free
+  memory statistics for the host.
+- `pg_sys_io_analysis_info` collects per-device read
+  and write I/O statistics.
+- `pg_sys_disk_info` collects disk capacity and used
+  space for each mounted filesystem.
+- `pg_sys_load_avg_info` collects 1, 5, and 15 minute
+  system load averages.
+- `pg_sys_process_info` collects process counts grouped
+  by execution state.
+- `pg_sys_network_info` collects per-interface network
+  send and receive statistics.
+- `pg_sys_cpu_memory_by_process` collects CPU and
+  memory consumption for the top processes.
 
 ## Default Collection Intervals
 

--- a/docs/admin-guide/probes.md
+++ b/docs/admin-guide/probes.md
@@ -7,7 +7,7 @@ enabled states through the admin panel or the REST API.
 
 ## Overview
 
-The Collector includes 34 built-in probes that cover
+The Collector includes 36 built-in probes that cover
 the most important PostgreSQL statistics views. Each
 probe runs on an independent schedule and stores
 results in partitioned metrics tables.
@@ -73,6 +73,12 @@ server:
   statistics (requires extension).
 - `pg_extension` collects installed extensions
   (change-tracked).
+- `spock_exception_log` collects rows added to
+  `spock.exception_log` in a rolling 15-minute window
+  and targets Spock v5 or later.
+- `spock_resolutions` collects rows added to
+  `spock.resolutions` in a rolling 15-minute window
+  and targets Spock v5 or later.
 
 ## Default Collection Intervals
 

--- a/docs/admin-guide/probes.md
+++ b/docs/admin-guide/probes.md
@@ -100,7 +100,7 @@ per monitored connection:
   and write I/O statistics.
 - `pg_sys_disk_info` collects disk capacity and used
   space for each mounted filesystem.
-- `pg_sys_load_avg_info` collects 1, 5, and 15 minute
+- `pg_sys_load_avg_info` collects 1-, 5-, and 15-minute
   system load averages.
 - `pg_sys_process_info` collects process counts grouped
   by execution state.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,25 @@ project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add the `spock_exception_log` and `spock_resolutions`
+  collector probes; both probes capture a rolling
+  15-minute window of the Spock extension's
+  exception and conflict-resolution catalogs and
+  no-op cleanly on databases without Spock installed.
+  (#200)
+- Add six built-in alert rules in the `replication`
+  category: `spock_recent_exceptions_present`,
+  `spock_recent_exceptions_high`,
+  `spock_recent_resolutions_present`,
+  `spock_recent_resolutions_high`,
+  `replication_slot_retention_warn`, and
+  `replication_slot_retention_high`; the Spock rules
+  require the `spock` extension and the slot
+  retention rules apply to every PostgreSQL
+  deployment. (#200)
+
 ### Changed
 
 - **Breaking change:** the collector, alerter, and

--- a/docs/developer-guide/collector/probe-reference.md
+++ b/docs/developer-guide/collector/probe-reference.md
@@ -10,7 +10,7 @@ The Collector organizes probes into two categories:
 - Server-scoped probes collect server-wide statistics
   and total 26 probes.
 - Database-scoped probes collect per-database
-  statistics and total 8 probes.
+  statistics and total 10 probes.
 
 ## Server-Scoped Probes
 
@@ -561,6 +561,130 @@ when installed extensions change.
 
 **Columns Collected**: extname, extversion,
 extrelocatable, schema_name
+
+### spock_exception_log
+
+This probe captures rows added to `spock.exception_log`
+within a rolling 15-minute source-side window. The
+probe targets Spock v5 or later; the probe checks for
+the `spock` extension through `CheckExtensionExists`
+against `pg_extension` and returns a successful no-op
+on databases without Spock installed.
+
+- Source View: `spock.exception_log`
+- Default Interval: 60 seconds
+- Default Retention: 7 days
+- Key Metrics: Recent apply-side exception count,
+  remote origin, error message, DDL statement
+- Use Cases: Detecting Spock apply errors, tracking
+  recent exception bursts, alerting on exception
+  presence
+- Required Extension: `spock`
+- Window Semantics: The query filters
+  `retry_errored_at > now() - interval '15 minutes'`
+  on the source side; alerts that read the
+  `recent_count` aggregate clear automatically as rows
+  age out of the window.
+
+The probe reads from the source view with the
+following query:
+
+```sql
+SELECT remote_origin,
+       remote_commit_ts,
+       command_counter,
+       retry_errored_at,
+       remote_xid,
+       local_origin,
+       local_commit_ts,
+       table_schema,
+       table_name,
+       operation,
+       local_tup,
+       remote_old_tup,
+       remote_new_tup,
+       ddl_statement,
+       ddl_user,
+       error_message
+  FROM spock.exception_log
+ WHERE retry_errored_at > now() - interval '15 minutes';
+```
+
+The probe stores rows in `metrics.spock_exception_log`,
+a partitioned table keyed on `collected_at`. The
+primary key is `(connection_id, collected_at,
+remote_origin, remote_commit_ts, command_counter,
+retry_errored_at)` so re-collected rows from a
+still-open window slot in cleanly.
+
+**Columns Collected**: connection_id, collected_at,
+remote_origin, remote_commit_ts, command_counter,
+retry_errored_at, remote_xid, local_origin,
+local_commit_ts, table_schema, table_name, operation,
+local_tup, remote_old_tup, remote_new_tup,
+ddl_statement, ddl_user, error_message
+
+### spock_resolutions
+
+This probe captures rows added to `spock.resolutions`
+within a rolling 15-minute source-side window. The
+probe targets Spock v5 or later; the probe checks for
+the `spock` extension through `CheckExtensionExists`
+against `pg_extension` and returns a successful no-op
+on databases without Spock installed.
+
+- Source View: `spock.resolutions`
+- Default Interval: 60 seconds
+- Default Retention: 7 days
+- Key Metrics: Recent auto-resolved conflict count,
+  conflict type, conflict resolution, node name
+- Use Cases: Detecting conflict-resolution activity,
+  alerting on resolution bursts, auditing applied
+  conflict resolutions
+- Required Extension: `spock`
+- Window Semantics: The query filters
+  `log_time > now() - interval '15 minutes'` on the
+  source side; alerts that read the `recent_count`
+  aggregate clear automatically as rows age out of
+  the window.
+
+The probe casts `xid` and `pg_lsn` columns to text on
+the source side so the values land in the destination
+`TEXT` columns without pgx type negotiation:
+
+```sql
+SELECT id,
+       node_name,
+       log_time,
+       relname,
+       idxname,
+       conflict_type,
+       conflict_resolution,
+       local_origin,
+       local_tuple,
+       local_xid::text  AS local_xid,
+       local_timestamp,
+       remote_origin,
+       remote_tuple,
+       remote_xid::text AS remote_xid,
+       remote_timestamp,
+       remote_lsn::text AS remote_lsn
+  FROM spock.resolutions
+ WHERE log_time > now() - interval '15 minutes';
+```
+
+The probe stores rows in `metrics.spock_resolutions`,
+a partitioned table keyed on `collected_at`. The
+primary key is `(connection_id, collected_at, id,
+node_name)` so re-collected rows from a still-open
+window slot in cleanly.
+
+**Columns Collected**: connection_id, collected_at,
+id, node_name, log_time, relname, idxname,
+conflict_type, conflict_resolution, local_origin,
+local_tuple, local_xid, local_timestamp,
+remote_origin, remote_tuple, remote_xid,
+remote_timestamp, remote_lsn
 
 ## System Statistics Probes
 

--- a/docs/developer-guide/collector/probe-reference.md
+++ b/docs/developer-guide/collector/probe-reference.md
@@ -612,16 +612,19 @@ SELECT remote_origin,
 
 The probe stores rows in `metrics.spock_exception_log`,
 a partitioned table keyed on `collected_at`. The
-primary key is `(connection_id, collected_at,
-remote_origin, remote_commit_ts, command_counter,
-retry_errored_at)` so re-collected rows from a
-still-open window slot in cleanly.
+primary key is `(connection_id, database_name,
+collected_at, remote_origin, remote_commit_ts,
+command_counter, retry_errored_at)`; `database_name`
+discriminates rows captured from different databases on
+the same monitored connection so the natural Spock keys
+remain unique within a `(connection, database, sample)`
+tuple.
 
-**Columns Collected**: connection_id, collected_at,
-remote_origin, remote_commit_ts, command_counter,
-retry_errored_at, remote_xid, local_origin,
-local_commit_ts, table_schema, table_name, operation,
-local_tup, remote_old_tup, remote_new_tup,
+**Columns Collected**: connection_id, database_name,
+collected_at, remote_origin, remote_commit_ts,
+command_counter, retry_errored_at, remote_xid,
+local_origin, local_commit_ts, table_schema, table_name,
+operation, local_tup, remote_old_tup, remote_new_tup,
 ddl_statement, ddl_user, error_message
 
 ### spock_resolutions
@@ -675,12 +678,14 @@ SELECT id,
 
 The probe stores rows in `metrics.spock_resolutions`,
 a partitioned table keyed on `collected_at`. The
-primary key is `(connection_id, collected_at, id,
-node_name)` so re-collected rows from a still-open
-window slot in cleanly.
+primary key is `(connection_id, database_name,
+collected_at, id, node_name)`; `database_name` is part
+of the key because the `spock.resolutions.id` sequence
+is per-database, so rows captured from two databases on
+the same monitored connection can otherwise collide.
 
-**Columns Collected**: connection_id, collected_at,
-id, node_name, log_time, relname, idxname,
+**Columns Collected**: connection_id, database_name,
+collected_at, id, node_name, log_time, relname, idxname,
 conflict_type, conflict_resolution, local_origin,
 local_tuple, local_xid, local_timestamp,
 remote_origin, remote_tuple, remote_xid,


### PR DESCRIPTION
## Summary

- Add two new collector probes — `spock_exception_log` and `spock_resolutions` — that capture rolling 15-minute windows of the Spock extension's exception and conflict-resolution catalogs. Both are database-scoped and gated on Spock presence via `CheckExtensionExists`, so they no-op cleanly on databases without Spock.
- Add four metric registry entries (two for the new probes' metrics tables, two over the existing `metrics.pg_replication_slots` table for `inactive_count` and `max_retained_bytes`).
- Seed six new built-in alert rules covering recent exceptions (warning/critical at thresholds 1/10), recent resolutions (warning/critical at 1/25), and replication-slot WAL retention (warning at 1 GiB, critical at 10 GiB).
- Schema migration v2 → v3 adds the partitioned `metrics.spock_exception_log` and `metrics.spock_resolutions` tables and seeds the new probe and rule rows. Idempotent re-runs are safe.

The change is purely additive — no changes to the alerter engine, server API, or web client.

Targets Spock v5+ (older versions not supported per spec). Auto-clear semantics: as source rows age out of the 15-minute window, the latest-sample count drops and the alert clears via the existing threshold path. No operator action required.

Design rationale and decisions documented in `.claude/specs/2026-05-05-spock-exception-and-conflict-alerts-design.md` (gitignored). Plan in `.claude/plans/2026-05-05-spock-exception-and-conflict-alerts.md`.

## Test plan

- [x] Probe surface, empty-store, and Spock-absent tests pass for both new probes (≥ 92% line coverage on each probe file)
- [x] Stub-Spock end-to-end Execute → Store integration tests for both probes
- [x] Schema migration v3 idempotency test passes
- [x] Four new metric registry entries verified by integration tests against seeded sample data
- [x] Six new built-in alert rules verified by fire/clear evaluation tests
- [x] Full collector + alerter test suites pass with no new regressions
- [x] `gofmt`, `go vet`, all three Go sub-projects build cleanly

## Notes

- A pre-existing `TestMigration_PgSettings` failure on hosts without pgvector is unrelated to this change (verified by reverting v3 migration; failure persists on baseline). Out of scope for this PR.
- `required_extension = 'spock'` is set on the four content rules as a forward-compatible label; alerter enforcement of `required_extension` is a pre-existing gap (the field is fetched but not consulted during evaluation). Correctness today is preserved by the metric values being 0 on non-Spock servers (empty source tables → empty metrics tables → metric value of 0 → threshold not crossed).

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two Spock probes collecting a rolling 15-minute window of exceptions and resolutions
  * Six built-in replication/Spock alert rules and two replication-slot metrics (inactive count, max retained bytes)
  * DB migration adding Spock metrics tables, indexes, and seeded probe/alert configs

* **Documentation**
  * Admin guide, probe reference, and changelog updated for Spock probes and replication rules

* **Tests**
  * New unit and integration tests for probes, metrics, migrations, and end-to-end alert evaluation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->