### PR TITLE
fix(client): use ESM imports for MUI icons and echarts-for-react

### DIFF
--- a/client/src/components/Chart/Chart.tsx
+++ b/client/src/components/Chart/Chart.tsx
@@ -22,7 +22,7 @@ import {
     DataZoomComponent,
 } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
-import ReactEChartsCore from 'echarts-for-react/lib/core';
+import ReactEChartsCore from 'echarts-for-react/esm/core';
 
 import useTheme from '@mui/material/styles/useTheme';
 import type { ChartProps, ChartData } from './types';

--- a/client/src/components/Chart/ChartToolbar.tsx
+++ b/client/src/components/Chart/ChartToolbar.tsx
@@ -11,9 +11,11 @@
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
-import PsychologyIcon from '@mui/icons-material/Psychology';
-import SaveAltIcon from '@mui/icons-material/SaveAlt';
-import RefreshIcon from '@mui/icons-material/Refresh';
+import {
+    Psychology as PsychologyIcon,
+    SaveAlt as SaveAltIcon,
+    Refresh as RefreshIcon,
+} from '@mui/icons-material';
 import { useAICapabilities } from '../../contexts/useAICapabilities';
 import { CHART_TOOLBAR_SX } from './styles';
 

--- a/client/src/components/ConnectionLostOverlay.tsx
+++ b/client/src/components/ConnectionLostOverlay.tsx
@@ -18,7 +18,7 @@ import {
     Button,
     Box,
 } from '@mui/material';
-import LinkOffIcon from '@mui/icons-material/LinkOff';
+import { LinkOff as LinkOffIcon } from '@mui/icons-material';
 import { useConnectionStatus } from '../contexts/useConnectionStatus';
 
 const reasonMessages: Record<string, string> = {

--- a/client/src/components/Dashboard/CollapsibleSection.tsx
+++ b/client/src/components/Dashboard/CollapsibleSection.tsx
@@ -15,8 +15,10 @@ import Collapse from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import type { SxProps, Theme } from '@mui/material/styles';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import {
+    ExpandMore as ExpandMoreIcon,
+    ExpandLess as ExpandLessIcon,
+} from '@mui/icons-material';
 import {
     SECTION_CONTAINER_SX,
     SECTION_HEADER_SX,

--- a/client/src/components/Dashboard/DatabaseDashboard/IndexLeaderboardSection.tsx
+++ b/client/src/components/Dashboard/DatabaseDashboard/IndexLeaderboardSection.tsx
@@ -15,7 +15,7 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
-import PsychologyIcon from '@mui/icons-material/Psychology';
+import { Psychology as PsychologyIcon } from '@mui/icons-material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useAuth } from '../../../contexts/useAuth';
 import { apiFetch } from '../../../utils/apiClient';

--- a/client/src/components/Dashboard/DatabaseDashboard/TableLeaderboardSection.tsx
+++ b/client/src/components/Dashboard/DatabaseDashboard/TableLeaderboardSection.tsx
@@ -15,7 +15,7 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
-import PsychologyIcon from '@mui/icons-material/Psychology';
+import { Psychology as PsychologyIcon } from '@mui/icons-material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useAuth } from '../../../contexts/useAuth';
 import { apiFetch } from '../../../utils/apiClient';

--- a/client/src/components/Dashboard/DatabaseDashboard/VacuumStatusSection.tsx
+++ b/client/src/components/Dashboard/DatabaseDashboard/VacuumStatusSection.tsx
@@ -15,7 +15,7 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
-import PsychologyIcon from '@mui/icons-material/Psychology';
+import { Psychology as PsychologyIcon } from '@mui/icons-material';
 import { useTheme, type Theme } from '@mui/material/styles';
 import { useAuth } from '../../../contexts/useAuth';
 import { apiFetch } from '../../../utils/apiClient';

--- a/client/src/components/Dashboard/KpiTile.tsx
+++ b/client/src/components/Dashboard/KpiTile.tsx
@@ -14,10 +14,12 @@ import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import PsychologyIcon from '@mui/icons-material/Psychology';
-import TrendingUpIcon from '@mui/icons-material/TrendingUp';
-import TrendingDownIcon from '@mui/icons-material/TrendingDown';
-import TrendingFlatIcon from '@mui/icons-material/TrendingFlat';
+import {
+    Psychology as PsychologyIcon,
+    TrendingUp as TrendingUpIcon,
+    TrendingDown as TrendingDownIcon,
+    TrendingFlat as TrendingFlatIcon,
+} from '@mui/icons-material';
 import { type Theme, useTheme } from '@mui/material/styles';
 import type { ChartAnalysisContext, ChartData } from '../Chart/types';
 import { ChartAnalysisDialog } from '../ChartAnalysisDialog';

--- a/client/src/components/Dashboard/MetricOverlay.tsx
+++ b/client/src/components/Dashboard/MetricOverlay.tsx
@@ -15,8 +15,10 @@ import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import Backdrop from '@mui/material/Backdrop';
 import Slide from '@mui/material/Slide';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import CloseIcon from '@mui/icons-material/Close';
+import {
+    ArrowBack as ArrowBackIcon,
+    Close as CloseIcon,
+} from '@mui/icons-material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useDashboard } from '../../contexts/useDashboard';
 import {

--- a/client/src/components/Dashboard/ObjectDashboard/QueryPlanPanel.tsx
+++ b/client/src/components/Dashboard/ObjectDashboard/QueryPlanPanel.tsx
@@ -18,7 +18,7 @@ import Alert from '@mui/material/Alert';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Tooltip from '@mui/material/Tooltip';
-import RefreshIcon from '@mui/icons-material/Refresh';
+import { Refresh as RefreshIcon } from '@mui/icons-material';
 import CollapsibleSection from '../CollapsibleSection';
 import PlanTree from './PlanTree';
 import { useQueryPlan } from '../../../hooks/useQueryPlan';

--- a/client/src/components/Dashboard/ServerDashboard/DatabaseSummariesSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/DatabaseSummariesSection.tsx
@@ -14,7 +14,7 @@ import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
-import ViewListIcon from '@mui/icons-material/ViewList';
+import { ViewList as ViewListIcon } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { useAuth } from '../../../contexts/useAuth';
 import { apiFetch } from '../../../utils/apiClient';

--- a/client/src/components/Dashboard/ServerDashboard/PostgresOverviewSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/PostgresOverviewSection.tsx
@@ -12,7 +12,7 @@ import type React from 'react';
 import { useMemo } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import StorageIcon from '@mui/icons-material/Storage';
+import { Storage as StorageIcon } from '@mui/icons-material';
 import { useDashboard } from '../../../contexts/useDashboard';
 import { useMetrics } from '../../../hooks/useMetrics';
 import type { MetricDataPoint, MetricQueryParams, MetricSeries } from '../types';

--- a/client/src/components/Dashboard/ServerDashboard/SystemResourcesSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/SystemResourcesSection.tsx
@@ -12,7 +12,7 @@ import type React from 'react';
 import { useMemo } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import ComputerIcon from '@mui/icons-material/Computer';
+import { Computer as ComputerIcon } from '@mui/icons-material';
 import { useDashboard } from '../../../contexts/useDashboard';
 import { useMetrics } from '../../../hooks/useMetrics';
 import type { MetricQueryParams, MetricSeries } from '../types';

--- a/client/src/components/Dashboard/ServerDashboard/TopQueriesSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/TopQueriesSection.tsx
@@ -15,7 +15,7 @@ import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
-import QueryStatsIcon from '@mui/icons-material/QueryStats';
+import { QueryStats as QueryStatsIcon } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { useAuth } from '../../../contexts/useAuth';
 import { apiFetch } from '../../../utils/apiClient';

--- a/client/src/components/Dashboard/ServerDashboard/WalReplicationSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/WalReplicationSection.tsx
@@ -12,7 +12,7 @@ import type React from 'react';
 import { useMemo } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import SyncIcon from '@mui/icons-material/Sync';
+import { Sync as SyncIcon } from '@mui/icons-material';
 import { useDashboard } from '../../../contexts/useDashboard';
 import { useMetrics } from '../../../hooks/useMetrics';
 import type { MetricQueryParams, MetricSeries } from '../types';

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -20,10 +20,12 @@ import {
     Collapse,
     IconButton,
 } from '@mui/material';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import RefreshIcon from '@mui/icons-material/Refresh';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import {
+    ErrorOutline as ErrorOutlineIcon,
+    Refresh as RefreshIcon,
+    ExpandMore as ExpandMoreIcon,
+    ExpandLess as ExpandLessIcon,
+} from '@mui/icons-material';
 import { logger } from '../utils/logger';
 
 interface ErrorBoundaryProps {

--- a/client/src/components/ServerDialog/SSLSettings.tsx
+++ b/client/src/components/ServerDialog/SSLSettings.tsx
@@ -17,7 +17,7 @@ import {
     TextField,
     MenuItem,
 } from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
 import {
     type ServerFormData,
     type FieldChangeHandler,

--- a/client/src/components/StatusPanel/PerformanceTiles/CacheHitTile.tsx
+++ b/client/src/components/StatusPanel/PerformanceTiles/CacheHitTile.tsx
@@ -11,7 +11,7 @@
 import type React from 'react';
 import { useMemo, useState, useCallback } from 'react';
 import { Box, Typography, useTheme, IconButton, Tooltip } from '@mui/material';
-import PsychologyIcon from '@mui/icons-material/Psychology';
+import { Psychology as PsychologyIcon } from '@mui/icons-material';
 import { Chart } from '../../Chart/Chart';
 import { ChartAnalysisDialog } from '../../ChartAnalysisDialog';
 import type { ChartAnalysisContext } from '../../Chart/types';

--- a/client/src/components/StatusPanel/PerformanceTiles/CheckpointTile.tsx
+++ b/client/src/components/StatusPanel/PerformanceTiles/CheckpointTile.tsx
@@ -12,7 +12,7 @@ import type React from 'react';
 import { useMemo, useState, useCallback } from 'react';
 import { Box, IconButton, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import PsychologyIcon from '@mui/icons-material/Psychology';
+import { Psychology as PsychologyIcon } from '@mui/icons-material';
 import { Chart } from '../../Chart/Chart';
 import { ChartAnalysisDialog } from '../../ChartAnalysisDialog';
 import type { ChartAnalysisContext } from '../../Chart/types';

--- a/client/src/components/StatusPanel/PerformanceTiles/DatabaseAgeTile.tsx
+++ b/client/src/components/StatusPanel/PerformanceTiles/DatabaseAgeTile.tsx
@@ -12,7 +12,7 @@ import type React from 'react';
 import { useState, useCallback } from 'react';
 import { Box, Typography, LinearProgress, IconButton, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import PsychologyIcon from '@mui/icons-material/Psychology';
+import { Psychology as PsychologyIcon } from '@mui/icons-material';
 import TileContainer from './TileContainer';
 import { ChartAnalysisDialog } from '../../ChartAnalysisDialog';
 import type { ChartData, ChartAnalysisContext } from '../../Chart/types';

--- a/client/src/components/StatusPanel/PerformanceTiles/TransactionTile.tsx
+++ b/client/src/components/StatusPanel/PerformanceTiles/TransactionTile.tsx
@@ -12,7 +12,7 @@ import type React from 'react';
 import { useMemo, useState, useCallback } from 'react';
 import { Box, IconButton, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import PsychologyIcon from '@mui/icons-material/Psychology';
+import { Psychology as PsychologyIcon } from '@mui/icons-material';
 import { Chart } from '../../Chart/Chart';
 import { ChartAnalysisDialog } from '../../ChartAnalysisDialog';
 import type { ChartAnalysisContext } from '../../Chart/types';

--- a/start_dev_web_client.sh
+++ b/start_dev_web_client.sh
@@ -105,22 +105,48 @@ else
 fi
 
 # Check if client dependencies need updating
-if [ ! -d "$CLIENT_DIR/node_modules" ]; then
-    echo -e "${BLUE}Installing client dependencies...${NC}"
+# Platform marker tracks OS/arch to detect cross-platform node_modules
+PLATFORM_MARKER="$CLIENT_DIR/node_modules/.platform_marker"
+CURRENT_PLATFORM="$(uname -s)-$(uname -m)"
+
+needs_npm_install() {
+    # No node_modules directory
+    if [ ! -d "$CLIENT_DIR/node_modules" ]; then
+        echo "node_modules directory missing"
+        return 0
+    fi
+
+    # Platform mismatch (cross-platform development)
+    if [ ! -f "$PLATFORM_MARKER" ] || [ "$(cat "$PLATFORM_MARKER" 2>/dev/null)" != "$CURRENT_PLATFORM" ]; then
+        echo "platform changed (native modules need rebuild)"
+        return 0
+    fi
+
+    # Package files newer than node_modules
+    if [ "$CLIENT_DIR/package.json" -nt "$CLIENT_DIR/node_modules" ]; then
+        echo "package.json changed"
+        return 0
+    fi
+
+    if [ -f "$CLIENT_DIR/package-lock.json" ] && [ "$CLIENT_DIR/package-lock.json" -nt "$CLIENT_DIR/node_modules" ]; then
+        echo "package-lock.json changed"
+        return 0
+    fi
+
+    return 1
+}
+
+echo -e "${BLUE}Checking if client dependencies need updating...${NC}"
+INSTALL_REASON=$(needs_npm_install)
+if [ $? -eq 0 ]; then
+    echo -e "${BLUE}Installing client dependencies ($INSTALL_REASON)...${NC}"
     cd "$CLIENT_DIR"
     npm install
+    # Record the platform for future cross-platform detection
+    echo "$CURRENT_PLATFORM" > "$PLATFORM_MARKER"
     cd "$SCRIPT_DIR"
 else
-    echo -e "${BLUE}Checking if client dependencies need updating...${NC}"
-    # Check if package.json or package-lock.json are newer than node_modules
-    if [ "$CLIENT_DIR/package.json" -nt "$CLIENT_DIR/node_modules" ] || [ -f "$CLIENT_DIR/package-lock.json" ] && [ "$CLIENT_DIR/package-lock.json" -nt "$CLIENT_DIR/node_modules" ]; then
-        echo -e "${BLUE}Package files changed, running npm install...${NC}"
-        cd "$CLIENT_DIR"
-        npm install
-        cd "$SCRIPT_DIR"
-    else
-        echo -e "${GREEN}Client dependencies are up to date${NC}"
-    fi
+    echo -e "${GREEN}Client dependencies are up to date${NC}"
 fi
 
 echo -e "${BLUE}+------------------------------------------------------------+${NC}"

--- a/start_dev_web_client.sh
+++ b/start_dev_web_client.sh
@@ -137,8 +137,7 @@ needs_npm_install() {
 }
 
 echo -e "${BLUE}Checking if client dependencies need updating...${NC}"
-INSTALL_REASON=$(needs_npm_install)
-if [ $? -eq 0 ]; then
+if INSTALL_REASON=$(needs_npm_install); then
     echo -e "${BLUE}Installing client dependencies ($INSTALL_REASON)...${NC}"
     cd "$CLIENT_DIR"
     npm install


### PR DESCRIPTION
## Summary

Fixes #203

- Converts all MUI icon imports from default imports (`import X from '@mui/icons-material/X'`) to named imports (`import { X } from '@mui/icons-material'`)
- Changes `echarts-for-react` import from CommonJS path (`lib/core`) to ESM path (`esm/core`)

Vite's dev server handles ESM module resolution differently than the test environment (jsdom). Default imports from deep paths return ES module namespace objects instead of React components, causing blank screens and "Element type is invalid: expected a string... but got: object" errors.

## Test plan

- [x] Build passes
- [x] All 2773 tests pass
- [x] Verified manually in Vite dev server on macOS - no more Chart rendering errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized UI library imports across many components for more consistent front-end behavior.

* **Chores**
  * Make local build/start script platform-aware to ensure dependencies are installed correctly across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->