### PR TITLE
refactor(client): extract ScopedOverridesPanel

### DIFF
--- a/client/src/components/AdminPanel/styles.ts
+++ b/client/src/components/AdminPanel/styles.ts
@@ -79,6 +79,17 @@ export const emptyRowTextSx: SxProps<Theme> = {
     fontSize: '1rem',
 };
 
+/**
+ * Italic, dimmed style applied to cells displaying inherited
+ * default values in scoped override tables. Shared between
+ * ProbeOverridesPanel and AlertOverridesPanel so the two panels
+ * stay visually consistent when a row inherits its defaults.
+ */
+export const inheritedCellSx: SxProps<Theme> = {
+    fontStyle: 'italic',
+    opacity: 0.6,
+};
+
 // --- Theme-dependent style-getter functions ---
 
 /**

--- a/client/src/components/AlertOverridesPanel.tsx
+++ b/client/src/components/AlertOverridesPanel.tsx
@@ -8,49 +8,46 @@
  *-------------------------------------------------------------------------
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
-import { apiGet, apiPut, apiDelete } from '../utils/apiClient';
+/**
+ * AlertOverridesPanel renders and manages per-scope overrides for
+ * alert rules. The cross-cutting list, fetch, banner, reset and
+ * scaffolding behaviour is delegated to ScopedOverridesPanel; this
+ * file owns only the alert-specific row projection (with category
+ * grouping) and the alert-specific edit dialog.
+ */
+
+import type React from 'react';
+import { useState } from 'react';
 import {
     Box,
-    Typography,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    Paper,
     Button,
-    IconButton,
-    Switch,
-    TextField,
-    MenuItem,
     Chip,
     CircularProgress,
-    Alert,
     Dialog,
-    DialogTitle,
-    DialogContent,
     DialogActions,
-    Tooltip,
+    DialogContent,
+    DialogTitle,
+    MenuItem,
+    Switch,
+    TableCell,
+    TextField,
+    Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import { apiPut } from '../utils/apiClient';
 import {
-    Edit as EditIcon,
-    RestartAlt as ResetIcon,
-} from '@mui/icons-material';
-import { SELECT_FIELD_SX, SELECT_FIELD_DEFAULT_BG_SX } from './shared/formStyles';
+    SELECT_FIELD_DEFAULT_BG_SX,
+    SELECT_FIELD_SX,
+} from './shared/formStyles';
 import {
-    tableHeaderCellSx,
-    dialogTitleSx,
     dialogActionsSx,
-    loadingContainerSx,
-    emptyRowSx,
-    emptyRowTextSx,
-    categoryLabelSx,
+    dialogTitleSx,
     getContainedButtonSx,
-    getTableContainerSx,
 } from './AdminPanel/styles';
+import ScopedOverridesPanel, {
+    type ScopedOverridesColumn,
+    type ScopedOverridesEditHelpers,
+} from './shared/ScopedOverridesPanel';
 
 const API_BASE_URL = '/api/v1';
 
@@ -80,304 +77,184 @@ interface AlertOverridesPanelProps {
     scopeId: number;
 }
 
-const severityColor = (severity: string): 'default' | 'info' | 'warning' | 'error' => {
+/** Map a severity string to the matching MUI Chip color variant. */
+const severityColor = (
+    severity: string,
+): 'default' | 'info' | 'warning' | 'error' => {
     switch (severity) {
-        case 'critical': return 'error';
-        case 'warning': return 'warning';
-        case 'info': return 'info';
-        default: return 'default';
+        case 'critical':
+            return 'error';
+        case 'warning':
+            return 'warning';
+        case 'info':
+            return 'info';
+        default:
+            return 'default';
     }
 };
 
-const AlertOverridesPanel: React.FC<AlertOverridesPanelProps> = ({ scope, scopeId }) => {
+/** Column definitions for the alert overrides table. */
+const ALERT_COLUMNS: ScopedOverridesColumn[] = [
+    { label: 'Name' },
+    { label: 'Metric' },
+    { label: 'Condition' },
+    { label: 'Severity' },
+    { label: 'Enabled' },
+];
+
+/** Italic, dimmed style applied to cells displaying inherited defaults. */
+const inheritedCellSx = {
+    fontStyle: 'italic',
+    opacity: 0.6,
+};
+
+/**
+ * Resolve the effective values for an alert rule row. Mirrors the
+ * server-side resolution: explicit override fields win, anything
+ * left null falls through to the corresponding default.
+ */
+const getDisplayValues = (item: AlertOverride) => {
+    if (item.has_override) {
+        return {
+            operator: item.override_operator ?? item.default_operator,
+            threshold: item.override_threshold ?? item.default_threshold,
+            severity: item.override_severity ?? item.default_severity,
+            enabled: item.override_enabled ?? item.default_enabled,
+        };
+    }
+    return {
+        operator: item.default_operator,
+        threshold: item.default_threshold,
+        severity: item.default_severity,
+        enabled: item.default_enabled,
+    };
+};
+
+const AlertOverridesPanel: React.FC<AlertOverridesPanelProps> = ({
+    scope,
+    scopeId,
+}) => {
     const theme = useTheme();
 
-    const [overrides, setOverrides] = useState<AlertOverride[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
-
-    // Edit override dialog
+    // The shared scaffold owns the list, alerts, and reset action;
+    // the dialog and its form state remain local because the field
+    // set is alert-specific.
     const [editOpen, setEditOpen] = useState(false);
-    const [editOverride, setEditOverride] = useState<AlertOverride | null>(null);
+    const [editOverride, setEditOverride] = useState<AlertOverride | null>(
+        null,
+    );
     const [editEnabled, setEditEnabled] = useState(false);
     const [editOperator, setEditOperator] = useState('');
     const [editThreshold, setEditThreshold] = useState('');
     const [editSeverity, setEditSeverity] = useState('');
     const [saving, setSaving] = useState(false);
 
-    const fetchOverrides = useCallback(async () => {
-        try {
-            setLoading(true);
-            const data = await apiGet<AlertOverride[]>(
-                `${API_BASE_URL}/alert-overrides/${scope}/${scopeId}`
-            );
-            setOverrides(data || []);
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setLoading(false);
-        }
-    }, [scope, scopeId]);
-
-    useEffect(() => {
-        void fetchOverrides();
-    }, [fetchOverrides]);
-
-    const handleEditOverride = (override: AlertOverride, e: React.MouseEvent) => {
-        e.stopPropagation();
+    /**
+     * Pre-populate the edit dialog with the row's effective values
+     * so the user starts from "current state" rather than blanks.
+     */
+    const handleEditRequested = (override: AlertOverride) => {
         setEditOverride(override);
-        setEditEnabled(
-            override.has_override
-                ? override.override_enabled ?? override.default_enabled
-                : override.default_enabled
-        );
-        setEditOperator(
-            override.has_override
-                ? override.override_operator ?? override.default_operator
-                : override.default_operator
-        );
-        setEditThreshold(
-            String(
-                override.has_override
-                    ? override.override_threshold ?? override.default_threshold
-                    : override.default_threshold
-            )
-        );
-        setEditSeverity(
-            override.has_override
-                ? override.override_severity ?? override.default_severity
-                : override.default_severity
-        );
-        setError(null);
+        const enabledValue = override.has_override
+            ? override.override_enabled ?? override.default_enabled
+            : override.default_enabled;
+        setEditEnabled(enabledValue);
+        const operatorValue = override.has_override
+            ? override.override_operator ?? override.default_operator
+            : override.default_operator;
+        setEditOperator(operatorValue);
+        const thresholdValue = override.has_override
+            ? override.override_threshold ?? override.default_threshold
+            : override.default_threshold;
+        setEditThreshold(String(thresholdValue));
+        const severityValue = override.has_override
+            ? override.override_severity ?? override.default_severity
+            : override.default_severity;
+        setEditSeverity(severityValue);
         setEditOpen(true);
     };
 
-    const handleSaveOverride = async () => {
-        if (!editOverride) {
-            return;
-        }
-        const thresholdNum = parseFloat(editThreshold);
-        if (Number.isNaN(thresholdNum)) {
-            setError('Threshold must be a valid number.');
-            return;
-        }
-        try {
-            setSaving(true);
-            setError(null);
-            await apiPut(
-                `${API_BASE_URL}/alert-overrides/${scope}/${scopeId}/${editOverride.rule_id}`,
-                {
-                    operator: editOperator,
-                    threshold: thresholdNum,
-                    severity: editSeverity,
-                    enabled: editEnabled,
-                }
-            );
-            setEditOpen(false);
-            setSuccess(`Override for "${editOverride.name}" saved successfully.`);
-            fetchOverrides();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setSaving(false);
-        }
-    };
-
-    const handleResetOverride = async (override: AlertOverride, e: React.MouseEvent) => {
-        e.stopPropagation();
-        try {
-            setError(null);
-            await apiDelete(
-                `${API_BASE_URL}/alert-overrides/${scope}/${scopeId}/${override.rule_id}`
-            );
-            setSuccess(`Override for "${override.name}" reset to default.`);
-            fetchOverrides();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        }
-    };
-
-    if (loading) {
+    const renderRowCells = (item: AlertOverride) => {
+        const display = getDisplayValues(item);
+        const cellSx = item.has_override ? {} : inheritedCellSx;
         return (
-            <Box sx={loadingContainerSx}>
-                <CircularProgress aria-label="Loading alert overrides" />
-            </Box>
+            <>
+                <TableCell sx={cellSx}>{item.name}</TableCell>
+                <TableCell sx={cellSx}>{item.metric_name}</TableCell>
+                <TableCell sx={cellSx}>
+                    {display.operator} {display.threshold}
+                    {item.metric_unit ? ` ${item.metric_unit}` : ''}
+                </TableCell>
+                <TableCell>
+                    <Chip
+                        label={display.severity}
+                        size="small"
+                        color={severityColor(display.severity)}
+                        sx={!item.has_override ? { opacity: 0.6 } : undefined}
+                    />
+                </TableCell>
+                <TableCell>
+                    <Switch
+                        checked={display.enabled}
+                        size="small"
+                        disabled
+                        sx={!item.has_override ? { opacity: 0.6 } : undefined}
+                    />
+                </TableCell>
+            </>
         );
-    }
+    };
 
     const containedButtonSx = getContainedButtonSx(theme);
-    const tableContainerSx = getTableContainerSx(theme);
 
-    // Group rules by category
-    const categories = Array.from(new Set(overrides.map((r) => r.category))).sort();
-
-    /** Return the effective display values for a rule row. */
-    const getDisplayValues = (item: AlertOverride) => {
-        if (item.has_override) {
-            return {
-                operator: item.override_operator ?? item.default_operator,
-                threshold: item.override_threshold ?? item.default_threshold,
-                severity: item.override_severity ?? item.default_severity,
-                enabled: item.override_enabled ?? item.default_enabled,
-            };
-        }
-        return {
-            operator: item.default_operator,
-            threshold: item.default_threshold,
-            severity: item.default_severity,
-            enabled: item.default_enabled,
+    /**
+     * Render the alert-specific edit dialog. Both validation
+     * failures and server errors flow through helpers.onSaveError
+     * so the user sees a single error banner above the table.
+     */
+    const renderEditDialog = (helpers: ScopedOverridesEditHelpers) => {
+        const handleSaveOverride = async () => {
+            if (!editOverride) {
+                return;
+            }
+            const thresholdNum = parseFloat(editThreshold);
+            if (Number.isNaN(thresholdNum)) {
+                helpers.onSaveError(
+                    new Error('Threshold must be a valid number.'),
+                );
+                return;
+            }
+            try {
+                setSaving(true);
+                await apiPut(
+                    `${API_BASE_URL}/alert-overrides/${scope}/${String(scopeId)}/${String(editOverride.rule_id)}`,
+                    {
+                        operator: editOperator,
+                        threshold: thresholdNum,
+                        severity: editSeverity,
+                        enabled: editEnabled,
+                    },
+                );
+                setEditOpen(false);
+                helpers.onSaveSuccess(
+                    `Override for "${editOverride.name}" saved successfully.`,
+                );
+                helpers.refresh();
+            } catch (err: unknown) {
+                helpers.onSaveError(err);
+            } finally {
+                setSaving(false);
+            }
         };
-    };
 
-    /** Style applied to cells that display inherited default values. */
-    const inheritedCellSx = {
-        fontStyle: 'italic',
-        opacity: 0.6,
-    };
-
-    return (
-        <Box>
-            {error && (
-                <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setError(null); }}>
-                    {error}
-                </Alert>
-            )}
-            {success && (
-                <Alert severity="success" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setSuccess(null); }}>
-                    {success}
-                </Alert>
-            )}
-
-            <TableContainer
-                component={Paper}
-                elevation={0}
-                sx={tableContainerSx}
-            >
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell sx={tableHeaderCellSx}>Name</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Metric</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Condition</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Severity</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Enabled</TableCell>
-                            <TableCell sx={tableHeaderCellSx} align="right">Actions</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {overrides.length > 0 ? (
-                            categories.map((category) => (
-                                <React.Fragment key={category}>
-                                    <TableRow>
-                                        <TableCell
-                                            colSpan={6}
-                                            sx={{
-                                                ...categoryLabelSx,
-                                                bgcolor: theme.palette.action.hover,
-                                                py: 0.75,
-                                            }}
-                                        >
-                                            {category}
-                                        </TableCell>
-                                    </TableRow>
-                                    {overrides
-                                        .filter((r) => r.category === category)
-                                        .map((item) => {
-                                            const display = getDisplayValues(item);
-                                            const cellSx = item.has_override ? {} : inheritedCellSx;
-
-                                            return (
-                                                <TableRow
-                                                    key={item.rule_id}
-                                                    hover
-                                                >
-                                                    <TableCell sx={cellSx}>{item.name}</TableCell>
-                                                    <TableCell sx={cellSx}>{item.metric_name}</TableCell>
-                                                    <TableCell sx={cellSx}>
-                                                        {display.operator} {display.threshold}
-                                                        {item.metric_unit ? ` ${item.metric_unit}` : ''}
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Chip
-                                                            label={display.severity}
-                                                            size="small"
-                                                            color={severityColor(display.severity)}
-                                                            sx={
-                                                                !item.has_override
-                                                                    ? { opacity: 0.6 }
-                                                                    : undefined
-                                                            }
-                                                        />
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Switch
-                                                            checked={display.enabled}
-                                                            size="small"
-                                                            disabled
-                                                            sx={
-                                                                !item.has_override
-                                                                    ? { opacity: 0.6 }
-                                                                    : undefined
-                                                            }
-                                                        />
-                                                    </TableCell>
-                                                    <TableCell align="right">
-                                                        <Tooltip title="Edit override">
-                                                            <IconButton
-                                                                size="small"
-                                                                onClick={(e) => { handleEditOverride(item, e); }}
-                                                                aria-label="edit override"
-                                                            >
-                                                                <EditIcon fontSize="small" />
-                                                            </IconButton>
-                                                        </Tooltip>
-                                                        {item.has_override && (
-                                                            <Tooltip title="Reset to default">
-                                                                <IconButton
-                                                                    size="small"
-                                                                    onClick={(e) => handleResetOverride(item, e)}
-                                                                    aria-label="reset override to default"
-                                                                >
-                                                                    <ResetIcon fontSize="small" />
-                                                                </IconButton>
-                                                            </Tooltip>
-                                                        )}
-                                                    </TableCell>
-                                                </TableRow>
-                                            );
-                                        })}
-                                </React.Fragment>
-                            ))
-                        ) : (
-                            <TableRow>
-                                <TableCell colSpan={6} align="center" sx={emptyRowSx}>
-                                    <Typography color="text.secondary" sx={emptyRowTextSx}>
-                                        No alert rules found.
-                                    </Typography>
-                                </TableCell>
-                            </TableRow>
-                        )}
-                    </TableBody>
-                </Table>
-            </TableContainer>
-
-            {/* Edit Override Dialog */}
+        return (
             <Dialog
                 open={editOpen}
-                onClose={() => void (!saving && setEditOpen(false))}
+                onClose={() => {
+                    if (!saving) {
+                        setEditOpen(false);
+                    }
+                }}
                 maxWidth="xs"
                 fullWidth
             >
@@ -385,11 +262,20 @@ const AlertOverridesPanel: React.FC<AlertOverridesPanelProps> = ({ scope, scopeI
                     Edit override: {editOverride?.name}
                 </DialogTitle>
                 <DialogContent>
-                    <Box sx={{ display: 'flex', alignItems: 'center', mt: 1, mb: 2 }}>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            mt: 1,
+                            mb: 2,
+                        }}
+                    >
                         <Typography sx={{ flex: 1 }}>Enabled</Typography>
                         <Switch
                             checked={editEnabled}
-                            onChange={(e) => { setEditEnabled(e.target.checked); }}
+                            onChange={(e) => {
+                                setEditEnabled(e.target.checked);
+                            }}
                             disabled={saving}
                         />
                     </Box>
@@ -398,14 +284,18 @@ const AlertOverridesPanel: React.FC<AlertOverridesPanelProps> = ({ scope, scopeI
                         fullWidth
                         label="Operator"
                         value={editOperator}
-                        onChange={(e) => { setEditOperator(e.target.value); }}
+                        onChange={(e) => {
+                            setEditOperator(e.target.value);
+                        }}
                         disabled={saving}
                         margin="dense"
                         InputLabelProps={{ shrink: true }}
                         sx={SELECT_FIELD_DEFAULT_BG_SX}
                     >
                         {OPERATORS.map((op) => (
-                            <MenuItem key={op} value={op}>{op}</MenuItem>
+                            <MenuItem key={op} value={op}>
+                                {op}
+                            </MenuItem>
                         ))}
                     </TextField>
                     <TextField
@@ -414,7 +304,9 @@ const AlertOverridesPanel: React.FC<AlertOverridesPanelProps> = ({ scope, scopeI
                         fullWidth
                         margin="dense"
                         value={editThreshold}
-                        onChange={(e) => { setEditThreshold(e.target.value); }}
+                        onChange={(e) => {
+                            setEditThreshold(e.target.value);
+                        }}
                         disabled={saving}
                         InputLabelProps={{ shrink: true }}
                         sx={SELECT_FIELD_SX}
@@ -424,32 +316,69 @@ const AlertOverridesPanel: React.FC<AlertOverridesPanelProps> = ({ scope, scopeI
                         fullWidth
                         label="Severity"
                         value={editSeverity}
-                        onChange={(e) => { setEditSeverity(e.target.value); }}
+                        onChange={(e) => {
+                            setEditSeverity(e.target.value);
+                        }}
                         disabled={saving}
                         margin="dense"
                         InputLabelProps={{ shrink: true }}
                         sx={SELECT_FIELD_DEFAULT_BG_SX}
                     >
                         {SEVERITIES.map((s) => (
-                            <MenuItem key={s} value={s}>{s}</MenuItem>
+                            <MenuItem key={s} value={s}>
+                                {s}
+                            </MenuItem>
                         ))}
                     </TextField>
                 </DialogContent>
                 <DialogActions sx={dialogActionsSx}>
-                    <Button onClick={() => { setEditOpen(false); }} disabled={saving}>
+                    <Button
+                        onClick={() => {
+                            setEditOpen(false);
+                        }}
+                        disabled={saving}
+                    >
                         Cancel
                     </Button>
                     <Button
-                        onClick={handleSaveOverride}
+                        onClick={() => {
+                            void handleSaveOverride();
+                        }}
                         variant="contained"
                         disabled={saving}
                         sx={containedButtonSx}
                     >
-                        {saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : 'Save'}
+                        {saving ? (
+                            <CircularProgress
+                                size={20}
+                                color="inherit"
+                                aria-label="Saving"
+                            />
+                        ) : (
+                            'Save'
+                        )}
                     </Button>
                 </DialogActions>
             </Dialog>
-        </Box>
+        );
+    };
+
+    return (
+        <ScopedOverridesPanel<AlertOverride>
+            scope={scope}
+            scopeId={scopeId}
+            apiBasePath={`${API_BASE_URL}/alert-overrides`}
+            itemKey={(item) => item.rule_id}
+            itemDisplayName={(item) => item.name}
+            hasOverride={(item) => item.has_override}
+            columns={ALERT_COLUMNS}
+            renderRowCells={renderRowCells}
+            groupBy={(item) => item.category}
+            emptyMessage="No alert rules found."
+            loadingLabel="Loading alert overrides"
+            onEditRequested={handleEditRequested}
+            renderEditDialog={renderEditDialog}
+        />
     );
 };
 

--- a/client/src/components/AlertOverridesPanel.tsx
+++ b/client/src/components/AlertOverridesPanel.tsx
@@ -43,6 +43,7 @@ import {
     dialogActionsSx,
     dialogTitleSx,
     getContainedButtonSx,
+    inheritedCellSx,
 } from './AdminPanel/styles';
 import ScopedOverridesPanel, {
     type ScopedOverridesColumn,
@@ -102,12 +103,6 @@ const ALERT_COLUMNS: ScopedOverridesColumn[] = [
     { label: 'Enabled' },
 ];
 
-/** Italic, dimmed style applied to cells displaying inherited defaults. */
-const inheritedCellSx = {
-    fontStyle: 'italic',
-    opacity: 0.6,
-};
-
 /**
  * Resolve the effective values for an alert rule row. Mirrors the
  * server-side resolution: explicit override fields win, anything
@@ -152,25 +147,17 @@ const AlertOverridesPanel: React.FC<AlertOverridesPanelProps> = ({
     /**
      * Pre-populate the edit dialog with the row's effective values
      * so the user starts from "current state" rather than blanks.
+     * Delegates the override-vs-default resolution to the shared
+     * `getDisplayValues` helper so the dialog and the table row stay
+     * in lockstep.
      */
     const handleEditRequested = (override: AlertOverride) => {
+        const display = getDisplayValues(override);
         setEditOverride(override);
-        const enabledValue = override.has_override
-            ? override.override_enabled ?? override.default_enabled
-            : override.default_enabled;
-        setEditEnabled(enabledValue);
-        const operatorValue = override.has_override
-            ? override.override_operator ?? override.default_operator
-            : override.default_operator;
-        setEditOperator(operatorValue);
-        const thresholdValue = override.has_override
-            ? override.override_threshold ?? override.default_threshold
-            : override.default_threshold;
-        setEditThreshold(String(thresholdValue));
-        const severityValue = override.has_override
-            ? override.override_severity ?? override.default_severity
-            : override.default_severity;
-        setEditSeverity(severityValue);
+        setEditEnabled(display.enabled);
+        setEditOperator(display.operator);
+        setEditThreshold(String(display.threshold));
+        setEditSeverity(display.severity);
         setEditOpen(true);
     };
 

--- a/client/src/components/ProbeOverridesPanel.tsx
+++ b/client/src/components/ProbeOverridesPanel.tsx
@@ -37,6 +37,7 @@ import {
     dialogActionsSx,
     dialogTitleSx,
     getContainedButtonSx,
+    inheritedCellSx,
 } from './AdminPanel/styles';
 import ScopedOverridesPanel, {
     type ScopedOverridesColumn,
@@ -70,12 +71,6 @@ const PROBE_COLUMNS: ScopedOverridesColumn[] = [
     { label: 'Interval' },
     { label: 'Retention' },
 ];
-
-/** Italic, dimmed style applied to cells displaying inherited defaults. */
-const inheritedCellSx = {
-    fontStyle: 'italic',
-    opacity: 0.6,
-};
 
 /**
  * Resolve the effective values for a probe row. When no override is
@@ -161,19 +156,38 @@ const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({
             if (!editOverride) {
                 return;
             }
+            // Trim first so we can distinguish "user left the field
+            // empty" from "user typed an invalid number". Without the
+            // pre-trim, Number('   ') returns 0 and the user would get
+            // the misleading "must be a positive integer" message for
+            // what is really a missing value.
+            const intervalTrimmed = editInterval.trim();
+            if (intervalTrimmed === '') {
+                helpers.onSaveError(
+                    new Error('Collection interval is required.'),
+                );
+                return;
+            }
             // parseInt would silently accept fractional or scientific
             // notation inputs (for example "1.5" -> 1, "1e2" -> 100),
             // so the saved value could differ from what the user typed.
             // Number() + Number.isInteger() rejects anything that is
             // not a finite integer outright.
-            const intervalNum = Number(editInterval);
+            const intervalNum = Number(intervalTrimmed);
             if (!Number.isInteger(intervalNum) || intervalNum < 1) {
                 helpers.onSaveError(
                     new Error('Collection interval must be a positive integer.'),
                 );
                 return;
             }
-            const retentionNum = Number(editRetention);
+            const retentionTrimmed = editRetention.trim();
+            if (retentionTrimmed === '') {
+                helpers.onSaveError(
+                    new Error('Retention days is required.'),
+                );
+                return;
+            }
+            const retentionNum = Number(retentionTrimmed);
             if (!Number.isInteger(retentionNum) || retentionNum < 1) {
                 helpers.onSaveError(
                     new Error('Retention days must be a positive integer.'),

--- a/client/src/components/ProbeOverridesPanel.tsx
+++ b/client/src/components/ProbeOverridesPanel.tsx
@@ -161,15 +161,20 @@ const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({
             if (!editOverride) {
                 return;
             }
-            const intervalNum = parseInt(editInterval, 10);
-            if (Number.isNaN(intervalNum) || intervalNum < 1) {
+            // parseInt would silently accept fractional or scientific
+            // notation inputs (for example "1.5" -> 1, "1e2" -> 100),
+            // so the saved value could differ from what the user typed.
+            // Number() + Number.isInteger() rejects anything that is
+            // not a finite integer outright.
+            const intervalNum = Number(editInterval);
+            if (!Number.isInteger(intervalNum) || intervalNum < 1) {
                 helpers.onSaveError(
                     new Error('Collection interval must be a positive integer.'),
                 );
                 return;
             }
-            const retentionNum = parseInt(editRetention, 10);
-            if (Number.isNaN(retentionNum) || retentionNum < 1) {
+            const retentionNum = Number(editRetention);
+            if (!Number.isInteger(retentionNum) || retentionNum < 1) {
                 helpers.onSaveError(
                     new Error('Retention days must be a positive integer.'),
                 );
@@ -177,8 +182,14 @@ const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({
             }
             try {
                 setSaving(true);
+                // Encode the probe name in case it ever contains URL
+                // path characters (for example "/", "+", "#", or
+                // whitespace). Today's probe names look like safe
+                // identifiers, but encoding is a no-op on those and
+                // future-proofs the call against breakage.
+                const encodedName = encodeURIComponent(editOverride.name);
                 await apiPut(
-                    `${API_BASE_URL}/probe-overrides/${scope}/${String(scopeId)}/${editOverride.name}`,
+                    `${API_BASE_URL}/probe-overrides/${scope}/${String(scopeId)}/${encodedName}`,
                     {
                         is_enabled: editEnabled,
                         collection_interval_seconds: intervalNum,

--- a/client/src/components/ProbeOverridesPanel.tsx
+++ b/client/src/components/ProbeOverridesPanel.tsx
@@ -8,47 +8,40 @@
  *-------------------------------------------------------------------------
  */
 
+/**
+ * ProbeOverridesPanel renders and manages per-scope overrides for
+ * collector probes. The cross-cutting list, fetch, banner, reset and
+ * scaffolding behaviour is delegated to ScopedOverridesPanel; this
+ * file owns only the probe-specific row projection and edit dialog.
+ */
+
 import type React from 'react';
-import { useState, useEffect, useCallback } from 'react';
-import { apiGet, apiPut, apiDelete } from '../utils/apiClient';
+import { useState } from 'react';
 import {
     Box,
-    Typography,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    Paper,
     Button,
-    IconButton,
-    Switch,
-    TextField,
     CircularProgress,
-    Alert,
     Dialog,
-    DialogTitle,
-    DialogContent,
     DialogActions,
-    Tooltip,
+    DialogContent,
+    DialogTitle,
+    Switch,
+    TableCell,
+    TextField,
+    Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import {
-    Edit as EditIcon,
-    RestartAlt as ResetIcon,
-} from '@mui/icons-material';
+import { apiPut } from '../utils/apiClient';
 import { SELECT_FIELD_SX } from './shared/formStyles';
 import {
-    tableHeaderCellSx,
-    dialogTitleSx,
     dialogActionsSx,
-    loadingContainerSx,
-    emptyRowSx,
-    emptyRowTextSx,
+    dialogTitleSx,
     getContainedButtonSx,
-    getTableContainerSx,
 } from './AdminPanel/styles';
+import ScopedOverridesPanel, {
+    type ScopedOverridesColumn,
+    type ScopedOverridesEditHelpers,
+} from './shared/ScopedOverridesPanel';
 
 const API_BASE_URL = '/api/v1';
 
@@ -69,15 +62,52 @@ interface ProbeOverridesPanelProps {
     scopeId: number;
 }
 
-const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({ scope, scopeId }) => {
+/** Column definitions for the probe overrides table. */
+const PROBE_COLUMNS: ScopedOverridesColumn[] = [
+    { label: 'Name' },
+    { label: 'Description' },
+    { label: 'Enabled' },
+    { label: 'Interval' },
+    { label: 'Retention' },
+];
+
+/** Italic, dimmed style applied to cells displaying inherited defaults. */
+const inheritedCellSx = {
+    fontStyle: 'italic',
+    opacity: 0.6,
+};
+
+/**
+ * Resolve the effective values for a probe row. When no override is
+ * present the defaults flow through unchanged; when an override is
+ * present any null fields fall back to the corresponding default.
+ */
+const getDisplayValues = (item: ProbeOverride) => {
+    if (item.has_override) {
+        return {
+            enabled: item.override_enabled ?? item.default_enabled,
+            interval:
+                item.override_interval_seconds ?? item.default_interval_seconds,
+            retention:
+                item.override_retention_days ?? item.default_retention_days,
+        };
+    }
+    return {
+        enabled: item.default_enabled,
+        interval: item.default_interval_seconds,
+        retention: item.default_retention_days,
+    };
+};
+
+const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({
+    scope,
+    scopeId,
+}) => {
     const theme = useTheme();
 
-    const [overrides, setOverrides] = useState<ProbeOverride[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
-
-    // Edit override dialog
+    // The shared scaffold owns the list, alerts, and reset action;
+    // the dialog and its form state remain local because the field
+    // set is probe-specific.
     const [editOpen, setEditOpen] = useState(false);
     const [editOverride, setEditOverride] = useState<ProbeOverride | null>(null);
     const [editEnabled, setEditEnabled] = useState(false);
@@ -85,231 +115,98 @@ const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({ scope, scopeI
     const [editRetention, setEditRetention] = useState('');
     const [saving, setSaving] = useState(false);
 
-    const fetchOverrides = useCallback(async () => {
-        try {
-            setLoading(true);
-            const data = await apiGet<ProbeOverride[]>(
-                `${API_BASE_URL}/probe-overrides/${scope}/${scopeId}`
-            );
-            setOverrides(data || []);
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setLoading(false);
-        }
-    }, [scope, scopeId]);
-
-    useEffect(() => {
-        fetchOverrides();
-    }, [fetchOverrides]);
-
-    const handleEditOverride = (override: ProbeOverride, e: React.MouseEvent) => {
-        e.stopPropagation();
+    /**
+     * Pre-populate the edit dialog with the row's effective values
+     * so the user starts from "current state" rather than blanks.
+     */
+    const handleEditRequested = (override: ProbeOverride) => {
         const display = getDisplayValues(override);
         setEditOverride(override);
         setEditEnabled(display.enabled);
         setEditInterval(String(display.interval));
         setEditRetention(String(display.retention));
-        setError(null);
         setEditOpen(true);
     };
 
-    const handleSaveOverride = async () => {
-        if (!editOverride) {
-            return;
-        }
-        const intervalNum = parseInt(editInterval, 10);
-        if (Number.isNaN(intervalNum) || intervalNum < 1) {
-            setError('Collection interval must be a positive integer.');
-            return;
-        }
-        const retentionNum = parseInt(editRetention, 10);
-        if (Number.isNaN(retentionNum) || retentionNum < 1) {
-            setError('Retention days must be a positive integer.');
-            return;
-        }
-        try {
-            setSaving(true);
-            setError(null);
-            await apiPut(
-                `${API_BASE_URL}/probe-overrides/${scope}/${scopeId}/${editOverride.name}`,
-                {
-                    is_enabled: editEnabled,
-                    collection_interval_seconds: intervalNum,
-                    retention_days: retentionNum,
-                }
-            );
-            setEditOpen(false);
-            setSuccess(`Override for "${editOverride.name}" saved successfully.`);
-            fetchOverrides();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setSaving(false);
-        }
-    };
-
-    const handleResetOverride = async (override: ProbeOverride, e: React.MouseEvent) => {
-        e.stopPropagation();
-        try {
-            setError(null);
-            await apiDelete(
-                `${API_BASE_URL}/probe-overrides/${scope}/${scopeId}/${override.name}`
-            );
-            setSuccess(`Override for "${override.name}" reset to default.`);
-            fetchOverrides();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        }
-    };
-
-    if (loading) {
+    const renderRowCells = (item: ProbeOverride) => {
+        const display = getDisplayValues(item);
+        const cellSx = item.has_override ? {} : inheritedCellSx;
         return (
-            <Box sx={loadingContainerSx}>
-                <CircularProgress aria-label="Loading probe overrides" />
-            </Box>
+            <>
+                <TableCell sx={cellSx}>{item.name}</TableCell>
+                <TableCell sx={cellSx}>{item.description}</TableCell>
+                <TableCell>
+                    <Switch
+                        checked={display.enabled}
+                        size="small"
+                        disabled
+                        sx={!item.has_override ? { opacity: 0.6 } : undefined}
+                    />
+                </TableCell>
+                <TableCell sx={cellSx}>{display.interval}s</TableCell>
+                <TableCell sx={cellSx}>{display.retention} days</TableCell>
+            </>
         );
-    }
+    };
 
     const containedButtonSx = getContainedButtonSx(theme);
-    const tableContainerSx = getTableContainerSx(theme);
 
-    /** Return the effective display values for a probe row. */
-    const getDisplayValues = (item: ProbeOverride) => {
-        if (item.has_override) {
-            return {
-                enabled: item.override_enabled ?? item.default_enabled,
-                interval: item.override_interval_seconds ?? item.default_interval_seconds,
-                retention: item.override_retention_days ?? item.default_retention_days,
-            };
-        }
-        return {
-            enabled: item.default_enabled,
-            interval: item.default_interval_seconds,
-            retention: item.default_retention_days,
+    /**
+     * Render the probe-specific edit dialog. Saving wires success
+     * and failure outcomes back through the helpers from the shared
+     * panel so the user sees a single error/success banner row.
+     */
+    const renderEditDialog = (helpers: ScopedOverridesEditHelpers) => {
+        const handleSaveOverride = async () => {
+            if (!editOverride) {
+                return;
+            }
+            const intervalNum = parseInt(editInterval, 10);
+            if (Number.isNaN(intervalNum) || intervalNum < 1) {
+                helpers.onSaveError(
+                    new Error('Collection interval must be a positive integer.'),
+                );
+                return;
+            }
+            const retentionNum = parseInt(editRetention, 10);
+            if (Number.isNaN(retentionNum) || retentionNum < 1) {
+                helpers.onSaveError(
+                    new Error('Retention days must be a positive integer.'),
+                );
+                return;
+            }
+            try {
+                setSaving(true);
+                await apiPut(
+                    `${API_BASE_URL}/probe-overrides/${scope}/${String(scopeId)}/${editOverride.name}`,
+                    {
+                        is_enabled: editEnabled,
+                        collection_interval_seconds: intervalNum,
+                        retention_days: retentionNum,
+                    },
+                );
+                setEditOpen(false);
+                helpers.onSaveSuccess(
+                    `Override for "${editOverride.name}" saved successfully.`,
+                );
+                helpers.refresh();
+            } catch (err: unknown) {
+                // Surface the failure on the shared banner so the
+                // user sees it even after the dialog closes.
+                helpers.onSaveError(err);
+            } finally {
+                setSaving(false);
+            }
         };
-    };
 
-    /** Style applied to cells that display inherited default values. */
-    const inheritedCellSx = {
-        fontStyle: 'italic',
-        opacity: 0.6,
-    };
-
-    return (
-        <Box>
-            {error && (
-                <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setError(null); }}>
-                    {error}
-                </Alert>
-            )}
-            {success && (
-                <Alert severity="success" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setSuccess(null); }}>
-                    {success}
-                </Alert>
-            )}
-
-            <TableContainer
-                component={Paper}
-                elevation={0}
-                sx={tableContainerSx}
-            >
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell sx={tableHeaderCellSx}>Name</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Description</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Enabled</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Interval</TableCell>
-                            <TableCell sx={tableHeaderCellSx}>Retention</TableCell>
-                            <TableCell sx={tableHeaderCellSx} align="right">Actions</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {overrides.length > 0 ? (
-                            overrides.map((item) => {
-                                const display = getDisplayValues(item);
-                                const cellSx = item.has_override ? {} : inheritedCellSx;
-
-                                return (
-                                    <TableRow
-                                        key={item.name}
-                                        hover
-                                    >
-                                        <TableCell sx={cellSx}>{item.name}</TableCell>
-                                        <TableCell sx={cellSx}>{item.description}</TableCell>
-                                        <TableCell>
-                                            <Switch
-                                                checked={display.enabled}
-                                                size="small"
-                                                disabled
-                                                sx={
-                                                    !item.has_override
-                                                        ? { opacity: 0.6 }
-                                                        : undefined
-                                                }
-                                            />
-                                        </TableCell>
-                                        <TableCell sx={cellSx}>
-                                            {display.interval}s
-                                        </TableCell>
-                                        <TableCell sx={cellSx}>
-                                            {display.retention} days
-                                        </TableCell>
-                                        <TableCell align="right">
-                                            <Tooltip title="Edit override">
-                                                <IconButton
-                                                    size="small"
-                                                    onClick={(e) => { handleEditOverride(item, e); }}
-                                                    aria-label="edit override"
-                                                >
-                                                    <EditIcon fontSize="small" />
-                                                </IconButton>
-                                            </Tooltip>
-                                            {item.has_override && (
-                                                <Tooltip title="Reset to default">
-                                                    <IconButton
-                                                        size="small"
-                                                        onClick={(e) => handleResetOverride(item, e)}
-                                                        aria-label="reset override to default"
-                                                    >
-                                                        <ResetIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                            )}
-                                        </TableCell>
-                                    </TableRow>
-                                );
-                            })
-                        ) : (
-                            <TableRow>
-                                <TableCell colSpan={6} align="center" sx={emptyRowSx}>
-                                    <Typography color="text.secondary" sx={emptyRowTextSx}>
-                                        No probe configurations found.
-                                    </Typography>
-                                </TableCell>
-                            </TableRow>
-                        )}
-                    </TableBody>
-                </Table>
-            </TableContainer>
-
-            {/* Edit Override Dialog */}
+        return (
             <Dialog
                 open={editOpen}
-                onClose={() => void (!saving && setEditOpen(false))}
+                onClose={() => {
+                    if (!saving) {
+                        setEditOpen(false);
+                    }
+                }}
                 maxWidth="xs"
                 fullWidth
             >
@@ -321,7 +218,9 @@ const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({ scope, scopeI
                         <Typography sx={{ flex: 1 }}>Enabled</Typography>
                         <Switch
                             checked={editEnabled}
-                            onChange={(e) => { setEditEnabled(e.target.checked); }}
+                            onChange={(e) => {
+                                setEditEnabled(e.target.checked);
+                            }}
                             disabled={saving}
                         />
                     </Box>
@@ -331,7 +230,9 @@ const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({ scope, scopeI
                         fullWidth
                         margin="dense"
                         value={editInterval}
-                        onChange={(e) => { setEditInterval(e.target.value); }}
+                        onChange={(e) => {
+                            setEditInterval(e.target.value);
+                        }}
                         disabled={saving}
                         inputProps={{ min: 1 }}
                         InputLabelProps={{ shrink: true }}
@@ -343,7 +244,9 @@ const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({ scope, scopeI
                         fullWidth
                         margin="dense"
                         value={editRetention}
-                        onChange={(e) => { setEditRetention(e.target.value); }}
+                        onChange={(e) => {
+                            setEditRetention(e.target.value);
+                        }}
                         disabled={saving}
                         inputProps={{ min: 1 }}
                         InputLabelProps={{ shrink: true }}
@@ -351,20 +254,52 @@ const ProbeOverridesPanel: React.FC<ProbeOverridesPanelProps> = ({ scope, scopeI
                     />
                 </DialogContent>
                 <DialogActions sx={dialogActionsSx}>
-                    <Button onClick={() => { setEditOpen(false); }} disabled={saving}>
+                    <Button
+                        onClick={() => {
+                            setEditOpen(false);
+                        }}
+                        disabled={saving}
+                    >
                         Cancel
                     </Button>
                     <Button
-                        onClick={handleSaveOverride}
+                        onClick={() => {
+                            void handleSaveOverride();
+                        }}
                         variant="contained"
                         disabled={saving}
                         sx={containedButtonSx}
                     >
-                        {saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : 'Save'}
+                        {saving ? (
+                            <CircularProgress
+                                size={20}
+                                color="inherit"
+                                aria-label="Saving"
+                            />
+                        ) : (
+                            'Save'
+                        )}
                     </Button>
                 </DialogActions>
             </Dialog>
-        </Box>
+        );
+    };
+
+    return (
+        <ScopedOverridesPanel<ProbeOverride>
+            scope={scope}
+            scopeId={scopeId}
+            apiBasePath={`${API_BASE_URL}/probe-overrides`}
+            itemKey={(item) => item.name}
+            itemDisplayName={(item) => item.name}
+            hasOverride={(item) => item.has_override}
+            columns={PROBE_COLUMNS}
+            renderRowCells={renderRowCells}
+            emptyMessage="No probe configurations found."
+            loadingLabel="Loading probe overrides"
+            onEditRequested={handleEditRequested}
+            renderEditDialog={renderEditDialog}
+        />
     );
 };
 

--- a/client/src/components/__tests__/AlertOverridesPanel.test.tsx
+++ b/client/src/components/__tests__/AlertOverridesPanel.test.tsx
@@ -338,4 +338,348 @@ describe('AlertOverridesPanel', () => {
         const editButtons = screen.getAllByLabelText('edit override');
         expect(editButtons).toHaveLength(3);
     });
+
+    // The following cases were added during the refactor to lift
+    // coverage of the dialog body and save / reset paths above the
+    // project's 90% line-coverage floor. They exercise behaviour
+    // that the original test suite did not previously cover.
+
+    it('edit dialog Cancel closes the dialog', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('High CPU Usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]'
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: High CPU Usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        await waitFor(() => {
+            expect(
+                screen.queryByText(/Edit override: High CPU Usage/)
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    it('edit dialog Save calls PUT with current form values', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('High CPU Usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]'
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: High CPU Usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/alert-overrides/server/1/1',
+                expect.objectContaining({
+                    method: 'PUT',
+                    credentials: 'include',
+                })
+            );
+        });
+    });
+
+    it('shows success banner after a successful save', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('High CPU Usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]'
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: High CPU Usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    'Override for "High CPU Usage" saved successfully.'
+                )
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('shows error banner when save PUT fails', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+                text: async () => JSON.stringify({ error: 'PUT exploded' }),
+            });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('High CPU Usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]'
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: High CPU Usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('PUT exploded')).toBeInTheDocument();
+        });
+    });
+
+    it('rejects invalid threshold input on save', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('High CPU Usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]'
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: High CPU Usage/)).toBeInTheDocument();
+        });
+
+        const thresholdInput = screen.getByLabelText('Threshold');
+        // Force a non-numeric value; <input type="number"> would
+        // normally block this, but we bypass via fireEvent.change.
+        fireEvent.change(thresholdInput, { target: { value: '' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Threshold must be a valid number.')
+            ).toBeInTheDocument();
+        });
+
+        // The initial GET fired; no PUT should have followed.
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('pre-populates dialog with defaults when no override exists', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Low Disk Space')).toBeInTheDocument();
+        });
+
+        // Low Disk Space has no override; the dialog should fall
+        // back to default_threshold (85). This exercises the
+        // "no override" branch of every getter in handleEditRequested.
+        const diskRow = screen.getByText('Low Disk Space').closest('tr');
+        const editButton = (diskRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]'
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: Low Disk Space/)).toBeInTheDocument();
+        });
+
+        const thresholdInput = screen.getByLabelText('Threshold');
+        expect(thresholdInput).toHaveValue(85);
+    });
+
+    it('changes operator, threshold, severity, and enabled values', async () => {
+        // This case drives the onChange handlers of every form
+        // control in the alert dialog so they show as covered.
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('High CPU Usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]'
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: High CPU Usage/)).toBeInTheDocument();
+        });
+
+        // Toggle the Enabled switch.
+        const switches = screen.getAllByRole('checkbox');
+        // The last checkbox in the dialog is the Enabled toggle;
+        // the table row switches are disabled, so this is reliable.
+        const dialogEnabledSwitch = switches[switches.length - 1];
+        fireEvent.click(dialogEnabledSwitch);
+
+        // Change Threshold via input.
+        fireEvent.change(screen.getByLabelText('Threshold'), {
+            target: { value: '99.5' },
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/alert-overrides/server/1/1',
+                expect.objectContaining({
+                    method: 'PUT',
+                    body: expect.stringContaining('"threshold":99.5'),
+                })
+            );
+        });
+    });
+
+    it('shows success banner after a successful reset', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByLabelText('reset override to default'));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    'Override for "High CPU Usage" reset to default.'
+                )
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('shows fallback message when fetch rejects with non-Error value', async () => {
+        mockFetch.mockRejectedValueOnce('kaboom');
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred')
+            ).toBeInTheDocument();
+        });
+    });
 });

--- a/client/src/components/__tests__/AlertOverridesPanel.test.tsx
+++ b/client/src/components/__tests__/AlertOverridesPanel.test.tsx
@@ -682,4 +682,228 @@ describe('AlertOverridesPanel', () => {
             ).toBeInTheDocument();
         });
     });
+
+    it('renders chip with default color for unknown severity', async () => {
+        // An unrecognised severity string falls through to the
+        // `default` branch of severityColor. Real backends should
+        // never emit one, but the defensive branch must be covered
+        // so a future schema drift cannot crash the chip render.
+        const unknownSeverityOverrides = [
+            {
+                rule_id: 77,
+                name: 'Unknown Sev Rule',
+                description: 'Defensive coverage',
+                category: 'Misc',
+                metric_name: 'some_metric',
+                metric_unit: null,
+                default_operator: '>',
+                default_threshold: 1,
+                default_severity: 'mystery',
+                default_enabled: true,
+                has_override: false,
+                override_operator: null,
+                override_threshold: null,
+                override_severity: null,
+                override_enabled: null,
+            },
+        ];
+
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => unknownSeverityOverrides,
+        });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Unknown Sev Rule')).toBeInTheDocument();
+        });
+
+        // The chip label renders the raw severity value verbatim;
+        // the colour falls through to MUI's 'default' grey variant.
+        expect(screen.getByText('mystery')).toBeInTheDocument();
+    });
+
+    it('exercises operator and severity dropdown change handlers', async () => {
+        // Cover the onChange handlers for the Operator and Severity
+        // <TextField select> controls in the edit dialog, plus the
+        // severityColor 'info' branch that is not hit by the other
+        // mock rows (all of which use 'warning' or 'critical').
+        // MUI's <TextField select> renders an MUI <Select> internally,
+        // which does NOT respond to fireEvent.change on the displayed
+        // element. Open the menu by clicking the combobox button, then
+        // click the desired option from the popover.
+        const infoRowOverrides = [
+            {
+                rule_id: 99,
+                name: 'Slow Query',
+                description: 'Query took too long',
+                category: 'Performance',
+                metric_name: 'query_latency_ms',
+                metric_unit: 'ms',
+                default_operator: '>',
+                default_threshold: 500,
+                default_severity: 'info',
+                default_enabled: true,
+                has_override: false,
+                override_operator: null,
+                override_threshold: null,
+                override_severity: null,
+                override_enabled: null,
+            },
+        ];
+
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => infoRowOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => infoRowOverrides,
+            });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Slow Query')).toBeInTheDocument();
+        });
+
+        // The info-severity chip must render with its standard color
+        // via the 'info' case of severityColor.
+        expect(screen.getByText('info')).toBeInTheDocument();
+
+        const slowRow = screen.getByText('Slow Query').closest('tr');
+        const editButton = (slowRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]'
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: Slow Query/)).toBeInTheDocument();
+        });
+
+        // Open the Operator dropdown and pick a new value.
+        const operatorCombo = screen.getByLabelText('Operator');
+        fireEvent.mouseDown(operatorCombo);
+        const operatorOption = await screen.findByRole('option', {
+            name: '>=',
+        });
+        fireEvent.click(operatorOption);
+
+        // Then open the Severity dropdown and pick critical.
+        const severityCombo = screen.getByLabelText('Severity');
+        fireEvent.mouseDown(severityCombo);
+        const severityOption = await screen.findByRole('option', {
+            name: 'critical',
+        });
+        fireEvent.click(severityOption);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/alert-overrides/server/1/99',
+                expect.objectContaining({
+                    method: 'PUT',
+                    body: expect.stringContaining('"operator":">="'),
+                })
+            );
+        });
+        // And the severity update also lands.
+        expect(mockFetch).toHaveBeenCalledWith(
+            '/api/v1/alert-overrides/server/1/99',
+            expect.objectContaining({
+                method: 'PUT',
+                body: expect.stringContaining('"severity":"critical"'),
+            })
+        );
+    });
+
+    it('clears stale success banner when a subsequent save fails', async () => {
+        // Save once successfully so the green banner appears, then
+        // re-open the dialog and force a backend 500. The red error
+        // banner must appear AND the green success banner must be
+        // gone, so the user never sees conflicting feedback.
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+                text: async () =>
+                    JSON.stringify({ error: 'second save failed' }),
+            });
+
+        renderWithTheme(
+            <AlertOverridesPanel scope="server" scopeId={1} />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+        });
+
+        const openEditor = () => {
+            const cpuRow = screen.getByText('High CPU Usage').closest('tr');
+            const editButton = (cpuRow as HTMLElement).querySelector(
+                '[aria-label="edit override"]'
+            );
+            fireEvent.click(editButton as HTMLElement);
+        };
+
+        openEditor();
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: High CPU Usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    'Override for "High CPU Usage" saved successfully.'
+                )
+            ).toBeInTheDocument();
+        });
+
+        // Re-open the dialog and submit again — this Save fails.
+        openEditor();
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: High CPU Usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('second save failed')
+            ).toBeInTheDocument();
+        });
+
+        expect(
+            screen.queryByText(
+                'Override for "High CPU Usage" saved successfully.'
+            )
+        ).not.toBeInTheDocument();
+    });
 });

--- a/client/src/components/__tests__/ProbeOverridesPanel.test.tsx
+++ b/client/src/components/__tests__/ProbeOverridesPanel.test.tsx
@@ -978,6 +978,164 @@ describe('ProbeOverridesPanel', () => {
         ).not.toBeInTheDocument();
     });
 
+    it('rejects whitespace-only interval input on save', async () => {
+        // Number('   ') is 0, which would otherwise fall through to
+        // the "must be a positive integer" message. Pre-trimming
+        // lets us surface a clearer "is required" message instead
+        // and no PUT must fire.
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        const intervalInput = screen.getByLabelText(
+            'Collection Interval (seconds)',
+        );
+        fireEvent.change(intervalInput, { target: { value: '   ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Collection interval is required.'),
+            ).toBeInTheDocument();
+        });
+
+        // Only the initial GET should have fired; no PUT yet.
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects whitespace-only retention input on save', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        const retentionInput = screen.getByLabelText('Retention Days');
+        fireEvent.change(retentionInput, { target: { value: '   ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Retention days is required.'),
+            ).toBeInTheDocument();
+        });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears stale success banner when a subsequent save fails', async () => {
+        // Sequence:
+        //  1) initial GET returns rows
+        //  2) PUT succeeds -> green success banner appears
+        //  3) refresh GET after save returns rows again
+        //  4) re-open edit dialog, type an invalid value, Save
+        //  5) red error banner must appear AND the green banner must be gone
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const openEditor = () => {
+            const cpuRow = screen.getByText('cpu_usage').closest('tr');
+            const editButton = (cpuRow as HTMLElement).querySelector(
+                '[aria-label="edit override"]',
+            );
+            fireEvent.click(editButton as HTMLElement);
+        };
+
+        openEditor();
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    'Override for "cpu_usage" saved successfully.',
+                ),
+            ).toBeInTheDocument();
+        });
+
+        // Re-open the dialog and submit an invalid interval. The
+        // validation error must surface AND the prior success banner
+        // must vanish so the user is not left with conflicting state.
+        openEditor();
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        const intervalInput = screen.getByLabelText(
+            'Collection Interval (seconds)',
+        );
+        fireEvent.change(intervalInput, { target: { value: '0' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    'Collection interval must be a positive integer.',
+                ),
+            ).toBeInTheDocument();
+        });
+
+        expect(
+            screen.queryByText(
+                'Override for "cpu_usage" saved successfully.',
+            ),
+        ).not.toBeInTheDocument();
+    });
+
     it('success banner can be dismissed after a reset', async () => {
         mockFetch
             .mockResolvedValueOnce({

--- a/client/src/components/__tests__/ProbeOverridesPanel.test.tsx
+++ b/client/src/components/__tests__/ProbeOverridesPanel.test.tsx
@@ -630,6 +630,354 @@ describe('ProbeOverridesPanel', () => {
         });
     });
 
+    it('rejects fractional interval input on save', async () => {
+        // parseInt("1.5", 10) would silently produce 1 and save a
+        // different value than the user typed. The Number() +
+        // Number.isInteger() guard must reject the fractional input
+        // before any PUT fires.
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        const intervalInput = screen.getByLabelText(
+            'Collection Interval (seconds)',
+        );
+        fireEvent.change(intervalInput, { target: { value: '1.5' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    'Collection interval must be a positive integer.',
+                ),
+            ).toBeInTheDocument();
+        });
+
+        // No PUT should have fired; only the initial GET.
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects fractional retention input on save', async () => {
+        // Mirror coverage of the retention validator: "30.7" -> 30
+        // under parseInt would be a silent data corruption.
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        const retentionInput = screen.getByLabelText('Retention Days');
+        fireEvent.change(retentionInput, { target: { value: '30.7' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Retention days must be a positive integer.'),
+            ).toBeInTheDocument();
+        });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('encodes probe name with reserved characters in PUT URL', async () => {
+        // Probe names today look like safe identifiers, but if one
+        // ever contains "/" or "+" the URL path would break without
+        // encoding. The PUT URL must carry the encoded name.
+        const reservedNameOverrides = [
+            {
+                name: 'probe/with+reserved#chars',
+                description: 'Defensive encoding check',
+                default_enabled: true,
+                default_interval_seconds: 60,
+                default_retention_days: 30,
+                has_override: true,
+                override_enabled: false,
+                override_interval_seconds: 120,
+                override_retention_days: 14,
+            },
+        ];
+
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => reservedNameOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => reservedNameOverrides,
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('probe/with+reserved#chars'),
+            ).toBeInTheDocument();
+        });
+
+        const editButton = screen.getByLabelText('edit override');
+        fireEvent.click(editButton);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/Edit override: probe\/with\+reserved#chars/),
+            ).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            // The raw "/", "+", and "#" should be percent-encoded.
+            const expected =
+                '/api/v1/probe-overrides/server/1/' +
+                encodeURIComponent('probe/with+reserved#chars');
+            expect(mockFetch).toHaveBeenCalledWith(
+                expected,
+                expect.objectContaining({
+                    method: 'PUT',
+                    credentials: 'include',
+                }),
+            );
+        });
+    });
+
+    it('encodes itemKey with reserved characters in DELETE URL', async () => {
+        // The shared scaffold's reset handler also interpolates the
+        // item key into the URL. The encoding must cover that path
+        // too — caller-supplied identifiers may contain anything.
+        const reservedNameOverrides = [
+            {
+                name: 'probe with space/slash',
+                description: 'Defensive encoding check',
+                default_enabled: true,
+                default_interval_seconds: 60,
+                default_retention_days: 30,
+                has_override: true,
+                override_enabled: false,
+                override_interval_seconds: 120,
+                override_retention_days: 14,
+            },
+        ];
+
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => reservedNameOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => reservedNameOverrides,
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('probe with space/slash'),
+            ).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByLabelText('reset override to default'));
+
+        await waitFor(() => {
+            const expected =
+                '/api/v1/probe-overrides/server/1/' +
+                encodeURIComponent('probe with space/slash');
+            expect(mockFetch).toHaveBeenCalledWith(
+                expected,
+                expect.objectContaining({
+                    method: 'DELETE',
+                    credentials: 'include',
+                }),
+            );
+        });
+    });
+
+    it('discards stale fetch responses when scope changes mid-flight', async () => {
+        // Setting up the race: the first GET (scope=server, id=1)
+        // returns a promise we resolve manually AFTER the second GET
+        // (scope=cluster, id=5) has already resolved. Without the
+        // request-token guard, the stale server response would land
+        // last and overwrite the cluster rows. With the guard in
+        // place, the stale response is dropped silently.
+
+        // First request: deferred. We'll resolve it explicitly later.
+        let resolveFirst: (value: {
+            ok: true;
+            json: () => Promise<typeof mockOverrides>;
+        }) => void = () => {};
+        const firstPromise = new Promise<{
+            ok: true;
+            json: () => Promise<typeof mockOverrides>;
+        }>((resolve) => {
+            resolveFirst = resolve;
+        });
+        mockFetch.mockReturnValueOnce(firstPromise);
+
+        // Second request: resolves immediately with a different,
+        // recognisable payload so we can assert it survives.
+        const clusterOverrides = [
+            {
+                name: 'cluster_only_probe',
+                description: 'Only visible after the rerender',
+                default_enabled: true,
+                default_interval_seconds: 15,
+                default_retention_days: 7,
+                has_override: false,
+                override_enabled: null,
+                override_interval_seconds: null,
+                override_retention_days: null,
+            },
+        ];
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => clusterOverrides,
+        });
+
+        const { rerender } = render(
+            <ThemeProvider theme={darkTheme}>
+                <ProbeOverridesPanel scope="server" scopeId={1} />
+            </ThemeProvider>,
+        );
+
+        // Force scope/scopeId to change while the first request is
+        // still pending. This triggers a second fetch with a new
+        // request token.
+        rerender(
+            <ThemeProvider theme={darkTheme}>
+                <ProbeOverridesPanel scope="cluster" scopeId={5} />
+            </ThemeProvider>,
+        );
+
+        // Wait for the second (newer) response to land.
+        await waitFor(() => {
+            expect(
+                screen.getByText('cluster_only_probe'),
+            ).toBeInTheDocument();
+        });
+
+        // Now resolve the stale first request. It must NOT replace
+        // the cluster rows we just rendered.
+        resolveFirst({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        // Give microtasks a chance to flush. Even after the stale
+        // response resolves, cluster_only_probe must remain and
+        // none of the server-scope probe names should appear.
+        await waitFor(() => {
+            expect(
+                screen.getByText('cluster_only_probe'),
+            ).toBeInTheDocument();
+            expect(screen.queryByText('cpu_usage')).not.toBeInTheDocument();
+            expect(screen.queryByText('disk_usage')).not.toBeInTheDocument();
+        });
+    });
+
+    it('discards stale fetch error responses when scope changes mid-flight', async () => {
+        // Mirror of the previous test but exercising the catch
+        // branch: the stale request rejects AFTER the newer request
+        // has succeeded. The error banner must NOT appear, because
+        // that error belongs to a discarded scope.
+        let rejectFirst: (reason: unknown) => void = () => {};
+        const firstPromise = new Promise((_, reject) => {
+            rejectFirst = reject;
+        });
+        mockFetch.mockReturnValueOnce(firstPromise);
+
+        const clusterOverrides = [
+            {
+                name: 'cluster_only_probe',
+                description: 'Only visible after the rerender',
+                default_enabled: true,
+                default_interval_seconds: 15,
+                default_retention_days: 7,
+                has_override: false,
+                override_enabled: null,
+                override_interval_seconds: null,
+                override_retention_days: null,
+            },
+        ];
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => clusterOverrides,
+        });
+
+        const { rerender } = render(
+            <ThemeProvider theme={darkTheme}>
+                <ProbeOverridesPanel scope="server" scopeId={1} />
+            </ThemeProvider>,
+        );
+
+        rerender(
+            <ThemeProvider theme={darkTheme}>
+                <ProbeOverridesPanel scope="cluster" scopeId={5} />
+            </ThemeProvider>,
+        );
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('cluster_only_probe'),
+            ).toBeInTheDocument();
+        });
+
+        // Reject the stale request with a recognisable message;
+        // the error banner must NOT surface this stale failure.
+        rejectFirst(new Error('stale request boom'));
+
+        // Allow microtasks to settle. cluster_only_probe should
+        // still be rendered and no stale error should be shown.
+        await waitFor(() => {
+            expect(
+                screen.getByText('cluster_only_probe'),
+            ).toBeInTheDocument();
+        });
+        expect(
+            screen.queryByText('stale request boom'),
+        ).not.toBeInTheDocument();
+    });
+
     it('success banner can be dismissed after a reset', async () => {
         mockFetch
             .mockResolvedValueOnce({

--- a/client/src/components/__tests__/ProbeOverridesPanel.test.tsx
+++ b/client/src/components/__tests__/ProbeOverridesPanel.test.tsx
@@ -1,0 +1,670 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import type React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import ProbeOverridesPanel from '../ProbeOverridesPanel';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const darkTheme = createTheme({ palette: { mode: 'dark' } });
+
+const renderWithTheme = (component: React.ReactElement) => {
+    return render(
+        <ThemeProvider theme={darkTheme}>{component}</ThemeProvider>,
+    );
+};
+
+const mockOverrides = [
+    {
+        name: 'cpu_usage',
+        description: 'Collect CPU usage metrics',
+        default_enabled: true,
+        default_interval_seconds: 60,
+        default_retention_days: 30,
+        has_override: true,
+        override_enabled: false,
+        override_interval_seconds: 120,
+        override_retention_days: 14,
+    },
+    {
+        name: 'disk_usage',
+        description: 'Collect disk usage metrics',
+        default_enabled: true,
+        default_interval_seconds: 300,
+        default_retention_days: 30,
+        has_override: false,
+        override_enabled: null,
+        override_interval_seconds: null,
+        override_retention_days: null,
+    },
+    {
+        name: 'connection_count',
+        description: 'Collect connection count metrics',
+        default_enabled: true,
+        default_interval_seconds: 30,
+        default_retention_days: 7,
+        has_override: false,
+        override_enabled: null,
+        override_interval_seconds: null,
+        override_retention_days: null,
+    },
+];
+
+describe('ProbeOverridesPanel', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders loading state', () => {
+        mockFetch.mockReturnValue(new Promise(() => {}));
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('renders probe rows from API', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+        expect(screen.getByText('disk_usage')).toBeInTheDocument();
+        expect(screen.getByText('connection_count')).toBeInTheDocument();
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            '/api/v1/probe-overrides/server/1',
+            expect.objectContaining({ credentials: 'include' }),
+        );
+    });
+
+    it('shows override values when present', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        // The overridden row should show its override interval (120s)
+        // and retention (14 days), not the defaults.
+        expect(screen.getByText('120s')).toBeInTheDocument();
+        expect(screen.getByText('14 days')).toBeInTheDocument();
+    });
+
+    it('shows default values when no override', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('disk_usage')).toBeInTheDocument();
+        });
+
+        // disk_usage has no override; default interval = 300, retention = 30
+        expect(screen.getByText('300s')).toBeInTheDocument();
+    });
+
+    it('renders table headers', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Name')).toBeInTheDocument();
+        });
+        expect(screen.getByText('Description')).toBeInTheDocument();
+        expect(screen.getByText('Enabled')).toBeInTheDocument();
+        expect(screen.getByText('Interval')).toBeInTheDocument();
+        expect(screen.getByText('Retention')).toBeInTheDocument();
+        expect(screen.getByText('Actions')).toBeInTheDocument();
+    });
+
+    it('edit button opens dialog with pre-populated values', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        // Click the edit button on the cpu_usage row.
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        expect(cpuRow).not.toBeNull();
+        const cpuEditButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        expect(cpuEditButton).not.toBeNull();
+        fireEvent.click(cpuEditButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        // The interval field should be populated with the override
+        // value (120 seconds), not the default.
+        const intervalInput = screen.getByLabelText(
+            'Collection Interval (seconds)',
+        );
+        expect(intervalInput).toHaveValue(120);
+
+        const retentionInput = screen.getByLabelText('Retention Days');
+        expect(retentionInput).toHaveValue(14);
+    });
+
+    it('edit dialog Cancel closes the dialog', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        await waitFor(() => {
+            expect(
+                screen.queryByText(/Edit override: cpu_usage/),
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    it('edit dialog Save calls PUT and refreshes', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/probe-overrides/server/1/cpu_usage',
+                expect.objectContaining({
+                    method: 'PUT',
+                    credentials: 'include',
+                }),
+            );
+        });
+    });
+
+    it('reset button calls DELETE endpoint', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        // Only the overridden row (cpu_usage) shows a reset button.
+        const resetButton = screen.getByLabelText('reset override to default');
+        fireEvent.click(resetButton);
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/probe-overrides/server/1/cpu_usage',
+                expect.objectContaining({
+                    method: 'DELETE',
+                    credentials: 'include',
+                }),
+            );
+        });
+    });
+
+    it('shows empty state when no probes are returned', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => [],
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('No probe configurations found.'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('shows error when fetch fails', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            text: async () =>
+                JSON.stringify({ error: 'Failed to fetch probe overrides' }),
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Failed to fetch probe overrides'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('shows fallback message when fetch rejects with non-Error value', async () => {
+        // A bare string rejection exercises the "unknown error"
+        // branch in the panel. The shared scaffold should fall
+        // back to the generic message.
+        mockFetch.mockRejectedValueOnce('boom');
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('uses correct API path for different scopes', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => [],
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="cluster" scopeId={5} />);
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/probe-overrides/cluster/5',
+                expect.objectContaining({ credentials: 'include' }),
+            );
+        });
+    });
+
+    it('uses correct API path for group scope', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => [],
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="group" scopeId={42} />);
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith(
+                '/api/v1/probe-overrides/group/42',
+                expect.objectContaining({ credentials: 'include' }),
+            );
+        });
+    });
+
+    it('only shows reset button on rows with overrides', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        // Only one row has has_override=true.
+        const resetButtons = screen.getAllByLabelText(
+            'reset override to default',
+        );
+        expect(resetButtons).toHaveLength(1);
+
+        // Every row should have an edit button.
+        const editButtons = screen.getAllByLabelText('edit override');
+        expect(editButtons).toHaveLength(3);
+    });
+
+    it('rejects non-numeric interval input on save', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        // Force the interval to an invalid value, then save. The
+        // dialog-local error should appear and no PUT should fire.
+        const intervalInput = screen.getByLabelText(
+            'Collection Interval (seconds)',
+        );
+        fireEvent.change(intervalInput, { target: { value: '0' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    'Collection interval must be a positive integer.',
+                ),
+            ).toBeInTheDocument();
+        });
+
+        // Only the initial GET should have fired; no PUT yet.
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects non-numeric retention input on save', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockOverrides,
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        const retentionInput = screen.getByLabelText('Retention Days');
+        fireEvent.change(retentionInput, { target: { value: '-1' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Retention days must be a positive integer.'),
+            ).toBeInTheDocument();
+        });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows error and keeps dialog open when save PUT fails', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+                text: async () =>
+                    JSON.stringify({ error: 'Server side blew up' }),
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Server side blew up')).toBeInTheDocument();
+        });
+    });
+
+    it('shows success banner after a successful save', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        const cpuRow = screen.getByText('cpu_usage').closest('tr');
+        const editButton = (cpuRow as HTMLElement).querySelector(
+            '[aria-label="edit override"]',
+        );
+        fireEvent.click(editButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Edit override: cpu_usage/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    'Override for "cpu_usage" saved successfully.',
+                ),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('shows success banner after a successful reset', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByLabelText('reset override to default'));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Override for "cpu_usage" reset to default.'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('shows error banner when reset DELETE fails', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+                text: async () => JSON.stringify({ error: 'Reset failed' }),
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByLabelText('reset override to default'));
+
+        await waitFor(() => {
+            expect(screen.getByText('Reset failed')).toBeInTheDocument();
+        });
+    });
+
+    it('error banner can be dismissed', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            text: async () => JSON.stringify({ error: 'Bang' }),
+        });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Bang')).toBeInTheDocument();
+        });
+
+        // The MUI Alert close button has aria-label "Close" by default.
+        fireEvent.click(screen.getByLabelText('Close'));
+
+        await waitFor(() => {
+            expect(screen.queryByText('Bang')).not.toBeInTheDocument();
+        });
+    });
+
+    it('success banner can be dismissed after a reset', async () => {
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockOverrides,
+            });
+
+        renderWithTheme(<ProbeOverridesPanel scope="server" scopeId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cpu_usage')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByLabelText('reset override to default'));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Override for "cpu_usage" reset to default.'),
+            ).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByLabelText('Close'));
+
+        await waitFor(() => {
+            expect(
+                screen.queryByText('Override for "cpu_usage" reset to default.'),
+            ).not.toBeInTheDocument();
+        });
+    });
+});

--- a/client/src/components/shared/ScopedOverridesPanel.tsx
+++ b/client/src/components/shared/ScopedOverridesPanel.tsx
@@ -43,7 +43,14 @@
  */
 
 import type React from 'react';
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import {
+    Fragment,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import {
     Alert,
     Box,
@@ -232,9 +239,12 @@ function ScopedOverridesPanel<T>(
      * Centralised error projection used by both the reset action
      * and the dialog's onSaveError helper. Anything `Error`-shaped
      * surfaces its message; everything else falls back to a generic
-     * label so the user is never left staring at nothing.
+     * label so the user is never left staring at nothing. The
+     * previous success banner is cleared at the same time so a
+     * stale "saved" message never appears alongside a fresh error.
      */
     const projectError = useCallback((err: unknown) => {
+        setSuccess(null);
         if (err instanceof Error) {
             setError(err.message);
         } else {
@@ -289,6 +299,32 @@ function ScopedOverridesPanel<T>(
             onEditRequested(item);
         },
         [onEditRequested],
+    );
+
+    // Memoise the helpers object so the caller's `renderEditDialog`
+    // receives a stable reference across renders. Without this the
+    // dialog render prop would see a new helpers identity every render,
+    // which defeats any memoisation the caller may apply downstream.
+    // Dependencies cover every value the object closes over: the two
+    // state setters (stable by React contract but listed for the
+    // exhaustive-deps lint rule), `projectError` (a stable useCallback),
+    // and `fetchOverrides` (a stable useCallback keyed off the API
+    // inputs, so it only changes when a new fetch is genuinely needed).
+    // This hook MUST sit above the early-return for `loading` below;
+    // moving it after the conditional return would change the hook
+    // count between renders and break the Rules of Hooks.
+    const editHelpers = useMemo<ScopedOverridesEditHelpers>(
+        () => ({
+            onSaveSuccess: (message) => {
+                setSuccess(message);
+                setError(null);
+            },
+            onSaveError: projectError,
+            refresh: () => {
+                void fetchOverrides();
+            },
+        }),
+        [fetchOverrides, projectError],
     );
 
     if (loading) {
@@ -388,17 +424,6 @@ function ScopedOverridesPanel<T>(
                     .map(renderItemRow)}
             </Fragment>
         ));
-    };
-
-    const editHelpers: ScopedOverridesEditHelpers = {
-        onSaveSuccess: (message) => {
-            setSuccess(message);
-            setError(null);
-        },
-        onSaveError: projectError,
-        refresh: () => {
-            void fetchOverrides();
-        },
     };
 
     return (

--- a/client/src/components/shared/ScopedOverridesPanel.tsx
+++ b/client/src/components/shared/ScopedOverridesPanel.tsx
@@ -43,7 +43,7 @@
  */
 
 import type React from 'react';
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import {
     Alert,
     Box,
@@ -179,21 +179,48 @@ function ScopedOverridesPanel<T>(
     const [error, setError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
 
+    // Monotonic request token used to discard stale fetch responses.
+    // When scope / scopeId / apiBasePath change rapidly, an earlier
+    // request can resolve AFTER a newer one and overwrite its rows.
+    // Each fetch captures the token value at dispatch time and only
+    // commits its results if the ref still matches when the promise
+    // settles. This is preferred over AbortController here because
+    // apiGet does not currently accept an abort signal from the
+    // caller and the token approach is dependency-light.
+    const requestTokenRef = useRef(0);
+
     const fetchOverrides = useCallback(async () => {
+        const token = requestTokenRef.current + 1;
+        requestTokenRef.current = token;
         try {
             setLoading(true);
             const data = await apiGet<T[]>(
                 `${apiBasePath}/${scope}/${String(scopeId)}`,
             );
+            // Drop the response if a newer fetch has been issued
+            // while this one was in flight.
+            if (requestTokenRef.current !== token) {
+                return;
+            }
             setOverrides(data || []);
         } catch (err: unknown) {
+            // Same guard for the error path: a stale error should
+            // not clobber the newer scope's banner state.
+            if (requestTokenRef.current !== token) {
+                return;
+            }
             if (err instanceof Error) {
                 setError(err.message);
             } else {
                 setError('An unexpected error occurred');
             }
         } finally {
-            setLoading(false);
+            // Only the latest request controls the spinner; an older
+            // request finishing late must not flip loading=false on
+            // top of the newer in-flight request.
+            if (requestTokenRef.current === token) {
+                setLoading(false);
+            }
         }
     }, [apiBasePath, scope, scopeId]);
 
@@ -220,8 +247,17 @@ function ScopedOverridesPanel<T>(
             e.stopPropagation();
             try {
                 setError(null);
+                // itemKey returns string | number; callers may pass
+                // arbitrary identifiers (for example probe names).
+                // Encode the trailing segment so reserved characters
+                // such as "/", "+", "#", or whitespace cannot break
+                // the URL path. Numeric ids and ASCII identifiers
+                // round-trip unchanged.
+                const encodedKey = encodeURIComponent(
+                    String(itemKey(item)),
+                );
                 await apiDelete(
-                    `${apiBasePath}/${scope}/${String(scopeId)}/${String(itemKey(item))}`,
+                    `${apiBasePath}/${scope}/${String(scopeId)}/${encodedKey}`,
                 );
                 setSuccess(
                     `Override for "${itemDisplayName(item)}" reset to default.`,

--- a/client/src/components/shared/ScopedOverridesPanel.tsx
+++ b/client/src/components/shared/ScopedOverridesPanel.tsx
@@ -1,0 +1,420 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * ScopedOverridesPanel is a generic, reusable scaffolding component
+ * for displaying and managing per-scope (server / cluster / group)
+ * overrides of monitoring rules. It is shared between the probe and
+ * alert override panels, both of which expose near-identical fetch,
+ * list, edit, and reset behaviour but differ in the schema of each
+ * row and in the field set of the edit dialog.
+ *
+ * Design notes:
+ *
+ * - The component owns the cross-cutting concerns that are genuinely
+ *   identical between the two panels: data fetching, loading state,
+ *   error and success banners, the bordered table shell, empty-state
+ *   rendering, optional category grouping, and the Reset action.
+ *
+ * - The component does NOT own the edit dialog. The edit dialog field
+ *   sets differ materially between probe rules (enabled / interval /
+ *   retention days) and alert rules (enabled / operator / threshold /
+ *   severity), so it would be a bad abstraction to merge them. The
+ *   caller renders its own dialog via the `renderEditDialog` prop and
+ *   receives helper callbacks (`onSaveSuccess`, `onSaveError`,
+ *   `refresh`) that wire the dialog into the shared state.
+ *
+ * - The Edit button on each row simply forwards the row's item to the
+ *   caller via `onEditRequested`. The caller is responsible for
+ *   storing the selected item and toggling the dialog's open state.
+ *
+ * - This component intentionally does not abstract a "scope tree
+ *   selector" because the existing override panels receive `scope`
+ *   and `scopeId` as props from their parent (see e.g. the cluster
+ *   detail and server detail screens). Adding a tree selector here
+ *   would be a different feature, not a refactor.
+ */
+
+import type React from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import {
+    Alert,
+    Box,
+    CircularProgress,
+    IconButton,
+    Paper,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import {
+    Edit as EditIcon,
+    RestartAlt as ResetIcon,
+} from '@mui/icons-material';
+import { apiDelete, apiGet } from '../../utils/apiClient';
+import {
+    categoryLabelSx,
+    emptyRowSx,
+    emptyRowTextSx,
+    getTableContainerSx,
+    loadingContainerSx,
+    tableHeaderCellSx,
+} from '../AdminPanel/styles';
+
+/**
+ * Description of a column header rendered above the body rows.
+ */
+export interface ScopedOverridesColumn {
+    /** Visible header label. */
+    label: string;
+    /** Cell alignment; defaults to left. */
+    align?: 'left' | 'right' | 'center';
+}
+
+/**
+ * Helpers passed to the caller's edit-dialog render prop. The dialog
+ * uses these to feed messages back into the shared error and success
+ * banners and to trigger a list refresh after a successful save.
+ */
+export interface ScopedOverridesEditHelpers {
+    /** Called by the dialog after a successful save. */
+    onSaveSuccess: (message: string) => void;
+    /** Called by the dialog when a save fails. */
+    onSaveError: (err: unknown) => void;
+    /** Re-runs the fetch to refresh the list. */
+    refresh: () => void;
+}
+
+export interface ScopedOverridesPanelProps<T> {
+    /** Scope kind in the API URL. */
+    scope: 'server' | 'cluster' | 'group';
+    /** Numeric identifier of the scope target. */
+    scopeId: number;
+    /**
+     * Base path for the override API (without trailing slash). The
+     * component issues `GET <basePath>/<scope>/<scopeId>` to load,
+     * and `DELETE <basePath>/<scope>/<scopeId>/<key>` to reset.
+     */
+    apiBasePath: string;
+    /**
+     * Returns the unique identifier used both as the React key and
+     * as the trailing path segment in the reset DELETE URL.
+     */
+    itemKey: (item: T) => string | number;
+    /** Returns the human-readable name used in success messages. */
+    itemDisplayName: (item: T) => string;
+    /** Returns whether the row currently has an explicit override. */
+    hasOverride: (item: T) => boolean;
+    /** Column header definitions (in order). */
+    columns: ScopedOverridesColumn[];
+    /**
+     * Render the data cells for a single row. The shared component
+     * appends the standard Actions cell with edit and reset buttons.
+     */
+    renderRowCells: (item: T) => React.ReactNode;
+    /**
+     * Optional row grouping function. When provided, rows are
+     * grouped under a category header row (sorted alphabetically).
+     */
+    groupBy?: (item: T) => string;
+    /** Message rendered when the API returns an empty list. */
+    emptyMessage: string;
+    /** ARIA label for the loading spinner. */
+    loadingLabel: string;
+    /** Handler invoked when the user clicks the row's edit button. */
+    onEditRequested: (item: T) => void;
+    /**
+     * Render prop for the caller-owned edit dialog. The shared
+     * component does not manage dialog open state or field state;
+     * the caller injects its own dialog and wires success and error
+     * outcomes back into the shared banners using the helpers.
+     */
+    renderEditDialog: (helpers: ScopedOverridesEditHelpers) => React.ReactNode;
+}
+
+/**
+ * Generic, reusable scaffolding for monitoring override panels.
+ *
+ * @typeParam T - The shape of an individual override row. The
+ *                shared component is agnostic to the fields T
+ *                exposes; the caller projects them into the table
+ *                via `renderRowCells`.
+ */
+function ScopedOverridesPanel<T>(
+    props: ScopedOverridesPanelProps<T>,
+): React.ReactElement {
+    const {
+        scope,
+        scopeId,
+        apiBasePath,
+        itemKey,
+        itemDisplayName,
+        hasOverride,
+        columns,
+        renderRowCells,
+        groupBy,
+        emptyMessage,
+        loadingLabel,
+        onEditRequested,
+        renderEditDialog,
+    } = props;
+
+    const theme = useTheme();
+
+    const [overrides, setOverrides] = useState<T[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState<string | null>(null);
+
+    const fetchOverrides = useCallback(async () => {
+        try {
+            setLoading(true);
+            const data = await apiGet<T[]>(
+                `${apiBasePath}/${scope}/${String(scopeId)}`,
+            );
+            setOverrides(data || []);
+        } catch (err: unknown) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('An unexpected error occurred');
+            }
+        } finally {
+            setLoading(false);
+        }
+    }, [apiBasePath, scope, scopeId]);
+
+    useEffect(() => {
+        void fetchOverrides();
+    }, [fetchOverrides]);
+
+    /**
+     * Centralised error projection used by both the reset action
+     * and the dialog's onSaveError helper. Anything `Error`-shaped
+     * surfaces its message; everything else falls back to a generic
+     * label so the user is never left staring at nothing.
+     */
+    const projectError = useCallback((err: unknown) => {
+        if (err instanceof Error) {
+            setError(err.message);
+        } else {
+            setError('An unexpected error occurred');
+        }
+    }, []);
+
+    const handleResetOverride = useCallback(
+        async (item: T, e: React.MouseEvent) => {
+            e.stopPropagation();
+            try {
+                setError(null);
+                await apiDelete(
+                    `${apiBasePath}/${scope}/${String(scopeId)}/${String(itemKey(item))}`,
+                );
+                setSuccess(
+                    `Override for "${itemDisplayName(item)}" reset to default.`,
+                );
+                void fetchOverrides();
+            } catch (err: unknown) {
+                projectError(err);
+            }
+        },
+        [
+            apiBasePath,
+            scope,
+            scopeId,
+            itemKey,
+            itemDisplayName,
+            fetchOverrides,
+            projectError,
+        ],
+    );
+
+    const handleEditClick = useCallback(
+        (item: T, e: React.MouseEvent) => {
+            e.stopPropagation();
+            // Clear any stale error so the dialog opens with a fresh
+            // banner state. Success messages are intentionally left
+            // alone — the user just took an explicit action so the
+            // previous "saved" message is still relevant context.
+            setError(null);
+            onEditRequested(item);
+        },
+        [onEditRequested],
+    );
+
+    if (loading) {
+        return (
+            <Box sx={loadingContainerSx}>
+                <CircularProgress aria-label={loadingLabel} />
+            </Box>
+        );
+    }
+
+    const tableContainerSx = getTableContainerSx(theme);
+
+    // Total column count including the trailing Actions cell. Used
+    // for the colSpan on the empty-state row and on category headers.
+    const totalColumns = columns.length + 1;
+
+    /**
+     * Render the data row for a single override item, including the
+     * trailing Actions cell. The Reset button only appears when the
+     * row has an override of its own.
+     */
+    const renderItemRow = (item: T) => (
+        <TableRow key={String(itemKey(item))} hover>
+            {renderRowCells(item)}
+            <TableCell align="right">
+                <Tooltip title="Edit override">
+                    <IconButton
+                        size="small"
+                        onClick={(e) => {
+                            handleEditClick(item, e);
+                        }}
+                        aria-label="edit override"
+                    >
+                        <EditIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+                {hasOverride(item) && (
+                    <Tooltip title="Reset to default">
+                        <IconButton
+                            size="small"
+                            onClick={(e) => {
+                                void handleResetOverride(item, e);
+                            }}
+                            aria-label="reset override to default"
+                        >
+                            <ResetIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                )}
+            </TableCell>
+        </TableRow>
+    );
+
+    /**
+     * Render the body rows. When `groupBy` is provided, items are
+     * organised under category header rows in alphabetical order;
+     * otherwise the rows render as a flat list. Empty input renders
+     * a single full-width "no data" row.
+     */
+    const renderBody = (): React.ReactNode => {
+        if (overrides.length === 0) {
+            return (
+                <TableRow>
+                    <TableCell colSpan={totalColumns} align="center" sx={emptyRowSx}>
+                        <Typography color="text.secondary" sx={emptyRowTextSx}>
+                            {emptyMessage}
+                        </Typography>
+                    </TableCell>
+                </TableRow>
+            );
+        }
+
+        if (!groupBy) {
+            return overrides.map(renderItemRow);
+        }
+
+        const categories = Array.from(
+            new Set(overrides.map((item) => groupBy(item))),
+        ).sort();
+
+        return categories.map((category) => (
+            <Fragment key={category}>
+                <TableRow>
+                    <TableCell
+                        colSpan={totalColumns}
+                        sx={{
+                            ...categoryLabelSx,
+                            bgcolor: theme.palette.action.hover,
+                            py: 0.75,
+                        }}
+                    >
+                        {category}
+                    </TableCell>
+                </TableRow>
+                {overrides
+                    .filter((item) => groupBy(item) === category)
+                    .map(renderItemRow)}
+            </Fragment>
+        ));
+    };
+
+    const editHelpers: ScopedOverridesEditHelpers = {
+        onSaveSuccess: (message) => {
+            setSuccess(message);
+            setError(null);
+        },
+        onSaveError: projectError,
+        refresh: () => {
+            void fetchOverrides();
+        },
+    };
+
+    return (
+        <Box>
+            {error && (
+                <Alert
+                    severity="error"
+                    sx={{ mb: 2, borderRadius: 1 }}
+                    onClose={() => {
+                        setError(null);
+                    }}
+                >
+                    {error}
+                </Alert>
+            )}
+            {success && (
+                <Alert
+                    severity="success"
+                    sx={{ mb: 2, borderRadius: 1 }}
+                    onClose={() => {
+                        setSuccess(null);
+                    }}
+                >
+                    {success}
+                </Alert>
+            )}
+
+            <TableContainer component={Paper} elevation={0} sx={tableContainerSx}>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            {columns.map((col) => (
+                                <TableCell
+                                    key={col.label}
+                                    sx={tableHeaderCellSx}
+                                    align={col.align}
+                                >
+                                    {col.label}
+                                </TableCell>
+                            ))}
+                            <TableCell sx={tableHeaderCellSx} align="right">
+                                Actions
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>{renderBody()}</TableBody>
+                </Table>
+            </TableContainer>
+
+            {renderEditDialog(editHelpers)}
+        </Box>
+    );
+}
+
+export default ScopedOverridesPanel;


### PR DESCRIPTION
## Summary

Codacy reports 22% project-wide code duplication (target 10%). The two override panels (`ProbeOverridesPanel`, `AlertOverridesPanel`) share near-identical scaffolding for managing monitoring rule overrides per scope: fetch-on-mount, grouped table rendering, optimistic refresh, reset action, success/error banners.

This change extracts the shared scaffolding into a generic `ScopedOverridesPanel<T>` and converts both panels to use it. Each panel keeps its own edit dialog and field-specific row rendering (the field sets — probe intervals/retention vs alert operator/threshold/severity — are too disjoint to merge usefully).

## Files touched

- `client/src/components/shared/ScopedOverridesPanel.tsx` (new, 420 LOC — ~90 are JSDoc/comments)
- `client/src/components/ProbeOverridesPanel.tsx` (371 → 306 LOC; -65)
- `client/src/components/AlertOverridesPanel.tsx` (456 → 385 LOC; -71)
- `client/src/components/__tests__/ProbeOverridesPanel.test.tsx` (new — file previously had no tests)
- `client/src/components/__tests__/AlertOverridesPanel.test.tsx` (12 existing cases preserved unchanged; 9 new cases appended for dialog coverage)

The shared component exposes `onSaveSuccess` / `onSaveError` / `refresh` helpers to the caller-owned edit dialog, so saves drive the shared banners and trigger an optimistic refresh.

## Behaviour preservation

All pre-existing tests pass unchanged. The original 12 alert-panel tests were not modified.

## Verification

- `npx vitest run`: 2924 / 2924 passing (145 test files)
- `npm run lint`: 0 errors, 39 warnings (identical to baseline)
- `npx tsc --noEmit`: clean on touched files (pre-existing errors in unrelated files remain)
- Coverage on touched files (90% project floor):
  - `shared/ScopedOverridesPanel.tsx`: 98.3% lines
  - `ProbeOverridesPanel.tsx`: 93.22% lines
  - `AlertOverridesPanel.tsx`: 90.27% lines

## Out of scope

- `AlertOverrideEditDialog.tsx` left untouched — disjoint field set from any hypothetical probe dialog
- `ChannelOverridesPanel.tsx` — similar pattern but explicitly excluded; could adopt this shared component in a follow-up
- Blackout components — different domain

## Test plan

- [x] Unit tests pass for both refactored panels
- [x] Full client suite passes
- [x] Lint and type-check clean
- [x] Coverage ≥ 90% on each touched file
- [ ] Manual smoke test of create/edit/delete on each panel (not run; defer to reviewer with running dev env)

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified scoped overrides panel with grouped rows, consistent loading/empty states, and standardized edit/reset actions with dismissible success/error banners.

* **Refactor**
  * Alert and probe override UIs now reuse shared scaffolding for consistent behavior and simpler component composition.

* **Bug Fixes / UX**
  * Improved input validation, blocked dialog close while saving, and clearer handling of stale requests and errors.

* **Style**
  * Added styling for inherited/default value cells.

* **Tests**
  * Significantly expanded tests for edit/save/reset flows, validation, error/success banners, and race conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/208)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->