### PR TITLE
refactor(client): extract Admin* CRUD panel pattern

### DIFF
--- a/client/src/components/AdminPanel/AdminAlertRules.tsx
+++ b/client/src/components/AdminPanel/AdminAlertRules.tsx
@@ -8,7 +8,7 @@
  *-------------------------------------------------------------------------
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
     Box,
     Typography,
@@ -51,6 +51,7 @@ import {
 } from './styles';
 import { apiGet, apiPut } from '../../utils/apiClient';
 import { getFriendlyTitle } from '../../utils/friendlyNames';
+import { useCrudPanel } from './_shared';
 
 const OPERATORS = ['>', '>=', '<', '<=', '==', '!='];
 const SEVERITIES = ['info', 'warning', 'critical'];
@@ -75,91 +76,80 @@ const severityColor = (severity: string): 'default' | 'info' | 'warning' | 'erro
     }
 };
 
+/**
+ * Fetches the alert-rule list from the server. The endpoint historically
+ * returned a bare array and was later wrapped in `{ alert_rules: [...] }`;
+ * both shapes are accepted so older deployments keep working.
+ */
+const fetchAlertRules = async (): Promise<AlertRule[]> => {
+    const data = await apiGet<{ alert_rules?: AlertRule[] } | AlertRule[]>(
+        '/api/v1/alert-rules',
+    );
+    if (Array.isArray(data)) {
+        return data;
+    }
+    return data.alert_rules ?? [];
+};
+
 const AdminAlertRules: React.FC = () => {
     const theme = useTheme();
 
-    const [rules, setRules] = useState<AlertRule[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
+    // The shared hook owns list state, dialog/edit state, success/error
+    // toasts, and the mutation try/catch boilerplate. The component is
+    // left with the form fields and the render tree.
+    const crud = useCrudPanel<AlertRule>({
+        fetchItems: useCallback(() => fetchAlertRules(), []),
+    });
 
-    // Edit rule dialog
-    const [editOpen, setEditOpen] = useState(false);
-    const [editRule, setEditRule] = useState<AlertRule | null>(null);
+    // Per-form fields for the edit dialog. The shared hook exposes
+    // `editingItem` and the open/close lifecycle; the field-level state
+    // remains here because it is rule-shape specific.
     const [editEnabled, setEditEnabled] = useState(false);
     const [editOperator, setEditOperator] = useState('');
     const [editThreshold, setEditThreshold] = useState('');
     const [editSeverity, setEditSeverity] = useState('');
-    const [saving, setSaving] = useState(false);
-
-    const fetchRules = useCallback(async () => {
-        try {
-            setLoading(true);
-            const data = await apiGet<{ alert_rules?: AlertRule[] } | AlertRule[]>(
-                '/api/v1/alert-rules',
-            );
-            if (Array.isArray(data)) {
-                setRules(data);
-            } else {
-                setRules(data.alert_rules ?? []);
-            }
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setLoading(false);
-        }
-    }, []);
-
-    useEffect(() => {
-        void fetchRules();
-    }, [fetchRules]);
 
     const handleEditRule = (rule: AlertRule, e: React.MouseEvent) => {
         e.stopPropagation();
-        setEditRule(rule);
         setEditEnabled(rule.default_enabled);
         setEditOperator(rule.default_operator);
         setEditThreshold(String(rule.default_threshold));
         setEditSeverity(rule.default_severity);
-        setError(null);
-        setEditOpen(true);
+        // Clear any stale page-level error so the validation error from
+        // the previous attempt does not bleed into a fresh edit.
+        crud.setError(null);
+        crud.openEdit(rule);
     };
 
     const handleSaveRule = async () => {
-        if (!editRule) {return;}
+        const editRule = crud.editingItem;
+        if (!editRule) { return; }
         const thresholdNum = parseFloat(editThreshold);
         if (Number.isNaN(thresholdNum)) {
-            setError('Threshold must be a valid number.');
+            // Validation must surface as a page-level error to preserve
+            // the historical UX where it appears above the table.
+            crud.setError('Threshold must be a valid number.');
             return;
         }
-        try {
-            setSaving(true);
-            setError(null);
-            await apiPut(`/api/v1/alert-rules/${editRule.id}`, {
-                default_enabled: editEnabled,
-                default_operator: editOperator,
-                default_threshold: thresholdNum,
-                default_severity: editSeverity,
-            });
-            setEditOpen(false);
-            setSuccess(`Alert rule "${getFriendlyTitle(editRule.name)}" updated successfully.`);
-            fetchRules();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setSaving(false);
+        const result = await crud.runMutation(
+            () =>
+                apiPut(`/api/v1/alert-rules/${editRule.id}`, {
+                    default_enabled: editEnabled,
+                    default_operator: editOperator,
+                    default_threshold: thresholdNum,
+                    default_severity: editSeverity,
+                }),
+            {
+                errorTarget: 'page',
+                successMessage: `Alert rule "${getFriendlyTitle(editRule.name)}" updated successfully.`,
+            },
+        );
+        if (result !== undefined) {
+            crud.closeDialog();
         }
     };
 
-    if (loading) {
+    if (crud.loading) {
         return (
             <Box sx={loadingContainerSx}>
                 <CircularProgress aria-label="Loading alert rules" />
@@ -171,7 +161,8 @@ const AdminAlertRules: React.FC = () => {
     const tableContainerSx = getTableContainerSx(theme);
 
     // Group rules by category
-    const categories = Array.from(new Set(rules.map((r) => r.category))).sort();
+    const categories = Array.from(new Set(crud.items.map((r) => r.category))).sort();
+    const editRule = crud.editingItem;
 
     return (
         <Box>
@@ -179,14 +170,14 @@ const AdminAlertRules: React.FC = () => {
                 Alert defaults
             </Typography>
 
-            {error && (
-                <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setError(null); }}>
-                    {error}
+            {crud.error && (
+                <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { crud.setError(null); }}>
+                    {crud.error}
                 </Alert>
             )}
-            {success && (
-                <Alert severity="success" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setSuccess(null); }}>
-                    {success}
+            {crud.success && (
+                <Alert severity="success" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { crud.setSuccess(null); }}>
+                    {crud.success}
                 </Alert>
             )}
 
@@ -199,7 +190,7 @@ const AdminAlertRules: React.FC = () => {
                     <TableHead>
                         <TableRow>
                             <TableCell sx={tableHeaderCellSx}>Name</TableCell>
-<TableCell sx={tableHeaderCellSx}>Metric</TableCell>
+                            <TableCell sx={tableHeaderCellSx}>Metric</TableCell>
                             <TableCell sx={tableHeaderCellSx}>Condition</TableCell>
                             <TableCell sx={tableHeaderCellSx}>Severity</TableCell>
                             <TableCell sx={tableHeaderCellSx}>Enabled</TableCell>
@@ -207,7 +198,7 @@ const AdminAlertRules: React.FC = () => {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {rules.length > 0 ? (
+                        {crud.items.length > 0 ? (
                             categories.map((category) => (
                                 <React.Fragment key={category}>
                                     <TableRow>
@@ -222,7 +213,7 @@ const AdminAlertRules: React.FC = () => {
                                             {category}
                                         </TableCell>
                                     </TableRow>
-                                    {rules
+                                    {crud.items
                                         .filter((r) => r.category === category)
                                         .map((rule) => (
                                             <TableRow
@@ -281,8 +272,8 @@ const AdminAlertRules: React.FC = () => {
 
             {/* Edit Rule Dialog */}
             <Dialog
-                open={editOpen}
-                onClose={() => void (!saving && setEditOpen(false))}
+                open={crud.dialogOpen}
+                onClose={() => { crud.closeDialog(); }}
                 maxWidth="xs"
                 fullWidth
             >
@@ -295,7 +286,7 @@ const AdminAlertRules: React.FC = () => {
                         <Switch
                             checked={editEnabled}
                             onChange={(e) => { setEditEnabled(e.target.checked); }}
-                            disabled={saving}
+                            disabled={crud.saving}
                             inputProps={{ 'aria-label': 'Enabled' }}
                         />
                     </Box>
@@ -305,7 +296,7 @@ const AdminAlertRules: React.FC = () => {
                         label="Operator"
                         value={editOperator}
                         onChange={(e) => { setEditOperator(e.target.value); }}
-                        disabled={saving}
+                        disabled={crud.saving}
                         margin="dense"
                         InputLabelProps={{ shrink: true }}
                         sx={SELECT_FIELD_SX}
@@ -321,7 +312,7 @@ const AdminAlertRules: React.FC = () => {
                         margin="dense"
                         value={editThreshold}
                         onChange={(e) => { setEditThreshold(e.target.value); }}
-                        disabled={saving}
+                        disabled={crud.saving}
                         InputLabelProps={{ shrink: true }}
                         sx={SELECT_FIELD_SX}
                     />
@@ -331,7 +322,7 @@ const AdminAlertRules: React.FC = () => {
                         label="Severity"
                         value={editSeverity}
                         onChange={(e) => { setEditSeverity(e.target.value); }}
-                        disabled={saving}
+                        disabled={crud.saving}
                         margin="dense"
                         InputLabelProps={{ shrink: true }}
                         sx={SELECT_FIELD_SX}
@@ -342,16 +333,16 @@ const AdminAlertRules: React.FC = () => {
                     </TextField>
                 </DialogContent>
                 <DialogActions sx={dialogActionsSx}>
-                    <Button onClick={() => { setEditOpen(false); }} disabled={saving}>
+                    <Button onClick={() => { crud.closeDialog(); }} disabled={crud.saving}>
                         Cancel
                     </Button>
                     <Button
                         onClick={handleSaveRule}
                         variant="contained"
-                        disabled={saving}
+                        disabled={crud.saving}
                         sx={containedButtonSx}
                     >
-                        {saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : 'Save'}
+                        {crud.saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : 'Save'}
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/client/src/components/AdminPanel/AdminGroups.tsx
+++ b/client/src/components/AdminPanel/AdminGroups.tsx
@@ -229,8 +229,18 @@ const AdminGroups: React.FC = () => {
     const handleDeleteGroup = async () => {
         const target = crud.deleteItem;
         if (!target) { return; }
+        // The groups DELETE endpoint returns 204 No Content, which the
+        // API client surfaces as `undefined`. `runMutation` uses
+        // `undefined` as its failure sentinel, so a bare apiDelete call
+        // would make a successful delete indistinguishable from a
+        // failure and leave the confirm dialog open (see issue from
+        // PR #209 manual QA). Returning an explicit success token lets
+        // `result !== undefined` correctly gate the close + cleanup.
         const result = await crud.runMutation(
-            () => apiDelete(`/api/v1/rbac/groups/${target.id}`),
+            async () => {
+                await apiDelete(`/api/v1/rbac/groups/${target.id}`);
+                return true as const;
+            },
             { errorTarget: 'page' },
         );
         if (result !== undefined) {

--- a/client/src/components/AdminPanel/AdminGroups.tsx
+++ b/client/src/components/AdminPanel/AdminGroups.tsx
@@ -8,7 +8,7 @@
  *-------------------------------------------------------------------------
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
     Box,
     Typography,
@@ -65,6 +65,7 @@ import {
     getTableContainerSx,
     getRadioSx,
 } from './styles';
+import { useCrudPanel, extractErrorMessage } from './_shared';
 
 
 interface RbacGroup {
@@ -96,37 +97,45 @@ const AdminGroups: React.FC = () => {
     const isDark = theme.palette.mode === 'dark';
     const { user } = useAuth();
     const isSuperuser = !!user?.isSuperuser;
-    const [groups, setGroups] = useState<RbacGroup[]>([]);
+
+    // The connections lookup is fetched alongside the group list and
+    // feeds the effective-permissions panel. Keeping it outside the
+    // shared hook because it is a peer dataset, not a CRUD target.
     const [connections, setConnections] = useState<{ id: number; name: string }[]>([]);
-    const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState<string | null>(null);
+
+    // Expandable row state — group detail and effective permissions are
+    // fetched on demand when a row is expanded.
     const [expandedGroup, setExpandedGroup] = useState<number | null>(null);
     const [groupDetail, setGroupDetail] = useState<GroupDetail | null>(null);
     const [detailLoading, setDetailLoading] = useState<boolean>(false);
     const [effectivePerms, setEffectivePerms] = useState<EffectivePermsData | null>(null);
     const [effectivePermsLoading, setEffectivePermsLoading] = useState<boolean>(false);
 
-    // Create group dialog
-    const [createOpen, setCreateOpen] = useState<boolean>(false);
-    const [createName, setCreateName] = useState<string>('');
-    const [createDesc, setCreateDesc] = useState<string>('');
-    const [createLoading, setCreateLoading] = useState<boolean>(false);
-    const [createError, setCreateError] = useState<string | null>(null);
+    const fetchGroupsAndConnections = useCallback(async (): Promise<RbacGroup[]> => {
+        const [groupsData, connResult] = await Promise.all([
+            apiGet<{ groups: RbacGroup[] }>('/api/v1/rbac/groups'),
+            apiGet<{ connections?: { id: number; name: string }[] }>('/api/v1/connections').catch(() => null),
+        ]);
+        if (connResult) {
+            setConnections(connResult.connections ?? []);
+        }
+        return groupsData.groups || [];
+    }, []);
 
-    // Edit group dialog
-    const [editOpen, setEditOpen] = useState<boolean>(false);
-    const [editGroup, setEditGroup] = useState<RbacGroup | null>(null);
-    const [editName, setEditName] = useState<string>('');
-    const [editDesc, setEditDesc] = useState<string>('');
-    const [editLoading, setEditLoading] = useState<boolean>(false);
-    const [editError, setEditError] = useState<string | null>(null);
+    const crud = useCrudPanel<RbacGroup>({
+        fetchItems: fetchGroupsAndConnections,
+    });
 
-    // Delete confirmation
-    const [deleteOpen, setDeleteOpen] = useState<boolean>(false);
-    const [deleteGroup, setDeleteGroup] = useState<RbacGroup | null>(null);
-    const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
+    // Two visual dialogs (Create + Edit) drive the same form fields.
+    // The shared hook treats them as the same dialog (`editingItem`
+    // === null implies create), but the markup remains two Dialog
+    // elements to preserve the historical UI shape one-for-one.
+    const [formName, setFormName] = useState<string>('');
+    const [formDesc, setFormDesc] = useState<string>('');
 
-    // Add member dialog
+    // Add-member dialog. Outside the shared hook because it is a
+    // group-detail child action, not a CRUD operation on the parent
+    // collection.
     const [addMemberOpen, setAddMemberOpen] = useState<boolean>(false);
     const [memberType, setMemberType] = useState<string>('user');
     const [selectedMemberId, setSelectedMemberId] = useState<string>('');
@@ -134,30 +143,6 @@ const AdminGroups: React.FC = () => {
     const [addMemberError, setAddMemberError] = useState<string | null>(null);
     const [availableUsers, setAvailableUsers] = useState<RbacUser[]>([]);
     const [availableGroups, setAvailableGroups] = useState<RbacGroup[]>([]);
-
-    const fetchGroups = useCallback(async () => {
-        try {
-            setLoading(true);
-            setError(null);
-            const [groupsData, connResult] = await Promise.all([
-                apiGet<{ groups: RbacGroup[] }>('/api/v1/rbac/groups'),
-                apiGet<{ connections?: { id: number; name: string }[] }>('/api/v1/connections').catch(() => null),
-            ]);
-            setGroups(groupsData.groups || []);
-            if (connResult) {
-                setConnections(connResult.connections ?? []);
-            }
-        } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
-        } finally {
-            setLoading(false);
-        }
-    }, []);
-
-    useEffect(() => {
-        void fetchGroups();
-    }, [fetchGroups]);
 
     const fetchGroupDetail = useCallback(async (groupId: number) => {
         try {
@@ -170,13 +155,12 @@ const AdminGroups: React.FC = () => {
             setGroupDetail(detailData);
             setEffectivePerms(effectiveResult);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            crud.setError(extractErrorMessage(err));
         } finally {
             setDetailLoading(false);
             setEffectivePermsLoading(false);
         }
-    }, []);
+    }, [crud]);
 
     const handleRowClick = (group: RbacGroup) => {
         if (expandedGroup === group.id) {
@@ -190,83 +174,71 @@ const AdminGroups: React.FC = () => {
     };
 
     // Create group
+    const handleOpenCreate = () => {
+        setFormName('');
+        setFormDesc('');
+        crud.openCreate();
+    };
+
     const handleCreateGroup = async () => {
-        if (!createName.trim()) {return;}
-        try {
-            setCreateLoading(true);
-            setCreateError(null);
-            await apiPost('/api/v1/rbac/groups', {
-                name: createName.trim(),
-                description: createDesc.trim(),
-            });
-            setCreateOpen(false);
-            setCreateName('');
-            setCreateDesc('');
-            fetchGroups();
-        } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setCreateError(message);
-        } finally {
-            setCreateLoading(false);
+        if (!formName.trim()) { return; }
+        const result = await crud.runMutation(
+            () =>
+                apiPost('/api/v1/rbac/groups', {
+                    name: formName.trim(),
+                    description: formDesc.trim(),
+                }),
+        );
+        if (result !== undefined) {
+            crud.closeDialog();
         }
     };
 
     // Edit group
     const handleOpenEdit = (e: React.MouseEvent, group: RbacGroup) => {
         e.stopPropagation();
-        setEditGroup(group);
-        setEditName(group.name);
-        setEditDesc(group.description ?? '');
-        setEditError(null);
-        setEditOpen(true);
+        setFormName(group.name);
+        setFormDesc(group.description ?? '');
+        crud.openEdit(group);
     };
 
     const handleEditGroup = async () => {
-        if (!editName.trim() || !editGroup) {return;}
-        try {
-            setEditLoading(true);
-            setEditError(null);
-            await apiPut(`/api/v1/rbac/groups/${editGroup.id}`, {
-                name: editName.trim(),
-                description: editDesc.trim(),
-            });
-            setEditOpen(false);
-            fetchGroups();
-            if (expandedGroup === editGroup.id) {
-                void fetchGroupDetail(editGroup.id);
+        const target = crud.editingItem;
+        if (!formName.trim() || !target) { return; }
+        const result = await crud.runMutation(
+            () =>
+                apiPut(`/api/v1/rbac/groups/${target.id}`, {
+                    name: formName.trim(),
+                    description: formDesc.trim(),
+                }),
+        );
+        if (result !== undefined) {
+            crud.closeDialog();
+            if (expandedGroup === target.id) {
+                void fetchGroupDetail(target.id);
             }
-        } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setEditError(message);
-        } finally {
-            setEditLoading(false);
         }
     };
 
     // Delete group
     const handleOpenDelete = (e: React.MouseEvent, group: RbacGroup) => {
         e.stopPropagation();
-        setDeleteGroup(group);
-        setDeleteOpen(true);
+        crud.openDelete(group);
     };
 
     const handleDeleteGroup = async () => {
-        if (!deleteGroup) {return;}
-        try {
-            setDeleteLoading(true);
-            await apiDelete(`/api/v1/rbac/groups/${deleteGroup.id}`);
-            setDeleteOpen(false);
-            setDeleteGroup(null);
-            if (expandedGroup === deleteGroup.id) {
+        const target = crud.deleteItem;
+        if (!target) { return; }
+        const result = await crud.runMutation(
+            () => apiDelete(`/api/v1/rbac/groups/${target.id}`),
+            { errorTarget: 'page' },
+        );
+        if (result !== undefined) {
+            if (expandedGroup === target.id) {
                 setExpandedGroup(null);
                 setGroupDetail(null);
             }
-            fetchGroups();
-        } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
-        } finally {
-            setDeleteLoading(false);
+            crud.closeDelete();
         }
     };
 
@@ -296,7 +268,7 @@ const AdminGroups: React.FC = () => {
     };
 
     const handleAddMember = async () => {
-        if (!selectedMemberId || !expandedGroup) {return;}
+        if (!selectedMemberId || !expandedGroup) { return; }
         try {
             setAddMemberLoading(true);
             setAddMemberError(null);
@@ -317,53 +289,50 @@ const AdminGroups: React.FC = () => {
             }
             setAddMemberOpen(false);
             void fetchGroupDetail(expandedGroup);
-            fetchGroups();
+            void crud.refresh();
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setAddMemberError(message);
+            setAddMemberError(extractErrorMessage(err));
         } finally {
             setAddMemberLoading(false);
         }
     };
 
     const handleRemoveMember = async (memberId: number, mType: string) => {
-        if (!expandedGroup) {return;}
+        if (!expandedGroup) { return; }
         try {
             await apiDelete(`/api/v1/rbac/groups/${expandedGroup}/members/${mType}/${memberId}`);
-            fetchGroupDetail(expandedGroup);
-            fetchGroups();
+            void fetchGroupDetail(expandedGroup);
+            void crud.refresh();
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            crud.setError(extractErrorMessage(err));
         }
     };
 
     const handleRemoveMemberByName = async (name: string, mType: string) => {
-        if (!expandedGroup) {return;}
+        if (!expandedGroup) { return; }
         try {
             let memberId: number | undefined;
             if (mType === 'user') {
                 try {
                     const data = await apiGet<{ users?: { id: number; username: string }[] }>('/api/v1/rbac/users');
                     const foundUser = (data.users ?? []).find(u => u.username === name);
-                    if (foundUser) {memberId = foundUser.id;}
+                    if (foundUser) { memberId = foundUser.id; }
                 } catch { /* ignore */ }
             } else {
-                const found = groups.find(g => g.name === name);
-                if (found) {memberId = found.id;}
+                const found = crud.items.find(g => g.name === name);
+                if (found) { memberId = found.id; }
             }
             if (!memberId) {
-                setError(`Could not find ${mType} "${name}"`);
+                crud.setError(`Could not find ${mType} "${name}"`);
                 return;
             }
             await handleRemoveMember(memberId, mType);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            crud.setError(extractErrorMessage(err));
         }
     };
 
-    if (loading) {
+    if (crud.loading) {
         return (
             <Box sx={loadingContainerSx}>
                 <CircularProgress aria-label="Loading groups" />
@@ -371,8 +340,8 @@ const AdminGroups: React.FC = () => {
         );
     }
 
-    if (error) {
-        return <Alert severity="error" sx={{ borderRadius: 1 }}>{error}</Alert>;
+    if (crud.error) {
+        return <Alert severity="error" sx={{ borderRadius: 1 }}>{crud.error}</Alert>;
     }
 
     const containedButtonSx = getContainedButtonSx(theme);
@@ -380,6 +349,14 @@ const AdminGroups: React.FC = () => {
     const deleteIconSx = getDeleteIconSx(theme);
     const tableContainerSx = getTableContainerSx(theme);
     const radioSx = getRadioSx(theme);
+    const isEditMode = crud.editingItem !== null;
+    // For the unified hook, the create and edit dialogs share dialogOpen.
+    // We split them by inspecting whether an `editingItem` is present so
+    // the two existing visual dialogs (with their distinct titles and
+    // submit-button labels) keep rendering exactly as before.
+    const createDialogOpen = crud.dialogOpen && !isEditMode;
+    const editDialogOpen = crud.dialogOpen && isEditMode;
+
     return (
         <Box>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
@@ -389,12 +366,7 @@ const AdminGroups: React.FC = () => {
                 <Button
                     variant="contained"
                     startIcon={<AddIcon />}
-                    onClick={() => {
-                        setCreateError(null);
-                        setCreateName('');
-                        setCreateDesc('');
-                        setCreateOpen(true);
-                    }}
+                    onClick={handleOpenCreate}
                     sx={containedButtonSx}
                 >
                     Create Group
@@ -417,7 +389,7 @@ const AdminGroups: React.FC = () => {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {groups.map((group) => (
+                        {crud.items.map((group) => (
                             <React.Fragment key={group.id}>
                                 <TableRow
                                     hover
@@ -557,7 +529,7 @@ const AdminGroups: React.FC = () => {
                                 </TableRow>
                             </React.Fragment>
                         ))}
-                        {groups.length === 0 && (
+                        {crud.items.length === 0 && (
                             <TableRow>
                                 <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
                                     <Typography color="text.secondary">No groups found.</Typography>
@@ -569,19 +541,19 @@ const AdminGroups: React.FC = () => {
             </TableContainer>
 
             {/* Create Group Dialog */}
-            <Dialog open={createOpen} onClose={() => void (!createLoading && setCreateOpen(false))} maxWidth="xs" fullWidth>
+            <Dialog open={createDialogOpen} onClose={() => { crud.closeDialog(); }} maxWidth="xs" fullWidth>
                 <DialogTitle sx={dialogTitleSx}>Create group</DialogTitle>
                 <DialogContent>
-                    {createError && (
-                        <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }}>{createError}</Alert>
+                    {crud.dialogError && (
+                        <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }}>{crud.dialogError}</Alert>
                     )}
                     <TextField
                         autoFocus
                         fullWidth
                         label="Name"
-                        value={createName}
-                        onChange={(e) => { setCreateName(e.target.value); }}
-                        disabled={createLoading}
+                        value={formName}
+                        onChange={(e) => { setFormName(e.target.value); }}
+                        disabled={crud.saving}
                         margin="dense"
                         required
                         InputLabelProps={{ shrink: true }}
@@ -590,9 +562,9 @@ const AdminGroups: React.FC = () => {
                     <TextField
                         fullWidth
                         label="Description"
-                        value={createDesc}
-                        onChange={(e) => { setCreateDesc(e.target.value); }}
-                        disabled={createLoading}
+                        value={formDesc}
+                        onChange={(e) => { setFormDesc(e.target.value); }}
+                        disabled={crud.saving}
                         margin="dense"
                         multiline
                         rows={2}
@@ -601,34 +573,34 @@ const AdminGroups: React.FC = () => {
                     />
                 </DialogContent>
                 <DialogActions sx={dialogActionsSx}>
-                    <Button onClick={() => { setCreateOpen(false); }} disabled={createLoading}>
+                    <Button onClick={() => { crud.closeDialog(); }} disabled={crud.saving}>
                         Cancel
                     </Button>
                     <Button
                         onClick={handleCreateGroup}
                         variant="contained"
-                        disabled={createLoading || !createName.trim()}
+                        disabled={crud.saving || !formName.trim()}
                         sx={containedButtonSx}
                     >
-                        {createLoading ? <CircularProgress size={20} color="inherit" aria-label="Creating" /> : 'Create'}
+                        {crud.saving ? <CircularProgress size={20} color="inherit" aria-label="Creating" /> : 'Create'}
                     </Button>
                 </DialogActions>
             </Dialog>
 
             {/* Edit Group Dialog */}
-            <Dialog open={editOpen} onClose={() => void (!editLoading && setEditOpen(false))} maxWidth="xs" fullWidth>
+            <Dialog open={editDialogOpen} onClose={() => { crud.closeDialog(); }} maxWidth="xs" fullWidth>
                 <DialogTitle sx={dialogTitleSx}>Edit group</DialogTitle>
                 <DialogContent>
-                    {editError && (
-                        <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }}>{editError}</Alert>
+                    {crud.dialogError && (
+                        <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }}>{crud.dialogError}</Alert>
                     )}
                     <TextField
                         autoFocus
                         fullWidth
                         label="Name"
-                        value={editName}
-                        onChange={(e) => { setEditName(e.target.value); }}
-                        disabled={editLoading}
+                        value={formName}
+                        onChange={(e) => { setFormName(e.target.value); }}
+                        disabled={crud.saving}
                         margin="dense"
                         required
                         InputLabelProps={{ shrink: true }}
@@ -637,9 +609,9 @@ const AdminGroups: React.FC = () => {
                     <TextField
                         fullWidth
                         label="Description"
-                        value={editDesc}
-                        onChange={(e) => { setEditDesc(e.target.value); }}
-                        disabled={editLoading}
+                        value={formDesc}
+                        onChange={(e) => { setFormDesc(e.target.value); }}
+                        disabled={crud.saving}
                         margin="dense"
                         multiline
                         rows={2}
@@ -648,29 +620,29 @@ const AdminGroups: React.FC = () => {
                     />
                 </DialogContent>
                 <DialogActions sx={dialogActionsSx}>
-                    <Button onClick={() => { setEditOpen(false); }} disabled={editLoading}>
+                    <Button onClick={() => { crud.closeDialog(); }} disabled={crud.saving}>
                         Cancel
                     </Button>
                     <Button
                         onClick={handleEditGroup}
                         variant="contained"
-                        disabled={editLoading || !editName.trim()}
+                        disabled={crud.saving || !formName.trim()}
                         sx={containedButtonSx}
                     >
-                        {editLoading ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : 'Save'}
+                        {crud.saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : 'Save'}
                     </Button>
                 </DialogActions>
             </Dialog>
 
             {/* Delete Confirmation Dialog */}
             <DeleteConfirmationDialog
-                open={deleteOpen}
-                onClose={() => { setDeleteOpen(false); setDeleteGroup(null); }}
+                open={crud.deleteOpen}
+                onClose={() => { crud.closeDelete(); }}
                 onConfirm={handleDeleteGroup}
                 title="Delete Group"
                 message="Are you sure you want to delete the group"
-                itemName={deleteGroup?.name ? `"${deleteGroup.name}"?` : '?'}
-                loading={deleteLoading}
+                itemName={crud.deleteItem?.name ? `"${crud.deleteItem.name}"?` : '?'}
+                loading={crud.deleteLoading}
             />
 
             {/* Add Member Dialog */}

--- a/client/src/components/AdminPanel/AdminMessagingChannels.tsx
+++ b/client/src/components/AdminPanel/AdminMessagingChannels.tsx
@@ -9,7 +9,7 @@
  */
 
 import type React from 'react';
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import {
     Box,
     Typography,
@@ -55,6 +55,7 @@ import {
     getDeleteIconSx,
     getTableContainerSx,
 } from './styles';
+import { useCrudPanel } from './_shared';
 
 /**
  * Configuration that varies between messaging platforms (Slack,
@@ -108,71 +109,48 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
     const theme = useTheme();
     const { channelType, platformName, webhookUrlLabel } = config;
 
-    const [channels, setChannels] = useState<MessagingChannel[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
-
-    // Create/Edit dialog state
-    const [dialogOpen, setDialogOpen] = useState(false);
-    const [editingChannel, setEditingChannel] = useState<MessagingChannel | null>(null);
-    const [form, setForm] = useState<ChannelFormState>(DEFAULT_FORM_STATE);
-    const [saving, setSaving] = useState(false);
-    const [dialogError, setDialogError] = useState<string | null>(null);
-
-    // Test channel state
-    const [testingChannelId, setTestingChannelId] = useState<number | null>(null);
-
-    // Delete channel confirmation
-    const [deleteOpen, setDeleteOpen] = useState(false);
-    const [deleteChannel, setDeleteChannel] = useState<MessagingChannel | null>(null);
-    const [deleteLoading, setDeleteLoading] = useState(false);
-
-    // --- Data fetching ---
-
-    const fetchChannels = useCallback(async () => {
-        try {
-            setLoading(true);
-            const data = await apiGet<Record<string, unknown>>('/api/v1/notification-channels');
-            const allChannels = (data.notification_channels || data || []) as Array<Record<string, unknown>>;
-            const filtered: MessagingChannel[] = allChannels
-                .filter((ch: Record<string, unknown>) => ch.channel_type === channelType)
-                .map((ch: Record<string, unknown>) => ({
-                    id: ch.id as number,
-                    name: ch.name as string,
-                    description: (ch.description as string) || '',
-                    enabled: ch.enabled as boolean,
-                    is_estate_default: ch.is_estate_default as boolean,
-                    webhook_url_set: Boolean(ch.webhook_url_set),
-                }));
-            setChannels(filtered);
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setLoading(false);
-        }
+    // Fetch and filter to this channel type. The endpoint returns every
+    // channel type; we narrow by `channel_type` and normalise the raw
+    // record into our typed shape.
+    const fetchChannels = useCallback(async (): Promise<MessagingChannel[]> => {
+        const data = await apiGet<Record<string, unknown>>('/api/v1/notification-channels');
+        const allChannels = (data.notification_channels || data || []) as Array<Record<string, unknown>>;
+        return allChannels
+            .filter((ch) => ch.channel_type === channelType)
+            .map((ch) => ({
+                id: ch.id as number,
+                name: ch.name as string,
+                description: (ch.description as string) || '',
+                enabled: ch.enabled as boolean,
+                is_estate_default: ch.is_estate_default as boolean,
+                webhook_url_set: Boolean(ch.webhook_url_set),
+            }));
     }, [channelType]);
 
-    useEffect(() => {
-        fetchChannels();
-    }, [fetchChannels]);
+    const crud = useCrudPanel<MessagingChannel>({
+        fetchItems: fetchChannels,
+        deps: [channelType],
+    });
+
+    // Per-form fields for the create/edit dialog. Kept here because the
+    // shape is channel-specific (name + description + webhook URL +
+    // toggle pair).
+    const [form, setForm] = useState<ChannelFormState>(DEFAULT_FORM_STATE);
+
+    // Test-notification button uses its own per-row spinner; tracked
+    // separately from the shared `saving` flag since it is a non-CRUD
+    // action that does not refresh the list.
+    const [testingChannelId, setTestingChannelId] = useState<number | null>(null);
 
     // --- Create / Edit dialog ---
 
     const handleOpenCreate = () => {
-        setEditingChannel(null);
         setForm(DEFAULT_FORM_STATE);
-        setDialogError(null);
-        setDialogOpen(true);
+        crud.openCreate();
     };
 
     const handleOpenEdit = (e: React.MouseEvent, channel: MessagingChannel) => {
         e.stopPropagation();
-        setEditingChannel(channel);
         // The webhook URL is a redacted secret on the server; never
         // pre-populate it. An empty value at save time means "leave the
         // existing URL unchanged".
@@ -183,14 +161,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
             enabled: channel.enabled,
             is_estate_default: channel.is_estate_default,
         });
-        setDialogError(null);
-        setDialogOpen(true);
-    };
-
-    const handleCloseDialog = () => {
-        if (saving) {return;}
-        setDialogOpen(false);
-        setEditingChannel(null);
+        crud.openEdit(channel);
     };
 
     const handleFormChange = (field: keyof ChannelFormState, value: string | boolean) => {
@@ -198,8 +169,9 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
     };
 
     const handleSaveChannel = async () => {
+        const editingChannel = crud.editingItem;
         if (!form.name.trim()) {
-            setDialogError('Name is required.');
+            crud.setDialogError('Name is required.');
             return;
         }
         // On create, the URL is required. On edit, an empty URL means
@@ -207,67 +179,57 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
         // server already has one configured.
         const trimmedUrl = form.webhook_url.trim();
         if (!editingChannel && !trimmedUrl) {
-            setDialogError('Webhook URL is required.');
+            crud.setDialogError('Webhook URL is required.');
             return;
         }
         if (editingChannel && !trimmedUrl && !editingChannel.webhook_url_set) {
-            setDialogError('Webhook URL is required.');
+            crud.setDialogError('Webhook URL is required.');
             return;
         }
 
-        try {
-            setSaving(true);
-            setDialogError(null);
-
-            if (editingChannel) {
-                // Update - send only changed fields. For the webhook URL,
-                // omit it entirely when the user left the form blank;
-                // the server preserves the stored value when the field
-                // is absent from the request body.
-                const body: Record<string, unknown> = {};
-                if (form.name.trim() !== editingChannel.name) {
-                    body.name = form.name.trim();
-                }
-                if (form.description.trim() !== editingChannel.description) {
-                    body.description = form.description.trim();
-                }
-                if (form.enabled !== editingChannel.enabled) {
-                    body.enabled = form.enabled;
-                }
-                if (form.is_estate_default !== editingChannel.is_estate_default) {
-                    body.is_estate_default = form.is_estate_default;
-                }
-                if (trimmedUrl) {
-                    body.webhook_url = trimmedUrl;
-                }
-
-                await apiPut(`/api/v1/notification-channels/${editingChannel.id}`, body);
-                setSuccess(`Channel "${form.name.trim()}" updated successfully.`);
-            } else {
-                // Create
-                const body = {
+        const successName = form.name.trim();
+        let request: () => Promise<unknown>;
+        if (editingChannel) {
+            // Update — send only changed fields. For the webhook URL,
+            // omit it entirely when the user left the form blank; the
+            // server preserves the stored value when the field is
+            // absent from the request body.
+            const body: Record<string, unknown> = {};
+            if (form.name.trim() !== editingChannel.name) {
+                body.name = form.name.trim();
+            }
+            if (form.description.trim() !== editingChannel.description) {
+                body.description = form.description.trim();
+            }
+            if (form.enabled !== editingChannel.enabled) {
+                body.enabled = form.enabled;
+            }
+            if (form.is_estate_default !== editingChannel.is_estate_default) {
+                body.is_estate_default = form.is_estate_default;
+            }
+            if (trimmedUrl) {
+                body.webhook_url = trimmedUrl;
+            }
+            request = () => apiPut(`/api/v1/notification-channels/${editingChannel.id}`, body);
+        } else {
+            request = () =>
+                apiPost('/api/v1/notification-channels', {
                     channel_type: channelType,
                     name: form.name.trim(),
                     description: form.description.trim(),
                     webhook_url: trimmedUrl,
                     enabled: form.enabled,
                     is_estate_default: form.is_estate_default,
-                };
-                await apiPost('/api/v1/notification-channels', body);
-                setSuccess(`Channel "${form.name.trim()}" created successfully.`);
-            }
+                });
+        }
 
-            setDialogOpen(false);
-            setEditingChannel(null);
-            fetchChannels();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setDialogError(err.message);
-            } else {
-                setDialogError('An unexpected error occurred');
-            }
-        } finally {
-            setSaving(false);
+        const result = await crud.runMutation(request, {
+            successMessage: editingChannel
+                ? `Channel "${successName}" updated successfully.`
+                : `Channel "${successName}" created successfully.`,
+        });
+        if (result !== undefined) {
+            crud.closeDialog();
         }
     };
 
@@ -275,60 +237,46 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
 
     const handleOpenDelete = (e: React.MouseEvent, channel: MessagingChannel) => {
         e.stopPropagation();
-        setDeleteChannel(channel);
-        setDeleteOpen(true);
+        crud.openDelete(channel);
     };
 
     const handleDeleteChannel = async () => {
-        if (!deleteChannel) {return;}
-        try {
-            setDeleteLoading(true);
-            await apiDelete(`/api/v1/notification-channels/${deleteChannel.id}`);
-            setDeleteOpen(false);
-            setDeleteChannel(null);
-            setSuccess(`Channel "${deleteChannel.name}" deleted successfully.`);
-            fetchChannels();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        } finally {
-            setDeleteLoading(false);
+        const target = crud.deleteItem;
+        if (!target) { return; }
+        const result = await crud.runMutation(
+            () => apiDelete(`/api/v1/notification-channels/${target.id}`),
+            {
+                errorTarget: 'page',
+                successMessage: `Channel "${target.name}" deleted successfully.`,
+            },
+        );
+        if (result !== undefined) {
+            crud.closeDelete();
         }
     };
 
     // --- Inline toggle enabled on main table ---
 
     const handleToggleEnabled = async (channel: MessagingChannel) => {
-        try {
-            await apiPut(`/api/v1/notification-channels/${channel.id}`, { enabled: !channel.enabled });
-            fetchChannels();
-        } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
-        }
+        await crud.runMutation(
+            () => apiPut(`/api/v1/notification-channels/${channel.id}`, { enabled: !channel.enabled }),
+            { errorTarget: 'page' },
+        );
     };
 
     // --- Test channel ---
 
     const handleTestChannel = async (e: React.MouseEvent, channel: MessagingChannel) => {
         e.stopPropagation();
+        setTestingChannelId(channel.id);
         try {
-            setTestingChannelId(channel.id);
-            setError(null);
+            crud.setError(null);
             await apiPost(`/api/v1/notification-channels/${channel.id}/test`);
-            setSuccess(`Test notification sent successfully for "${channel.name}".`);
+            crud.setSuccess(`Test notification sent successfully for "${channel.name}".`);
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('Failed to send test notification');
-            }
+            crud.setError(
+                err instanceof Error ? err.message : 'Failed to send test notification',
+            );
         } finally {
             setTestingChannelId(null);
         }
@@ -336,7 +284,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
 
     // --- Render ---
 
-    if (loading) {
+    if (crud.loading) {
         return (
             <Box sx={loadingContainerSx}>
                 <CircularProgress aria-label="Loading channels" />
@@ -347,6 +295,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
     const containedButtonSx = getContainedButtonSx(theme);
     const deleteIconSx = getDeleteIconSx(theme);
     const tableContainerSx = getTableContainerSx(theme);
+    const editingChannel = crud.editingItem;
     const isEditing = editingChannel !== null;
     // When editing a channel that already has a URL configured, allow
     // saving without re-typing the URL. The empty value will be omitted
@@ -356,7 +305,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
         ? 'Leave blank to keep existing URL'
         : '';
     const submitDisabled =
-        saving
+        crud.saving
         || !form.name.trim()
         || (!form.webhook_url.trim() && !webhookUrlOptional);
 
@@ -376,14 +325,14 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                 </Button>
             </Box>
 
-            {error && (
-                <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setError(null); }}>
-                    {error}
+            {crud.error && (
+                <Alert severity="error" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { crud.setError(null); }}>
+                    {crud.error}
                 </Alert>
             )}
-            {success && (
-                <Alert severity="success" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { setSuccess(null); }}>
-                    {success}
+            {crud.success && (
+                <Alert severity="success" sx={{ mb: 2, borderRadius: 1 }} onClose={() => { crud.setSuccess(null); }}>
+                    {crud.success}
                 </Alert>
             )}
 
@@ -403,8 +352,8 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {channels.length > 0 ? (
-                            channels.map((channel) => (
+                        {crud.items.length > 0 ? (
+                            crud.items.map((channel) => (
                                 <TableRow key={channel.id} hover>
                                     <TableCell>
                                         {channel.name}
@@ -482,8 +431,8 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
 
             {/* Create / Edit Channel Dialog */}
             <Dialog
-                open={dialogOpen}
-                onClose={handleCloseDialog}
+                open={crud.dialogOpen}
+                onClose={() => { crud.closeDialog(); }}
                 maxWidth="sm"
                 fullWidth
             >
@@ -491,9 +440,9 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                     {isEditing ? `Edit channel: ${editingChannel.name}` : `Create ${platformName} channel`}
                 </DialogTitle>
                 <DialogContent>
-                    {dialogError && (
+                    {crud.dialogError && (
                         <Alert severity="error" sx={{ mb: 2, mt: 1, borderRadius: 1 }}>
-                            {dialogError}
+                            {crud.dialogError}
                         </Alert>
                     )}
                     <TextField
@@ -502,7 +451,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                         label="Name"
                         value={form.name}
                         onChange={(e) => { handleFormChange('name', e.target.value); }}
-                        disabled={saving}
+                        disabled={crud.saving}
                         margin="dense"
                         required
                         InputLabelProps={{ shrink: true }}
@@ -512,7 +461,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                         label="Description"
                         value={form.description}
                         onChange={(e) => { handleFormChange('description', e.target.value); }}
-                        disabled={saving}
+                        disabled={crud.saving}
                         margin="dense"
                         multiline
                         rows={2}
@@ -523,7 +472,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                         label={webhookUrlLabel}
                         value={form.webhook_url}
                         onChange={(e) => { handleFormChange('webhook_url', e.target.value); }}
-                        disabled={saving}
+                        disabled={crud.saving}
                         margin="dense"
                         required={!webhookUrlOptional}
                         placeholder={webhookUrlPlaceholder}
@@ -541,7 +490,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                                 <Switch
                                     checked={form.enabled}
                                     onChange={(e) => { handleFormChange('enabled', e.target.checked); }}
-                                    disabled={saving}
+                                    disabled={crud.saving}
                                     inputProps={{ 'aria-label': 'Toggle channel enabled' }}
                                 />
                             }
@@ -553,7 +502,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                                 <Switch
                                     checked={form.is_estate_default}
                                     onChange={(e) => { handleFormChange('is_estate_default', e.target.checked); }}
-                                    disabled={saving}
+                                    disabled={crud.saving}
                                     inputProps={{ 'aria-label': 'Toggle estate default' }}
                                 />
                             }
@@ -569,7 +518,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                     </Box>
                 </DialogContent>
                 <DialogActions sx={dialogActionsSx}>
-                    <Button onClick={handleCloseDialog} disabled={saving}>
+                    <Button onClick={() => { crud.closeDialog(); }} disabled={crud.saving}>
                         Cancel
                     </Button>
                     <Button
@@ -578,20 +527,20 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                         disabled={submitDisabled}
                         sx={containedButtonSx}
                     >
-                        {saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : (isEditing ? 'Save' : 'Create')}
+                        {crud.saving ? <CircularProgress size={20} color="inherit" aria-label="Saving" /> : (isEditing ? 'Save' : 'Create')}
                     </Button>
                 </DialogActions>
             </Dialog>
 
             {/* Delete Confirmation Dialog */}
             <DeleteConfirmationDialog
-                open={deleteOpen}
-                onClose={() => { setDeleteOpen(false); setDeleteChannel(null); }}
+                open={crud.deleteOpen}
+                onClose={() => { crud.closeDelete(); }}
                 onConfirm={handleDeleteChannel}
                 title={`Delete ${platformName} Channel`}
                 message={`Are you sure you want to delete the ${platformName} channel`}
-                itemName={deleteChannel?.name ? `"${deleteChannel.name}"?` : '?'}
-                loading={deleteLoading}
+                itemName={crud.deleteItem?.name ? `"${crud.deleteItem.name}"?` : '?'}
+                loading={crud.deleteLoading}
             />
         </Box>
     );

--- a/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
@@ -1,0 +1,282 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+const mockApiPut = vi.fn();
+const mockApiDelete = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+}));
+
+// useAuth is required by AdminGroups to drive the isSuperuser flag for
+// the expanded EffectivePermissionsPanel. We stub a non-superuser user
+// so the panel renders in its standard mode.
+vi.mock('../../../contexts/useAuth', () => ({
+    useAuth: () => ({ user: { isSuperuser: false } }),
+}));
+
+import AdminGroups from '../AdminGroups';
+
+const GROUPS = [
+    { id: 1, name: 'eng', description: 'Engineering', member_count: 2 },
+    { id: 2, name: 'ops', description: 'Operations', member_count: 1 },
+];
+
+const CONNECTIONS = [{ id: 11, name: 'prod-db' }];
+
+/**
+ * Routes the apiGet mock to per-URL fixtures so each test only needs to
+ * specify what differs from the defaults. Each route may be overridden
+ * by passing a custom map.
+ */
+function setupApiGetRouter(overrides: Record<string, unknown> = {}) {
+    const defaults: Record<string, unknown> = {
+        '/api/v1/rbac/groups': { groups: GROUPS },
+        '/api/v1/connections': { connections: CONNECTIONS },
+    };
+    const routes = { ...defaults, ...overrides };
+    mockApiGet.mockImplementation((url: string) => {
+        const matchKey = Object.keys(routes).find((k) => url === k || url.startsWith(`${k}/`) || url.startsWith(k));
+        if (!matchKey) {
+            return Promise.reject(new Error(`No fixture for ${url}`));
+        }
+        const fixture = routes[matchKey];
+        if (fixture instanceof Error) {
+            return Promise.reject(fixture);
+        }
+        return Promise.resolve(fixture);
+    });
+}
+
+describe('AdminGroups', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('shows the loading indicator then the groups table', async () => {
+        // First call (the list fetch) hangs forever — we rely on this
+        // to assert that the loading spinner is rendered.
+        mockApiGet.mockReturnValue(new Promise(() => {}));
+
+        renderWithTheme(<AdminGroups />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(screen.getByLabelText('Loading groups')).toBeInTheDocument();
+    });
+
+    it('renders the group list returned by the API', async () => {
+        setupApiGetRouter();
+
+        renderWithTheme(<AdminGroups />);
+
+        await waitFor(() => {
+            expect(screen.getByText('eng')).toBeInTheDocument();
+        });
+        expect(screen.getByText('ops')).toBeInTheDocument();
+        expect(screen.getByText('Engineering')).toBeInTheDocument();
+        expect(screen.getByText('Operations')).toBeInTheDocument();
+    });
+
+    it('shows the empty state when no groups exist', async () => {
+        setupApiGetRouter({ '/api/v1/rbac/groups': { groups: [] } });
+
+        renderWithTheme(<AdminGroups />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No groups found.')).toBeInTheDocument();
+        });
+    });
+
+    it('shows an error alert when the group fetch fails', async () => {
+        setupApiGetRouter({
+            '/api/v1/rbac/groups': new Error('Server unavailable'),
+        });
+
+        renderWithTheme(<AdminGroups />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Server unavailable')).toBeInTheDocument();
+        });
+    });
+
+    describe('Create group dialog', () => {
+        it('opens, accepts input, and posts to the API', async () => {
+            setupApiGetRouter({ '/api/v1/rbac/groups': { groups: [] } });
+            mockApiPost.mockResolvedValue({ id: 99 });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No groups found.')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /Create Group/i }),
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Create group')).toBeInTheDocument();
+            });
+
+            const dialog = screen.getByRole('dialog');
+            const createButton = within(dialog).getByRole('button', {
+                name: /Create/i,
+            });
+            expect(createButton).toBeDisabled();
+
+            fireEvent.change(within(dialog).getByLabelText('Name *'), {
+                target: { value: 'new-group' },
+            });
+            fireEvent.change(within(dialog).getByLabelText('Description'), {
+                target: { value: 'Brand new' },
+            });
+            expect(createButton).not.toBeDisabled();
+
+            await user.click(createButton);
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    '/api/v1/rbac/groups',
+                    { name: 'new-group', description: 'Brand new' },
+                );
+            });
+        });
+
+        it('surfaces a server error in the create dialog', async () => {
+            setupApiGetRouter({ '/api/v1/rbac/groups': { groups: [] } });
+            mockApiPost.mockRejectedValue(new Error('duplicate name'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+
+            await waitFor(() => {
+                expect(screen.getByText('No groups found.')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /Create Group/i }),
+            );
+            const dialog = screen.getByRole('dialog');
+            fireEvent.change(within(dialog).getByLabelText('Name *'), {
+                target: { value: 'eng' },
+            });
+            await user.click(
+                within(dialog).getByRole('button', { name: /Create/i }),
+            );
+
+            await waitFor(() => {
+                expect(within(dialog).getByText('duplicate name')).toBeInTheDocument();
+            });
+        });
+
+        it('closes the create dialog on Cancel', async () => {
+            setupApiGetRouter({ '/api/v1/rbac/groups': { groups: [] } });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('No groups found.')).toBeInTheDocument();
+            });
+            await user.click(
+                screen.getByRole('button', { name: /Create Group/i }),
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Create group')).toBeInTheDocument();
+            });
+            await user.click(screen.getByRole('button', { name: /Cancel/i }));
+            await waitFor(() => {
+                expect(screen.queryByText('Create group')).not.toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Edit group dialog', () => {
+        it('pre-populates fields with the selected group and PUTs changes', async () => {
+            setupApiGetRouter();
+            mockApiPut.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', {
+                name: /edit group/i,
+            });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit group')).toBeInTheDocument();
+            });
+            const dialog = screen.getByRole('dialog');
+            expect(within(dialog).getByLabelText('Name *')).toHaveValue('eng');
+            expect(within(dialog).getByLabelText('Description')).toHaveValue(
+                'Engineering',
+            );
+
+            fireEvent.change(within(dialog).getByLabelText('Description'), {
+                target: { value: 'Updated' },
+            });
+            await user.click(
+                within(dialog).getByRole('button', { name: /Save/i }),
+            );
+
+            await waitFor(() => {
+                expect(mockApiPut).toHaveBeenCalledWith('/api/v1/rbac/groups/1', {
+                    name: 'eng',
+                    description: 'Updated',
+                });
+            });
+        });
+    });
+
+    describe('Delete group', () => {
+        it('opens the confirmation dialog and deletes via the API', async () => {
+            setupApiGetRouter();
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            const deleteButtons = screen.getAllByRole('button', {
+                name: /delete group/i,
+            });
+            await user.click(deleteButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Delete Group')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Delete/i }));
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/rbac/groups/1');
+            });
+        });
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
@@ -366,6 +366,58 @@ describe('AdminGroups', () => {
             });
         });
 
+        it('closes the confirmation dialog after a successful delete and does not re-issue the request', async () => {
+            // Regression test for the PR #209 bug: the rbac/groups DELETE
+            // endpoint returns 204 No Content, which apiClient surfaces
+            // as `undefined`. The earlier `runMutation` consumer keyed
+            // its `closeDelete()` call on `result !== undefined`, treating
+            // a 204 success identically to a thrown error. The dialog
+            // stayed open with the just-deleted target still selected, so
+            // a second confirm click 404'd the now-missing group and the
+            // user saw "Failed to delete group".
+            setupApiGetRouter({
+                '/api/v1/rbac/groups': { groups: GROUPS },
+            });
+            // Mirror the real apiClient behaviour for HTTP 204: a bare
+            // `undefined` return value.
+            mockApiDelete.mockResolvedValue(undefined);
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getAllByRole('button', { name: /delete group/i })[0],
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Delete Group')).toBeInTheDocument();
+            });
+            const dialog = screen.getByRole('dialog');
+            await user.click(
+                within(dialog).getByRole('button', { name: /Delete/i }),
+            );
+
+            // The delete API call should have been made exactly once.
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith(
+                    '/api/v1/rbac/groups/1',
+                );
+            });
+
+            // The dialog must close after the successful delete.
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Delete Group'),
+                ).not.toBeInTheDocument();
+            });
+
+            // Critical: even though the dialog re-mounts when the refresh
+            // toggles `loading`, no second apiDelete call may fire.
+            expect(mockApiDelete).toHaveBeenCalledTimes(1);
+        });
+
         it('surfaces a page-level error when the delete API rejects', async () => {
             setupApiGetRouter();
             mockApiDelete.mockRejectedValue(new Error('delete failed'));

--- a/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
@@ -32,6 +32,15 @@ vi.mock('../../../contexts/useAuth', () => ({
     useAuth: () => ({ user: { isSuperuser: false } }),
 }));
 
+// Replace the panel with a marker so expanded-row tests can detect the
+// effective-permissions section without depending on the panel's internal
+// markup or its real ConnectionIcon/AdminIcon imports.
+vi.mock('../EffectivePermissionsPanel', () => ({
+    default: () => (
+        <div data-testid="effective-permissions">Effective permissions</div>
+    ),
+}));
+
 import AdminGroups from '../AdminGroups';
 
 const GROUPS = [
@@ -45,6 +54,10 @@ const CONNECTIONS = [{ id: 11, name: 'prod-db' }];
  * Routes the apiGet mock to per-URL fixtures so each test only needs to
  * specify what differs from the defaults. Each route may be overridden
  * by passing a custom map.
+ *
+ * The router selects the longest matching key so that nested routes
+ * like `/api/v1/rbac/groups/1/effective-privileges` resolve before the
+ * shorter `/api/v1/rbac/groups` collection route.
  */
 function setupApiGetRouter(overrides: Record<string, unknown> = {}) {
     const defaults: Record<string, unknown> = {
@@ -53,7 +66,10 @@ function setupApiGetRouter(overrides: Record<string, unknown> = {}) {
     };
     const routes = { ...defaults, ...overrides };
     mockApiGet.mockImplementation((url: string) => {
-        const matchKey = Object.keys(routes).find((k) => url === k || url.startsWith(`${k}/`) || url.startsWith(k));
+        const keys = Object.keys(routes).sort((a, b) => b.length - a.length);
+        const matchKey = keys.find(
+            (k) => url === k || url.startsWith(`${k}/`),
+        );
         if (!matchKey) {
             return Promise.reject(new Error(`No fixture for ${url}`));
         }
@@ -277,6 +293,727 @@ describe('AdminGroups', () => {
             await waitFor(() => {
                 expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/rbac/groups/1');
             });
+        });
+
+        it('cancels the delete dialog without calling the API', async () => {
+            setupApiGetRouter();
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getAllByRole('button', { name: /delete group/i })[0],
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Delete Group')).toBeInTheDocument();
+            });
+            const dialog = screen.getByRole('dialog');
+            await user.click(
+                within(dialog).getByRole('button', { name: /Cancel/i }),
+            );
+            await waitFor(() => {
+                expect(screen.queryByText('Delete Group')).not.toBeInTheDocument();
+            });
+            expect(mockApiDelete).not.toHaveBeenCalled();
+        });
+
+        it('clears the expanded row when the deleted group was expanded', async () => {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: ['alice'],
+                    group_members: [],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': {
+                    connection_privileges: [],
+                    admin_permissions: [],
+                    mcp_privileges: [],
+                },
+            });
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            // Expand the first group so the delete path also exercises the
+            // expanded-row cleanup branch.
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(screen.getByText('alice')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getAllByRole('button', { name: /delete group/i })[0],
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Delete Group')).toBeInTheDocument();
+            });
+            const dialog = screen.getByRole('dialog');
+            await user.click(
+                within(dialog).getByRole('button', { name: /Delete/i }),
+            );
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith('/api/v1/rbac/groups/1');
+            });
+            // The expanded section should have collapsed.
+            await waitFor(() => {
+                expect(screen.queryByText('alice')).not.toBeInTheDocument();
+            });
+        });
+
+        it('surfaces a page-level error when the delete API rejects', async () => {
+            setupApiGetRouter();
+            mockApiDelete.mockRejectedValue(new Error('delete failed'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getAllByRole('button', { name: /delete group/i })[0],
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Delete Group')).toBeInTheDocument();
+            });
+            const dialog = screen.getByRole('dialog');
+            await user.click(
+                within(dialog).getByRole('button', { name: /Delete/i }),
+            );
+            await waitFor(() => {
+                expect(screen.getByText('delete failed')).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Row expansion', () => {
+        it('expands a row and loads members + effective permissions', async () => {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: ['alice', 'bob'],
+                    group_members: ['nested-group'],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': {
+                    connection_privileges: [
+                        { connection_id: 11, level: 'read' },
+                    ],
+                    admin_permissions: ['manage_users'],
+                    mcp_privileges: [],
+                },
+            });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByText('eng'));
+
+            // Group detail came back with user + group members.
+            await waitFor(() => {
+                expect(screen.getByText('alice')).toBeInTheDocument();
+            });
+            expect(screen.getByText('bob')).toBeInTheDocument();
+            expect(screen.getByText('nested-group')).toBeInTheDocument();
+
+            // The mocked permissions panel should be present.
+            expect(
+                screen.getByTestId('effective-permissions'),
+            ).toBeInTheDocument();
+
+            // Clicking the row again should collapse it.
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(screen.queryByText('alice')).not.toBeInTheDocument();
+            });
+        });
+
+        it('renders the empty-members message when both lists are empty', async () => {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: [],
+                    group_members: [],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': null,
+            });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByText('eng'));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('No members in this group.'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('shows a page-level error when group detail fetch fails', async () => {
+            // Reject the detail endpoint and accept everything else.
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: GROUPS });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve({ connections: CONNECTIONS });
+                }
+                if (url.startsWith('/api/v1/rbac/groups/1/effective')) {
+                    return Promise.reject(new Error('perm fail'));
+                }
+                if (url === '/api/v1/rbac/groups/1') {
+                    return Promise.reject(new Error('detail fail'));
+                }
+                return Promise.reject(new Error(`unexpected ${url}`));
+            });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByText('eng'));
+
+            await waitFor(() => {
+                expect(screen.getByText('detail fail')).toBeInTheDocument();
+            });
+        });
+
+        it('refetches the expanded group detail after a successful edit', async () => {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: ['alice'],
+                    group_members: [],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': {
+                    connection_privileges: [],
+                    admin_permissions: [],
+                    mcp_privileges: [],
+                },
+            });
+            mockApiPut.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+
+            // Expand 'eng' first so that editing it should refetch detail.
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(screen.getByText('alice')).toBeInTheDocument();
+            });
+
+            mockApiGet.mockClear();
+            await user.click(
+                screen.getAllByRole('button', { name: /edit group/i })[0],
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Edit group')).toBeInTheDocument();
+            });
+            const dialog = screen.getByRole('dialog');
+            await user.click(
+                within(dialog).getByRole('button', { name: /Save/i }),
+            );
+
+            await waitFor(() => {
+                expect(mockApiPut).toHaveBeenCalledWith(
+                    '/api/v1/rbac/groups/1',
+                    { name: 'eng', description: 'Engineering' },
+                );
+            });
+            // The detail endpoint should be re-hit after the edit succeeds.
+            await waitFor(() => {
+                expect(mockApiGet).toHaveBeenCalledWith('/api/v1/rbac/groups/1');
+            });
+        });
+    });
+
+    describe('Add member dialog', () => {
+        function setupExpandedRouter(overrides: Record<string, unknown> = {}) {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: [],
+                    group_members: [],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': null,
+                '/api/v1/rbac/users': {
+                    users: [
+                        { id: 100, username: 'alice' },
+                        { id: 101, username: 'bob' },
+                    ],
+                },
+                ...overrides,
+            });
+        }
+
+        async function openAddMember(user: ReturnType<typeof userEvent.setup>) {
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(
+                    screen.getByText('No members in this group.'),
+                ).toBeInTheDocument();
+            });
+            await user.click(
+                screen.getByRole('button', { name: /Add Member/i }),
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Add member')).toBeInTheDocument();
+            });
+        }
+
+        it('opens the dialog and loads available users + groups', async () => {
+            setupExpandedRouter();
+            const user = userEvent.setup({ delay: null });
+
+            await openAddMember(user);
+
+            // The radio defaults to "user".
+            await waitFor(() => {
+                expect(screen.getByLabelText('User')).toBeChecked();
+            });
+
+            // The Select trigger should be reachable via its label.
+            const combo = screen.getByRole('combobox', {
+                name: /Select User/i,
+            });
+            await user.click(combo);
+            const listbox = await screen.findByRole('listbox');
+            expect(
+                within(listbox).getByRole('option', { name: 'alice' }),
+            ).toBeInTheDocument();
+            expect(
+                within(listbox).getByRole('option', { name: 'bob' }),
+            ).toBeInTheDocument();
+        });
+
+        it('switches member type to group and lists available groups', async () => {
+            setupExpandedRouter();
+            const user = userEvent.setup({ delay: null });
+
+            await openAddMember(user);
+
+            await user.click(screen.getByLabelText('Group'));
+            const combo = screen.getByRole('combobox', {
+                name: /Select Group/i,
+            });
+            await user.click(combo);
+            const listbox = await screen.findByRole('listbox');
+            // The expanded group ('eng', id=1) should be filtered out.
+            expect(
+                within(listbox).queryByRole('option', { name: 'eng' }),
+            ).not.toBeInTheDocument();
+            expect(
+                within(listbox).getByRole('option', { name: 'ops' }),
+            ).toBeInTheDocument();
+        });
+
+        it('posts the selected user and refreshes on success', async () => {
+            setupExpandedRouter();
+            mockApiPost.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            await openAddMember(user);
+
+            const combo = screen.getByRole('combobox', {
+                name: /Select User/i,
+            });
+            await user.click(combo);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(
+                within(listbox).getByRole('option', { name: 'alice' }),
+            );
+            await user.click(screen.getByRole('button', { name: /^Add$/ }));
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    '/api/v1/rbac/groups/1/members',
+                    { user_id: 100 },
+                );
+            });
+        });
+
+        it('posts the selected group when member type is group', async () => {
+            setupExpandedRouter();
+            mockApiPost.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            await openAddMember(user);
+
+            await user.click(screen.getByLabelText('Group'));
+            const combo = screen.getByRole('combobox', {
+                name: /Select Group/i,
+            });
+            await user.click(combo);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(
+                within(listbox).getByRole('option', { name: 'ops' }),
+            );
+            await user.click(screen.getByRole('button', { name: /^Add$/ }));
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    '/api/v1/rbac/groups/1/members',
+                    { group_id: 2 },
+                );
+            });
+        });
+
+        it('rewrites UNIQUE constraint errors to a friendly message', async () => {
+            setupExpandedRouter();
+            mockApiPost.mockRejectedValue(
+                new Error('SQLite: UNIQUE constraint failed: members'),
+            );
+            const user = userEvent.setup({ delay: null });
+
+            await openAddMember(user);
+
+            const combo = screen.getByRole('combobox', {
+                name: /Select User/i,
+            });
+            await user.click(combo);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(
+                within(listbox).getByRole('option', { name: 'alice' }),
+            );
+            await user.click(screen.getByRole('button', { name: /^Add$/ }));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('This member is already in the group.'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('surfaces a generic API error in the dialog alert', async () => {
+            setupExpandedRouter();
+            mockApiPost.mockRejectedValue(new Error('upstream 500'));
+            const user = userEvent.setup({ delay: null });
+
+            await openAddMember(user);
+
+            const combo = screen.getByRole('combobox', {
+                name: /Select User/i,
+            });
+            await user.click(combo);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(
+                within(listbox).getByRole('option', { name: 'alice' }),
+            );
+            await user.click(screen.getByRole('button', { name: /^Add$/ }));
+
+            await waitFor(() => {
+                expect(screen.getByText('upstream 500')).toBeInTheDocument();
+            });
+        });
+
+        it('renders a dialog-level error when loading available members fails', async () => {
+            // Reject both lookup endpoints so the catch branch fires.
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: GROUPS });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve({ connections: CONNECTIONS });
+                }
+                if (url === '/api/v1/rbac/groups/1') {
+                    return Promise.resolve({
+                        user_members: [],
+                        group_members: [],
+                    });
+                }
+                if (url === '/api/v1/rbac/groups/1/effective-privileges') {
+                    return Promise.resolve(null);
+                }
+                return Promise.reject(new Error('load fail'));
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(
+                    screen.getByText('No members in this group.'),
+                ).toBeInTheDocument();
+            });
+            // The .catch on each lookup swallows individual failures so the
+            // outer try/catch does not fire; available lists stay empty.
+            await user.click(
+                screen.getByRole('button', { name: /Add Member/i }),
+            );
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+            // Submit is disabled because no selection is possible.
+            expect(
+                screen.getByRole('button', { name: /^Add$/ }),
+            ).toBeDisabled();
+        });
+
+        it('closes the dialog on Cancel without posting', async () => {
+            setupExpandedRouter();
+            const user = userEvent.setup({ delay: null });
+
+            await openAddMember(user);
+
+            await user.click(screen.getByRole('button', { name: /Cancel/i }));
+            await waitFor(() => {
+                expect(screen.queryByText('Add member')).not.toBeInTheDocument();
+            });
+            expect(mockApiPost).not.toHaveBeenCalled();
+        });
+
+        it('returns early when handleAddMember runs without a selected member', async () => {
+            setupExpandedRouter();
+            const user = userEvent.setup({ delay: null });
+
+            await openAddMember(user);
+
+            // Without a selection the Add button is disabled, so the early
+            // return inside handleAddMember is guarded by the disabled
+            // attribute. Verifying it's disabled is sufficient.
+            expect(
+                screen.getByRole('button', { name: /^Add$/ }),
+            ).toBeDisabled();
+        });
+    });
+
+    describe('Remove member', () => {
+        it('looks up the user id and deletes a user member', async () => {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: ['alice'],
+                    group_members: [],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': null,
+                '/api/v1/rbac/users': {
+                    users: [{ id: 100, username: 'alice' }],
+                },
+            });
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(screen.getByText('alice')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getAllByRole('button', { name: /remove member/i })[0],
+            );
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith(
+                    '/api/v1/rbac/groups/1/members/user/100',
+                );
+            });
+        });
+
+        it('uses the in-memory group list for group members', async () => {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: [],
+                    group_members: ['ops'],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': null,
+            });
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                // The 'ops' name should appear in the expanded panel
+                // (in addition to its own row), so the remove button
+                // exists.
+                expect(
+                    screen.getAllByRole('button', { name: /remove member/i }),
+                ).toHaveLength(1);
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /remove member/i }),
+            );
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith(
+                    '/api/v1/rbac/groups/1/members/group/2',
+                );
+            });
+        });
+
+        it('reports an error when the user lookup cannot resolve the name', async () => {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: ['ghost'],
+                    group_members: [],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': null,
+                '/api/v1/rbac/users': {
+                    users: [{ id: 100, username: 'alice' }],
+                },
+            });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(screen.getByText('ghost')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /remove member/i }),
+            );
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Could not find user "ghost"'),
+                ).toBeInTheDocument();
+            });
+            expect(mockApiDelete).not.toHaveBeenCalled();
+        });
+
+        it('surfaces a page-level error when the delete call rejects', async () => {
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: ['alice'],
+                    group_members: [],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': null,
+                '/api/v1/rbac/users': {
+                    users: [{ id: 100, username: 'alice' }],
+                },
+            });
+            mockApiDelete.mockRejectedValue(new Error('cannot remove'));
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(screen.getByText('alice')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /remove member/i }),
+            );
+
+            await waitFor(() => {
+                expect(screen.getByText('cannot remove')).toBeInTheDocument();
+            });
+        });
+
+        it('skips delete when the group lookup cannot find the name', async () => {
+            // The group_members entry references a name not in the items list
+            // (because the only groups available are 'eng' and 'ops'), so the
+            // lookup branch returns the "Could not find" error.
+            setupApiGetRouter({
+                '/api/v1/rbac/groups/1': {
+                    user_members: [],
+                    group_members: ['nowhere'],
+                },
+                '/api/v1/rbac/groups/1/effective-privileges': null,
+            });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(screen.getByText('eng'));
+            await waitFor(() => {
+                expect(screen.getByText('nowhere')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /remove member/i }),
+            );
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Could not find group "nowhere"'),
+                ).toBeInTheDocument();
+            });
+            expect(mockApiDelete).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Edit dialog cancel', () => {
+        it('closes the edit dialog on Cancel without calling PUT', async () => {
+            setupApiGetRouter();
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(
+                screen.getAllByRole('button', { name: /edit group/i })[0],
+            );
+            await waitFor(() => {
+                expect(screen.getByText('Edit group')).toBeInTheDocument();
+            });
+            const dialog = screen.getByRole('dialog');
+            await user.click(
+                within(dialog).getByRole('button', { name: /Cancel/i }),
+            );
+            await waitFor(() => {
+                expect(screen.queryByText('Edit group')).not.toBeInTheDocument();
+            });
+            expect(mockApiPut).not.toHaveBeenCalled();
+        });
+
+        it('returns early when the edit form is submitted with a blank name', async () => {
+            setupApiGetRouter();
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminGroups />);
+            await waitFor(() => {
+                expect(screen.getByText('eng')).toBeInTheDocument();
+            });
+            await user.click(
+                screen.getAllByRole('button', { name: /edit group/i })[0],
+            );
+            const dialog = await screen.findByRole('dialog');
+            // Empty the Name field; the Save button should then be
+            // disabled, and the underlying early-return guard is
+            // exercised by the disabled attribute.
+            fireEvent.change(within(dialog).getByLabelText('Name *'), {
+                target: { value: '' },
+            });
+            expect(
+                within(dialog).getByRole('button', { name: /Save/i }),
+            ).toBeDisabled();
         });
     });
 });

--- a/client/src/components/AdminPanel/__tests__/_shared/errors.test.ts
+++ b/client/src/components/AdminPanel/__tests__/_shared/errors.test.ts
@@ -1,3 +1,13 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
 import { describe, it, expect } from 'vitest';
 import {
     extractErrorMessage,

--- a/client/src/components/AdminPanel/__tests__/_shared/errors.test.ts
+++ b/client/src/components/AdminPanel/__tests__/_shared/errors.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import {
+    extractErrorMessage,
+    DEFAULT_ERROR_MESSAGE,
+} from '../../_shared/errors';
+
+describe('extractErrorMessage', () => {
+    it('returns the message of an Error instance', () => {
+        expect(extractErrorMessage(new Error('boom'))).toBe('boom');
+    });
+
+    it('returns the default fallback for non-Error values', () => {
+        expect(extractErrorMessage('weird')).toBe(DEFAULT_ERROR_MESSAGE);
+        expect(extractErrorMessage(null)).toBe(DEFAULT_ERROR_MESSAGE);
+        expect(extractErrorMessage(undefined)).toBe(DEFAULT_ERROR_MESSAGE);
+        expect(extractErrorMessage({ foo: 'bar' })).toBe(DEFAULT_ERROR_MESSAGE);
+    });
+
+    it('honours a caller-supplied fallback for non-Error values', () => {
+        expect(extractErrorMessage('weird', 'custom fallback')).toBe(
+            'custom fallback',
+        );
+    });
+
+    it('prefers the Error message even when a fallback is supplied', () => {
+        expect(extractErrorMessage(new Error('boom'), 'unused fallback')).toBe(
+            'boom',
+        );
+    });
+
+    it('exports the canonical default message constant', () => {
+        expect(DEFAULT_ERROR_MESSAGE).toBe('An unexpected error occurred');
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
@@ -1,0 +1,445 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useCrudPanel } from '../../_shared/useCrudPanel';
+
+interface Item {
+    id: number;
+    name: string;
+}
+
+const ITEMS: Item[] = [
+    { id: 1, name: 'one' },
+    { id: 2, name: 'two' },
+];
+
+describe('useCrudPanel', () => {
+    it('fetches the initial list and exposes loading transitions', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel({ fetchItems }));
+
+        // The initial synchronous render shows loading=true and no items.
+        expect(result.current.loading).toBe(true);
+        expect(result.current.items).toEqual([]);
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.items).toEqual(ITEMS);
+        expect(fetchItems).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a fetch failure on the page-level error slot', async () => {
+        const fetchItems = vi.fn().mockRejectedValue(new Error('Network down'));
+        const { result } = renderHook(() => useCrudPanel({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.error).toBe('Network down');
+        });
+        expect(result.current.loading).toBe(false);
+    });
+
+    it('falls back to a generic message for non-Error fetch rejections', async () => {
+        const fetchItems = vi.fn().mockRejectedValue('weird');
+        const { result } = renderHook(() => useCrudPanel({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.error).toBe('An unexpected error occurred');
+        });
+    });
+
+    it('re-runs the fetch when refresh() is called', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        await act(async () => {
+            await result.current.refresh();
+        });
+        expect(fetchItems).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-runs the fetch when deps change', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        let depValue = 'a';
+        const { result, rerender } = renderHook(
+            () => useCrudPanel({ fetchItems, deps: [depValue] }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+        expect(fetchItems).toHaveBeenCalledTimes(1);
+
+        depValue = 'b';
+        rerender();
+        await waitFor(() => {
+            expect(fetchItems).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it('opens the dialog in create mode', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        act(() => {
+            result.current.setDialogError('stale error');
+        });
+        expect(result.current.dialogError).toBe('stale error');
+
+        act(() => {
+            result.current.openCreate();
+        });
+        expect(result.current.dialogOpen).toBe(true);
+        expect(result.current.editingItem).toBeNull();
+        expect(result.current.dialogError).toBeNull();
+    });
+
+    it('opens the dialog in edit mode and tracks the editing item', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel<Item>({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        act(() => {
+            result.current.openEdit(ITEMS[0]);
+        });
+        expect(result.current.dialogOpen).toBe(true);
+        expect(result.current.editingItem).toEqual(ITEMS[0]);
+    });
+
+    it('closeDialog clears editing state and dialog error', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel<Item>({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        act(() => {
+            result.current.openEdit(ITEMS[0]);
+            result.current.setDialogError('boom');
+        });
+        act(() => {
+            result.current.closeDialog();
+        });
+        expect(result.current.dialogOpen).toBe(false);
+        expect(result.current.editingItem).toBeNull();
+        expect(result.current.dialogError).toBeNull();
+    });
+
+    it('closeDialog does nothing while saving is in flight', async () => {
+        let resolveSave: (() => void) | null = null;
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel<Item>({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        act(() => {
+            result.current.openEdit(ITEMS[0]);
+        });
+
+        // Start a mutation that we control via an external resolver.
+        const slowMutation = new Promise<void>((res) => {
+            resolveSave = res;
+        });
+        let mutationPromise: Promise<unknown> | undefined;
+        act(() => {
+            mutationPromise = result.current.runMutation(() => slowMutation);
+        });
+        await waitFor(() => expect(result.current.saving).toBe(true));
+
+        // Try to close mid-save; the hook must keep the dialog open.
+        act(() => {
+            result.current.closeDialog();
+        });
+        expect(result.current.dialogOpen).toBe(true);
+        expect(result.current.editingItem).toEqual(ITEMS[0]);
+
+        // Let the mutation finish so the hook can settle.
+        act(() => {
+            resolveSave?.();
+        });
+        await mutationPromise;
+        await waitFor(() => expect(result.current.saving).toBe(false));
+    });
+
+    it('opens and closes the delete confirmation dialog', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel<Item>({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        act(() => {
+            result.current.openDelete(ITEMS[1]);
+        });
+        expect(result.current.deleteOpen).toBe(true);
+        expect(result.current.deleteItem).toEqual(ITEMS[1]);
+
+        act(() => {
+            result.current.closeDelete();
+        });
+        expect(result.current.deleteOpen).toBe(false);
+        expect(result.current.deleteItem).toBeNull();
+    });
+
+    it('setError and setSuccess update page-level toasts', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel<Item>({ fetchItems }));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        act(() => {
+            result.current.setError('page error');
+            result.current.setSuccess('did the thing');
+        });
+        expect(result.current.error).toBe('page error');
+        expect(result.current.success).toBe('did the thing');
+
+        act(() => {
+            result.current.setError(null);
+            result.current.setSuccess(null);
+        });
+        expect(result.current.error).toBeNull();
+        expect(result.current.success).toBeNull();
+    });
+
+    it('setItems replaces the list and supports updater fns', async () => {
+        const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+        const { result } = renderHook(() => useCrudPanel<Item>({ fetchItems }));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        act(() => {
+            result.current.setItems([{ id: 9, name: 'nine' }]);
+        });
+        expect(result.current.items).toEqual([{ id: 9, name: 'nine' }]);
+
+        act(() => {
+            result.current.setItems((prev) => [
+                ...prev,
+                { id: 10, name: 'ten' },
+            ]);
+        });
+        expect(result.current.items).toHaveLength(2);
+    });
+
+    describe('runMutation', () => {
+        it('runs the mutation, refreshes, and posts a success toast', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+            fetchItems.mockClear();
+
+            const fn = vi.fn().mockResolvedValue('ok');
+            let returned: unknown;
+            await act(async () => {
+                returned = await result.current.runMutation(fn, {
+                    successMessage: 'created',
+                });
+            });
+            expect(returned).toBe('ok');
+            expect(result.current.success).toBe('created');
+            expect(fetchItems).toHaveBeenCalledTimes(1);
+        });
+
+        it('skips refresh when refresh: false is set', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+            fetchItems.mockClear();
+
+            await act(async () => {
+                await result.current.runMutation(
+                    () => Promise.resolve(),
+                    { refresh: false },
+                );
+            });
+            expect(fetchItems).not.toHaveBeenCalled();
+        });
+
+        it('writes errors to the dialog slot by default', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            const fn = vi.fn().mockRejectedValue(new Error('save bad'));
+            await act(async () => {
+                await result.current.runMutation(fn);
+            });
+            expect(result.current.dialogError).toBe('save bad');
+            expect(result.current.error).toBeNull();
+            expect(result.current.saving).toBe(false);
+        });
+
+        it('writes errors to the page slot when errorTarget=page', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            const fn = vi.fn().mockRejectedValue(new Error('delete bad'));
+            await act(async () => {
+                await result.current.runMutation(fn, { errorTarget: 'page' });
+            });
+            expect(result.current.error).toBe('delete bad');
+            expect(result.current.dialogError).toBeNull();
+            expect(result.current.deleteLoading).toBe(false);
+        });
+
+        it('uses errorFallback for non-Error rejections', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            const fn = vi.fn().mockRejectedValue('weird');
+            await act(async () => {
+                await result.current.runMutation(fn, {
+                    errorTarget: 'page',
+                    errorFallback: 'custom message',
+                });
+            });
+            expect(result.current.error).toBe('custom message');
+        });
+
+        it('honours a mapError function to translate errors', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            const fn = vi.fn().mockRejectedValue(
+                new Error('UNIQUE constraint violated'),
+            );
+            await act(async () => {
+                await result.current.runMutation(fn, {
+                    mapError: (err) =>
+                        err instanceof Error
+                            && err.message.includes('UNIQUE constraint')
+                            ? 'Already exists.'
+                            : 'other',
+                });
+            });
+            expect(result.current.dialogError).toBe('Already exists.');
+        });
+
+        it('returns undefined when the mutation fails', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            const fn = vi.fn().mockRejectedValue(new Error('nope'));
+            let returned: unknown = 'sentinel';
+            await act(async () => {
+                returned = await result.current.runMutation(fn);
+            });
+            expect(returned).toBeUndefined();
+        });
+
+        it('clears prior dialog error before each mutation', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            act(() => {
+                result.current.setDialogError('stale');
+            });
+            await act(async () => {
+                await result.current.runMutation(() => Promise.resolve('ok'));
+            });
+            expect(result.current.dialogError).toBeNull();
+        });
+
+        it('clears prior page error before page-target mutations', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            act(() => {
+                result.current.setError('stale');
+            });
+            await act(async () => {
+                await result.current.runMutation(() => Promise.resolve('ok'), {
+                    errorTarget: 'page',
+                });
+            });
+            expect(result.current.error).toBeNull();
+        });
+
+        it('sets saving=true during dialog mutations and resets after', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            let resolver: ((value: string) => void) | null = null;
+            const fn = vi.fn(
+                () => new Promise<string>((res) => { resolver = res; }),
+            );
+            let mutationPromise: Promise<unknown> | undefined;
+            act(() => {
+                mutationPromise = result.current.runMutation(fn);
+            });
+            await waitFor(() => expect(result.current.saving).toBe(true));
+            act(() => resolver?.('done'));
+            await mutationPromise;
+            await waitFor(() => expect(result.current.saving).toBe(false));
+        });
+
+        it('sets deleteLoading during page-target mutations', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            let resolver: ((value: string) => void) | null = null;
+            const fn = vi.fn(
+                () => new Promise<string>((res) => { resolver = res; }),
+            );
+            let mutationPromise: Promise<unknown> | undefined;
+            act(() => {
+                mutationPromise = result.current.runMutation(fn, {
+                    errorTarget: 'page',
+                });
+            });
+            await waitFor(() => expect(result.current.deleteLoading).toBe(true));
+            act(() => resolver?.('done'));
+            await mutationPromise;
+            await waitFor(() =>
+                expect(result.current.deleteLoading).toBe(false),
+            );
+        });
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
@@ -1,3 +1,13 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
 import { describe, it, expect, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useCrudPanel } from '../../_shared/useCrudPanel';

--- a/client/src/components/AdminPanel/_shared/errors.ts
+++ b/client/src/components/AdminPanel/_shared/errors.ts
@@ -1,0 +1,38 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Error helpers shared by the AdminPanel CRUD components.
+ *
+ * Every AdminPanel mutation handler used to inline an `err instanceof Error`
+ * check followed by a fallback string; centralising that here removes a
+ * substantial amount of duplication and keeps fallback wording consistent.
+ */
+
+/**
+ * Default fallback message used when a thrown value is not an `Error`
+ * instance. AdminPanel components historically use this exact wording.
+ */
+export const DEFAULT_ERROR_MESSAGE = 'An unexpected error occurred';
+
+/**
+ * Extracts a user-displayable message from a thrown value. When the value
+ * is an `Error`, returns its `message`. Otherwise returns `fallback`,
+ * which defaults to {@link DEFAULT_ERROR_MESSAGE}.
+ */
+export function extractErrorMessage(
+    err: unknown,
+    fallback: string = DEFAULT_ERROR_MESSAGE,
+): string {
+    if (err instanceof Error) {
+        return err.message;
+    }
+    return fallback;
+}

--- a/client/src/components/AdminPanel/_shared/index.ts
+++ b/client/src/components/AdminPanel/_shared/index.ts
@@ -1,0 +1,26 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Shared helpers for AdminPanel CRUD screens. Each AdminPanel component
+ * (groups, alert rules, messaging channels, etc.) re-implemented similar
+ * list-fetch / dialog / delete / mutation machinery. This module exposes
+ * narrow primitives that those panels can compose, eliminating the bulk
+ * of the duplication without forcing a single component shape on screens
+ * with substantially different forms.
+ */
+
+export {
+    useCrudPanel,
+    type CrudPanelApi,
+    type RunMutationOptions,
+    type UseCrudPanelOptions,
+} from './useCrudPanel';
+export { extractErrorMessage, DEFAULT_ERROR_MESSAGE } from './errors';

--- a/client/src/components/AdminPanel/_shared/useCrudPanel.ts
+++ b/client/src/components/AdminPanel/_shared/useCrudPanel.ts
@@ -1,0 +1,287 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { extractErrorMessage } from './errors';
+
+/**
+ * Generic CRUD-panel hook used by the AdminPanel screens.
+ *
+ * Every AdminPanel screen previously re-implemented the same machinery:
+ *
+ *   1. fetch a list, manage `loading` + `error`;
+ *   2. surface page-level success/error toasts;
+ *   3. drive a create/edit dialog with its own `saving` + `dialogError`;
+ *   4. drive a delete-confirmation dialog with `deleteLoading` and
+ *      open/close handlers;
+ *   5. wrap every mutation in `try/catch` boilerplate that maps thrown
+ *      values to a user-facing message and refreshes the list on success.
+ *
+ * This hook collapses that boilerplate. Each panel still owns its
+ * dialog markup, form state, and per-mutation API request — those vary
+ * too much between panels to share without contortions — but the
+ * surrounding lifecycle is uniform.
+ *
+ * The hook is intentionally narrow in scope. It is NOT a generic data
+ * layer; it is an AdminPanel-specific helper. Adding fields here should
+ * be cheap, removing them is hard.
+ */
+
+/**
+ * Options for a single mutation invocation.
+ */
+export interface RunMutationOptions {
+    /**
+     * Toast to show on success. Omit to leave success state untouched.
+     */
+    successMessage?: string;
+    /**
+     * Where to report errors. The default reports to the dialog-level
+     * `dialogError` slot, which matches the create/edit flow. Page-level
+     * mutations (delete, inline toggles, etc.) should pass `'page'`.
+     */
+    errorTarget?: 'page' | 'dialog';
+    /**
+     * Whether to refresh the list after a successful mutation. Defaults
+     * to `true` because the vast majority of mutations need it.
+     */
+    refresh?: boolean;
+    /**
+     * Custom fallback message for non-Error throws. Defaults to the
+     * shared {@link extractErrorMessage} fallback.
+     */
+    errorFallback?: string;
+    /**
+     * Maps the thrown value to a user-facing message before display.
+     * Useful for translating server constraint errors into friendlier
+     * wording (e.g. UNIQUE constraint -> "already exists").
+     */
+    mapError?: (err: unknown) => string;
+}
+
+/**
+ * Public API returned by {@link useCrudPanel}.
+ */
+export interface CrudPanelApi<T> {
+    // --- List state ---
+    items: T[];
+    setItems: React.Dispatch<React.SetStateAction<T[]>>;
+    loading: boolean;
+    error: string | null;
+    setError: (value: string | null) => void;
+    success: string | null;
+    setSuccess: (value: string | null) => void;
+    refresh: () => Promise<void>;
+
+    // --- Edit/create dialog state ---
+    dialogOpen: boolean;
+    editingItem: T | null;
+    saving: boolean;
+    dialogError: string | null;
+    setDialogError: (value: string | null) => void;
+    openCreate: () => void;
+    openEdit: (item: T) => void;
+    closeDialog: () => void;
+
+    // --- Delete-confirmation dialog state ---
+    deleteOpen: boolean;
+    deleteItem: T | null;
+    deleteLoading: boolean;
+    openDelete: (item: T) => void;
+    closeDelete: () => void;
+
+    // --- Mutation helper ---
+    runMutation: <R>(fn: () => Promise<R>, options?: RunMutationOptions) => Promise<R | undefined>;
+}
+
+/**
+ * Configures the hook. The fetcher is the only required option; an empty
+ * panel that just lists items is a valid use of the hook.
+ */
+export interface UseCrudPanelOptions<T> {
+    /**
+     * Asynchronously fetch the list of items. Should throw on failure
+     * so the hook can capture and display the error.
+     */
+    fetchItems: () => Promise<T[]>;
+    /**
+     * Optional list of values whose change forces a refresh. The
+     * fetcher itself is always tracked, so consumers usually wrap it
+     * in `useCallback` and put cross-cutting deps inside the closure.
+     */
+    deps?: ReadonlyArray<unknown>;
+}
+
+/**
+ * Hook that owns list, dialog, and delete state for an AdminPanel screen.
+ *
+ * Usage sketch:
+ *
+ *   const crud = useCrudPanel<MyItem>({
+ *       fetchItems: useCallback(async () => {
+ *           const data = await apiGet<{ items: MyItem[] }>('/api/v1/things');
+ *           return data.items ?? [];
+ *       }, []),
+ *   });
+ *
+ *   const handleSave = async () => {
+ *       await crud.runMutation(
+ *           () => apiPost('/api/v1/things', body),
+ *           { successMessage: 'Created!' },
+ *       );
+ *       crud.closeDialog();
+ *   };
+ */
+export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T> {
+    const { fetchItems, deps } = options;
+
+    // --- List state ---
+    const [items, setItems] = useState<T[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState<string | null>(null);
+
+    // --- Dialog state ---
+    const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+    const [editingItem, setEditingItem] = useState<T | null>(null);
+    const [saving, setSaving] = useState<boolean>(false);
+    const [dialogError, setDialogError] = useState<string | null>(null);
+
+    // --- Delete dialog state ---
+    const [deleteOpen, setDeleteOpen] = useState<boolean>(false);
+    const [deleteItem, setDeleteItem] = useState<T | null>(null);
+    const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
+
+    const refresh = useCallback(async () => {
+        try {
+            setLoading(true);
+            const next = await fetchItems();
+            setItems(next);
+        } catch (err: unknown) {
+            setError(extractErrorMessage(err));
+        } finally {
+            setLoading(false);
+        }
+    }, [fetchItems]);
+
+    // Run refresh once on mount and whenever the caller's `deps` change.
+    // We intentionally do not include `refresh` in this effect's deps —
+    // the consumer drives invalidation via the `deps` array, which lets
+    // them wrap `fetchItems` in a stable `useCallback`.
+    useEffect(() => {
+        void refresh();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [refresh, ...(deps ?? [])]);
+
+    const openCreate = useCallback(() => {
+        setEditingItem(null);
+        setDialogError(null);
+        setDialogOpen(true);
+    }, []);
+
+    const openEdit = useCallback((item: T) => {
+        setEditingItem(item);
+        setDialogError(null);
+        setDialogOpen(true);
+    }, []);
+
+    const closeDialog = useCallback(() => {
+        // Block close while a save is in flight — the saving handler
+        // owns the close transition.
+        setSaving((isSaving) => {
+            if (!isSaving) {
+                setDialogOpen(false);
+                setEditingItem(null);
+                setDialogError(null);
+            }
+            return isSaving;
+        });
+    }, []);
+
+    const openDelete = useCallback((item: T) => {
+        setDeleteItem(item);
+        setDeleteOpen(true);
+    }, []);
+
+    const closeDelete = useCallback(() => {
+        setDeleteOpen(false);
+        setDeleteItem(null);
+    }, []);
+
+    const runMutation = useCallback(async function runMutationInner<R>(
+        fn: () => Promise<R>,
+        opts: RunMutationOptions = {},
+    ): Promise<R | undefined> {
+        const {
+            successMessage,
+            errorTarget = 'dialog',
+            refresh: shouldRefresh = true,
+            errorFallback,
+            mapError,
+        } = opts;
+
+        const setBusy = errorTarget === 'dialog' ? setSaving : setDeleteLoading;
+        const writeError = errorTarget === 'dialog' ? setDialogError : setError;
+
+        try {
+            setBusy(true);
+            if (errorTarget === 'dialog') {
+                setDialogError(null);
+            } else {
+                setError(null);
+            }
+            const result = await fn();
+            if (successMessage) {
+                setSuccess(successMessage);
+            }
+            if (shouldRefresh) {
+                await refresh();
+            }
+            return result;
+        } catch (err: unknown) {
+            const message = mapError
+                ? mapError(err)
+                : extractErrorMessage(err, errorFallback);
+            writeError(message);
+            return undefined;
+        } finally {
+            setBusy(false);
+        }
+    }, [refresh]);
+
+    return {
+        // List
+        items,
+        setItems,
+        loading,
+        error,
+        setError,
+        success,
+        setSuccess,
+        refresh,
+        // Dialog
+        dialogOpen,
+        editingItem,
+        saving,
+        dialogError,
+        setDialogError,
+        openCreate,
+        openEdit,
+        closeDialog,
+        // Delete
+        deleteOpen,
+        deleteItem,
+        deleteLoading,
+        openDelete,
+        closeDelete,
+        // Mutation
+        runMutation,
+    };
+}

--- a/client/src/components/AdminPanel/_shared/useCrudPanel.ts
+++ b/client/src/components/AdminPanel/_shared/useCrudPanel.ts
@@ -115,6 +115,10 @@ export interface UseCrudPanelOptions<T> {
      * Optional list of values whose change forces a refresh. The
      * fetcher itself is always tracked, so consumers usually wrap it
      * in `useCallback` and put cross-cutting deps inside the closure.
+     *
+     * `deps` must have a stable length across renders; React throws
+     * "The final argument passed to useEffect changed size between
+     * renders" if a caller passes a variable-length array.
      */
     deps?: ReadonlyArray<unknown>;
 }
@@ -172,9 +176,9 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
     }, [fetchItems]);
 
     // Run refresh once on mount and whenever the caller's `deps` change.
-    // We intentionally do not include `refresh` in this effect's deps —
-    // the consumer drives invalidation via the `deps` array, which lets
-    // them wrap `fetchItems` in a stable `useCallback`.
+    // `refresh` is included in the deps array; the eslint-disable below
+    // is required because we spread caller-supplied `deps`, which the
+    // exhaustive-deps rule cannot statically verify.
     useEffect(() => {
         void refresh();
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

Extracts the repeated CRUD-panel state machine from three Admin* components in `client/src/components/AdminPanel/` into a shared `useCrudPanel<T>` hook plus small error helpers. Targets the largest single cluster identified by Codacy's duplication metric (22%, goal 10%). Out of scope for this PR (follow-up): `AdminUsers.tsx`, `AdminProbes.tsx`, `AdminPermissions.tsx`.

## What changed

New shared module at `client/src/components/AdminPanel/_shared/`:

- `useCrudPanel.ts` — manages `items`, `loading`, `error`, `success`, `saving`, `dialogError`, `deleteLoading`, edit-target tracking, dialog open/close, and a `runMutation` wrapper that handles API try/catch and either-or `dialog`/`page` error placement. 100% line coverage.
- `errors.ts` — `extractErrorMessage` + `DEFAULT_ERROR_MESSAGE`. 100% line coverage.
- `index.ts` — barrel export.

Each panel still owns its dialog markup and field-level form state — the brief's recommendation was to extract the state machine, not force a generic dialog component that ends up uglier than the duplication it replaces. The savings come from eliminating the recurring state shape and the mutation try/catch boilerplate, which is what Codacy was flagging as clones.

Three panels converted:

| File | LOC before → after |
|---|---|
| `AdminAlertRules.tsx` | 362 → 353 |
| `AdminMessagingChannels.tsx` | 600 → 549 |
| `AdminGroups.tsx` | 731 → 703 |

The LOC delta is modest because each panel keeps its dialog body verbatim; the duplicated state-management cluster (which dominated the CPD signal) is gone.

## Test impact

- All 270 pre-existing AdminPanel tests pass unmodified (no behavioral rewrites).
- Net new tests:
  - 28 tests for the shared module (22 for the hook, 6 for the error helpers)
  - 32 tests in a new `AdminGroups.test.tsx` (no test file existed previously)
- Full client suite: **2952 tests, 147 files, all green**.

## Coverage (per touched file)

| File | Line coverage |
|---|---|
| `_shared/useCrudPanel.ts` | 100.0% |
| `_shared/errors.ts` | 100.0% |
| `AdminAlertRules.tsx` | 93.3% |
| `AdminMessagingChannels.tsx` | 90.8% |
| `AdminEmailChannels.tsx` | 91.7% |
| `AdminWebhookChannels.tsx` | 95.8% |
| `AdminGroups.tsx` | 95.8% (was 0 — no prior tests) |

All clear the project's 90% line-coverage floor.

## Quality gates

| Gate | Baseline (main) | This PR |
|---|---|---|
| `npx eslint src` | 39 warnings, 0 errors | 39 warnings, 0 errors |
| `npx tsc --noEmit` error count | 562 | 562 |
| AdminPanel test suite | 270 / 11 files | 330 / 14 files |
| Full client test suite | n/a | 2952 / 147 files |

## Design choices worth flagging for review

1. **`errorTarget: 'dialog' | 'page'`**. Existing panels mixed error surfaces (AlertRules → page; MessagingChannels → dialog for create/edit, page for delete and inline toggle; Groups → page for delete). The hook exposes both targets per `runMutation` call rather than forcing a single convention.
2. **No auto-close on success**. Each panel decides whether to close the dialog after inspecting `runMutation`'s return. This preserved AdminGroups' behavior of re-fetching expanded-row detail when an edit succeeds.
3. **`closeDialog()` is a no-op while `saving` is true**, matching the original Dialog `onClose` guards.
4. **AdminGroups' add-member flow and expandable-row detail fetching are intentionally panel-local**. They don't fit a CRUD shape and forcing them in would hurt readability.

## Files touched

```
client/src/components/AdminPanel/AdminAlertRules.tsx        | 151 +-
client/src/components/AdminPanel/AdminGroups.tsx            | 294 +--
client/src/components/AdminPanel/AdminMessagingChannels.tsx | 291 +--
client/src/components/AdminPanel/_shared/errors.ts          | +38
client/src/components/AdminPanel/_shared/index.ts           | +26
client/src/components/AdminPanel/_shared/useCrudPanel.ts    | +287
client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx                 | +1019
client/src/components/AdminPanel/__tests__/_shared/errors.test.ts               | +34
client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx        | +445
```

## Test plan

- [x] AdminPanel test suite passes (330/330)
- [x] Full client test suite passes (2952/2952)
- [x] Lint clean (no new warnings/errors vs main)
- [x] Typecheck clean (no new errors vs main)
- [x] Every touched file ≥90% line coverage
- [ ] Codacy run on CI confirms the duplication metric drops (the duplication signal was the motivation; the count should fall on these three files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified CRUD behavior across Admin panels for consistent list loading, dialog, save/delete flows, and centralized page-level success/error handling.
  * UI lists and dialogs now derive state from the shared CRUD layer; controls are disabled while saves are in progress.

* **Bug Fixes**
  * Improved error extraction and fallback messaging for admin screens.

* **Tests**
  * Expanded test coverage for groups, channels, alert rules, and the shared CRUD/error utilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/209)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->