### PR TITLE
fix(client): unify non-Error fallback wording across Admin panels (#212)

### DIFF
--- a/.claude/react-expert/quality-checklist.md
+++ b/.claude/react-expert/quality-checklist.md
@@ -71,6 +71,63 @@ existing instances do not need to be fixed in unrelated changes.
   `instanceof Error`.
 - Missing error boundaries around component subtrees.
 
+## AdminPanel Error Handling
+
+AdminPanel components must use the shared `extractErrorMessage`
+helper from `client/src/components/AdminPanel/_shared/errors.ts`
+for every catch block that surfaces an error string to the user.
+Do not reintroduce ad-hoc patterns; the helper guarantees a
+uniform fallback wording for non-`Error` throws.
+
+Banned patterns in AdminPanel catch blocks:
+
+- `String(err)` or `String(apiErr)` — produces unfriendly
+  `[object Object]`-style output for non-`Error` rejections.
+- Inline `err instanceof Error ? err.message : '...'` ternaries
+  that hard-code a divergent fallback wording.
+- Verbose `if (err instanceof Error) { setError(err.message) }
+  else { setError('An unexpected error occurred') }` blocks.
+
+Required pattern for the generic case:
+
+```ts
+try {
+    await apiPost('/api/v1/something', body);
+} catch (err: unknown) {
+    setError(extractErrorMessage(err));
+}
+```
+
+When the call site needs a more descriptive fallback (for
+example, a recipient-add handler), pass the context as the
+second argument; the helper still returns the `Error.message`
+when available:
+
+```ts
+crud.setDialogError(
+    extractErrorMessage(err, 'Failed to add recipient'),
+);
+```
+
+Reference implementations:
+
+- `client/src/components/AdminPanel/_shared/errors.ts` defines
+  the helper and the `DEFAULT_ERROR_MESSAGE` constant.
+- `client/src/components/AdminPanel/AdminUsers.tsx`,
+  `AdminPermissions.tsx`, `AdminMemories.tsx`, `AdminProbes.tsx`,
+  `AdminTokenScopes.tsx`, `AdminEmailChannels.tsx`,
+  `AdminWebhookChannels.tsx`, `AdminMessagingChannels.tsx`,
+  `AdminAlertRules.tsx`, `AdminGroups.tsx`, and
+  `channels/useChannelCRUD.ts` all route their catch blocks
+  through `extractErrorMessage`.
+
+Tests for AdminPanel mutation paths must cover both the
+`Error`-instance branch and the non-`Error` fallback. Reject a
+mock with a plain string and assert that
+`'An unexpected error occurred'` (or the contextual fallback
+passed at the call site) renders in the appropriate alert or
+dialog.
+
 ## TypeScript Standards
 
 ### Naming Conventions

--- a/client/src/components/AdminPanel/AdminEmailChannels.tsx
+++ b/client/src/components/AdminPanel/AdminEmailChannels.tsx
@@ -27,6 +27,7 @@ import {
     EmailSettingsTab,
     EmailRecipientsTab,
 } from './email';
+import { extractErrorMessage } from './_shared';
 
 /**
  * Map raw API response to EmailChannel type.
@@ -104,11 +105,7 @@ const AdminEmailChannels: React.FC = () => {
         } catch (err: unknown) {
             // Only show error if still editing the same channel
             if (editingChannelIdRef.current !== channelId) { return; }
-            if (err instanceof Error) {
-                crud.setDialogError(err.message);
-            } else {
-                crud.setDialogError('Failed to load recipients');
-            }
+            crud.setDialogError(extractErrorMessage(err, 'Failed to load recipients'));
         } finally {
             // Only clear loading if still editing the same channel
             if (editingChannelIdRef.current === channelId) {
@@ -305,11 +302,7 @@ const AdminEmailChannels: React.FC = () => {
             setPendingRecipients([]);
             crud.fetchChannels();
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                crud.setDialogError(err.message);
-            } else {
-                crud.setDialogError('An unexpected error occurred');
-            }
+            crud.setDialogError(extractErrorMessage(err));
         } finally {
             crud.setSaving(false);
         }
@@ -344,11 +337,7 @@ const AdminEmailChannels: React.FC = () => {
         } catch (err: unknown) {
             // Only show error if still editing the same channel
             if (editingChannelIdRef.current === channelId) {
-                if (err instanceof Error) {
-                    crud.setDialogError(err.message);
-                } else {
-                    crud.setDialogError('Failed to add recipient');
-                }
+                crud.setDialogError(extractErrorMessage(err, 'Failed to add recipient'));
             }
         } finally {
             setRecipientSaving(false);
@@ -371,11 +360,7 @@ const AdminEmailChannels: React.FC = () => {
         } catch (err: unknown) {
             // Only show error if still editing the same channel
             if (editingChannelIdRef.current === channelId) {
-                if (err instanceof Error) {
-                    crud.setDialogError(err.message);
-                } else {
-                    crud.setDialogError('Failed to update recipient');
-                }
+                crud.setDialogError(extractErrorMessage(err, 'Failed to update recipient'));
             }
         } finally {
             setRecipientSaving(false);
@@ -397,11 +382,7 @@ const AdminEmailChannels: React.FC = () => {
         } catch (err: unknown) {
             // Only show error if still editing the same channel
             if (editingChannelIdRef.current === channelId) {
-                if (err instanceof Error) {
-                    crud.setDialogError(err.message);
-                } else {
-                    crud.setDialogError('Failed to delete recipient');
-                }
+                crud.setDialogError(extractErrorMessage(err, 'Failed to delete recipient'));
             }
         } finally {
             setRecipientSaving(false);

--- a/client/src/components/AdminPanel/AdminGroups.tsx
+++ b/client/src/components/AdminPanel/AdminGroups.tsx
@@ -290,7 +290,7 @@ const AdminGroups: React.FC = () => {
                         : { group_id: parseInt(selectedMemberId, 10) }
                 );
             } catch (apiErr: unknown) {
-                const errorMsg = apiErr instanceof Error ? apiErr.message : String(apiErr);
+                const errorMsg = extractErrorMessage(apiErr);
                 throw new Error(
                     errorMsg.includes('UNIQUE constraint')
                         ? 'This member is already in the group.'

--- a/client/src/components/AdminPanel/AdminMemories.tsx
+++ b/client/src/components/AdminPanel/AdminMemories.tsx
@@ -38,6 +38,7 @@ import {
     getDeleteIconSx,
     getTableContainerSx,
 } from './styles';
+import { extractErrorMessage } from './_shared';
 
 interface Memory {
     id: number;
@@ -103,8 +104,7 @@ const AdminMemories: React.FC = () => {
             );
             setMemories(data.memories || []);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         } finally {
             setLoading(false);
         }
@@ -136,8 +136,7 @@ const AdminMemories: React.FC = () => {
                     m.id === mem.id ? { ...m, pinned: mem.pinned } : m,
                 ),
             );
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         }
     };
 
@@ -158,8 +157,7 @@ const AdminMemories: React.FC = () => {
             setDeleteMemory(null);
             fetchMemories();
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         } finally {
             setDeleteLoading(false);
         }

--- a/client/src/components/AdminPanel/AdminMessagingChannels.tsx
+++ b/client/src/components/AdminPanel/AdminMessagingChannels.tsx
@@ -55,7 +55,7 @@ import {
     getDeleteIconSx,
     getTableContainerSx,
 } from './styles';
-import { useCrudPanel } from './_shared';
+import { useCrudPanel, extractErrorMessage } from './_shared';
 
 /**
  * Configuration that varies between messaging platforms (Slack,
@@ -274,9 +274,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
             await apiPost(`/api/v1/notification-channels/${channel.id}/test`);
             crud.setSuccess(`Test notification sent successfully for "${channel.name}".`);
         } catch (err: unknown) {
-            crud.setError(
-                err instanceof Error ? err.message : 'Failed to send test notification',
-            );
+            crud.setError(extractErrorMessage(err, 'Failed to send test notification'));
         } finally {
             setTestingChannelId(null);
         }

--- a/client/src/components/AdminPanel/AdminPermissions.tsx
+++ b/client/src/components/AdminPanel/AdminPermissions.tsx
@@ -55,6 +55,7 @@ import {
     getDeleteIconSx,
     getTableContainerSx,
 } from './styles';
+import { extractErrorMessage } from './_shared';
 
 const API_BASE_URL = '/api/v1';
 
@@ -159,8 +160,7 @@ const AdminPermissions: React.FC = () => {
                 const data = await apiGet<{ groups?: RbacGroup[] }>(`${API_BASE_URL}/rbac/groups`);
                 setGroups(data.groups ?? []);
             } catch (err: unknown) {
-                const message = err instanceof Error ? err.message : String(err);
-                setError(message);
+                setError(extractErrorMessage(err));
             } finally {
                 setLoading(false);
             }
@@ -192,8 +192,7 @@ const AdminPermissions: React.FC = () => {
                 }
             }
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         } finally {
             setMcpLoading(false);
             setConnLoading(false);
@@ -210,8 +209,7 @@ const AdminPermissions: React.FC = () => {
             );
             setAdminPermissions(data.permissions ?? []);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         } finally {
             setAdminPermsLoading(false);
         }
@@ -267,8 +265,7 @@ const AdminPermissions: React.FC = () => {
             setGrantMcpOpen(false);
             fetchPermissions(selectedGroupId);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setGrantMcpError(message);
+            setGrantMcpError(extractErrorMessage(err));
         } finally {
             setGrantMcpLoading(false);
         }
@@ -282,8 +279,7 @@ const AdminPermissions: React.FC = () => {
             );
             fetchPermissions(selectedGroupId);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         }
     };
 
@@ -317,8 +313,7 @@ const AdminPermissions: React.FC = () => {
             setGrantConnOpen(false);
             fetchPermissions(selectedGroupId);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setGrantConnError(message);
+            setGrantConnError(extractErrorMessage(err));
         } finally {
             setGrantConnLoading(false);
         }
@@ -331,8 +326,7 @@ const AdminPermissions: React.FC = () => {
             );
             fetchPermissions(selectedGroupId);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         }
     };
 
@@ -349,8 +343,7 @@ const AdminPermissions: React.FC = () => {
             setGrantAdminOpen(false);
             fetchAdminPermissions(selectedGroupId);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setGrantAdminError(message);
+            setGrantAdminError(extractErrorMessage(err));
         } finally {
             setGrantAdminLoading(false);
         }
@@ -363,8 +356,7 @@ const AdminPermissions: React.FC = () => {
             );
             fetchAdminPermissions(selectedGroupId);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         }
     };
 

--- a/client/src/components/AdminPanel/AdminProbes.tsx
+++ b/client/src/components/AdminPanel/AdminProbes.tsx
@@ -49,6 +49,7 @@ import {
     getContainedButtonSx,
     getTableContainerSx,
 } from './styles';
+import { extractErrorMessage } from './_shared';
 
 interface ProbeConfig {
     id: number;
@@ -82,11 +83,7 @@ const AdminProbes: React.FC = () => {
             const data = await apiGet<Record<string, unknown>>('/api/v1/probe-configs');
             setProbes((data.probe_configs || data || []) as ProbeConfig[]);
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
+            setError(extractErrorMessage(err));
         } finally {
             setLoading(false);
         }
@@ -119,11 +116,7 @@ const AdminProbes: React.FC = () => {
             setSuccess(`Probe "${getFriendlyProbeName(editProbe.name)}" updated successfully.`);
             fetchProbes();
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
+            setError(extractErrorMessage(err));
         } finally {
             setSaving(false);
         }

--- a/client/src/components/AdminPanel/AdminTokenScopes.tsx
+++ b/client/src/components/AdminPanel/AdminTokenScopes.tsx
@@ -17,6 +17,7 @@ import DeleteConfirmationDialog from '../DeleteConfirmationDialog';
 import { apiGet, apiPost, apiPut, apiDelete } from '../../utils/apiClient';
 import { copyToClipboard } from '../../utils/clipboard';
 import { loadingContainerSx, pageHeadingSx, getContainedButtonSx } from './styles';
+import { extractErrorMessage } from './_shared';
 import {
     TokensTable,
     CreateTokenDialog,
@@ -126,7 +127,7 @@ const AdminTokenScopes: React.FC = () => {
                 setUsers(usersResult.users ?? []);
             }
         } catch (err: unknown) {
-            setError(err instanceof Error ? err.message : String(err));
+            setError(extractErrorMessage(err));
         } finally {
             setLoading(false);
         }
@@ -234,7 +235,7 @@ const AdminTokenScopes: React.FC = () => {
             setCreatedDialogOpen(true);
             fetchData();
         } catch (err: unknown) {
-            setCreateError(err instanceof Error ? err.message : String(err));
+            setCreateError(extractErrorMessage(err));
         } finally {
             setCreateLoading(false);
         }
@@ -356,7 +357,7 @@ const AdminTokenScopes: React.FC = () => {
             setEditOpen(false);
             fetchData();
         } catch (err: unknown) {
-            setEditError(err instanceof Error ? err.message : String(err));
+            setEditError(extractErrorMessage(err));
         } finally {
             setEditLoading(false);
         }
@@ -379,7 +380,7 @@ const AdminTokenScopes: React.FC = () => {
             setDeleteToken(null);
             fetchData();
         } catch (err: unknown) {
-            setError(err instanceof Error ? err.message : String(err));
+            setError(extractErrorMessage(err));
         } finally {
             setDeleteLoading(false);
         }

--- a/client/src/components/AdminPanel/AdminUsers.tsx
+++ b/client/src/components/AdminPanel/AdminUsers.tsx
@@ -59,6 +59,7 @@ import {
     getDeleteIconSx,
     getTableContainerSx,
 } from './styles';
+import { extractErrorMessage } from './_shared';
 
 
 interface RbacUser {
@@ -154,8 +155,7 @@ const AdminUsers: React.FC = () => {
                 setConnections(connResult.connections || []);
             }
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         } finally {
             setLoading(false);
         }
@@ -179,8 +179,7 @@ const AdminUsers: React.FC = () => {
             const data = await apiGet<UserPermissions>(`/api/v1/rbac/users/${rowUser.id}/privileges`);
             setPermissions(data);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setPermissionsError(message);
+            setPermissionsError(extractErrorMessage(err));
         } finally {
             setPermissionsLoading(false);
         }
@@ -227,8 +226,7 @@ const AdminUsers: React.FC = () => {
             setCreateSuperuser(false);
             fetchUsers();
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setCreateError(message);
+            setCreateError(extractErrorMessage(err));
         } finally {
             setCreateLoading(false);
         }
@@ -281,8 +279,7 @@ const AdminUsers: React.FC = () => {
             setEditOpen(false);
             fetchUsers();
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setEditError(message);
+            setEditError(extractErrorMessage(err));
         } finally {
             setEditLoading(false);
         }
@@ -304,8 +301,7 @@ const AdminUsers: React.FC = () => {
             setDeleteUser(null);
             fetchUsers();
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         } finally {
             setDeleteLoading(false);
         }
@@ -324,8 +320,7 @@ const AdminUsers: React.FC = () => {
                 setPermissions(data);
             }
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         }
     };
 
@@ -341,8 +336,7 @@ const AdminUsers: React.FC = () => {
                 setPermissions(data);
             }
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
+            setError(extractErrorMessage(err));
         }
     };
 

--- a/client/src/components/AdminPanel/AdminWebhookChannels.tsx
+++ b/client/src/components/AdminPanel/AdminWebhookChannels.tsx
@@ -13,6 +13,7 @@ import { useState, useCallback } from 'react';
 import DeleteConfirmationDialog from '../DeleteConfirmationDialog';
 import { apiPost, apiPut } from '../../utils/apiClient';
 import { useChannelCRUD, ChannelTable, ChannelDialogShell } from './channels';
+import { extractErrorMessage } from './_shared';
 import {
     type WebhookChannel,
     type WebhookFormState,
@@ -380,11 +381,7 @@ const AdminWebhookChannels: React.FC = () => {
             crud.closeDialog();
             crud.fetchChannels();
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                crud.setDialogError(err.message);
-            } else {
-                crud.setDialogError('An unexpected error occurred');
-            }
+            crud.setDialogError(extractErrorMessage(err));
         } finally {
             crud.setSaving(false);
         }

--- a/client/src/components/AdminPanel/__tests__/AdminEmailChannels.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminEmailChannels.test.tsx
@@ -1402,6 +1402,38 @@ describe('AdminEmailChannels', () => {
                 expect(screen.getByText('Failed to delete recipient')).toBeInTheDocument();
             });
         });
+
+        it('shows the contextual fallback when fetchRecipients throws a non-Error', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/notification-channels') {
+                    return Promise.resolve({ notification_channels: mockEmailChannels });
+                }
+                if (url.includes('/recipients')) {
+                    return Promise.reject('plain string reject');
+                }
+                return Promise.resolve({});
+            });
+            const user = userEvent.setup({ delay: null });
+
+            renderWithTheme(<AdminEmailChannels />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Test Email')).toBeInTheDocument();
+            });
+
+            const editButtons = screen.getAllByRole('button', { name: /edit channel/i });
+            await user.click(editButtons[0]);
+
+            await waitFor(() => {
+                expect(screen.getByText('Edit channel: Test Email')).toBeInTheDocument();
+            });
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Failed to load recipients'),
+                ).toBeInTheDocument();
+            });
+        });
     });
 
     describe('Close Dialog', () => {

--- a/client/src/components/AdminPanel/__tests__/AdminMemories.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminMemories.test.tsx
@@ -165,6 +165,18 @@ describe('AdminMemories', () => {
         });
     });
 
+    it('shows the unified fallback when fetch throws a non-Error', async () => {
+        mockApiGet.mockRejectedValue('plain string reject');
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
+        });
+    });
+
     it('toggles pinned state optimistically', async () => {
         mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
         mockApiPatch.mockResolvedValue({});
@@ -207,6 +219,27 @@ describe('AdminMemories', () => {
         // Error message should be displayed
         await waitFor(() => {
             expect(screen.getByText('Patch failed')).toBeInTheDocument();
+        });
+    });
+
+    it('shows the unified fallback when pin toggle throws a non-Error', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        mockApiPatch.mockRejectedValue('plain string reject');
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const pinnedSwitches = screen.getAllByRole('checkbox', { name: /toggle pinned/i });
+        await user.click(pinnedSwitches[0]);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
         });
     });
 
@@ -301,6 +334,33 @@ describe('AdminMemories', () => {
 
         await waitFor(() => {
             expect(screen.getByText('Delete failed')).toBeInTheDocument();
+        });
+    });
+
+    it('shows the unified fallback when delete throws a non-Error', async () => {
+        mockApiGet.mockResolvedValue({ memories: MOCK_MEMORIES });
+        mockApiDelete.mockRejectedValue('plain string reject');
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminMemories />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Always use EXPLAIN ANALYZE/)).toBeInTheDocument();
+        });
+
+        const deleteButtons = screen.getAllByRole('button', { name: /delete memory/i });
+        await user.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByText('Delete Memory')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
         });
     });
 

--- a/client/src/components/AdminPanel/__tests__/AdminPermissions.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminPermissions.test.tsx
@@ -1,0 +1,1285 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, waitFor, within, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+    describe,
+    it,
+    expect,
+    vi,
+    beforeEach,
+    afterEach,
+} from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+const mockApiDelete = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock('../../../contexts/useAuth', () => ({
+    useAuth: () => mockUseAuth(),
+}));
+
+import AdminPermissions from '../AdminPermissions';
+
+const mockGroups = [
+    { id: 1, name: 'admins' },
+    { id: 2, name: 'developers' },
+];
+
+interface GroupApiOverrides {
+    groupsRejection?: unknown;
+    permissionsRejection?: unknown;
+    adminPermsRejection?: unknown;
+    mcpPrivileges?: unknown[];
+    connPrivileges?: unknown[];
+    adminPermissions?: string[];
+    connectionsList?: unknown[];
+}
+
+function installListMocks(overrides: GroupApiOverrides = {}): void {
+    mockApiGet.mockImplementation((url: string) => {
+        if (url === '/api/v1/rbac/groups') {
+            if (overrides.groupsRejection !== undefined) {
+                return Promise.reject(overrides.groupsRejection);
+            }
+            return Promise.resolve({ groups: mockGroups });
+        }
+        if (/^\/api\/v1\/rbac\/groups\/\d+$/.test(url)) {
+            if (overrides.permissionsRejection !== undefined) {
+                return Promise.reject(overrides.permissionsRejection);
+            }
+            return Promise.resolve({
+                mcp_privileges: overrides.mcpPrivileges ?? [],
+                connection_privileges: overrides.connPrivileges ?? [],
+            });
+        }
+        if (/^\/api\/v1\/rbac\/groups\/\d+\/permissions$/.test(url)) {
+            if (overrides.adminPermsRejection !== undefined) {
+                return Promise.reject(overrides.adminPermsRejection);
+            }
+            return Promise.resolve({
+                permissions: overrides.adminPermissions ?? [],
+            });
+        }
+        if (url === '/api/v1/connections') {
+            return Promise.resolve({
+                connections: overrides.connectionsList ?? [],
+            });
+        }
+        if (url === '/api/v1/rbac/privileges/mcp') {
+            return Promise.resolve([]);
+        }
+        return Promise.resolve({});
+    });
+}
+
+describe('AdminPermissions', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseAuth.mockReturnValue({
+            user: { username: 'alice', isSuperuser: true },
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('Group list fetch', () => {
+        it('renders the group selector once loaded', async () => {
+            installListMocks();
+            renderWithTheme(<AdminPermissions />);
+            await waitFor(() => {
+                expect(screen.getByText('Permissions')).toBeInTheDocument();
+            });
+            expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+        });
+
+        it('shows the unified fallback when group list throws a non-Error', async () => {
+            installListMocks({ groupsRejection: 'plain string reject' });
+            renderWithTheme(<AdminPermissions />);
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('shows the error message when group list rejects with an Error', async () => {
+            installListMocks({ groupsRejection: new Error('boom') });
+            renderWithTheme(<AdminPermissions />);
+            await waitFor(() => {
+                expect(screen.getByText('boom')).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Group permissions fetch', () => {
+        it('shows the unified fallback when permissions load throws a non-Error', async () => {
+            installListMocks({ permissionsRejection: 'plain string reject' });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('shows the unified fallback when admin permissions fetch throws a non-Error', async () => {
+            installListMocks({ adminPermsRejection: 'plain string reject' });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Revoke handlers', () => {
+        it('shows the unified fallback when revoking an MCP privilege throws a non-Error', async () => {
+            installListMocks({
+                mcpPrivileges: [
+                    { identifier: 'query_read', item_type: 'tool' },
+                ],
+            });
+            mockApiDelete.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Tool: query_read')).toBeInTheDocument();
+            });
+
+            const revokeButtons = screen.getAllByLabelText(/revoke permission/i);
+            await user.click(revokeButtons[revokeButtons.length - 1]);
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('shows the unified fallback when revoking a connection throws a non-Error', async () => {
+            installListMocks({
+                connPrivileges: [
+                    { connection_id: 5, access_level: 'read' },
+                ],
+                connectionsList: [{ id: 5, name: 'primary-db' }],
+            });
+            mockApiDelete.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('primary-db')).toBeInTheDocument();
+            });
+
+            const revokeButtons = screen.getAllByLabelText(/revoke permission/i);
+            await user.click(revokeButtons[0]);
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('shows the unified fallback when revoking an admin permission throws a non-Error', async () => {
+            installListMocks({
+                adminPermissions: ['manage_users'],
+            });
+            mockApiDelete.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Manage Users')).toBeInTheDocument();
+            });
+
+            const revokeButtons = screen.getAllByLabelText(/revoke permission/i);
+            await user.click(revokeButtons[0]);
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Grant handlers', () => {
+        it('shows the unified fallback when granting an admin permission throws a non-Error', async () => {
+            installListMocks();
+            mockApiPost.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const groupListbox = await screen.findByRole('listbox');
+            await user.click(within(groupListbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Admin Permissions')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /Grant Permission/i }),
+            );
+
+            const dialog = await screen.findByRole('dialog');
+            const permSelect = within(dialog).getByLabelText(/Permission/i);
+            fireEvent.mouseDown(permSelect);
+            const permListbox = await screen.findByRole('listbox');
+            await user.click(within(permListbox).getByText('Manage Users'));
+
+            await user.click(
+                within(dialog).getByRole('button', { name: /^grant$/i }),
+            );
+
+            await waitFor(() => {
+                expect(
+                    within(dialog).getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('shows the unified fallback when granting an MCP privilege throws a non-Error', async () => {
+            installListMocks();
+            mockApiGet.mockImplementationOnce((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: mockGroups });
+                }
+                return Promise.resolve({});
+            });
+            // Default the rest of the GETs and provide MCP privileges
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: mockGroups });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+$/.test(url)) {
+                    return Promise.resolve({
+                        mcp_privileges: [],
+                        connection_privileges: [],
+                    });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+\/permissions$/.test(url)) {
+                    return Promise.resolve({ permissions: [] });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve({ connections: [] });
+                }
+                if (url === '/api/v1/rbac/privileges/mcp') {
+                    return Promise.resolve([
+                        { identifier: 'query_read', item_type: 'tool' },
+                    ]);
+                }
+                return Promise.resolve({});
+            });
+            mockApiPost.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const groupListbox = await screen.findByRole('listbox');
+            await user.click(within(groupListbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('MCP Permissions')).toBeInTheDocument();
+            });
+
+            // MCP section: locate the Grant button under the MCP Permissions
+            // header. There are two "Grant" buttons (connection + MCP); click
+            // the second one (MCP comes after the Admin section).
+            const grantButtons = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantButtons[grantButtons.length - 1]);
+
+            const dialog = await screen.findByRole('dialog');
+            // Open the Autocomplete and pick the only available option
+            const mcpInput = within(dialog).getByLabelText(/Permission/i);
+            await user.click(mcpInput);
+            const mcpOption = await screen.findByRole('option', {
+                name: /Tool: query_read/i,
+            });
+            await user.click(mcpOption);
+
+            await user.click(
+                within(dialog).getByRole('button', { name: /^grant$/i }),
+            );
+
+            await waitFor(() => {
+                expect(
+                    within(dialog).getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('shows the unified fallback when granting a connection privilege throws a non-Error', async () => {
+            installListMocks({
+                connectionsList: [{ id: 5, name: 'primary-db' }],
+            });
+            mockApiPost.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const groupListbox = await screen.findByRole('listbox');
+            await user.click(within(groupListbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Connection Permissions'),
+                ).toBeInTheDocument();
+            });
+
+            const grantButtons = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantButtons[0]);
+
+            const dialog = await screen.findByRole('dialog');
+            const connSelect = within(dialog).getByLabelText(/Connection/i);
+            fireEvent.mouseDown(connSelect);
+            const connListbox = await screen.findByRole('listbox');
+            await user.click(within(connListbox).getByText('primary-db'));
+
+            await user.click(
+                within(dialog).getByRole('button', { name: /^grant$/i }),
+            );
+
+            await waitFor(() => {
+                expect(
+                    within(dialog).getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('MCP permission rendering', () => {
+        it('formats resource, prompt, default API and wildcard MCP entries', async () => {
+            installListMocks({
+                mcpPrivileges: [
+                    { identifier: 'logs_read', item_type: 'resource' },
+                    { identifier: 'summarize', item_type: 'prompt' },
+                    { identifier: 'rest_endpoint', item_type: 'other' },
+                    { identifier: 'naked' },
+                ],
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Resource: logs_read')).toBeInTheDocument();
+            });
+            expect(screen.getByText('Prompt: summarize')).toBeInTheDocument();
+            expect(screen.getByText('API: rest_endpoint')).toBeInTheDocument();
+            // No item_type and no wildcard - falls through to bare identifier.
+            expect(screen.getByText('naked')).toBeInTheDocument();
+        });
+
+        it('renders the wildcard sentinel label for "All MCP Privileges"', async () => {
+            installListMocks({
+                mcpPrivileges: [{ identifier: '*' }],
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('All MCP Privileges'),
+                ).toBeInTheDocument();
+            });
+
+            // The Grant button for MCP should be hidden because wildcard is
+            // already granted. Confirm the only Grant present is from
+            // Connection Permissions (1 instance for non-superuser-style
+            // rendering) plus Admin's "Grant Permission" label.
+            const grants = screen.queryAllByRole('button', { name: /^Grant$/ });
+            expect(grants.length).toBeLessThanOrEqual(1);
+        });
+    });
+
+    describe('Success paths and dialog dismissals', () => {
+        it('successfully revokes an existing MCP permission', async () => {
+            installListMocks({
+                mcpPrivileges: [
+                    { identifier: 'query_read', item_type: 'tool' },
+                ],
+            });
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Tool: query_read')).toBeInTheDocument();
+            });
+
+            const revokeBtns = screen.getAllByLabelText(/revoke permission/i);
+            await user.click(revokeBtns[revokeBtns.length - 1]);
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith(
+                    expect.stringMatching(/privileges\/mcp\?name=query_read$/),
+                );
+            });
+        });
+
+        it('successfully revokes an existing connection permission', async () => {
+            installListMocks({
+                connPrivileges: [{ connection_id: 5, access_level: 'read' }],
+                connectionsList: [{ id: 5, name: 'primary-db' }],
+            });
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('primary-db')).toBeInTheDocument();
+            });
+
+            const revokeBtns = screen.getAllByLabelText(/revoke permission/i);
+            await user.click(revokeBtns[0]);
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith(
+                    expect.stringMatching(/privileges\/connections\/5$/),
+                );
+            });
+        });
+
+        it('successfully revokes an existing admin permission', async () => {
+            installListMocks({ adminPermissions: ['manage_users'] });
+            mockApiDelete.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Manage Users')).toBeInTheDocument();
+            });
+
+            const revokeBtns = screen.getAllByLabelText(/revoke permission/i);
+            await user.click(revokeBtns[0]);
+
+            await waitFor(() => {
+                expect(mockApiDelete).toHaveBeenCalledWith(
+                    expect.stringMatching(/permissions\/manage_users$/),
+                );
+            });
+        });
+
+        it('successfully grants a connection privilege and changes the access level', async () => {
+            installListMocks({
+                connectionsList: [{ id: 5, name: 'primary-db' }],
+            });
+            mockApiPost.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Connection Permissions'),
+                ).toBeInTheDocument();
+            });
+
+            const grantBtns = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantBtns[0]);
+
+            const dialog = await screen.findByRole('dialog');
+            const connSel = within(dialog).getByLabelText(/Connection/i);
+            fireEvent.mouseDown(connSel);
+            const connListbox = await screen.findByRole('listbox');
+            await user.click(within(connListbox).getByText('primary-db'));
+
+            // Change access level to read_write.
+            const accessSel = within(dialog).getByLabelText(/Access Level/i);
+            fireEvent.mouseDown(accessSel);
+            const accessListbox = await screen.findByRole('listbox');
+            await user.click(within(accessListbox).getByText(/Read\/Write/i));
+
+            await user.click(
+                within(dialog).getByRole('button', { name: /^grant$/i }),
+            );
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    expect.stringMatching(/privileges\/connections$/),
+                    {
+                        connection_id: 5,
+                        access_level: 'read_write',
+                    },
+                );
+            });
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant connection permission'),
+                ).not.toBeInTheDocument();
+            });
+        });
+
+        it('successfully grants an admin permission', async () => {
+            installListMocks();
+            mockApiPost.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Admin Permissions')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /Grant Permission/i }),
+            );
+            const dialog = await screen.findByRole('dialog');
+            const permSel = within(dialog).getByLabelText(/Permission/i);
+            fireEvent.mouseDown(permSel);
+            const permListbox = await screen.findByRole('listbox');
+            await user.click(within(permListbox).getByText('Manage Users'));
+
+            await user.click(
+                within(dialog).getByRole('button', { name: /^grant$/i }),
+            );
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    expect.stringMatching(/groups\/\d+\/permissions$/),
+                    { permission: 'manage_users' },
+                );
+            });
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant admin permission'),
+                ).not.toBeInTheDocument();
+            });
+        });
+
+        it('successfully grants an MCP privilege', async () => {
+            installListMocks();
+            // Add available privilege after a successful list call.
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: mockGroups });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+$/.test(url)) {
+                    return Promise.resolve({
+                        mcp_privileges: [],
+                        connection_privileges: [],
+                    });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+\/permissions$/.test(url)) {
+                    return Promise.resolve({ permissions: [] });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve({ connections: [] });
+                }
+                if (url === '/api/v1/rbac/privileges/mcp') {
+                    return Promise.resolve([
+                        { identifier: 'query_write', item_type: 'tool' },
+                    ]);
+                }
+                return Promise.resolve({});
+            });
+            mockApiPost.mockResolvedValue({});
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('MCP Permissions')).toBeInTheDocument();
+            });
+
+            const grantBtns = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantBtns[grantBtns.length - 1]);
+
+            const dialog = await screen.findByRole('dialog');
+            const mcpInput = within(dialog).getByLabelText(/Permission/i);
+            await user.click(mcpInput);
+            const mcpOption = await screen.findByRole('option', {
+                name: /Tool: query_write/i,
+            });
+            await user.click(mcpOption);
+
+            await user.click(
+                within(dialog).getByRole('button', { name: /^grant$/i }),
+            );
+
+            await waitFor(() => {
+                expect(mockApiPost).toHaveBeenCalledWith(
+                    expect.stringMatching(/privileges\/mcp$/),
+                    { privilege: 'query_write' },
+                );
+            });
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant MCP permission'),
+                ).not.toBeInTheDocument();
+            });
+        });
+
+        it('cancels each grant dialog without firing apiPost', async () => {
+            installListMocks();
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const groupListbox = await screen.findByRole('listbox');
+            await user.click(within(groupListbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Connection Permissions'),
+                ).toBeInTheDocument();
+            });
+
+            // Open Grant Connection dialog and Cancel.
+            const grantBtns = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantBtns[0]);
+            const connDialog = await screen.findByRole('dialog');
+            await user.click(
+                within(connDialog).getByRole('button', { name: /Cancel/i }),
+            );
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant connection permission'),
+                ).not.toBeInTheDocument();
+            });
+
+            // Open Grant Admin dialog and Cancel.
+            await user.click(
+                screen.getByRole('button', { name: /Grant Permission/i }),
+            );
+            const adminDialog = await screen.findByRole('dialog');
+            await user.click(
+                within(adminDialog).getByRole('button', { name: /Cancel/i }),
+            );
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant admin permission'),
+                ).not.toBeInTheDocument();
+            });
+
+            // Open Grant MCP dialog and Cancel.
+            const grantBtnsAfter = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantBtnsAfter[grantBtnsAfter.length - 1]);
+            const mcpDialog = await screen.findByRole('dialog');
+            await user.click(
+                within(mcpDialog).getByRole('button', { name: /Cancel/i }),
+            );
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant MCP permission'),
+                ).not.toBeInTheDocument();
+            });
+
+            expect(mockApiPost).not.toHaveBeenCalled();
+        });
+
+        it('renders connection name from API list and handles missing connection id', async () => {
+            installListMocks({
+                connPrivileges: [
+                    { connection_id: 0, access_level: 'read' },
+                    { connection_id: 99, access_level: 'read_write' },
+                ],
+                // Use the array-shaped connections response branch.
+                connectionsList: [{ id: 5, name: 'primary-db' }],
+            });
+            // Override the connections endpoint to return a raw array,
+            // exercising the Array.isArray(connData) branch.
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: mockGroups });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+$/.test(url)) {
+                    return Promise.resolve({
+                        mcp_privileges: [],
+                        connection_privileges: [
+                            { connection_id: 0, access_level: 'read' },
+                            { connection_id: 99, access_level: 'read_write' },
+                        ],
+                    });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+\/permissions$/.test(url)) {
+                    return Promise.resolve({ permissions: [] });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve([{ id: 5, name: 'primary-db' }]);
+                }
+                return Promise.resolve({});
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            // id === 0 maps to "All Connections".
+            await waitFor(() => {
+                expect(
+                    screen.getByText('All Connections'),
+                ).toBeInTheDocument();
+            });
+            // id 99 is not in connections list - falls back to String(id).
+            expect(screen.getByText('99')).toBeInTheDocument();
+        });
+
+        it('falls back when the MCP options endpoint rejects', async () => {
+            installListMocks();
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: mockGroups });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+$/.test(url)) {
+                    return Promise.resolve({
+                        mcp_privileges: [],
+                        connection_privileges: [],
+                    });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+\/permissions$/.test(url)) {
+                    return Promise.resolve({ permissions: [] });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve({ connections: [] });
+                }
+                if (url === '/api/v1/rbac/privileges/mcp') {
+                    return Promise.reject(new Error('mcp boom'));
+                }
+                return Promise.resolve({});
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('MCP Permissions')).toBeInTheDocument();
+            });
+
+            const grantBtns = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantBtns[grantBtns.length - 1]);
+
+            const dialog = await screen.findByRole('dialog');
+            await waitFor(() => {
+                expect(
+                    within(dialog).getByText(
+                        'Failed to load available permissions',
+                    ),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('dismisses the top-level error alert via the close button', async () => {
+            installListMocks({ groupsRejection: new Error('boom') });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByText('boom')).toBeInTheDocument();
+            });
+
+            const alert = screen.getByText('boom').closest('[role="alert"]');
+            expect(alert).not.toBeNull();
+            const closeBtn = within(alert as HTMLElement).getByRole('button');
+            await user.click(closeBtn);
+
+            await waitFor(() => {
+                expect(screen.queryByText('boom')).not.toBeInTheDocument();
+            });
+        });
+
+        it('skips admin permission fetch for non-superusers', async () => {
+            mockUseAuth.mockReturnValue({
+                user: { username: 'alice', isSuperuser: false },
+            });
+            installListMocks();
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            // Connection Permissions section renders, but the Admin section
+            // is hidden for non-superusers (line 475 isSuperuser guard).
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Connection Permissions'),
+                ).toBeInTheDocument();
+            });
+            expect(screen.queryByText('Admin Permissions')).not.toBeInTheDocument();
+
+            // No GET to /permissions endpoint should have happened.
+            expect(mockApiGet).not.toHaveBeenCalledWith(
+                expect.stringMatching(/groups\/\d+\/permissions$/),
+            );
+        });
+
+        it('hides the connection Grant button when wildcard is already granted', async () => {
+            installListMocks({
+                connPrivileges: [{ connection_id: 0, access_level: 'read' }],
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('All Connections')).toBeInTheDocument();
+            });
+
+            // Verify no "Grant" button appears for the connections section
+            // (only Admin's "Grant Permission" and MCP "Grant" should remain).
+            const grants = screen.queryAllByRole('button', { name: /^Grant$/ });
+            // MCP grant button remains (wildcard not in mcp set).
+            expect(grants.length).toBe(1);
+        });
+
+        it('filters out already-granted connections from the Grant connection dialog', async () => {
+            installListMocks({
+                connPrivileges: [{ connection_id: 5, access_level: 'read' }],
+                connectionsList: [
+                    { id: 5, name: 'primary-db' },
+                    { id: 6, name: 'replica-db' },
+                ],
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('primary-db')).toBeInTheDocument();
+            });
+
+            // Open the Grant connection dialog and inspect dropdown options.
+            const grants = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grants[0]);
+
+            const dialog = await screen.findByRole('dialog');
+            const connSel = within(dialog).getByLabelText(/Connection/i);
+            fireEvent.mouseDown(connSel);
+            const optsBox = await screen.findByRole('listbox');
+            // primary-db should NOT appear (already granted), replica-db should.
+            expect(within(optsBox).queryByText('primary-db')).not.toBeInTheDocument();
+            expect(within(optsBox).getByText('replica-db')).toBeInTheDocument();
+        });
+
+        it('shows empty MCP options when the wildcard is already granted (dialog reachable via state path)', async () => {
+            // Render with MCP wildcard and an unrelated assignment; the Grant
+            // button is hidden, so we render with no wildcard first, then
+            // dispatch the open via the existing button. Because the wildcard
+            // hides the button, instead we exercise the assignedIdentifiers
+            // map (line 237) with one named privilege.
+            installListMocks({
+                mcpPrivileges: [
+                    { identifier: 'query_read', item_type: 'tool' },
+                ],
+            });
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: mockGroups });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+$/.test(url)) {
+                    return Promise.resolve({
+                        mcp_privileges: [
+                            { identifier: 'query_read', item_type: 'tool' },
+                        ],
+                        connection_privileges: [],
+                    });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+\/permissions$/.test(url)) {
+                    return Promise.resolve({ permissions: [] });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve({ connections: [] });
+                }
+                if (url === '/api/v1/rbac/privileges/mcp') {
+                    return Promise.resolve([
+                        { identifier: 'query_read', item_type: 'tool' },
+                        { identifier: 'query_write', item_type: 'tool' },
+                    ]);
+                }
+                return Promise.resolve({});
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Tool: query_read')).toBeInTheDocument();
+            });
+
+            const grantBtns = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantBtns[grantBtns.length - 1]);
+
+            const dialog = await screen.findByRole('dialog');
+            const mcpInput = within(dialog).getByLabelText(/Permission/i);
+            await user.click(mcpInput);
+            // Already-granted privilege should be filtered out.
+            expect(
+                screen.queryByRole('option', { name: /Tool: query_read/i }),
+            ).not.toBeInTheDocument();
+            // "All MCP Privileges" sentinel and query_write should appear.
+            expect(
+                screen.getByRole('option', { name: /All MCP Privileges/i }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('option', { name: /Tool: query_write/i }),
+            ).toBeInTheDocument();
+        });
+
+        it('clears state when the group selector is cleared', async () => {
+            installListMocks();
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            await waitFor(() => {
+                expect(screen.getByText('MCP Permissions')).toBeInTheDocument();
+            });
+
+            // Re-select empty value by changing select directly.
+            // fireEvent.change does not work with native select-style MUI; we
+            // simulate by re-clicking the select and choosing a different
+            // group, then verify the effect cleared MCP/Conn/Admin state and
+            // re-fetched permissions for the new group.
+            mockApiGet.mockClear();
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: mockGroups });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+$/.test(url)) {
+                    return Promise.resolve({
+                        mcp_privileges: [],
+                        connection_privileges: [],
+                    });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+\/permissions$/.test(url)) {
+                    return Promise.resolve({ permissions: [] });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve({ connections: [] });
+                }
+                return Promise.resolve({});
+            });
+
+            fireEvent.mouseDown(select);
+            const listbox2 = await screen.findByRole('listbox');
+            await user.click(within(listbox2).getByText('developers'));
+
+            // Verify the group permissions endpoint was hit for developers (id 2).
+            await waitFor(() => {
+                expect(mockApiGet).toHaveBeenCalledWith(
+                    '/api/v1/rbac/groups/2',
+                );
+            });
+        });
+
+        it('closes the MCP grant dialog when Escape is pressed', async () => {
+            installListMocks();
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+            await waitFor(() => {
+                expect(screen.getByText('MCP Permissions')).toBeInTheDocument();
+            });
+
+            const grantBtns = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantBtns[grantBtns.length - 1]);
+            await screen.findByText('Grant MCP permission');
+
+            // Escape triggers the Dialog's onClose, which in turn invokes the
+            // inline onClose callback (line 622).
+            await user.keyboard('{Escape}');
+
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant MCP permission'),
+                ).not.toBeInTheDocument();
+            });
+        });
+
+        it('closes the connection grant dialog when Escape is pressed', async () => {
+            installListMocks({
+                connectionsList: [{ id: 5, name: 'primary-db' }],
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Connection Permissions'),
+                ).toBeInTheDocument();
+            });
+
+            const grantBtns = screen.getAllByRole('button', { name: /^Grant$/i });
+            await user.click(grantBtns[0]);
+            await screen.findByText('Grant connection permission');
+
+            await user.keyboard('{Escape}');
+
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant connection permission'),
+                ).not.toBeInTheDocument();
+            });
+        });
+
+        it('still renders permissions when the connections endpoint fails', async () => {
+            // Cover the connections.catch(() => null) arm at line 183 and
+            // the `if (connData)` guard so connections stays empty.
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/groups') {
+                    return Promise.resolve({ groups: mockGroups });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+$/.test(url)) {
+                    return Promise.resolve({
+                        mcp_privileges: [],
+                        connection_privileges: [
+                            { connection_id: 9, access_level: 'read' },
+                        ],
+                    });
+                }
+                if (/^\/api\/v1\/rbac\/groups\/\d+\/permissions$/.test(url)) {
+                    return Promise.resolve({ permissions: [] });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.reject(new Error('connections down'));
+                }
+                return Promise.resolve({});
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+
+            // Connection 9 is unknown - getConnectionName falls back to String(id).
+            await waitFor(() => {
+                expect(screen.getByText('9')).toBeInTheDocument();
+            });
+        });
+
+        it('closes the admin grant dialog when Escape is pressed', async () => {
+            installListMocks();
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminPermissions />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Select Group/i)).toBeInTheDocument();
+            });
+            const select = screen.getByLabelText(/Select Group/i);
+            fireEvent.mouseDown(select);
+            const listbox = await screen.findByRole('listbox');
+            await user.click(within(listbox).getByText('admins'));
+            await waitFor(() => {
+                expect(screen.getByText('Admin Permissions')).toBeInTheDocument();
+            });
+
+            await user.click(
+                screen.getByRole('button', { name: /Grant Permission/i }),
+            );
+            await screen.findByText('Grant admin permission');
+
+            await user.keyboard('{Escape}');
+
+            await waitFor(() => {
+                expect(
+                    screen.queryByText('Grant admin permission'),
+                ).not.toBeInTheDocument();
+            });
+        });
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminProbes.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminProbes.test.tsx
@@ -295,6 +295,45 @@ describe('AdminProbes', () => {
         });
     });
 
+    it('shows the unified fallback when fetch throws a non-Error', async () => {
+        mockApiGet.mockRejectedValue('plain string reject');
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('shows the unified fallback when save throws a non-Error', async () => {
+        mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
+        mockApiPut.mockRejectedValue('plain string reject');
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminProbes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Database Activity')).toBeInTheDocument();
+        });
+
+        const editButtons = screen.getAllByRole('button', { name: /edit probe/i });
+        await user.click(editButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Collection Interval/i)).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole('button', { name: /Save/i }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
+        });
+    });
+
     it('displays success message after successful save', async () => {
         mockApiGet.mockResolvedValue({ probe_configs: MOCK_PROBES });
         mockApiPut.mockResolvedValue({});

--- a/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
@@ -534,3 +534,1411 @@ describe('AdminTokenScopes', () => {
         }
     });
 });
+
+describe('AdminTokenScopes - unified error fallback', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('surfaces the unified fallback when token fetch throws a non-Error', async () => {
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.reject('plain string reject');
+            }
+            return Promise.resolve({});
+        });
+        renderPanel();
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('surfaces the unified fallback when create-token throws a non-Error', async () => {
+        setupApiGetMock();
+        mockApiPost.mockRejectedValue('plain string reject');
+        const user = userEvent.setup({ delay: null });
+        renderPanel();
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: /create token/i }),
+            ).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        const nameInput = await screen.findByLabelText(/^Name/i);
+        await user.type(nameInput, 'Test token');
+
+        const ownerInput = screen.getByLabelText(/^Owner/i);
+        await user.click(ownerInput);
+        await user.type(ownerInput, 'alice');
+        const aliceOption = await screen.findByRole('option', { name: /alice/ });
+        await user.click(aliceOption);
+
+        const createBtn = screen.getByRole('button', { name: /^Create$/ });
+        await user.click(createBtn);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('surfaces the unified fallback when delete-token throws a non-Error', async () => {
+        const TOKEN = {
+            id: 7,
+            name: 'alice-token',
+            token_prefix: 'abc',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            return Promise.resolve({});
+        });
+        mockApiDelete.mockRejectedValue('plain string reject');
+        const user = userEvent.setup({ delay: null });
+        renderPanel();
+
+        await waitFor(() => {
+            expect(screen.getByText('alice-token')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByLabelText(/delete token/i));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(
+            within(dialog).getByRole('button', { name: /^delete$/i }),
+        );
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('surfaces the unified fallback when save-scope throws a non-Error', async () => {
+        const TOKEN = {
+            id: 7,
+            name: 'alice-token',
+            token_prefix: 'abc',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: true,
+                    connection_privileges: {},
+                    mcp_privileges: [],
+                    admin_permissions: [],
+                });
+            }
+            return Promise.resolve({});
+        });
+        mockApiPut.mockRejectedValue('plain string reject');
+        const user = userEvent.setup({ delay: null });
+        renderPanel();
+
+        await waitFor(() => {
+            expect(screen.getByText('alice-token')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByLabelText(/edit token/i));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(
+            within(dialog).getByRole('button', { name: /^save$/i }),
+        );
+
+        await waitFor(() => {
+            expect(
+                within(dialog).getByText('An unexpected error occurred'),
+            ).toBeInTheDocument();
+        });
+    });
+});
+
+describe('AdminTokenScopes - additional coverage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders the empty-state when fetchData succeeds with no tokens', async () => {
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: [] });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve([]);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: [] });
+            }
+            return Promise.resolve({});
+        });
+        renderPanel();
+        await waitFor(() => {
+            expect(screen.getByText('No tokens found.')).toBeInTheDocument();
+        });
+    });
+
+    it('tolerates connection/mcp/user endpoint failures (fetchData catch arms)', async () => {
+        // Each non-tokens endpoint rejects so the `.catch(() => null)` arms
+        // (lines 115-117) execute and the corresponding state setters stay
+        // empty. The panel still renders because /tokens succeeds.
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [] });
+            }
+            return Promise.reject(new Error(`fail: ${url}`));
+        });
+        renderPanel();
+        await waitFor(() => {
+            expect(screen.getByText('No tokens found.')).toBeInTheDocument();
+        });
+        // No error should be surfaced since the catches swallow the rejection.
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('renders connections list when /connections returns a raw array', async () => {
+        // Cover the alternative shape: `(connResult.connections ?? connResult)`
+        // when connResult is a raw array.
+        const TOKEN = {
+            id: 1,
+            name: 'inline-token',
+            token_prefix: 'x1',
+            username: 'alice',
+            user_id: 42,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: {
+                scoped: true,
+                connections: [{ connection_id: 100, access_level: 'read' }],
+                mcp_privileges: [],
+                admin_permissions: [],
+            },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve([{ id: 100, name: 'array-conn' }]);
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve([]);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: [] });
+            }
+            return Promise.resolve({});
+        });
+        const user = userEvent.setup({ delay: null });
+        renderPanel();
+
+        await waitFor(() => {
+            expect(screen.getByText('inline-token')).toBeInTheDocument();
+        });
+
+        // Expand the row so the EffectivePermissionsPanel renders. (It is
+        // mocked to render null, but the click still triggers the row click
+        // handler at handleTokenRowClick.)
+        await user.click(screen.getByText('inline-token'));
+
+        // Toggle off again via row click to exercise the equal-id branch.
+        await user.click(screen.getByText('inline-token'));
+    });
+
+    it('clears owner-derived state when the owner is cleared in the create dialog', async () => {
+        setupApiGetMock();
+        const user = userEvent.setup({ delay: null });
+        renderPanel();
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: /create token/i }),
+            ).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        // Pick alice (wildcard mcp/admin from setupApiGetMock).
+        const ownerCombo = await screen.findByRole('combobox', { name: /owner/i });
+        await user.click(ownerCombo);
+        const aliceOption = await screen.findByRole('option', { name: 'alice' });
+        await user.click(aliceOption);
+
+        // Confirm the MCP combobox now has the "All MCP Privileges" option.
+        const mcpCombo = await screen.findByRole('combobox', {
+            name: /allowed mcp privileges/i,
+        });
+        await user.click(mcpCombo);
+        await screen.findByRole('option', { name: 'All MCP Privileges' });
+        await user.keyboard('{Escape}');
+
+        // Clear the owner via the Autocomplete clear button.
+        const clearButton = within(
+            ownerCombo.closest('.MuiAutocomplete-root') as HTMLElement,
+        ).getByLabelText(/clear/i);
+        await user.click(clearButton);
+
+        // After clearing, the MCP combo's listbox shows no options.
+        await user.click(mcpCombo);
+        // After clearing, available MCP privileges are reset; no item options.
+        const listbox = screen.queryByRole('listbox');
+        // listbox may exist but be empty (Autocomplete shows "no options" text).
+        if (listbox) {
+            expect(
+                within(listbox).queryByRole('option', {
+                    name: /All MCP Privileges/,
+                }),
+            ).not.toBeInTheDocument();
+        }
+    });
+
+    it('falls back to all privileges when the owner-privileges fetch fails', async () => {
+        // setupApiGetMock returns wildcard for alice; replace the privileges
+        // endpoint with a rejection so the catch arm (lines 190-192) runs.
+        const failingPrivs = (url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.reject(new Error('privs down'));
+            }
+            return Promise.resolve({});
+        };
+        mockApiGet.mockImplementation(failingPrivs);
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: /create token/i }),
+            ).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        const ownerCombo = await screen.findByRole('combobox', { name: /owner/i });
+        await user.click(ownerCombo);
+        const aliceOption = await screen.findByRole('option', { name: 'alice' });
+        await user.click(aliceOption);
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledWith(
+                `/api/v1/rbac/users/${USERS[0].id}/privileges`,
+            );
+        });
+
+        // Fallback path sets ownerConnections=connections,
+        // ownerMcpPrivileges=mcpPrivileges, ownerAdminPermissions=ADMIN_PERMISSIONS.
+        const mcpCombo = await screen.findByRole('combobox', {
+            name: /allowed mcp privileges/i,
+        });
+        await user.click(mcpCombo);
+        const mcpListbox = await screen.findByRole('listbox');
+        // All MCP privileges should still be selectable.
+        expect(
+            within(mcpListbox).getByRole('option', { name: 'query_read' }),
+        ).toBeInTheDocument();
+    });
+
+    it('treats connection_id=0 in owner privileges as access to all connections', async () => {
+        // Cover the allowedConnIds.includes(0) branch (line 181).
+        const customConnections = [
+            { id: 100, name: 'primary-db' },
+            { id: 200, name: 'replica-db' },
+        ];
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: customConnections });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: false,
+                    connection_privileges: { 0: 'read_write' },
+                    mcp_privileges: [],
+                    admin_permissions: [],
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: /create token/i }),
+            ).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        const ownerCombo = await screen.findByRole('combobox', { name: /owner/i });
+        await user.click(ownerCombo);
+        const aliceOption = await screen.findByRole('option', { name: 'alice' });
+        await user.click(aliceOption);
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledWith(
+                `/api/v1/rbac/users/${USERS[0].id}/privileges`,
+            );
+        });
+
+        // All connections should appear in the Add Connection combobox.
+        const addConnCombo = screen.getByRole('combobox', {
+            name: /add connection/i,
+        });
+        await user.click(addConnCombo);
+        const listbox = await screen.findByRole('listbox');
+        expect(
+            within(listbox).getByRole('option', { name: 'primary-db' }),
+        ).toBeInTheDocument();
+        expect(
+            within(listbox).getByRole('option', { name: 'replica-db' }),
+        ).toBeInTheDocument();
+    });
+
+    it('restricts connection list to owner-allowed ids when wildcard is absent', async () => {
+        const customConnections = [
+            { id: 100, name: 'primary-db' },
+            { id: 200, name: 'replica-db' },
+        ];
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: customConnections });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: false,
+                    connection_privileges: { 100: 'read' },
+                    mcp_privileges: ['query_read'],
+                    admin_permissions: ['manage_users'],
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: /create token/i }),
+            ).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        const ownerCombo = await screen.findByRole('combobox', { name: /owner/i });
+        await user.click(ownerCombo);
+        const aliceOption = await screen.findByRole('option', { name: 'alice' });
+        await user.click(aliceOption);
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledWith(
+                `/api/v1/rbac/users/${USERS[0].id}/privileges`,
+            );
+        });
+
+        // Only primary-db should be available.
+        const addConnCombo = screen.getByRole('combobox', {
+            name: /add connection/i,
+        });
+        await user.click(addConnCombo);
+        const listbox = await screen.findByRole('listbox');
+        expect(
+            within(listbox).getByRole('option', { name: 'primary-db' }),
+        ).toBeInTheDocument();
+        expect(
+            within(listbox).queryByRole('option', { name: 'replica-db' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('creates a token with scope (connection, MCP, admin) and surfaces the created dialog', async () => {
+        const customConnections = [{ id: 100, name: 'primary-db' }];
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: customConnections });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: true,
+                    connection_privileges: {},
+                    mcp_privileges: [],
+                    admin_permissions: [],
+                });
+            }
+            return Promise.resolve({});
+        });
+        mockApiPost.mockResolvedValue({ id: 42, token: 'pgedge_token_xyz' });
+        mockApiPut.mockResolvedValue({});
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: /create token/i }),
+            ).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        await user.type(screen.getByLabelText(/^Name/i), 'scoped-token');
+
+        const ownerCombo = await screen.findByRole('combobox', { name: /owner/i });
+        await user.click(ownerCombo);
+        const aliceOption = await screen.findByRole('option', { name: 'alice' });
+        await user.click(aliceOption);
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledWith(
+                `/api/v1/rbac/users/${USERS[0].id}/privileges`,
+            );
+        });
+
+        // Add a connection to scope.
+        const addConnCombo = screen.getByRole('combobox', {
+            name: /add connection/i,
+        });
+        await user.click(addConnCombo);
+        const addConnListbox = await screen.findByRole('listbox');
+        await user.click(
+            within(addConnListbox).getByRole('option', { name: 'primary-db' }),
+        );
+
+        // Add a specific MCP privilege. Click the Name field afterwards to
+        // dismiss the listbox without using Escape (which would close the
+        // dialog).
+        const mcpCombo = screen.getByRole('combobox', {
+            name: /allowed mcp privileges/i,
+        });
+        await user.click(mcpCombo);
+        const mcpListbox = await screen.findByRole('listbox');
+        await user.click(
+            within(mcpListbox).getByRole('option', { name: 'query_read' }),
+        );
+        // Click the Name field to take focus away from the multi-select.
+        await user.click(screen.getByLabelText(/^Name/i));
+
+        // Add the "All Admin Permissions" wildcard to exercise the _isAll
+        // mapping path (line 220-221).
+        const adminCombo = screen.getByRole('combobox', {
+            name: /allowed admin permissions/i,
+        });
+        await user.click(adminCombo);
+        const adminListbox = await screen.findByRole('listbox');
+        await user.click(
+            within(adminListbox).getByRole('option', {
+                name: 'All Admin Permissions',
+            }),
+        );
+        await user.click(screen.getByLabelText(/^Name/i));
+
+        // Submit the dialog.
+        await user.click(screen.getByRole('button', { name: /^Create$/ }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Token created')).toBeInTheDocument();
+        });
+        expect(mockApiPut).toHaveBeenCalledWith(
+            '/api/v1/rbac/tokens/42/scope',
+            expect.objectContaining({
+                connections: [
+                    { connection_id: 100, access_level: 'read_write' },
+                ],
+                mcp_privileges: ['query_read'],
+                admin_permissions: ['*'],
+            }),
+        );
+    });
+
+    it('creates a token with the "All MCP Privileges" wildcard via the _isAll mapping', async () => {
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: [] });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: true,
+                    connection_privileges: {},
+                    mcp_privileges: [],
+                    admin_permissions: [],
+                });
+            }
+            return Promise.resolve({});
+        });
+        mockApiPost.mockResolvedValue({ id: 7, token: 'pgedge_token_wildcard' });
+        mockApiPut.mockResolvedValue({});
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: /create token/i }),
+            ).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        await user.type(screen.getByLabelText(/^Name/i), 'wild-token');
+
+        const ownerCombo = await screen.findByRole('combobox', { name: /owner/i });
+        await user.click(ownerCombo);
+        const aliceOption = await screen.findByRole('option', { name: 'alice' });
+        await user.click(aliceOption);
+
+        // Select All MCP wildcard.
+        const mcpCombo = await screen.findByRole('combobox', {
+            name: /allowed mcp privileges/i,
+        });
+        await user.click(mcpCombo);
+        const mcpListbox = await screen.findByRole('listbox');
+        await user.click(
+            within(mcpListbox).getByRole('option', { name: 'All MCP Privileges' }),
+        );
+        await user.click(screen.getByLabelText(/^Name/i));
+
+        await user.click(screen.getByRole('button', { name: /^Create$/ }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/rbac/tokens/7/scope',
+                expect.objectContaining({
+                    mcp_privileges: ['*'],
+                }),
+            );
+        });
+    });
+
+    it('cancels the create dialog and resets the form state', async () => {
+        setupApiGetMock();
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('button', { name: /create token/i }),
+            ).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', { name: /create token/i }));
+
+        // Click the Cancel button (line 487 onClose handler).
+        const cancel = await screen.findByRole('button', { name: /Cancel/i });
+        await user.click(cancel);
+
+        await waitFor(() => {
+            expect(screen.queryByLabelText(/^Name/i)).not.toBeInTheDocument();
+        });
+    });
+
+    it('opens the edit dialog for a token without user_id (no-user fallback path)', async () => {
+        const TOKEN = {
+            id: 9,
+            name: 'orphan-token',
+            token_prefix: 'orf',
+            // user_id intentionally omitted to exercise the else-branch at
+            // line 329-335.
+            username: 'alice',
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: {
+                scoped: true,
+                connections: [],
+                mcp_privileges: [],
+                admin_permissions: [],
+            },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            return Promise.reject(new Error(`Unexpected URL: ${url}`));
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('orphan-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/edit token/i));
+
+        // The dialog should open without triggering a privileges fetch.
+        await screen.findByRole('dialog');
+        expect(mockApiGet).not.toHaveBeenCalledWith(
+            expect.stringMatching(/\/privileges$/),
+        );
+    });
+
+    it('opens the edit dialog when owner-privileges fetch fails (catch path)', async () => {
+        const TOKEN = {
+            id: 11,
+            name: 'broken-privs-token',
+            token_prefix: 'brp',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: {
+                scoped: true,
+                connections: [
+                    { connection_id: 100, access_level: 'read' },
+                ],
+                mcp_privileges: [-1],
+                admin_permissions: ['*'],
+            },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.reject(new Error('privs down'));
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('broken-privs-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/edit token/i));
+
+        // The dialog renders. The wildcard MCP scope (id=-1) triggers the
+        // ALL_MCP_OPTION path (line 277). The "*" admin scope triggers the
+        // ALL_ADMIN_OPTION path (line 284).
+        await screen.findByRole('dialog');
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledWith(
+                `/api/v1/rbac/users/${USERS[0].id}/privileges`,
+            );
+        });
+    });
+
+    it('opens the edit dialog for a non-superuser owner with a wildcard connection privilege', async () => {
+        const TOKEN = {
+            id: 12,
+            name: 'nonsuper-token',
+            token_prefix: 'nst',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                // Owner has wildcard connection privilege (0) and a specific
+                // mcp privilege.
+                return Promise.resolve({
+                    is_superuser: false,
+                    connection_privileges: { 0: 'read_write' },
+                    mcp_privileges: ['query_read'],
+                    admin_permissions: ['manage_users'],
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('nonsuper-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/edit token/i));
+
+        await screen.findByRole('dialog');
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalledWith(
+                `/api/v1/rbac/users/${USERS[0].id}/privileges`,
+            );
+        });
+
+        // The Add Connection combobox should include primary-db (wildcard 0).
+        const addConnCombo = await screen.findByRole('combobox', {
+            name: /add connection/i,
+        });
+        await user.click(addConnCombo);
+        const optsBox = await screen.findByRole('listbox');
+        expect(
+            within(optsBox).getByRole('option', { name: 'primary-db' }),
+        ).toBeInTheDocument();
+    });
+
+    it('opens the edit dialog for a non-superuser owner without wildcard, filtering connections', async () => {
+        const customConnections = [
+            { id: 100, name: 'primary-db' },
+            { id: 200, name: 'replica-db' },
+        ];
+        const TOKEN = {
+            id: 13,
+            name: 'restricted-token',
+            token_prefix: 'res',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: customConnections });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: false,
+                    connection_privileges: { 100: 'read' },
+                    mcp_privileges: ['query_read'],
+                    admin_permissions: ['manage_users'],
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('restricted-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/edit token/i));
+
+        await screen.findByRole('dialog');
+        const addConnCombo = await screen.findByRole('combobox', {
+            name: /add connection/i,
+        });
+        await user.click(addConnCombo);
+        const listbox = await screen.findByRole('listbox');
+        expect(
+            within(listbox).getByRole('option', { name: 'primary-db' }),
+        ).toBeInTheDocument();
+        expect(
+            within(listbox).queryByRole('option', { name: 'replica-db' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('saves the edited scope successfully and closes the dialog', async () => {
+        const TOKEN = {
+            id: 14,
+            name: 'save-token',
+            token_prefix: 'sv',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: true,
+                    connection_privileges: {},
+                    mcp_privileges: [],
+                    admin_permissions: [],
+                });
+            }
+            return Promise.resolve({});
+        });
+        mockApiPut.mockResolvedValue({});
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('save-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/edit token/i));
+        const dialog = await screen.findByRole('dialog');
+
+        await user.click(within(dialog).getByRole('button', { name: /^Save$/ }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                `/api/v1/rbac/tokens/${TOKEN.id}/scope`,
+                expect.any(Object),
+            );
+        });
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('saves the edited scope with wildcard mcp and admin via _isAll mapping', async () => {
+        // The wildcard MCP privilege from the API surfaces as identifier '*'.
+        // The panel's getMcpPrivilegeName maps that id back to '*', enabling
+        // the editMcpPrivileges to set to ALL_MCP_OPTION (line 277).
+        const MCP_WITH_WILDCARD = [
+            { id: -1, identifier: '*' },
+            ...MCP_PRIVILEGES,
+        ];
+        const TOKEN = {
+            id: 15,
+            name: 'wild-edit-token',
+            token_prefix: 'we',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: {
+                scoped: true,
+                connections: [],
+                mcp_privileges: [-1],
+                admin_permissions: ['*'],
+            },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_WITH_WILDCARD);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: true,
+                    connection_privileges: {},
+                    mcp_privileges: [],
+                    admin_permissions: [],
+                });
+            }
+            return Promise.resolve({});
+        });
+        mockApiPut.mockResolvedValue({});
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('wild-edit-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/edit token/i));
+        const dialog = await screen.findByRole('dialog');
+
+        // Save unchanged - wildcard selections are already pre-populated.
+        await user.click(within(dialog).getByRole('button', { name: /^Save$/ }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                `/api/v1/rbac/tokens/${TOKEN.id}/scope`,
+                expect.objectContaining({
+                    mcp_privileges: ['*'],
+                    admin_permissions: ['*'],
+                }),
+            );
+        });
+    });
+
+    it('saves the edited scope with explicit connection and admin selections', async () => {
+        const customConnections = [{ id: 100, name: 'primary-db' }];
+        const TOKEN = {
+            id: 21,
+            name: 'explicit-scope-token',
+            token_prefix: 'es',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: {
+                scoped: true,
+                connections: [
+                    { connection_id: 100, access_level: 'read' },
+                ],
+                mcp_privileges: [1],
+                admin_permissions: ['manage_users'],
+            },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: customConnections });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: true,
+                    connection_privileges: {},
+                    mcp_privileges: [],
+                    admin_permissions: [],
+                });
+            }
+            return Promise.resolve({});
+        });
+        mockApiPut.mockResolvedValue({});
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('explicit-scope-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/edit token/i));
+        const dialog = await screen.findByRole('dialog');
+
+        await user.click(within(dialog).getByRole('button', { name: /^Save$/ }));
+
+        await waitFor(() => {
+            expect(mockApiPut).toHaveBeenCalledWith(
+                `/api/v1/rbac/tokens/${TOKEN.id}/scope`,
+                expect.objectContaining({
+                    connections: [
+                        { connection_id: 100, access_level: 'read' },
+                    ],
+                    mcp_privileges: ['query_read'],
+                    admin_permissions: ['manage_users'],
+                }),
+            );
+        });
+    });
+
+    it('cancels the edit dialog without saving', async () => {
+        const TOKEN = {
+            id: 16,
+            name: 'cancel-token',
+            token_prefix: 'cn',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            if (url === `/api/v1/rbac/users/${USERS[0].id}/privileges`) {
+                return Promise.resolve({
+                    is_superuser: true,
+                    connection_privileges: {},
+                    mcp_privileges: [],
+                    admin_permissions: [],
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('cancel-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/edit token/i));
+        const dialog = await screen.findByRole('dialog');
+
+        // Click Cancel (line 522 onClose handler).
+        await user.click(within(dialog).getByRole('button', { name: /Cancel/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(mockApiPut).not.toHaveBeenCalled();
+    });
+
+    it('cancels the delete-confirmation dialog without deleting', async () => {
+        const TOKEN = {
+            id: 17,
+            name: 'undelete-token',
+            token_prefix: 'ud',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('undelete-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/delete token/i));
+        const dialog = await screen.findByRole('dialog');
+
+        // The DeleteConfirmationDialog has a Cancel button bound to its
+        // onClose prop (lines 542-544 in the panel).
+        await user.click(within(dialog).getByRole('button', { name: /Cancel/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(mockApiDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes a token successfully and refreshes the table', async () => {
+        const TOKEN = {
+            id: 18,
+            name: 'delete-success-token',
+            token_prefix: 'dsx',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: { scoped: false },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            return Promise.resolve({});
+        });
+        mockApiDelete.mockResolvedValue({});
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('delete-success-token')).toBeInTheDocument();
+        });
+        await user.click(screen.getByLabelText(/delete token/i));
+        const dialog = await screen.findByRole('dialog');
+
+        await user.click(within(dialog).getByRole('button', { name: /^Delete$/ }));
+
+        await waitFor(() => {
+            expect(mockApiDelete).toHaveBeenCalledWith(
+                `/api/v1/rbac/tokens/${TOKEN.id}`,
+            );
+        });
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('renders a non-zero, non-wildcard MCP privilege name via getMcpPrivilegeName', async () => {
+        // Render with token whose scope mcp_privileges references a real id
+        // and another unknown id, exercising both arms of the find().
+        const TOKEN = {
+            id: 19,
+            name: 'mcp-label-token',
+            token_prefix: 'mlb',
+            username: 'alice',
+            user_id: USERS[0].id,
+            is_service_account: false,
+            is_superuser: false,
+            expires_at: null,
+            scope: {
+                scoped: true,
+                connections: [],
+                mcp_privileges: [1, 999],
+                admin_permissions: [],
+            },
+        };
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.resolve({ tokens: [TOKEN] });
+            }
+            if (url === '/api/v1/connections') {
+                return Promise.resolve({ connections: CONNECTIONS });
+            }
+            if (url === '/api/v1/rbac/privileges/mcp') {
+                return Promise.resolve(MCP_PRIVILEGES);
+            }
+            if (url === '/api/v1/rbac/users') {
+                return Promise.resolve({ users: USERS });
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        render(<AdminTokenScopes />);
+
+        await waitFor(() => {
+            expect(screen.getByText('mcp-label-token')).toBeInTheDocument();
+        });
+
+        // Open edit dialog so the scope mcp_privileges are mapped through
+        // getMcpPrivilegeName (lines 105-106). The dialog reflects them in
+        // the Allowed MCP Privileges combobox.
+        await user.click(screen.getByLabelText(/edit token/i));
+        const dialog = await screen.findByRole('dialog');
+        // The selected MCP set should contain "query_read" (id 1) since
+        // 999 is unknown and filtered out by the panel's editor (it only
+        // includes ids that exist in mcpPrivileges via filter).
+        expect(
+            within(dialog).getByText('query_read'),
+        ).toBeInTheDocument();
+    });
+
+    it('dismisses the top-level error alert', async () => {
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/api/v1/rbac/tokens') {
+                return Promise.reject(new Error('boom'));
+            }
+            return Promise.resolve({});
+        });
+
+        const user = userEvent.setup({ delay: null });
+        renderPanel();
+
+        await waitFor(() => {
+            expect(screen.getByText('boom')).toBeInTheDocument();
+        });
+
+        const alert = screen.getByText('boom').closest('[role="alert"]');
+        expect(alert).not.toBeNull();
+        const closeBtn = within(alert as HTMLElement).getByRole('button');
+        await user.click(closeBtn);
+
+        await waitFor(() => {
+            expect(screen.queryByText('boom')).not.toBeInTheDocument();
+        });
+    });
+
+    it('flips the copied state back to the copy icon after the 2s timeout', async () => {
+        installCreateFlowApiMocks();
+        mockApiPost.mockResolvedValue({
+            id: 99,
+            token: 'pgedge_timer_token',
+        });
+
+        // Capture the setTimeout callback registered by handleCopyToken so we
+        // can invoke it manually without using fake timers (fake timers break
+        // userEvent and waitFor flows).
+        let capturedCallback: (() => void) | null = null;
+        const originalSetTimeout = window.setTimeout;
+        const setTimeoutSpy = vi
+            .spyOn(window, 'setTimeout')
+            .mockImplementation((fn: TimerHandler, ms?: number) => {
+                if (ms === 2000 && typeof fn === 'function') {
+                    capturedCallback = fn as () => void;
+                    return 12345 as unknown as ReturnType<typeof setTimeout>;
+                }
+                return originalSetTimeout(fn, ms);
+            });
+
+        try {
+            const writeText = vi.fn().mockResolvedValue(undefined);
+            const user = await openCreatedDialog();
+            installClipboardMock(writeText);
+
+            const copyBtn = screen.getByRole('button', {
+                name: /copy token/i,
+            });
+            await act(async () => {
+                fireEvent.click(copyBtn);
+            });
+
+            await waitFor(() => {
+                expect(screen.getByTestId('CheckIcon')).toBeInTheDocument();
+            });
+
+            // Invoke the captured setTimeout callback manually to exercise
+            // the reset path (lines 404-406).
+            expect(capturedCallback).not.toBeNull();
+            await act(async () => {
+                (capturedCallback as () => void)();
+            });
+
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId('ContentCopyIcon'),
+                ).toBeInTheDocument();
+            });
+            expect(screen.queryByTestId('CheckIcon')).not.toBeInTheDocument();
+            // Reference `user` to satisfy the no-unused-vars check.
+            expect(user).toBeDefined();
+        } finally {
+            setTimeoutSpy.mockRestore();
+        }
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
@@ -1116,9 +1116,12 @@ describe('AdminTokenScopes - additional coverage', () => {
         // Submit the dialog.
         await user.click(screen.getByRole('button', { name: /^Create$/ }));
 
-        await waitFor(() => {
-            expect(screen.getByText('Token created')).toBeInTheDocument();
-        });
+        await waitFor(
+            () => {
+                expect(screen.getByText('Token created')).toBeInTheDocument();
+            },
+            { timeout: 10000 },
+        );
         expect(mockApiPut).toHaveBeenCalledWith(
             '/api/v1/rbac/tokens/42/scope',
             expect.objectContaining({
@@ -1129,7 +1132,7 @@ describe('AdminTokenScopes - additional coverage', () => {
                 admin_permissions: ['*'],
             }),
         );
-    });
+    }, 15000);
 
     it('creates a token with the "All MCP Privileges" wildcard via the _isAll mapping', async () => {
         mockApiGet.mockImplementation((url: string) => {

--- a/client/src/components/AdminPanel/__tests__/AdminUsers.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminUsers.test.tsx
@@ -198,6 +198,21 @@ describe('AdminUsers', () => {
                 expect(screen.getByText('list failed')).toBeInTheDocument();
             });
         });
+
+        it('shows the unified fallback when the list fetch throws a non-Error', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/users') {
+                    return Promise.reject('plain string reject');
+                }
+                return Promise.resolve({});
+            });
+            renderWithTheme(<AdminUsers />);
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
     });
 
     describe('Create user dialog', () => {
@@ -389,6 +404,35 @@ describe('AdminUsers', () => {
                     within(dialog).getByText(
                         /password is too common/i
                     )
+                ).toBeInTheDocument();
+            });
+        }, 15000);
+
+        it('shows the unified fallback when create throws a non-Error', async () => {
+            installListMocks();
+            mockApiPost.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminUsers />);
+            await waitFor(() => {
+                expect(screen.getByText('alice')).toBeInTheDocument();
+            });
+            await user.click(
+                screen.getByRole('button', { name: /create user/i })
+            );
+            const dialog = await screen.findByRole('dialog');
+            await user.type(
+                findFieldByLabel(dialog, 'Username'),
+                'charlie'
+            );
+            fireEvent.change(findFieldByLabel(dialog, 'Password'), {
+                target: { value: 'StrongPassword123!' },
+            });
+            await user.click(
+                within(dialog).getByRole('button', { name: /^create$/i })
+            );
+            await waitFor(() => {
+                expect(
+                    within(dialog).getByText('An unexpected error occurred'),
                 ).toBeInTheDocument();
             });
         }, 15000);
@@ -595,6 +639,28 @@ describe('AdminUsers', () => {
             });
         }, 15000);
 
+        it('shows the unified fallback when edit throws a non-Error', async () => {
+            installListMocks();
+            mockApiPut.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminUsers />);
+            await waitFor(() => {
+                expect(screen.getByText('bob')).toBeInTheDocument();
+            });
+            await user.click(screen.getAllByLabelText('edit user')[1]);
+            const dialog = await screen.findByRole('dialog');
+            const notesInput = findFieldByLabel(dialog, 'Notes');
+            fireEvent.change(notesInput, { target: { value: 'change' } });
+            await user.click(
+                within(dialog).getByRole('button', { name: /^save$/i })
+            );
+            await waitFor(() => {
+                expect(
+                    within(dialog).getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        }, 15000);
+
         it('submits non-password edits without the password field', async () => {
             installListMocks();
             mockApiPut.mockResolvedValue({});
@@ -721,6 +787,32 @@ describe('AdminUsers', () => {
             });
         });
 
+        it('shows the unified fallback when permissions load throws a non-Error', async () => {
+            mockApiGet.mockImplementation((url: string) => {
+                if (url === '/api/v1/rbac/users') {
+                    return Promise.resolve({ users: mockUsers });
+                }
+                if (url === '/api/v1/connections') {
+                    return Promise.resolve({ connections: [] });
+                }
+                if (/^\/api\/v1\/rbac\/users\/\d+\/privileges$/.test(url)) {
+                    return Promise.reject('plain string reject');
+                }
+                return Promise.resolve({});
+            });
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminUsers />);
+            await waitFor(() => {
+                expect(screen.getByText('bob')).toBeInTheDocument();
+            });
+            await user.click(screen.getByText('bob'));
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+
         it('toggles superuser via the inline switch', async () => {
             installListMocks();
             mockApiPut.mockResolvedValue({});
@@ -775,6 +867,40 @@ describe('AdminUsers', () => {
                 expect(screen.getByText('toggle fail')).toBeInTheDocument();
             });
         });
+
+        it('shows the unified fallback when superuser toggle throws a non-Error', async () => {
+            installListMocks();
+            mockApiPut.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminUsers />);
+            await waitFor(() => {
+                expect(screen.getByText('bob')).toBeInTheDocument();
+            });
+            const supSwitches = screen.getAllByLabelText('Toggle superuser');
+            await user.click(supSwitches[1]);
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('shows the unified fallback when enabled toggle throws a non-Error', async () => {
+            installListMocks();
+            mockApiPut.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminUsers />);
+            await waitFor(() => {
+                expect(screen.getByText('bob')).toBeInTheDocument();
+            });
+            const enabledSwitches = screen.getAllByLabelText('Toggle enabled');
+            await user.click(enabledSwitches[1]);
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
+            });
+        });
     });
 
     describe('Delete user', () => {
@@ -813,6 +939,26 @@ describe('AdminUsers', () => {
             );
             await waitFor(() => {
                 expect(screen.getByText('delete fail')).toBeInTheDocument();
+            });
+        });
+
+        it('shows the unified fallback when delete throws a non-Error', async () => {
+            installListMocks();
+            mockApiDelete.mockRejectedValue('plain string reject');
+            const user = userEvent.setup({ delay: null });
+            renderWithTheme(<AdminUsers />);
+            await waitFor(() => {
+                expect(screen.getByText('bob')).toBeInTheDocument();
+            });
+            await user.click(screen.getAllByLabelText('delete user')[1]);
+            const dialog = await screen.findByRole('dialog');
+            await user.click(
+                within(dialog).getByRole('button', { name: /delete/i })
+            );
+            await waitFor(() => {
+                expect(
+                    screen.getByText('An unexpected error occurred'),
+                ).toBeInTheDocument();
             });
         });
     });

--- a/client/src/components/AdminPanel/_shared/errors.ts
+++ b/client/src/components/AdminPanel/_shared/errors.ts
@@ -14,18 +14,49 @@
  * Every AdminPanel mutation handler used to inline an `err instanceof Error`
  * check followed by a fallback string; centralising that here removes a
  * substantial amount of duplication and keeps fallback wording consistent.
+ *
+ * AdminPanel components MUST use {@link extractErrorMessage} for the generic
+ * "something went wrong" path in their catch blocks. Do not reintroduce
+ * ad-hoc patterns such as `String(err)` (which produces unfriendly
+ * `[object Object]`-style output) or inline `err instanceof Error ? ... : ...`
+ * ternaries that hard-code a divergent fallback wording. The only acceptable
+ * variation is passing a context-specific `fallback` argument when the
+ * surrounding code already conveys meaningful context (for example,
+ * `extractErrorMessage(err, 'Failed to load recipients')`).
  */
 
 /**
  * Default fallback message used when a thrown value is not an `Error`
- * instance. AdminPanel components historically use this exact wording.
+ * instance. AdminPanel components surface this exact wording to keep
+ * non-`Error` throws presenting a consistent, user-friendly string.
  */
 export const DEFAULT_ERROR_MESSAGE = 'An unexpected error occurred';
 
 /**
- * Extracts a user-displayable message from a thrown value. When the value
- * is an `Error`, returns its `message`. Otherwise returns `fallback`,
- * which defaults to {@link DEFAULT_ERROR_MESSAGE}.
+ * Extracts a user-displayable message from a thrown value.
+ *
+ * Contract:
+ *
+ * - When `err` is an `Error` instance, returns its `message` property
+ *   verbatim. Callers therefore never need to special-case `Error` themselves.
+ * - When `err` is any other value (a string, `null`, `undefined`, a plain
+ *   object, etc.), returns `fallback`, which defaults to
+ *   {@link DEFAULT_ERROR_MESSAGE} (`'An unexpected error occurred'`). This
+ *   guarantees AdminPanel components never display `[object Object]` or
+ *   other implementation-leaking strings produced by `String(err)`.
+ *
+ * Pass an explicit `fallback` only when the call site can provide a more
+ * descriptive, context-specific message (for example, "Failed to load
+ * recipients"). Otherwise rely on the default to keep wording uniform
+ * across the AdminPanel.
+ *
+ * @param err - The value thrown from a `try`/`catch` block. Typed as
+ *   `unknown` because TypeScript widens the catch parameter to `unknown`
+ *   under `useUnknownInCatchVariables`.
+ * @param fallback - Optional override for the non-`Error` fallback string.
+ *   Defaults to {@link DEFAULT_ERROR_MESSAGE}.
+ * @returns A user-safe error message string suitable for display in an
+ *   `Alert`, toast, or form-level error banner.
  */
 export function extractErrorMessage(
     err: unknown,

--- a/client/src/components/AdminPanel/channels/useChannelCRUD.ts
+++ b/client/src/components/AdminPanel/channels/useChannelCRUD.ts
@@ -10,6 +10,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { apiGet, apiPost, apiPut, apiDelete } from '../../../utils/apiClient';
+import { extractErrorMessage } from '../_shared';
 import type { BaseChannel } from './channelTypes';
 
 /**
@@ -135,11 +136,7 @@ export function useChannelCRUD<T extends BaseChannel>(
             }
         } catch (err: unknown) {
             if (requestId === fetchRequestIdRef.current) {
-                if (err instanceof Error) {
-                    setError(err.message);
-                } else {
-                    setError('An unexpected error occurred');
-                }
+                setError(extractErrorMessage(err));
             }
         } finally {
             if (requestId === fetchRequestIdRef.current) {
@@ -161,11 +158,7 @@ export function useChannelCRUD<T extends BaseChannel>(
             });
             await fetchChannels();
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
+            setError(extractErrorMessage(err));
         }
     }, [fetchChannels]);
 
@@ -179,11 +172,7 @@ export function useChannelCRUD<T extends BaseChannel>(
             await apiPost(`/api/v1/notification-channels/${channel.id}/test`);
             setSuccess(`Test notification sent successfully for "${channel.name}".`);
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('Failed to send test notification');
-            }
+            setError(extractErrorMessage(err, 'Failed to send test notification'));
         } finally {
             setTestingChannelId(null);
         }
@@ -207,11 +196,7 @@ export function useChannelCRUD<T extends BaseChannel>(
             setDeleteChannel(null);
             await fetchChannels();
         } catch (err: unknown) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError('An unexpected error occurred');
-            }
+            setError(extractErrorMessage(err));
         } finally {
             setDeleteLoading(false);
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -336,8 +336,8 @@ project adheres to
   `AdminMessagingChannels`, and `AdminGroups` panels, along
   with the `useChannelCRUD` hook, now route non-`Error`
   throws through the shared `extractErrorMessage` helper in
-  `client/src/components/AdminPanel/_shared/errors.ts`. The
-  helper returns the generic `'An unexpected error
+  [`client/src/components/AdminPanel/_shared/errors.ts`](https://github.com/pgEdge/ai-dba-workbench/blob/main/client/src/components/AdminPanel/_shared/errors.ts).
+  The helper returns the generic `'An unexpected error
   occurred'` message instead of leaking output such as
   `[object Object]` produced by `String(err)`. Panels that
   pass a contextual fallback (for example, "Failed to add

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -328,6 +328,21 @@ project adheres to
 
 ### Fixed
 
+- Fix the divergent error fallback wording shown by the
+  Admin panels when a thrown value is not an `Error`
+  instance. The `AdminUsers`, `AdminMemories`,
+  `AdminTokenScopes`, `AdminPermissions`, `AdminProbes`,
+  `AdminEmailChannels`, `AdminWebhookChannels`,
+  `AdminMessagingChannels`, and `AdminGroups` panels, along
+  with the `useChannelCRUD` hook, now route non-`Error`
+  throws through the shared `extractErrorMessage` helper in
+  `client/src/components/AdminPanel/_shared/errors.ts`. The
+  helper returns the generic `'An unexpected error
+  occurred'` message instead of leaking output such as
+  `[object Object]` produced by `String(err)`. Panels that
+  pass a contextual fallback (for example, "Failed to add
+  recipient") to the helper's second argument retain that
+  context-specific wording. (#212)
 - Fix the `Chart.test.tsx` regression introduced in
   commit `aa28aa8` that has been failing the CI -
   Client workflow on every commit since; the


### PR DESCRIPTION
## Summary

Closes #212.

- Migrate `AdminUsers`, `AdminMemories`, `AdminTokenScopes`, `AdminPermissions`, `AdminProbes`, `AdminEmailChannels`, `AdminWebhookChannels`, `AdminMessagingChannels`, `AdminGroups`, and `useChannelCRUD` from `String(err)` / inline `instanceof Error` fallbacks to the shared `extractErrorMessage` helper in `client/src/components/AdminPanel/_shared/errors.ts`.
- Non-`Error` throws now surface the same generic `'An unexpected error occurred'` wording everywhere (or a contextual fallback when the call site passes one via the helper's second argument) instead of leaking `[object Object]`-style output.
- Expand the `extractErrorMessage` TSDoc to document the fallback contract and banned patterns, and update the react-expert KB checklist accordingly.

## Test plan

- [x] `make test-all` passes (150 test files, 3079 tests).
- [x] Per-file coverage for every touched panel meets the project's 90% line-coverage floor (`AdminPermissions.tsx` 98.48% lines, `AdminTokenScopes.tsx` 97.68% lines, others ≥90%).
- [x] `npm run lint` introduces no new warnings; remaining warnings are pre-existing in untouched files.
- [x] Added/updated tests cover the non-`Error` fallback branches and the previously-untested dialog/rendering paths in `AdminPermissions` and `AdminTokenScopes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin panel components now surface consistent, user-friendly error messages for both Error and non-Error failures; avoids leaking raw/stringified error values while preserving contextual fallback text.

* **Tests**
  * Added extensive tests verifying unified fallback behavior and non-Error rejection handling across admin panels.

* **Documentation**
  * Added checklist/guidance enforcing the standardized error-handling pattern for admin mutation handlers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/218)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->