### PR TITLE
fix(server,client): gate cluster mutations on manage_connections (#207)

### DIFF
--- a/.claude/golang-expert/rbac-patterns.md
+++ b/.claude/golang-expert/rbac-patterns.md
@@ -110,6 +110,16 @@ do not own the row and lack `PermManageConnections` cannot distinguish
 the 404 happens before the 403 check. That matches the existing
 issue-#35 visibility contract.
 
+Note on handler comments: the Variant 2 implementation must call
+`Get<Resource>` to read `owner_username` before it can decide
+ownership, so the authorization check is NOT strictly "before any
+datastore read". Describe the property as "authorization enforced
+early (before request decoding and any response body write)" rather
+than "before any datastore read". The OpenAPI description for a
+Variant 2 endpoint must reflect the owner fallback, e.g. "Requires
+manage_connections permission or ownership of the &lt;resource&gt;",
+and the 403 response wording in the spec must match.
+
 ## Variant 3: Plain Admin Gate (visibility-stake reasoning)
 
 Use this for per-object cluster mutations (`updateCluster`,
@@ -164,6 +174,30 @@ The handler is built with a nil datastore so the test asserts that
 the 403 happens BEFORE any datastore call. A panic from a nil
 datastore is a regression: it means the gate was placed after the
 datastore call.
+
+`assertForbiddenWithMessage` checks that the 403 response body
+contains the canonical substring `"Permission denied"`, which is the
+stable prefix of the plain admin gate (Variant 1/3). New plain-admin
+handlers MUST emit the canonical wording
+(`"Permission denied: requires manage_connections permission"`) so
+the helper continues to lock in a regression to an empty or
+differently-worded message. Variant 2 handlers use a different,
+resource-specific wording (e.g.
+`"You do not have permission to delete this cluster group"`) and
+their tests should assert their own canonical substring inline
+rather than reuse `assertForbiddenWithMessage`.
+
+`assertGatePassed` rejects both `403 Forbidden` and `401
+Unauthorized` so a regression where the auth lookup itself starts
+denying a previously valid request also surfaces as a test failure.
+Mirror the same shape in any inline "allowed caller" assertion:
+
+```go
+if rec.Code == http.StatusForbidden || rec.Code == http.StatusUnauthorized {
+    t.Fatalf("Permitted caller failed auth (status %d): %s",
+        rec.Code, rec.Body.String())
+}
+```
 
 ### "Denied skips decode" test
 

--- a/.claude/golang-expert/rbac-patterns.md
+++ b/.claude/golang-expert/rbac-patterns.md
@@ -1,0 +1,236 @@
+/*-----------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - RBAC Patterns
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-----------------------------------------------------------
+ */
+
+# RBAC Gating Patterns for HTTP Handlers
+
+This document captures the authorization-gate patterns the server's
+HTTP handlers use, when each variant applies, and the test patterns
+that lock them in. The cluster-handler audit for GitHub issue #207
+established three canonical models; new handlers MUST pick one
+deliberately rather than invent a fourth.
+
+## When To Gate
+
+Every mutating handler (POST, PUT, PATCH, DELETE) must perform an
+authorization check before any of the following:
+
+- Decoding the request body (`DecodeJSONBody`).
+- Reading or writing the datastore.
+- Issuing any side-effecting call (logging, metrics tag emission with
+  user-supplied keys, outbound HTTP).
+
+Placing the gate first prevents denied callers from probing payload
+shape via validation error messages, and avoids needless datastore
+load on rejected requests.
+
+GET handlers gate on visibility (`resolveVisibleConnections` +
+`clusterMembersVisible` / `clusterHasVisibleConnection`) rather than
+admin permission; that is a different surface and is documented in
+the issue-#35 regression test files.
+
+## Variant 1: Plain Admin Gate
+
+Use this when the handler creates a new object (no owner yet), or
+when the resource is a system-wide concern with no per-object owner
+concept. Examples: cluster creation, topology relationship rewrites,
+server attach/detach, auto-detected group/cluster mutations.
+
+The canonical form, copied as a literal block at the top of the
+handler body:
+
+```go
+if !h.rbacChecker.HasAdminPermission(r.Context(),
+    auth.PermManageConnections) {
+    RespondError(w, http.StatusForbidden,
+        "Permission denied: requires manage_connections permission")
+    return
+}
+```
+
+The reference implementation is `updateAutoDetectedCluster` in
+`server/src/internal/api/cluster_handlers.go`. Use the same error
+wording so the client-facing message stays uniform across endpoints.
+
+## Variant 2: Owner-Fallback Gate
+
+Use this for per-object mutations where the row has an
+`owner_username` column populated at creation time. A non-admin
+caller who owns the row may still mutate it; everyone else needs
+`PermManageConnections`. The reference is `updateClusterGroup` /
+`deleteClusterGroup` in `cluster_handlers.go`:
+
+```go
+username, _, err := getUserInfoCompat(r, h.authStore)
+if err != nil {
+    RespondError(w, http.StatusUnauthorized,
+        "Invalid or missing authentication token")
+    return
+}
+
+hasManageConns := h.rbacChecker.HasAdminPermission(r.Context(),
+    auth.PermManageConnections)
+
+ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+defer cancel()
+
+existing, err := h.datastore.Get<Resource>(ctx, id)
+if err != nil {
+    log.Printf("[ERROR] <resource> not found for <action> (id=%d): %v",
+        id, err)
+    RespondError(w, http.StatusNotFound, "<Resource> not found")
+    return
+}
+
+isOwner := existing.OwnerUsername.Valid &&
+    existing.OwnerUsername.String == username
+if !hasManageConns && !isOwner {
+    RespondError(w, http.StatusForbidden,
+        "You do not have permission to <verb> this <resource>")
+    return
+}
+```
+
+`getUserInfoCompat` validates the bearer token against the auth
+store, while `HasAdminPermission` reads the user ID from the request
+context. Both must succeed: handler-level tests bypass the middleware
+that normally populates the context, so callers must set BOTH the
+`Authorization` header (via `withBearer`) AND the user context (via
+`withUser`).
+
+A 404 leak here is acceptable: callers who can authenticate but who
+do not own the row and lack `PermManageConnections` cannot distinguish
+"row exists but I can't touch it" from "row doesn't exist" because
+the 404 happens before the 403 check. That matches the existing
+issue-#35 visibility contract.
+
+## Variant 3: Plain Admin Gate (visibility-stake reasoning)
+
+Use this for per-object cluster mutations (`updateCluster`,
+`deleteCluster`) where there is no `owner_username` column on the
+underlying table. The `clusters` table (see
+`collector/src/database/schema.go`) deliberately omits ownership;
+cluster authorship is encoded through the cluster's member
+connections, not directly on the cluster row.
+
+The gate is the plain admin variant. The handler's existing
+visibility check (`clusterHasVisibleConnection`) still returns 404
+for callers who cannot see the cluster, so denied callers are
+correctly hidden from the topology. The gate adds a separate
+"non-admin callers cannot mutate" rule on top.
+
+Do NOT attempt to fake ownership from visibility (e.g. "caller can
+see at least one member connection"). Visibility includes connections
+shared with the caller via groups; a shared-stake user is not the
+cluster's owner and should not be granted mutation rights.
+
+If a future schema change adds `owner_username` to the `clusters`
+table, migrate these two handlers to Variant 2.
+
+## Test Patterns
+
+The regression tests live in
+`server/src/internal/api/rbac_issue207_clusters_test.go`. Mirror them
+when adding a new gated handler.
+
+### Denial test (no Postgres required)
+
+```go
+func TestHandler_FeatureName_Issue207_Denied(t *testing.T) {
+    handler, store, cleanup := newIssue207Handler(t)
+    defer cleanup()
+    userID := newIssue207UnprivilegedUser(t, store, "issue207_feature")
+
+    body, _ := json.Marshal(SomeRequest{...})
+    req := httptest.NewRequest(http.MethodPost, "/api/v1/...",
+        bytes.NewReader(body))
+    req.Header.Set("Content-Type", "application/json")
+    req = withUser(req, userID)
+    rec := httptest.NewRecorder()
+
+    handler.theHandler(rec, req, ...)
+
+    assertForbiddenWithMessage(t, rec)
+}
+```
+
+The handler is built with a nil datastore so the test asserts that
+the 403 happens BEFORE any datastore call. A panic from a nil
+datastore is a regression: it means the gate was placed after the
+datastore call.
+
+### "Denied skips decode" test
+
+For handlers that decode a JSON body, add a second denial test that
+sends invalid JSON. Without the gate ordering rule the handler would
+return 400 ("Invalid request body"); with the gate first it must
+return 403. This catches a regression where someone moves the gate
+below `DecodeJSONBody`.
+
+### Admin-allowed sanity test (no Postgres required)
+
+```go
+func TestHandler_FeatureName_Issue207_AdminAllowed(t *testing.T) {
+    _, store, cleanup := createTestRBACHandler(t)
+    defer cleanup()
+    userID := setupUserWithPermission(t, store, "issue207_admin",
+        auth.PermManageConnections)
+    checker := auth.NewRBACChecker(store)
+    handler := NewClusterHandler(nil, store, checker)
+
+    body, _ := json.Marshal(SomeRequest{...})
+    req := httptest.NewRequest(http.MethodPost, "/api/v1/...",
+        bytes.NewReader(body))
+    req.Header.Set("Content-Type", "application/json")
+    req = withUser(req, userID)
+    rec := httptest.NewRecorder()
+
+    assertGatePassed(t, rec, func() {
+        handler.theHandler(rec, req, ...)
+    })
+}
+```
+
+`assertGatePassed` runs the handler with a deferred recover() so the
+test asserts only that the gate did not return 403. Coverage of the
+post-gate datastore code path lives in the integration tests gated on
+`TEST_AI_WORKBENCH_SERVER`.
+
+### Owner-fallback test (requires Postgres)
+
+For Variant 2 handlers, add an integration test that:
+
+1. Creates a fresh row owned by the caller (UPDATE
+   `owner_username = $caller` if `CreateX` does not set it).
+2. Sends the mutating request with `withBearer` AND `withUser`.
+3. Asserts 200/204 (allowed), then verifies the row was actually
+   mutated/deleted via a follow-up datastore query.
+
+A second test should cover the denial case: a non-owner non-admin
+caller, with the same row, gets 403 and the row is unchanged.
+
+## Coverage Floor
+
+Per `CLAUDE.md`, every modified file must reach at least 90% line
+coverage. Cluster handlers depend heavily on the datastore, so most
+of the coverage uplift comes from the integration suite. CI runs
+`make coverage` with `TEST_AI_WORKBENCH_SERVER` set, exercising the
+integration paths; local runs without Postgres will show lower
+numbers but should still cover every newly-added gate via the
+unit-style "denied" and "admin allowed" tests above.
+
+When you add a gate, add at minimum:
+
+- One "denied" unit test (negative path, no Postgres).
+- One "admin allowed" unit test (gate passes, no Postgres).
+- For Variant 2 handlers: one "owner allowed" integration test
+  (Postgres-gated).
+
+The denial test plus the gate body (5 statements) covers the new
+lines; the admin-allowed test covers the not-taken branch.

--- a/.claude/react-expert/quality-checklist.md
+++ b/.claude/react-expert/quality-checklist.md
@@ -145,6 +145,67 @@ existing instances do not need to be fixed in unrelated changes.
 - [ ] Edge cases covered (empty, error, loading).
 - [ ] Accessibility tested.
 
+## Permission-Gated UI
+
+Hide actions a user cannot perform; do not render disabled
+placeholders. Read permissions from the `useAuth` context hook at
+`client/src/contexts/useAuth.ts`. The hook returns
+`hasPermission(perm: string)`, which already accounts for the
+`isSuperuser` flag and the `*` wildcard in `adminPermissions`, so
+call sites only need to ask for the specific permission they
+require.
+
+In the following example, the menu item only renders when the user
+holds `manage_connections`:
+
+```tsx
+import { useAuth } from '../contexts/useAuth';
+
+const { hasPermission } = useAuth();
+const canManageConnections = hasPermission('manage_connections');
+
+return (
+    <Menu>
+        <MenuItem>Always visible</MenuItem>
+        {canManageConnections && (
+            <MenuItem onClick={onAddCluster}>Add Cluster</MenuItem>
+        )}
+    </Menu>
+);
+```
+
+Reference implementations:
+
+- `client/src/components/AdminPanel/index.tsx` filters whole nav
+  sections by `hasPermission(item.permission)`.
+- `client/src/components/AddMenu.tsx` hides Add Cluster and Add
+  Cluster Group when the user lacks `manage_connections`.
+
+Permission strings must match the server-side constants exactly;
+see `server/src/internal/auth/token_scope.go` for the canonical
+list (for example, `auth.PermManageConnections` maps to the string
+`"manage_connections"`).
+
+Tests for gated UI should cover three states:
+
+- User with the permission renders the gated items.
+- User without the permission renders neither the items nor any
+  divider or affordance that only exists to separate them, but
+  every ungated item still renders.
+- The unauthenticated or still-loading state (where
+  `hasPermission` returns `false` for everything) renders the
+  same safe default as the "without permission" case.
+
+Mock `useAuth` per test file rather than the full `AuthProvider`
+so the permission shape is explicit at the call site:
+
+```ts
+const mockHasPermission = vi.fn<(perm: string) => boolean>(() => true);
+vi.mock('../../contexts/useAuth', () => ({
+    useAuth: () => ({ hasPermission: mockHasPermission }),
+}));
+```
+
 ## New Feature Review Checklist
 
 ### Code Quality

--- a/client/src/components/AddMenu.tsx
+++ b/client/src/components/AddMenu.tsx
@@ -21,6 +21,7 @@ import {
     Folder as FolderIcon,
     Hub as HubIcon,
 } from '@mui/icons-material';
+import { useAuth } from '../contexts/useAuth';
 
 interface AddMenuProps {
     anchorEl: HTMLElement | null;
@@ -33,6 +34,12 @@ interface AddMenuProps {
 
 /**
  * A dropdown menu for adding servers or cluster groups.
+ *
+ * The "Add Cluster" and "Add Cluster Group" entries require the
+ * `manage_connections` admin permission and are omitted entirely for
+ * users that lack it. The server enforces the same restriction with a
+ * 403 response, so hiding the menu items keeps unauthorized users from
+ * seeing actions they cannot perform.
  */
 const AddMenu: React.FC<AddMenuProps> = ({
     anchorEl,
@@ -42,6 +49,9 @@ const AddMenu: React.FC<AddMenuProps> = ({
     onAddCluster,
     onAddGroup,
 }) => {
+    const { hasPermission } = useAuth();
+    const canManageConnections = hasPermission('manage_connections');
+
     const handleAddServer = () => {
         if (onAddServer) {
             onAddServer();
@@ -89,19 +99,23 @@ const AddMenu: React.FC<AddMenuProps> = ({
                 </ListItemIcon>
                 <ListItemText primary="Add Server" />
             </MenuItem>
-            <MenuItem onClick={handleAddCluster}>
-                <ListItemIcon>
-                    <HubIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary="Add Cluster" />
-            </MenuItem>
-            <Divider />
-            <MenuItem onClick={handleAddGroup}>
-                <ListItemIcon>
-                    <FolderIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary="Add Cluster Group" />
-            </MenuItem>
+            {canManageConnections && (
+                <MenuItem onClick={handleAddCluster}>
+                    <ListItemIcon>
+                        <HubIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Add Cluster" />
+                </MenuItem>
+            )}
+            {canManageConnections && <Divider />}
+            {canManageConnections && (
+                <MenuItem onClick={handleAddGroup}>
+                    <ListItemIcon>
+                        <FolderIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Add Cluster Group" />
+                </MenuItem>
+            )}
         </Menu>
     );
 };

--- a/client/src/components/__tests__/AddMenu.test.tsx
+++ b/client/src/components/__tests__/AddMenu.test.tsx
@@ -132,6 +132,7 @@ describe('AddMenu', () => {
             expect(
                 screen.queryByText('Add Cluster Group'),
             ).not.toBeInTheDocument();
+            expect(screen.queryByRole('separator')).not.toBeInTheDocument();
         });
 
         it('still allows Add Server to fire its callback', () => {
@@ -160,6 +161,7 @@ describe('AddMenu', () => {
             expect(
                 screen.queryByText('Add Cluster Group'),
             ).not.toBeInTheDocument();
+            expect(screen.queryByRole('separator')).not.toBeInTheDocument();
         });
     });
 

--- a/client/src/components/__tests__/AddMenu.test.tsx
+++ b/client/src/components/__tests__/AddMenu.test.tsx
@@ -1,0 +1,177 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import renderWithTheme from '../../test/renderWithTheme';
+import AddMenu from '../AddMenu';
+
+// Mock useAuth so the test can vary the user's permissions without
+// having to mount the full AuthProvider and stub the user info API.
+const mockHasPermission = vi.fn<(perm: string) => boolean>(() => true);
+
+vi.mock('../../contexts/useAuth', () => ({
+    useAuth: () => ({
+        hasPermission: mockHasPermission,
+    }),
+}));
+
+interface RenderOptions {
+    open?: boolean;
+    onAddServer?: () => void;
+    onAddCluster?: () => void;
+    onAddGroup?: () => void;
+    onClose?: () => void;
+}
+
+const renderAddMenu = (options: RenderOptions = {}) => {
+    const anchor = document.createElement('div');
+    document.body.appendChild(anchor);
+
+    const props = {
+        anchorEl: anchor,
+        open: options.open ?? true,
+        onClose: options.onClose ?? vi.fn(),
+        onAddServer: options.onAddServer,
+        onAddCluster: options.onAddCluster,
+        onAddGroup: options.onAddGroup,
+    };
+
+    return renderWithTheme(<AddMenu {...props} />);
+};
+
+describe('AddMenu', () => {
+    beforeEach(() => {
+        mockHasPermission.mockReset();
+        mockHasPermission.mockReturnValue(true);
+    });
+
+    describe('with manage_connections permission', () => {
+        beforeEach(() => {
+            mockHasPermission.mockImplementation(
+                (perm: string) => perm === 'manage_connections',
+            );
+        });
+
+        it('renders Add Server, Add Cluster, and Add Cluster Group', () => {
+            renderAddMenu();
+
+            expect(screen.getByText('Add Server')).toBeInTheDocument();
+            expect(screen.getByText('Add Cluster')).toBeInTheDocument();
+            expect(screen.getByText('Add Cluster Group')).toBeInTheDocument();
+        });
+
+        it('queries for the manage_connections permission', () => {
+            renderAddMenu();
+
+            expect(mockHasPermission).toHaveBeenCalledWith('manage_connections');
+        });
+
+        it('invokes onAddServer and closes when Add Server is clicked', () => {
+            const onAddServer = vi.fn();
+            const onClose = vi.fn();
+            renderAddMenu({ onAddServer, onClose });
+
+            fireEvent.click(screen.getByText('Add Server'));
+
+            expect(onAddServer).toHaveBeenCalledTimes(1);
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('invokes onAddCluster and closes when Add Cluster is clicked', () => {
+            const onAddCluster = vi.fn();
+            const onClose = vi.fn();
+            renderAddMenu({ onAddCluster, onClose });
+
+            fireEvent.click(screen.getByText('Add Cluster'));
+
+            expect(onAddCluster).toHaveBeenCalledTimes(1);
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('invokes onAddGroup and closes when Add Cluster Group is clicked', () => {
+            const onAddGroup = vi.fn();
+            const onClose = vi.fn();
+            renderAddMenu({ onAddGroup, onClose });
+
+            fireEvent.click(screen.getByText('Add Cluster Group'));
+
+            expect(onAddGroup).toHaveBeenCalledTimes(1);
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('closes even when callbacks are not provided', () => {
+            const onClose = vi.fn();
+            renderAddMenu({ onClose });
+
+            fireEvent.click(screen.getByText('Add Server'));
+            fireEvent.click(screen.getByText('Add Cluster'));
+            fireEvent.click(screen.getByText('Add Cluster Group'));
+
+            expect(onClose).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe('without manage_connections permission', () => {
+        beforeEach(() => {
+            mockHasPermission.mockReturnValue(false);
+        });
+
+        it('renders only Add Server', () => {
+            renderAddMenu();
+
+            expect(screen.getByText('Add Server')).toBeInTheDocument();
+            expect(screen.queryByText('Add Cluster')).not.toBeInTheDocument();
+            expect(
+                screen.queryByText('Add Cluster Group'),
+            ).not.toBeInTheDocument();
+        });
+
+        it('still allows Add Server to fire its callback', () => {
+            const onAddServer = vi.fn();
+            const onClose = vi.fn();
+            renderAddMenu({ onAddServer, onClose });
+
+            fireEvent.click(screen.getByText('Add Server'));
+
+            expect(onAddServer).toHaveBeenCalledTimes(1);
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('loading or unauthenticated state', () => {
+        it('hides gated items when hasPermission always returns false', () => {
+            // Simulates the AuthProvider's initial state where the user
+            // has not yet loaded and adminPermissions is the empty array,
+            // so hasPermission returns false for every probe.
+            mockHasPermission.mockReturnValue(false);
+
+            renderAddMenu();
+
+            expect(screen.getByText('Add Server')).toBeInTheDocument();
+            expect(screen.queryByText('Add Cluster')).not.toBeInTheDocument();
+            expect(
+                screen.queryByText('Add Cluster Group'),
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('open state', () => {
+        it('does not render menu items when open is false', () => {
+            renderAddMenu({ open: false });
+
+            expect(screen.queryByText('Add Server')).not.toBeInTheDocument();
+            expect(screen.queryByText('Add Cluster')).not.toBeInTheDocument();
+            expect(
+                screen.queryByText('Add Cluster Group'),
+            ).not.toBeInTheDocument();
+        });
+    });
+});

--- a/client/src/components/__tests__/ClusterNavigator.test.tsx
+++ b/client/src/components/__tests__/ClusterNavigator.test.tsx
@@ -39,7 +39,13 @@ const {
     mockDeleteGroup: vi.fn(),
     mockMoveClusterToGroup: vi.fn(),
     mockFetchClusterData: vi.fn(),
-    mockUseAuth: vi.fn(() => ({ user: { isSuperuser: false } })),
+    mockUseAuth: vi.fn((): {
+        user: { isSuperuser: boolean };
+        hasPermission: (perm: string) => boolean;
+    } => ({
+        user: { isSuperuser: false },
+        hasPermission: () => false,
+    })),
 }));
 
 // Mock the AuthContext
@@ -181,6 +187,7 @@ describe('ClusterNavigator', () => {
         mockFetchClusterData.mockReset().mockResolvedValue(undefined);
         mockUseAuth.mockReset().mockReturnValue({
             user: { isSuperuser: false },
+            hasPermission: () => false,
         });
     });
 
@@ -497,7 +504,10 @@ describe('ClusterNavigator', () => {
 
         it('passes the unchanged "group-{id}" string from configure to updateGroupName', async () => {
             // Superuser is required to see the settings (configure) button
-            mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
+            mockUseAuth.mockReturnValue({
+                user: { isSuperuser: true },
+                hasPermission: () => true,
+            });
 
             renderWithTheme(
                 <ClusterNavigator
@@ -559,7 +569,10 @@ describe('ClusterNavigator', () => {
         }, 20000);
 
         it('calls createGroup (not updateGroupName) when saving from the Add Group flow', async () => {
-            mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
+            mockUseAuth.mockReturnValue({
+                user: { isSuperuser: true },
+                hasPermission: () => true,
+            });
 
             renderWithTheme(
                 <ClusterNavigator
@@ -613,7 +626,10 @@ describe('ClusterNavigator', () => {
         }, 20000);
 
         it('renders the Alert overrides panel with a numeric scopeId extracted from "group-{id}"', async () => {
-            mockUseAuth.mockReturnValue({ user: { isSuperuser: true } });
+            mockUseAuth.mockReturnValue({
+                user: { isSuperuser: true },
+                hasPermission: () => true,
+            });
 
             renderWithTheme(
                 <ClusterNavigator

--- a/docs/admin-guide/api/openapi.json
+++ b/docs/admin-guide/api/openapi.json
@@ -2281,7 +2281,7 @@
       },
       "post": {
         "summary": "Create a cluster group",
-        "description": "Creates a new cluster group",
+        "description": "Creates a new cluster group. Requires manage_connections permission.",
         "operationId": "createClusterGroup",
         "tags": [
           "Cluster Groups"
@@ -2320,6 +2320,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -2482,7 +2492,7 @@
       },
       "delete": {
         "summary": "Delete a cluster group",
-        "description": "Deletes a cluster group",
+        "description": "Deletes a cluster group. Requires manage_connections permission.",
         "operationId": "deleteClusterGroup",
         "tags": [
           "Cluster Groups"
@@ -2513,7 +2523,7 @@
             }
           },
           "403": {
-            "description": "Cannot delete default group",
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -2602,7 +2612,7 @@
       },
       "post": {
         "summary": "Create a cluster in a group",
-        "description": "Creates a new cluster within a group",
+        "description": "Creates a new cluster within a group. Requires manage_connections permission.",
         "operationId": "createClusterInGroup",
         "tags": [
           "Cluster Groups"
@@ -2652,6 +2662,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -2716,7 +2736,7 @@
       },
       "post": {
         "summary": "Create a cluster",
-        "description": "Creates a new cluster, optionally assigned to a group",
+        "description": "Creates a new cluster, optionally assigned to a group. Requires manage_connections permission.",
         "operationId": "createCluster",
         "tags": [
           "Clusters"
@@ -2764,7 +2784,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -2880,7 +2900,7 @@
       },
       "put": {
         "summary": "Update a cluster",
-        "description": "Updates cluster name, description, or group assignment",
+        "description": "Updates cluster name, description, or group assignment. Requires manage_connections permission.",
         "operationId": "updateCluster",
         "tags": [
           "Clusters"
@@ -2939,7 +2959,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -2967,7 +2987,7 @@
       },
       "delete": {
         "summary": "Delete a cluster",
-        "description": "Deletes a cluster. Manually created clusters are hard-deleted. Auto-detected clusters are soft-deleted by setting dismissed=true so they do not reappear in topology. This applies to persisted auto-detected clusters addressed by numeric ID and to transient auto-detected IDs (server-{id} or cluster-spock-{prefix}).",
+        "description": "Deletes a cluster. Manually created clusters are hard-deleted. Auto-detected clusters are soft-deleted by setting dismissed=true so they do not reappear in topology. This applies to persisted auto-detected clusters addressed by numeric ID and to transient auto-detected IDs (server-{id} or cluster-spock-{prefix}). Requires manage_connections permission.",
         "operationId": "deleteCluster",
         "tags": [
           "Clusters"
@@ -2998,7 +3018,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -3009,6 +3029,175 @@
           },
           "404": {
             "description": "Cluster not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/clusters/{id}/connections/{connId}/relationships": {
+      "put": {
+        "summary": "Set connection relationships",
+        "description": "Replaces the replication relationships for a connection within a cluster. Requires manage_connections permission.",
+        "operationId": "setConnectionRelationships",
+        "tags": [
+          "Clusters"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Cluster ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "connId",
+            "in": "path",
+            "description": "Source connection ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Relationship definitions",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetRelationshipsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Relationships updated"
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Requires manage_connections permission",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Cluster or connection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Clear connection relationships",
+        "description": "Removes all replication relationships for a connection within a cluster. Requires manage_connections permission.",
+        "operationId": "clearConnectionRelationships",
+        "tags": [
+          "Clusters"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Cluster ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "connId",
+            "in": "path",
+            "description": "Source connection ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Relationships cleared"
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Requires manage_connections permission",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Cluster or connection not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3079,7 +3268,7 @@
     "/clusters/{id}/relationships/{relationshipId}": {
       "delete": {
         "summary": "Delete cluster relationship",
-        "description": "Deletes a specific cluster relationship",
+        "description": "Deletes a specific cluster relationship. Requires manage_connections permission.",
         "operationId": "deleteClusterRelationship",
         "tags": [
           "Clusters"
@@ -3120,6 +3309,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -3198,7 +3397,7 @@
       },
       "post": {
         "summary": "Add server to cluster",
-        "description": "Assigns a server connection to a cluster with an optional role",
+        "description": "Assigns a server connection to a cluster with an optional role. Requires manage_connections permission.",
         "operationId": "addServerToCluster",
         "tags": [
           "Clusters"
@@ -3250,7 +3449,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -3270,7 +3469,7 @@
     "/clusters/{id}/servers/{connectionId}": {
       "delete": {
         "summary": "Remove server from cluster",
-        "description": "Removes a server connection from a cluster",
+        "description": "Removes a server connection from a cluster. Requires manage_connections permission.",
         "operationId": "removeServerFromCluster",
         "tags": [
           "Clusters"
@@ -3320,7 +3519,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {
@@ -11141,6 +11340,23 @@
           }
         }
       },
+      "RelationshipInput": {
+        "type": "object",
+        "properties": {
+          "relationship_type": {
+            "type": "string",
+            "description": "Relationship type"
+          },
+          "target_connection_id": {
+            "type": "integer",
+            "description": "Target connection ID"
+          }
+        },
+        "required": [
+          "target_connection_id",
+          "relationship_type"
+        ]
+      },
       "SaveAnalysisRequest": {
         "type": "object",
         "properties": {
@@ -11245,6 +11461,21 @@
             "description": "System information (OS, CPU, memory, disks)"
           }
         }
+      },
+      "SetRelationshipsRequest": {
+        "type": "object",
+        "properties": {
+          "relationships": {
+            "type": "array",
+            "description": "Relationship definitions from the source connection",
+            "items": {
+              "$ref": "#/components/schemas/RelationshipInput"
+            }
+          }
+        },
+        "required": [
+          "relationships"
+        ]
       },
       "StatusResponse": {
         "type": "object",

--- a/docs/admin-guide/api/openapi.json
+++ b/docs/admin-guide/api/openapi.json
@@ -2492,7 +2492,7 @@
       },
       "delete": {
         "summary": "Delete a cluster group",
-        "description": "Deletes a cluster group. Requires manage_connections permission.",
+        "description": "Deletes a cluster group. Requires manage_connections permission or ownership of the cluster group.",
         "operationId": "deleteClusterGroup",
         "tags": [
           "Cluster Groups"
@@ -2523,7 +2523,7 @@
             }
           },
           "403": {
-            "description": "Requires manage_connections permission",
+            "description": "Requires manage_connections permission or ownership of the cluster group",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -300,6 +300,32 @@ project adheres to
   regression tests cover every affected handler.
   (#67)
 
+- Require the `manage_connections` permission on all
+  cluster and cluster-group mutating endpoints; users
+  without the permission previously could create
+  cluster groups and clusters through the REST API,
+  and the server silently committed the rows and
+  returned a success status even though the resulting
+  records were invisible to the creator while remaining
+  visible to administrators. A follow-up audit found
+  the same gap on additional mutating routes, so the
+  fix now gates eleven endpoints in total: creating
+  and deleting cluster groups, adding clusters to a
+  group, creating, updating, and deleting clusters,
+  adding and removing cluster servers, and creating,
+  updating, and deleting cluster relationships.
+  Unauthorized callers now receive a `403 Forbidden`
+  response with a clear authorization error instead of
+  a misleading success, and the group owner can still
+  delete a group they own even without the permission.
+  The web client's Add menu now hides the "Add Cluster
+  Group" and "Add Cluster" entries from users who lack
+  `manage_connections`, and the OpenAPI specification
+  and static `docs/admin-guide/api/openapi.json`
+  document the `403 Forbidden` response on the
+  affected paths. Administrators see no functional
+  change. (#207)
+
 ### Fixed
 
 - Fix the `Chart.test.tsx` regression introduced in

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -597,9 +597,11 @@ func (h *ClusterHandler) updateClusterGroup(w http.ResponseWriter, r *http.Reque
 func (h *ClusterHandler) deleteClusterGroup(w http.ResponseWriter, r *http.Request, id int) {
 	// Issue #207: owner-fallback authorization. Admins with
 	// manage_connections can delete any group; the group's owner can
-	// delete their own group. Anyone else gets 403 before any datastore
-	// read so denied callers cannot probe group existence via timing or
-	// error wording.
+	// delete their own group. Authorization is enforced early (before
+	// request decoding and any response body write). GetClusterGroup is
+	// necessarily called to verify ownership, so a callable user can
+	// still distinguish 404 vs 403, but unauthenticated and clearly
+	// unauthorized callers are rejected up front.
 	username, _, err := getUserInfoCompat(r, h.authStore)
 	if err != nil {
 		RespondError(w, http.StatusUnauthorized,

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -513,6 +513,15 @@ func (h *ClusterHandler) getClusterGroup(w http.ResponseWriter, r *http.Request,
 }
 
 func (h *ClusterHandler) createClusterGroup(w http.ResponseWriter, r *http.Request) {
+	// Issue #207: gate cluster-group creation on manage_connections.
+	// Check before decoding the body so denied callers cannot probe payload
+	// shape via validation error messages.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	var req ClusterGroupRequest
 	if !DecodeJSONBody(w, r, &req) {
 		return
@@ -586,8 +595,38 @@ func (h *ClusterHandler) updateClusterGroup(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *ClusterHandler) deleteClusterGroup(w http.ResponseWriter, r *http.Request, id int) {
+	// Issue #207: owner-fallback authorization. Admins with
+	// manage_connections can delete any group; the group's owner can
+	// delete their own group. Anyone else gets 403 before any datastore
+	// read so denied callers cannot probe group existence via timing or
+	// error wording.
+	username, _, err := getUserInfoCompat(r, h.authStore)
+	if err != nil {
+		RespondError(w, http.StatusUnauthorized,
+			"Invalid or missing authentication token")
+		return
+	}
+
+	hasManageConns := h.rbacChecker.HasAdminPermission(r.Context(),
+		auth.PermManageConnections)
+
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
+
+	existingGroup, err := h.datastore.GetClusterGroup(ctx, id)
+	if err != nil {
+		log.Printf("[ERROR] Cluster group not found for delete (id=%d): %v", id, err)
+		RespondError(w, http.StatusNotFound, "Cluster group not found")
+		return
+	}
+
+	isOwner := existingGroup.OwnerUsername.Valid &&
+		existingGroup.OwnerUsername.String == username
+	if !hasManageConns && !isOwner {
+		RespondError(w, http.StatusForbidden,
+			"You do not have permission to delete this cluster group")
+		return
+	}
 
 	visible, allConnections, err := h.resolveVisibleConnections(ctx)
 	if err != nil {
@@ -698,6 +737,13 @@ func (h *ClusterHandler) listClustersInGroup(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *ClusterHandler) createClusterInGroup(w http.ResponseWriter, r *http.Request, groupID int) {
+	// Issue #207: gate cluster creation under a group on manage_connections.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	var req ClusterRequest
 	if !DecodeJSONBody(w, r, &req) {
 		return
@@ -755,6 +801,19 @@ func (h *ClusterHandler) getCluster(w http.ResponseWriter, r *http.Request, id i
 }
 
 func (h *ClusterHandler) updateCluster(w http.ResponseWriter, r *http.Request, id int) {
+	// Issue #207: gate cluster mutations on manage_connections. The
+	// spec asked for an owner-fallback variant, but the clusters table
+	// (see collector/src/database/schema.go) has no owner_username
+	// column, so no literal owner check is possible without a schema
+	// change. Apply the plain admin gate; the visibility check farther
+	// down still returns 404 for callers who cannot see the cluster, so
+	// the gate is layered on top of existing visibility filtering.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	var req ClusterRequest
 	if !DecodeJSONBody(w, r, &req) {
 		return
@@ -799,6 +858,17 @@ func (h *ClusterHandler) updateCluster(w http.ResponseWriter, r *http.Request, i
 }
 
 func (h *ClusterHandler) deleteCluster(w http.ResponseWriter, r *http.Request, id int) {
+	// Issue #207: plain admin gate. Same rationale as updateCluster: the
+	// clusters table has no owner_username column, so the spec's
+	// "owner-fallback" cannot be applied literally. Admins with
+	// manage_connections can delete; everyone else is rejected before
+	// any datastore read.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
@@ -1055,6 +1125,14 @@ func (h *ClusterHandler) listServersInCluster(w http.ResponseWriter, r *http.Req
 
 // addServerToCluster handles POST /api/v1/clusters/{id}/servers
 func (h *ClusterHandler) addServerToCluster(w http.ResponseWriter, r *http.Request, clusterID int) {
+	// Issue #207: server-attach is a system-topology mutation with no
+	// clear owner concept; apply the plain admin gate.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	var req AddServerToClusterRequest
 	if !DecodeJSONBody(w, r, &req) {
 		return
@@ -1118,6 +1196,14 @@ func (h *ClusterHandler) handleRemoveServerFromCluster(w http.ResponseWriter, r 
 	if r.Method != http.MethodDelete {
 		w.Header().Set("Allow", "DELETE")
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Issue #207: server-detach is a system-topology mutation with no
+	// clear owner concept; apply the plain admin gate.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
 		return
 	}
 
@@ -1213,6 +1299,14 @@ func (h *ClusterHandler) handleListClusters(w http.ResponseWriter, r *http.Reque
 
 // handleCreateCluster handles POST /api/v1/clusters
 func (h *ClusterHandler) handleCreateCluster(w http.ResponseWriter, r *http.Request) {
+	// Issue #207: cluster creation has no notion of owner before
+	// creation, so apply the plain admin gate.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	var req ManualClusterRequest
 	if !DecodeJSONBody(w, r, &req) {
 		return
@@ -1294,6 +1388,14 @@ func (h *ClusterHandler) handleConnectionRelationships(w http.ResponseWriter, r 
 // setConnectionRelationships handles PUT
 // /api/v1/clusters/{id}/connections/{connId}/relationships
 func (h *ClusterHandler) setConnectionRelationships(w http.ResponseWriter, r *http.Request, clusterID int, connID int) {
+	// Issue #207: topology relationships are a system-wide concern with
+	// no per-object owner; apply the plain admin gate.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	var req SetRelationshipsRequest
 	if !DecodeJSONBody(w, r, &req) {
 		return
@@ -1409,6 +1511,14 @@ func (h *ClusterHandler) handleDeleteRelationship(w http.ResponseWriter, r *http
 		return
 	}
 
+	// Issue #207: topology relationships are a system-wide concern with
+	// no per-object owner; apply the plain admin gate.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
@@ -1424,6 +1534,14 @@ func (h *ClusterHandler) handleDeleteRelationship(w http.ResponseWriter, r *http
 // clearConnectionRelationships handles DELETE
 // /api/v1/clusters/{id}/connections/{connId}/relationships
 func (h *ClusterHandler) clearConnectionRelationships(w http.ResponseWriter, r *http.Request, clusterID int, connID int) {
+	// Issue #207: topology relationships are a system-wide concern with
+	// no per-object owner; apply the plain admin gate.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -983,8 +983,19 @@ func TestClusterHandler_UpdateAutoDetectedGroup_InvalidJSON(t *testing.T) {
 // cluster group operations touch. It is a trimmed copy of the collector
 // migration and is intentionally limited to the columns and constraints
 // referenced by GetClusterGroup, CreateClusterGroup, UpdateClusterGroup,
-// DeleteClusterGroup, GetDefaultGroupID, and UpsertGroupByAutoKey.
+// DeleteClusterGroup, GetDefaultGroupID, UpsertGroupByAutoKey, and the
+// RBAC visibility helpers that run as part of deleteClusterGroup
+// (resolveVisibleConnections -> GetAllConnections, and
+// groupHasVisibleConnection -> getConnectionIDsForGroup, which joins
+// connections to clusters). The clusters and connections tables are
+// created empty: the cluster_groups operations do not depend on rows in
+// either, and the visibility helpers tolerate an empty connections set
+// (allConnections=false, empty visible map). This keeps the schema
+// closed under the queries the handler actually issues without pulling
+// in the full collector migration.
 const clusterGroupsTestSchema = `
+DROP TABLE IF EXISTS connections CASCADE;
+DROP TABLE IF EXISTS clusters CASCADE;
 DROP TABLE IF EXISTS cluster_groups CASCADE;
 CREATE TABLE cluster_groups (
     id SERIAL PRIMARY KEY,
@@ -1001,6 +1012,33 @@ CREATE TABLE cluster_groups (
 );
 CREATE UNIQUE INDEX idx_cluster_groups_is_default
     ON cluster_groups (is_default) WHERE is_default = TRUE;
+CREATE TABLE clusters (
+    id SERIAL PRIMARY KEY,
+    group_id INTEGER REFERENCES cluster_groups(id) ON DELETE CASCADE,
+    auto_cluster_key VARCHAR(255) UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    replication_type VARCHAR(50),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT clusters_group_name_unique UNIQUE (group_id, name)
+);
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    owner_username VARCHAR(255),
+    owner_token VARCHAR(255),
+    is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+    is_monitored BOOLEAN NOT NULL DEFAULT FALSE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT DEFAULT '',
+    host VARCHAR(255) NOT NULL DEFAULT 'localhost',
+    port INTEGER NOT NULL DEFAULT 5432,
+    database_name VARCHAR(255) NOT NULL DEFAULT 'postgres',
+    cluster_id INTEGER REFERENCES clusters(id) ON DELETE SET NULL,
+    membership_source VARCHAR(20) NOT NULL DEFAULT 'auto',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 `
 
 // newTestDatastore returns a *database.Datastore wired to the Postgres
@@ -1037,7 +1075,11 @@ func newTestDatastore(t *testing.T) (*database.Datastore, *pgxpool.Pool, func())
 	ds := database.NewTestDatastore(pool)
 
 	cleanup := func() {
-		// Best-effort teardown of the test schema.
+		// Best-effort teardown of the test schema. Drop in
+		// dependency order: connections -> clusters -> cluster_groups.
+		// CASCADE handles any auxiliary objects (indexes, FKs).
+		_, _ = pool.Exec(context.Background(), "DROP TABLE IF EXISTS connections CASCADE")
+		_, _ = pool.Exec(context.Background(), "DROP TABLE IF EXISTS clusters CASCADE")
 		_, _ = pool.Exec(context.Background(), "DROP TABLE IF EXISTS cluster_groups CASCADE")
 		pool.Close()
 	}

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -200,7 +200,12 @@ func TestAssignServerRequest_JSON(t *testing.T) {
 }
 
 func TestClusterHandler_CreateClusterGroup_InvalidRequest(t *testing.T) {
-	handler := NewClusterHandler(nil, nil, nil)
+	// Issue #207 added an admin-permission gate at the top of
+	// createClusterGroup. Using auth.NewRBACChecker(nil) gives a checker
+	// whose HasAdminPermission returns true for every call (nil store =
+	// full access), so the gate is satisfied and the decode-error path
+	// remains the unit under test.
+	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
 
 	// Test with invalid JSON
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups", bytes.NewBufferString("invalid json"))
@@ -223,7 +228,10 @@ func TestClusterHandler_CreateClusterGroup_InvalidRequest(t *testing.T) {
 }
 
 func TestClusterHandler_CreateClusterGroup_MissingName(t *testing.T) {
-	handler := NewClusterHandler(nil, nil, nil)
+	// Use auth.NewRBACChecker(nil) so the issue #207 admin gate at the
+	// top of createClusterGroup is satisfied; the unit under test is the
+	// "Name is required" validation downstream.
+	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
 
 	// Test with missing name
 	body := `{"description": "Test group"}`
@@ -248,7 +256,10 @@ func TestClusterHandler_CreateClusterGroup_MissingName(t *testing.T) {
 }
 
 func TestClusterHandler_UpdateCluster_MissingBothNameAndGroupID(t *testing.T) {
-	handler := NewClusterHandler(nil, nil, nil)
+	// Issue #207 added an admin gate at the top of updateCluster. A
+	// nil-store checker satisfies the gate so the unit under test
+	// remains the "at least one field required" validation.
+	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
 
 	// Test with missing both name and group_id
 	body := `{}`
@@ -462,7 +473,10 @@ func TestClusterHandler_HandleGroupClusters_MethodNotAllowed(t *testing.T) {
 }
 
 func TestClusterHandler_CreateClusterInGroup_MissingName(t *testing.T) {
-	handler := NewClusterHandler(nil, nil, nil)
+	// Issue #207 added an admin gate at the top of createClusterInGroup;
+	// a nil-store checker satisfies the gate so the body-validation path
+	// remains exercised.
+	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
 
 	body := `{"description": "Test"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups/1/clusters",
@@ -609,7 +623,10 @@ func TestClusterHandler_HandleDeleteRelationship_MethodNotAllowed(t *testing.T) 
 }
 
 func TestClusterHandler_SetRelationships_InvalidJSON(t *testing.T) {
-	handler := NewClusterHandler(nil, nil, nil)
+	// Issue #207 added an admin gate at the top of
+	// setConnectionRelationships; a nil-store checker satisfies the gate
+	// so the JSON-decoding path remains the unit under test.
+	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/clusters/1/connections/2/relationships",
 		bytes.NewBufferString("invalid json"))

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -199,13 +199,20 @@ func TestAssignServerRequest_JSON(t *testing.T) {
 	}
 }
 
+// permissionSatisfiedHandler returns a ClusterHandler with no datastore,
+// suitable for tests that only need to verify the auth gate accepts the
+// caller. The RBACChecker is built from a nil auth store, whose
+// HasAdminPermission returns true for every call; the issue #207
+// admin-permission gates therefore pass and the body-validation or
+// decode-error path remains the unit under test. Any post-gate
+// datastore call will panic, which the tests recover from via
+// assertGatePassed or by exercising only pre-datastore paths.
+func permissionSatisfiedHandler() *ClusterHandler {
+	return NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
+}
+
 func TestClusterHandler_CreateClusterGroup_InvalidRequest(t *testing.T) {
-	// Issue #207 added an admin-permission gate at the top of
-	// createClusterGroup. Using auth.NewRBACChecker(nil) gives a checker
-	// whose HasAdminPermission returns true for every call (nil store =
-	// full access), so the gate is satisfied and the decode-error path
-	// remains the unit under test.
-	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
+	handler := permissionSatisfiedHandler()
 
 	// Test with invalid JSON
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups", bytes.NewBufferString("invalid json"))
@@ -228,10 +235,7 @@ func TestClusterHandler_CreateClusterGroup_InvalidRequest(t *testing.T) {
 }
 
 func TestClusterHandler_CreateClusterGroup_MissingName(t *testing.T) {
-	// Use auth.NewRBACChecker(nil) so the issue #207 admin gate at the
-	// top of createClusterGroup is satisfied; the unit under test is the
-	// "Name is required" validation downstream.
-	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
+	handler := permissionSatisfiedHandler()
 
 	// Test with missing name
 	body := `{"description": "Test group"}`
@@ -256,10 +260,7 @@ func TestClusterHandler_CreateClusterGroup_MissingName(t *testing.T) {
 }
 
 func TestClusterHandler_UpdateCluster_MissingBothNameAndGroupID(t *testing.T) {
-	// Issue #207 added an admin gate at the top of updateCluster. A
-	// nil-store checker satisfies the gate so the unit under test
-	// remains the "at least one field required" validation.
-	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
+	handler := permissionSatisfiedHandler()
 
 	// Test with missing both name and group_id
 	body := `{}`
@@ -473,10 +474,7 @@ func TestClusterHandler_HandleGroupClusters_MethodNotAllowed(t *testing.T) {
 }
 
 func TestClusterHandler_CreateClusterInGroup_MissingName(t *testing.T) {
-	// Issue #207 added an admin gate at the top of createClusterInGroup;
-	// a nil-store checker satisfies the gate so the body-validation path
-	// remains exercised.
-	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
+	handler := permissionSatisfiedHandler()
 
 	body := `{"description": "Test"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups/1/clusters",
@@ -623,10 +621,7 @@ func TestClusterHandler_HandleDeleteRelationship_MethodNotAllowed(t *testing.T) 
 }
 
 func TestClusterHandler_SetRelationships_InvalidJSON(t *testing.T) {
-	// Issue #207 added an admin gate at the top of
-	// setConnectionRelationships; a nil-store checker satisfies the gate
-	// so the JSON-decoding path remains the unit under test.
-	handler := NewClusterHandler(nil, nil, auth.NewRBACChecker(nil))
+	handler := permissionSatisfiedHandler()
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/clusters/1/connections/2/relationships",
 		bytes.NewBufferString("invalid json"))

--- a/server/src/internal/api/openapi.go
+++ b/server/src/internal/api/openapi.go
@@ -776,6 +776,25 @@ func buildSchemas() map[string]*OpenAPISchema {
 				"metric_value": {Type: "number", Description: "Metric value at time of analysis"},
 			},
 		},
+		"RelationshipInput": {
+			Type:     "object",
+			Required: []string{"target_connection_id", "relationship_type"},
+			Properties: map[string]*OpenAPISchema{
+				"target_connection_id": {Type: "integer", Description: "Target connection ID"},
+				"relationship_type":    {Type: "string", Description: "Relationship type"},
+			},
+		},
+		"SetRelationshipsRequest": {
+			Type:     "object",
+			Required: []string{"relationships"},
+			Properties: map[string]*OpenAPISchema{
+				"relationships": {
+					Type:        "array",
+					Description: "Relationship definitions from the source connection",
+					Items:       &OpenAPISchema{Ref: "#/components/schemas/RelationshipInput"},
+				},
+			},
+		},
 		"AddServerToClusterRequest": {
 			Type:     "object",
 			Required: []string{"connection_id"},
@@ -1522,7 +1541,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Post: &OpenAPIOperation{
 				Summary:     "Create a cluster",
-				Description: "Creates a new cluster, optionally assigned to a group",
+				Description: "Creates a new cluster, optionally assigned to a group. Requires manage_connections permission.",
 				OperationID: "createCluster",
 				Tags:        []string{"Clusters"},
 				Security:    bearerAuth,
@@ -1531,7 +1550,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"201": jsonResponse("Cluster", "Cluster created"),
 					"400": jsonResponse("ErrorResponse", "Invalid request"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
-					"403": jsonResponse("ErrorResponse", "Forbidden"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 				},
 			},
 		},
@@ -1552,7 +1571,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Put: &OpenAPIOperation{
 				Summary:     "Update a cluster",
-				Description: "Updates cluster name, description, or group assignment",
+				Description: "Updates cluster name, description, or group assignment. Requires manage_connections permission.",
 				OperationID: "updateCluster",
 				Tags:        []string{"Clusters"},
 				Security:    bearerAuth,
@@ -1562,13 +1581,13 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"200": jsonResponse("Cluster", "Updated cluster"),
 					"400": jsonResponse("ErrorResponse", "Invalid request"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
-					"403": jsonResponse("ErrorResponse", "Forbidden"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 					"404": jsonResponse("ErrorResponse", "Cluster not found"),
 				},
 			},
 			Delete: &OpenAPIOperation{
 				Summary:     "Delete a cluster",
-				Description: "Deletes a cluster. Manually created clusters are hard-deleted. Auto-detected clusters are soft-deleted by setting dismissed=true so they do not reappear in topology. This applies to persisted auto-detected clusters addressed by numeric ID and to transient auto-detected IDs (server-{id} or cluster-spock-{prefix}).",
+				Description: "Deletes a cluster. Manually created clusters are hard-deleted. Auto-detected clusters are soft-deleted by setting dismissed=true so they do not reappear in topology. This applies to persisted auto-detected clusters addressed by numeric ID and to transient auto-detected IDs (server-{id} or cluster-spock-{prefix}). Requires manage_connections permission.",
 				OperationID: "deleteCluster",
 				Tags:        []string{"Clusters"},
 				Security:    bearerAuth,
@@ -1576,7 +1595,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 				Responses: map[string]OpenAPIResponse{
 					"204": {Description: "Cluster deleted"},
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
-					"403": jsonResponse("ErrorResponse", "Forbidden"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 					"404": jsonResponse("ErrorResponse", "Cluster not found"),
 				},
 			},
@@ -1598,7 +1617,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Post: &OpenAPIOperation{
 				Summary:     "Add server to cluster",
-				Description: "Assigns a server connection to a cluster with an optional role",
+				Description: "Assigns a server connection to a cluster with an optional role. Requires manage_connections permission.",
 				OperationID: "addServerToCluster",
 				Tags:        []string{"Clusters"},
 				Security:    bearerAuth,
@@ -1608,7 +1627,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"204": {Description: "Server added to cluster"},
 					"400": jsonResponse("ErrorResponse", "Invalid request"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
-					"403": jsonResponse("ErrorResponse", "Forbidden"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 				},
 			},
 		},
@@ -1629,7 +1648,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Post: &OpenAPIOperation{
 				Summary:     "Create a cluster group",
-				Description: "Creates a new cluster group",
+				Description: "Creates a new cluster group. Requires manage_connections permission.",
 				OperationID: "createClusterGroup",
 				Tags:        []string{"Cluster Groups"},
 				Security:    bearerAuth,
@@ -1638,6 +1657,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"201": jsonResponse("ClusterGroup", "Group created"),
 					"400": jsonResponse("ErrorResponse", "Invalid request"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 				},
 			},
 		},
@@ -1674,7 +1694,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Delete: &OpenAPIOperation{
 				Summary:     "Delete a cluster group",
-				Description: "Deletes a cluster group",
+				Description: "Deletes a cluster group. Requires manage_connections permission.",
 				OperationID: "deleteClusterGroup",
 				Tags:        []string{"Cluster Groups"},
 				Security:    bearerAuth,
@@ -1682,7 +1702,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 				Responses: map[string]OpenAPIResponse{
 					"204": {Description: "Group deleted"},
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
-					"403": jsonResponse("ErrorResponse", "Cannot delete default group"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 					"404": jsonResponse("ErrorResponse", "Group not found"),
 				},
 			},
@@ -1704,7 +1724,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Post: &OpenAPIOperation{
 				Summary:     "Create a cluster in a group",
-				Description: "Creates a new cluster within a group",
+				Description: "Creates a new cluster within a group. Requires manage_connections permission.",
 				OperationID: "createClusterInGroup",
 				Tags:        []string{"Cluster Groups"},
 				Security:    bearerAuth,
@@ -1714,6 +1734,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"201": jsonResponse("Cluster", "Cluster created"),
 					"400": jsonResponse("ErrorResponse", "Invalid request"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 				},
 			},
 		},
@@ -2137,7 +2158,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 		"/clusters/{id}/servers/{connectionId}": {
 			Delete: &OpenAPIOperation{
 				Summary:     "Remove server from cluster",
-				Description: "Removes a server connection from a cluster",
+				Description: "Removes a server connection from a cluster. Requires manage_connections permission.",
 				OperationID: "removeServerFromCluster",
 				Tags:        []string{"Clusters"},
 				Security:    bearerAuth,
@@ -2149,7 +2170,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"204": {Description: "Server removed from cluster"},
 					"400": jsonResponse("ErrorResponse", "Invalid request"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
-					"403": jsonResponse("ErrorResponse", "Forbidden"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 				},
 			},
 		},
@@ -2178,7 +2199,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 		"/clusters/{id}/relationships/{relationshipId}": {
 			Delete: &OpenAPIOperation{
 				Summary:     "Delete cluster relationship",
-				Description: "Deletes a specific cluster relationship",
+				Description: "Deletes a specific cluster relationship. Requires manage_connections permission.",
 				OperationID: "deleteClusterRelationship",
 				Tags:        []string{"Clusters"},
 				Security:    bearerAuth,
@@ -2190,6 +2211,48 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"204": {Description: "Relationship deleted"},
 					"400": jsonResponse("ErrorResponse", "Invalid request"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
+				},
+			},
+		},
+
+		// Clusters - per-connection relationships (Issue #207)
+		"/clusters/{id}/connections/{connId}/relationships": {
+			Put: &OpenAPIOperation{
+				Summary:     "Set connection relationships",
+				Description: "Replaces the replication relationships for a connection within a cluster. Requires manage_connections permission.",
+				OperationID: "setConnectionRelationships",
+				Tags:        []string{"Clusters"},
+				Security:    bearerAuth,
+				Parameters: []OpenAPIParameter{
+					pathParamInt("id", "Cluster ID"),
+					pathParamInt("connId", "Source connection ID"),
+				},
+				RequestBody: jsonRequestBody("SetRelationshipsRequest", "Relationship definitions", true),
+				Responses: map[string]OpenAPIResponse{
+					"204": {Description: "Relationships updated"},
+					"400": jsonResponse("ErrorResponse", "Invalid request"),
+					"401": jsonResponse("ErrorResponse", "Unauthorized"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
+					"404": jsonResponse("ErrorResponse", "Cluster or connection not found"),
+				},
+			},
+			Delete: &OpenAPIOperation{
+				Summary:     "Clear connection relationships",
+				Description: "Removes all replication relationships for a connection within a cluster. Requires manage_connections permission.",
+				OperationID: "clearConnectionRelationships",
+				Tags:        []string{"Clusters"},
+				Security:    bearerAuth,
+				Parameters: []OpenAPIParameter{
+					pathParamInt("id", "Cluster ID"),
+					pathParamInt("connId", "Source connection ID"),
+				},
+				Responses: map[string]OpenAPIResponse{
+					"204": {Description: "Relationships cleared"},
+					"400": jsonResponse("ErrorResponse", "Invalid request"),
+					"401": jsonResponse("ErrorResponse", "Unauthorized"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
+					"404": jsonResponse("ErrorResponse", "Cluster or connection not found"),
 				},
 			},
 		},

--- a/server/src/internal/api/openapi.go
+++ b/server/src/internal/api/openapi.go
@@ -1694,7 +1694,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Delete: &OpenAPIOperation{
 				Summary:     "Delete a cluster group",
-				Description: "Deletes a cluster group. Requires manage_connections permission.",
+				Description: "Deletes a cluster group. Requires manage_connections permission or ownership of the cluster group.",
 				OperationID: "deleteClusterGroup",
 				Tags:        []string{"Cluster Groups"},
 				Security:    bearerAuth,
@@ -1702,7 +1702,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 				Responses: map[string]OpenAPIResponse{
 					"204": {Description: "Group deleted"},
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
-					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission or ownership of the cluster group"),
 					"404": jsonResponse("ErrorResponse", "Group not found"),
 				},
 			},

--- a/server/src/internal/api/rbac_issue207_clusters_test.go
+++ b/server/src/internal/api/rbac_issue207_clusters_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/pgedge/ai-workbench/server/internal/auth"
@@ -89,6 +90,10 @@ func newIssue207UnprivilegedUser(t *testing.T, store *auth.AuthStore, name strin
 
 // assertForbiddenWithMessage fails the test if the recorded response is
 // not a 403 carrying the canonical permission-denied error message.
+// The substring "Permission denied" is the stable prefix of the plain
+// admin gate response (see cluster_handlers.go); locking on it ensures
+// a future change to an empty or differently-worded message surfaces as
+// a test failure rather than a silent regression.
 func assertForbiddenWithMessage(t *testing.T, rec *httptest.ResponseRecorder) {
 	t.Helper()
 	if rec.Code != http.StatusForbidden {
@@ -99,8 +104,9 @@ func assertForbiddenWithMessage(t *testing.T, rec *httptest.ResponseRecorder) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("Failed to decode response body: %v", err)
 	}
-	if resp.Error == "" {
-		t.Error("Expected non-empty error message in 403 response")
+	if !strings.Contains(resp.Error, "Permission denied") {
+		t.Errorf("Expected error message to contain %q, got %q",
+			"Permission denied", resp.Error)
 	}
 }
 
@@ -175,9 +181,9 @@ func TestClusterHandler_CreateClusterGroup_Issue207_SuperuserAllowed(t *testing.
 	}()
 	handler.createClusterGroup(rec, req)
 
-	if rec.Code == http.StatusForbidden {
-		t.Fatalf("Superuser must not be blocked by the gate; got 403: %s",
-			rec.Body.String())
+	if rec.Code == http.StatusForbidden || rec.Code == http.StatusUnauthorized {
+		t.Fatalf("Superuser failed auth (status %d): %s",
+			rec.Code, rec.Body.String())
 	}
 }
 
@@ -628,16 +634,18 @@ func TestClusterHandler_DeleteClusterGroup_Issue207_MissingAuth(t *testing.T) {
 // =============================================================================
 
 // assertGatePassed runs the supplied call and asserts that the recorded
-// response is not a 403. A panic from the nil datastore is recovered
-// silently; the only way the test fails is if the gate rejects the
-// caller.
+// response is neither a 403 nor a 401. A panic from the nil datastore
+// is recovered silently; the test fails only if the gate rejected the
+// caller. Treating 401 as a failure too catches regressions where the
+// auth lookup itself starts rejecting a context that previously
+// satisfied the gate.
 func assertGatePassed(t *testing.T, rec *httptest.ResponseRecorder, call func()) {
 	t.Helper()
 	defer func() {
 		_ = recover()
-		if rec.Code == http.StatusForbidden {
-			t.Fatalf("Permitted caller was blocked by the gate: %s",
-				rec.Body.String())
+		if rec.Code == http.StatusForbidden || rec.Code == http.StatusUnauthorized {
+			t.Fatalf("Permitted caller failed auth (status %d): %s",
+				rec.Code, rec.Body.String())
 		}
 	}()
 	call()
@@ -813,8 +821,9 @@ func TestClusterHandler_UpdateCluster_Issue207_AdminAllowed(t *testing.T) {
 
 	handler.updateCluster(rec, req, 1)
 
-	if rec.Code == http.StatusForbidden {
-		t.Fatalf("Admin caller was blocked by the gate: %s", rec.Body.String())
+	if rec.Code == http.StatusForbidden || rec.Code == http.StatusUnauthorized {
+		t.Fatalf("Admin caller failed auth (status %d): %s",
+			rec.Code, rec.Body.String())
 	}
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("Expected 400 after gate passes (empty body), got %d: %s",

--- a/server/src/internal/api/rbac_issue207_clusters_test.go
+++ b/server/src/internal/api/rbac_issue207_clusters_test.go
@@ -497,11 +497,35 @@ func TestClusterHandler_DeleteClusterGroup_Issue207_OwnerAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to mark group as owned: %v", err)
 	}
+	// Seed a cluster + owner-visible connection inside the group so the
+	// post-gate visibility check in deleteClusterGroup
+	// (groupHasVisibleConnection) succeeds. Without a visible member
+	// connection the handler responds 404 even when the gate passes.
+	// The connection is unshared and owned by the caller, which mirrors
+	// the realistic owner-fallback scenario: an owner of an unshared
+	// group + connection can delete their own group.
+	var clusterID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO clusters (group_id, name) VALUES ($1, $2) RETURNING id`,
+		created.ID, "owner-cluster").Scan(&clusterID); err != nil {
+		t.Fatalf("Failed to seed cluster: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO connections (name, owner_username, is_shared, cluster_id)
+         VALUES ($1, $2, FALSE, $3)`,
+		"owner-conn", "issue207_owner", clusterID); err != nil {
+		t.Fatalf("Failed to seed connection: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodDelete,
 		"/api/v1/cluster-groups/"+strconv.Itoa(created.ID), nil)
 	req = withBearer(req, token)
 	req = withUser(req, userID)
+	// VisibleConnectionIDs reads the username from the request context to
+	// apply the owner-visible rule for unshared connections. Production
+	// middleware populates UsernameContextKey from the same bearer token
+	// withBearer sets above; the test fixture must add it explicitly.
+	req = withUsername(req, "issue207_owner")
 	rec := httptest.NewRecorder()
 
 	handler.handleClusterGroupSubpath(rec, req)
@@ -521,7 +545,7 @@ func TestClusterHandler_DeleteClusterGroup_Issue207_OwnerAllowed(t *testing.T) {
 // the positive admin path: a manage_connections grant lets a non-owner
 // delete a cluster group.
 func TestClusterHandler_DeleteClusterGroup_Issue207_AdminAllowed(t *testing.T) {
-	ds, _, cleanupDS := newTestDatastore(t)
+	ds, pool, cleanupDS := newTestDatastore(t)
 	defer cleanupDS()
 
 	_, store, cleanupStore := createTestRBACHandler(t)
@@ -539,6 +563,25 @@ func TestClusterHandler_DeleteClusterGroup_Issue207_AdminAllowed(t *testing.T) {
 	created, err := ds.CreateClusterGroup(ctx, "Issue207 Admin Target", nil)
 	if err != nil {
 		t.Fatalf("Failed to create cluster group: %v", err)
+	}
+	// Seed a cluster + shared connection inside the group so the
+	// post-gate visibility check in deleteClusterGroup succeeds for the
+	// admin caller. manage_connections is an admin permission and does
+	// NOT grant ConnectionIDAll visibility, so the visibility helper
+	// still applies the standard owner-or-shared rule. A shared
+	// connection authored by another user is enough to make the group
+	// visible to the admin caller without making them the owner.
+	var clusterID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO clusters (group_id, name) VALUES ($1, $2) RETURNING id`,
+		created.ID, "admin-cluster").Scan(&clusterID); err != nil {
+		t.Fatalf("Failed to seed cluster: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO connections (name, owner_username, is_shared, cluster_id)
+         VALUES ($1, $2, TRUE, $3)`,
+		"admin-conn", "someone_else", clusterID); err != nil {
+		t.Fatalf("Failed to seed connection: %v", err)
 	}
 
 	req := httptest.NewRequest(http.MethodDelete,

--- a/server/src/internal/api/rbac_issue207_clusters_test.go
+++ b/server/src/internal/api/rbac_issue207_clusters_test.go
@@ -1,0 +1,875 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+)
+
+// =============================================================================
+// Regression Test Coverage for GitHub Issue #207
+//
+// Issue #207 was an authorization gap: eleven cluster-handler entry
+// points performed cluster-group and cluster mutations without checking
+// the manage_connections admin permission, so any authenticated caller
+// could create groups, create clusters, attach/detach servers, or
+// rewrite topology relationships.
+//
+// The production fix added one of two gates at the very top of each
+// handler (before request decoding) so denied callers cannot probe
+// payload shape via validation error messages:
+//
+//   - Plain admin gate: RBACChecker.HasAdminPermission with
+//     auth.PermManageConnections. Used by all create handlers,
+//     the server-attach/detach handlers, and the topology-relationship
+//     handlers, where no per-object owner concept exists.
+//   - Owner-fallback gate: same admin check, but on failure an
+//     ownership check via getUserInfoCompat against the object's
+//     owner_username column lets the row's owner through. Used by
+//     deleteClusterGroup. NOTE: updateCluster and deleteCluster were
+//     originally specified to use the owner-fallback variant too, but
+//     the clusters table has no owner_username column, so the plain
+//     admin gate is applied to them instead. See the source comments in
+//     updateCluster/deleteCluster for the rationale.
+//
+// The tests below exercise the "denied" path for every newly gated
+// handler without requiring Postgres. The handler returns 403 before
+// any datastore access, so a nil-datastore handler with a real
+// RBACChecker is sufficient for the negative path; the assertion that
+// the rejection happens BEFORE the datastore would have been touched is
+// implicit in the nil datastore not panicking.
+//
+// The integration-style "owner-fallback success" cases for
+// deleteClusterGroup require Postgres and are gated on
+// TEST_AI_WORKBENCH_SERVER through the same path as the existing
+// TestClusterHandler_UpdateClusterGroup_Integration_* tests in
+// cluster_handlers_test.go.
+// =============================================================================
+
+// newIssue207Handler builds a ClusterHandler with a real RBACChecker
+// backed by a temporary auth store. The datastore is intentionally nil;
+// the gate must return 403 before any datastore call, so a panic from a
+// nil datastore would itself be a regression.
+func newIssue207Handler(t *testing.T) (*ClusterHandler, *auth.AuthStore, func()) {
+	t.Helper()
+	_, store, cleanup := createTestRBACHandler(t)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+	return handler, store, cleanup
+}
+
+// newIssue207UnprivilegedUser creates an authenticated user with no
+// admin permissions. Returns the user ID for use with withUser.
+func newIssue207UnprivilegedUser(t *testing.T, store *auth.AuthStore, name string) int64 {
+	t.Helper()
+	if err := store.CreateUser(name, "Password1234", "", "", ""); err != nil {
+		t.Fatalf("Failed to create user %q: %v", name, err)
+	}
+	userID, err := store.GetUserID(name)
+	if err != nil {
+		t.Fatalf("Failed to get user ID for %q: %v", name, err)
+	}
+	return userID
+}
+
+// assertForbiddenWithMessage fails the test if the recorded response is
+// not a 403 carrying the canonical permission-denied error message.
+func assertForbiddenWithMessage(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response body: %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("Expected non-empty error message in 403 response")
+	}
+}
+
+// =============================================================================
+// Plain admin gate: critical create + topology handlers
+// =============================================================================
+
+// TestClusterHandler_CreateClusterGroup_Issue207_Denied verifies that an
+// authenticated user without manage_connections cannot create a cluster
+// group. The handler must return 403 before reading the request body so
+// a denied caller cannot enumerate validation errors.
+func TestClusterHandler_CreateClusterGroup_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_create_group")
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: "Attempt"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createClusterGroup(rec, req)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_CreateClusterGroup_Issue207_DeniedSkipsDecode
+// verifies that the 403 happens before JSON decoding: a body that would
+// otherwise trigger a 400 ("Invalid request body") returns 403 instead.
+// This is the "no payload probing" property the gate ordering protects.
+func TestClusterHandler_CreateClusterGroup_Issue207_DeniedSkipsDecode(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_create_group_bad")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createClusterGroup(rec, req)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_CreateClusterGroup_Issue207_SuperuserAllowed
+// confirms that the gate is satisfied by the superuser bypass. A nil
+// datastore deliberately panics if the handler reaches the datastore
+// call, so this test additionally proves the gate path returns to the
+// caller before any datastore work.
+func TestClusterHandler_CreateClusterGroup_Issue207_SuperuserAllowed(t *testing.T) {
+	handler, _, cleanup := newIssue207Handler(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: "AdminGroup"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		// We intentionally allow a panic here: the nil datastore will
+		// blow up when the handler reaches CreateClusterGroup. The
+		// security contract we are testing is that the handler PASSES
+		// the gate (i.e., does NOT return 403). The integration tests
+		// against a real Postgres cover the success-write path.
+		_ = recover()
+	}()
+	handler.createClusterGroup(rec, req)
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("Superuser must not be blocked by the gate; got 403: %s",
+			rec.Body.String())
+	}
+}
+
+// TestClusterHandler_CreateClusterInGroup_Issue207_Denied verifies that
+// a non-admin caller cannot POST to /api/v1/cluster-groups/{id}/clusters.
+func TestClusterHandler_CreateClusterInGroup_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_create_in_group")
+
+	body, _ := json.Marshal(ClusterRequest{Name: "Attempt"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups/1/clusters",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createClusterInGroup(rec, req, 1)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_CreateClusterInGroup_Issue207_DeniedSkipsDecode
+// confirms that the 403 happens before JSON decoding.
+func TestClusterHandler_CreateClusterInGroup_Issue207_DeniedSkipsDecode(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_create_in_group_bad")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups/1/clusters",
+		bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createClusterInGroup(rec, req, 1)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_HandleCreateCluster_Issue207_Denied verifies that
+// a non-admin caller cannot POST to /api/v1/clusters.
+func TestClusterHandler_HandleCreateCluster_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_create_cluster")
+
+	body, _ := json.Marshal(ManualClusterRequest{Name: "Attempt"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleCreateCluster(rec, req)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_HandleCreateCluster_Issue207_DeniedSkipsDecode
+// confirms that the 403 happens before JSON decoding.
+func TestClusterHandler_HandleCreateCluster_Issue207_DeniedSkipsDecode(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_create_cluster_bad")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters",
+		bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleCreateCluster(rec, req)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_AddServerToCluster_Issue207_Denied verifies that a
+// non-admin caller cannot attach a server to a cluster.
+func TestClusterHandler_AddServerToCluster_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_attach")
+
+	body, _ := json.Marshal(AddServerToClusterRequest{ConnectionID: 42})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters/1/servers",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.addServerToCluster(rec, req, 1)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_HandleRemoveServerFromCluster_Issue207_Denied
+// verifies that a non-admin caller cannot detach a server from a
+// cluster.
+func TestClusterHandler_HandleRemoveServerFromCluster_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_detach")
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/clusters/1/servers/42", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleRemoveServerFromCluster(rec, req, 1, 42)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_SetConnectionRelationships_Issue207_Denied
+// verifies that a non-admin caller cannot rewrite topology
+// relationships.
+func TestClusterHandler_SetConnectionRelationships_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_setrel")
+
+	body := `{"relationships":[{"target_connection_id":3,"relationship_type":"streams_from"}]}`
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/clusters/1/connections/2/relationships",
+		bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.setConnectionRelationships(rec, req, 1, 2)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_SetConnectionRelationships_Issue207_DeniedSkipsDecode
+// confirms the 403 happens before JSON decoding.
+func TestClusterHandler_SetConnectionRelationships_Issue207_DeniedSkipsDecode(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_setrel_bad")
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/clusters/1/connections/2/relationships",
+		bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.setConnectionRelationships(rec, req, 1, 2)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_ClearConnectionRelationships_Issue207_Denied
+// verifies that a non-admin caller cannot clear topology relationships.
+func TestClusterHandler_ClearConnectionRelationships_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_clearrel")
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/clusters/1/connections/2/relationships", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.clearConnectionRelationships(rec, req, 1, 2)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_HandleDeleteRelationship_Issue207_Denied verifies
+// that a non-admin caller cannot delete a relationship row.
+func TestClusterHandler_HandleDeleteRelationship_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_delrel")
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/clusters/1/relationships/5", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleDeleteRelationship(rec, req, 1, 5)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_UpdateCluster_Issue207_Denied verifies that a
+// non-admin caller cannot rename or move a cluster. The body must
+// otherwise pass the "at least one field" validation; we test that the
+// 403 happens before that validation runs.
+func TestClusterHandler_UpdateCluster_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_update_cluster")
+
+	body, _ := json.Marshal(ClusterRequest{Name: "Attempt"})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/clusters/1",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.updateCluster(rec, req, 1)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_UpdateCluster_Issue207_DeniedSkipsDecode confirms
+// the 403 happens before JSON decoding even when the body would have
+// been valid for the legacy code path.
+func TestClusterHandler_UpdateCluster_Issue207_DeniedSkipsDecode(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_update_cluster_bad")
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/clusters/1",
+		bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.updateCluster(rec, req, 1)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_DeleteCluster_Issue207_Denied verifies that a
+// non-admin caller cannot delete a cluster.
+func TestClusterHandler_DeleteCluster_Issue207_Denied(t *testing.T) {
+	handler, store, cleanup := newIssue207Handler(t)
+	defer cleanup()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_delete_cluster")
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/clusters/1", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.deleteCluster(rec, req, 1)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestClusterHandler_DeleteClusterGroup_Issue207_Denied verifies the
+// owner-fallback variant on the negative path: a non-owner caller
+// without manage_connections cannot delete a cluster group. The handler
+// must look up the group's owner before deciding, so the datastore is a
+// real Postgres instance gated on TEST_AI_WORKBENCH_SERVER.
+func TestClusterHandler_DeleteClusterGroup_Issue207_Denied(t *testing.T) {
+	ds, _, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_outsider")
+	token, _, err := store.AuthenticateUser("issue207_outsider", "Password1234")
+	if err != nil {
+		t.Fatalf("Failed to authenticate: %v", err)
+	}
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(ds, store, checker)
+
+	ctx := context.Background()
+	created, err := ds.CreateClusterGroup(ctx, "Issue207 Target", nil)
+	if err != nil {
+		t.Fatalf("Failed to create cluster group: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/cluster-groups/"+strconv.Itoa(created.ID), nil)
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterGroupSubpath(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("Expected status %d, got %d. Body: %s",
+			http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+
+	// The group must still exist after the rejected delete.
+	if _, err := ds.GetClusterGroup(ctx, created.ID); err != nil {
+		t.Errorf("Group should still exist after rejected delete: %v", err)
+	}
+}
+
+// TestClusterHandler_DeleteClusterGroup_Issue207_OwnerAllowed verifies
+// the positive owner-fallback path: a non-admin caller who owns the
+// cluster group can delete it. The group is created with the caller's
+// username so the ownership branch fires.
+func TestClusterHandler_DeleteClusterGroup_Issue207_OwnerAllowed(t *testing.T) {
+	ds, pool, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+	userID := newIssue207UnprivilegedUser(t, store, "issue207_owner")
+	token, _, err := store.AuthenticateUser("issue207_owner", "Password1234")
+	if err != nil {
+		t.Fatalf("Failed to authenticate: %v", err)
+	}
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(ds, store, checker)
+
+	ctx := context.Background()
+	created, err := ds.CreateClusterGroup(ctx, "Issue207 Owned", nil)
+	if err != nil {
+		t.Fatalf("Failed to create cluster group: %v", err)
+	}
+	// Mark the group as owned by the caller. CreateClusterGroup does
+	// not set the owner_username column directly, so we update it here.
+	_, err = pool.Exec(ctx,
+		`UPDATE cluster_groups SET owner_username = $1 WHERE id = $2`,
+		"issue207_owner", created.ID)
+	if err != nil {
+		t.Fatalf("Failed to mark group as owned: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/cluster-groups/"+strconv.Itoa(created.ID), nil)
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterGroupSubpath(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("Expected status %d (owner allowed), got %d. Body: %s",
+			http.StatusNoContent, rec.Code, rec.Body.String())
+	}
+
+	// The group should be gone now.
+	if _, err := ds.GetClusterGroup(ctx, created.ID); err == nil {
+		t.Errorf("Group should be deleted; GetClusterGroup unexpectedly succeeded")
+	}
+}
+
+// TestClusterHandler_DeleteClusterGroup_Issue207_AdminAllowed verifies
+// the positive admin path: a manage_connections grant lets a non-owner
+// delete a cluster group.
+func TestClusterHandler_DeleteClusterGroup_Issue207_AdminAllowed(t *testing.T) {
+	ds, _, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+	userID := setupUserWithPermission(t, store, "issue207_admin",
+		auth.PermManageConnections)
+	token, _, err := store.AuthenticateUser("issue207_admin", "Password1234")
+	if err != nil {
+		t.Fatalf("Failed to authenticate: %v", err)
+	}
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(ds, store, checker)
+
+	ctx := context.Background()
+	created, err := ds.CreateClusterGroup(ctx, "Issue207 Admin Target", nil)
+	if err != nil {
+		t.Fatalf("Failed to create cluster group: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/cluster-groups/"+strconv.Itoa(created.ID), nil)
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterGroupSubpath(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("Expected status %d (admin allowed), got %d. Body: %s",
+			http.StatusNoContent, rec.Code, rec.Body.String())
+	}
+}
+
+// TestClusterHandler_DeleteClusterGroup_Issue207_MissingAuth verifies
+// the unauthenticated path: a delete with no bearer token returns 401
+// from getUserInfoCompat before any datastore call.
+func TestClusterHandler_DeleteClusterGroup_Issue207_MissingAuth(t *testing.T) {
+	handler, _, cleanup := newIssue207Handler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/cluster-groups/1", nil)
+	rec := httptest.NewRecorder()
+
+	handler.deleteClusterGroup(rec, req, 1)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status %d, got %d. Body: %s",
+			http.StatusUnauthorized, rec.Code, rec.Body.String())
+	}
+}
+
+// =============================================================================
+// Allowed-path sanity tests for the plain-admin gates
+//
+// These tests pair an admin-permission grant with a nil datastore. The
+// gate must let the caller through; the subsequent datastore call will
+// panic. We use a deferred recover() so the test asserts only the
+// pre-datastore behavior (no 403). Integration tests against a real
+// Postgres cover the write side of the success path.
+// =============================================================================
+
+// assertGatePassed runs the supplied call and asserts that the recorded
+// response is not a 403. A panic from the nil datastore is recovered
+// silently; the only way the test fails is if the gate rejects the
+// caller.
+func assertGatePassed(t *testing.T, rec *httptest.ResponseRecorder, call func()) {
+	t.Helper()
+	defer func() {
+		_ = recover()
+		if rec.Code == http.StatusForbidden {
+			t.Fatalf("Permitted caller was blocked by the gate: %s",
+				rec.Body.String())
+		}
+	}()
+	call()
+}
+
+// TestClusterHandler_CreateClusterInGroup_Issue207_AdminAllowed
+// confirms the gate lets a manage_connections caller through.
+func TestClusterHandler_CreateClusterInGroup_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_create_in_group_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	body, _ := json.Marshal(ClusterRequest{Name: "Attempt"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups/1/clusters",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.createClusterInGroup(rec, req, 1)
+	})
+}
+
+// TestClusterHandler_HandleCreateCluster_Issue207_AdminAllowed
+// confirms the gate lets a manage_connections caller through.
+func TestClusterHandler_HandleCreateCluster_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_create_cluster_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	body, _ := json.Marshal(ManualClusterRequest{Name: "Attempt"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.handleCreateCluster(rec, req)
+	})
+}
+
+// TestClusterHandler_AddServerToCluster_Issue207_AdminAllowed confirms
+// the gate lets a manage_connections caller through.
+func TestClusterHandler_AddServerToCluster_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_attach_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	body, _ := json.Marshal(AddServerToClusterRequest{ConnectionID: 42})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters/1/servers",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.addServerToCluster(rec, req, 1)
+	})
+}
+
+// TestClusterHandler_HandleRemoveServerFromCluster_Issue207_AdminAllowed
+// confirms the gate lets a manage_connections caller through.
+func TestClusterHandler_HandleRemoveServerFromCluster_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_detach_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/clusters/1/servers/42", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.handleRemoveServerFromCluster(rec, req, 1, 42)
+	})
+}
+
+// TestClusterHandler_SetConnectionRelationships_Issue207_AdminAllowed
+// confirms the gate lets a manage_connections caller through.
+func TestClusterHandler_SetConnectionRelationships_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_setrel_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	body := `{"relationships":[{"target_connection_id":3,"relationship_type":"streams_from"}]}`
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/clusters/1/connections/2/relationships",
+		bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.setConnectionRelationships(rec, req, 1, 2)
+	})
+}
+
+// TestClusterHandler_ClearConnectionRelationships_Issue207_AdminAllowed
+// confirms the gate lets a manage_connections caller through.
+func TestClusterHandler_ClearConnectionRelationships_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_clearrel_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/clusters/1/connections/2/relationships", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.clearConnectionRelationships(rec, req, 1, 2)
+	})
+}
+
+// TestClusterHandler_HandleDeleteRelationship_Issue207_AdminAllowed
+// confirms the gate lets a manage_connections caller through.
+func TestClusterHandler_HandleDeleteRelationship_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_delrel_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/clusters/1/relationships/5", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.handleDeleteRelationship(rec, req, 1, 5)
+	})
+}
+
+// TestClusterHandler_UpdateCluster_Issue207_AdminAllowed confirms the
+// gate lets a manage_connections caller through to the body-validation
+// path. The body is intentionally empty so the handler returns a 400
+// after the gate; we assert only that the gate did not return 403.
+func TestClusterHandler_UpdateCluster_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_update_cluster_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	body := `{}` // Empty body -> 400 "at least one field required" after the gate.
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/clusters/1",
+		bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.updateCluster(rec, req, 1)
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("Admin caller was blocked by the gate: %s", rec.Body.String())
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Expected 400 after gate passes (empty body), got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestClusterHandler_DeleteCluster_Issue207_AdminAllowed confirms the
+// gate lets a manage_connections caller through.
+func TestClusterHandler_DeleteCluster_Issue207_AdminAllowed(t *testing.T) {
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+	userID := setupUserWithPermission(t, store, "issue207_delete_cluster_admin",
+		auth.PermManageConnections)
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(nil, store, checker)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/clusters/1", nil)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.deleteCluster(rec, req, 1)
+	})
+}
+
+// =============================================================================
+// Issue #207 type smoke tests
+//
+// These tests anchor the JSON shape of the request bodies used by the
+// gated handlers so a future struct rename will surface here rather
+// than as a silent regression in the gate tests above.
+// =============================================================================
+
+// TestIssue207ClusterRequest_JSONShape verifies the ClusterRequest
+// struct encodes the fields the gate tests rely on.
+func TestIssue207ClusterRequest_JSONShape(t *testing.T) {
+	desc := "test"
+	repl := "binary"
+	gid := 1
+	req := ClusterRequest{
+		Name:            "n",
+		Description:     &desc,
+		ReplicationType: &repl,
+		GroupID:         &gid,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded ClusterRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.Name != "n" || decoded.Description == nil ||
+		*decoded.Description != "test" {
+		t.Errorf("Round-trip mismatch: %+v", decoded)
+	}
+}
+
+// TestIssue207AddServerToClusterRequest_JSONShape verifies the body
+// shape used by the addServerToCluster denial test.
+func TestIssue207AddServerToClusterRequest_JSONShape(t *testing.T) {
+	role := "primary"
+	req := AddServerToClusterRequest{ConnectionID: 42, Role: &role}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded AddServerToClusterRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.ConnectionID != 42 || decoded.Role == nil ||
+		*decoded.Role != "primary" {
+		t.Errorf("Round-trip mismatch: %+v", decoded)
+	}
+}
+
+// TestIssue207ManualClusterRequest_JSONShape verifies the body shape
+// used by the handleCreateCluster denial test.
+func TestIssue207ManualClusterRequest_JSONShape(t *testing.T) {
+	gid := 1
+	req := ManualClusterRequest{
+		Name:            "x",
+		Description:     "y",
+		ReplicationType: "binary",
+		GroupID:         &gid,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded ManualClusterRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.Name != "x" || decoded.GroupID == nil || *decoded.GroupID != 1 {
+		t.Errorf("Round-trip mismatch: %+v", decoded)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #207 — unauthorized users could POST to cluster-group and cluster
create endpoints; the server silently committed the rows and returned a
success status, but the rows were invisible to the creator (only admins
could see them).

An audit triggered by the report found additional unprotected mutating
routes in `cluster_handlers.go`. Eleven handlers in total now check
`manage_connections` and return `403 Forbidden` on denial.

### Server (`cluster_handlers.go`)
- **Plain admin gate** on create / topology mutations:
  - `POST /api/v1/cluster-groups`
  - `POST /api/v1/cluster-groups/{id}/clusters`
  - `POST /api/v1/clusters`
  - `POST /api/v1/clusters/{id}/servers`
  - `DELETE /api/v1/clusters/{id}/servers/{connectionId}`
  - `PUT /api/v1/clusters/{id}/connections/{connId}/relationships`
  - `DELETE /api/v1/clusters/{id}/connections/{connId}/relationships`
  - `DELETE /api/v1/clusters/{id}/relationships/{relationshipId}`
- **Owner-fallback** (group owner can still manage their own group):
  - `DELETE /api/v1/cluster-groups/{id}`
- **Plain admin gate** on per-cluster updates (the `clusters` table has
  no `owner_username` column, so a true owner-fallback isn't possible
  without a schema change):
  - `PUT /api/v1/clusters/{id}`
  - `DELETE /api/v1/clusters/{id}`

The denial check fires **before** request decoding so payload shape
isn't leaked to unauthorized callers.

### Client (`AddMenu.tsx`)
- "Add Cluster Group" and "Add Cluster" menu items are hidden when the
  user lacks `manage_connections`. "Add Server" is unchanged.

### OpenAPI
- All 11 routes document a `403 Forbidden` response with consistent
  wording (`Requires manage_connections permission`).
- One previously-undocumented relationship route was added.
- `docs/admin-guide/api/openapi.json` regenerated.

### Tests
- 32 new server tests in `rbac_issue207_clusters_test.go` covering
  403-on-denied, success-on-grant, owner-fallback, and "denied-before-
  decode" assertions.
- 10 new client tests for `AddMenu` (100% line coverage on AddMenu.tsx).
- `make test-all` passes; lint warning count unchanged from baseline.

## Test plan
- [x] `make test-all` passes locally
- [x] New tests cover the 403 path for every newly gated handler
- [x] OpenAPI tests pass
- [x] AddMenu hides items for users without `manage_connections`
- [ ] Verify in CI with full Postgres-backed integration suite
- [ ] Manual: log in as a user without `manage_connections`, attempt to
      create a cluster group via the API → expect 403, no row inserted
- [ ] Manual: same user via UI → Add menu shows only "Add Server"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Cluster and cluster-group mutation operations now require the manage_connections permission and return 403 for unauthorized requests.

* **New Features / API**
  * Added endpoints to set/clear per-connection relationship mappings and new request schemas for relationship updates.

* **UI Updates**
  * “Add Cluster” and “Add Cluster Group” menu items are shown only when permitted.

* **Documentation**
  * Added RBAC gating patterns and permission-gated UI guidance.

* **Tests**
  * New regression and integration tests covering RBAC gates, owner/admin paths, and request-shape checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/217)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->