### PR TITLE
fix(client): guard useCrudPanel refresh against stale results

### DIFF
--- a/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
@@ -8,9 +8,27 @@
  *-------------------------------------------------------------------------
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useCrudPanel } from '../../_shared/useCrudPanel';
+
+/**
+ * Build an externally-resolvable promise. Useful for ordering multiple
+ * in-flight fetches in tests that exercise the stale-result race.
+ */
+function deferred<T>(): {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason?: unknown) => void;
+} {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
 
 interface Item {
     id: number;
@@ -450,6 +468,155 @@ describe('useCrudPanel', () => {
             await waitFor(() =>
                 expect(result.current.deleteLoading).toBe(false),
             );
+        });
+    });
+
+    describe('stale-result protection', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('drops a stale fetch that resolves after a newer one (deps change)', async () => {
+            // The hook should only commit results from the most recent
+            // refresh. Here the first fetch (triggered by mount) is slow
+            // and returns ['stale']; the deps change kicks off a second
+            // fetch that resolves immediately with ['fresh']. The final
+            // `items` must be ['fresh'].
+            const slow = deferred<string[]>();
+            const fast = deferred<string[]>();
+            const fetchItems = vi.fn<() => Promise<string[]>>()
+                .mockImplementationOnce(() => slow.promise)
+                .mockImplementationOnce(() => fast.promise);
+
+            let dep = 'a';
+            const { result, rerender } = renderHook(
+                () => useCrudPanel<string>({ fetchItems, deps: [dep] }),
+            );
+
+            // First fetch is in flight; loading must be true and no items
+            // committed yet.
+            expect(result.current.loading).toBe(true);
+            expect(result.current.items).toEqual([]);
+            await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(1));
+
+            // Change deps; this triggers a second fetch with the next
+            // generation. Both fetches are now in flight.
+            dep = 'b';
+            rerender();
+            await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(2));
+
+            // Resolve the fast (newer) fetch first.
+            await act(async () => {
+                fast.resolve(['fresh']);
+                await fast.promise;
+            });
+            await waitFor(() => expect(result.current.items).toEqual(['fresh']));
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            // Now resolve the slow (older) fetch. It must NOT overwrite
+            // the fresh result, and must NOT flip `loading` back to true
+            // or anything else.
+            await act(async () => {
+                slow.resolve(['stale']);
+                await slow.promise;
+            });
+
+            expect(result.current.items).toEqual(['fresh']);
+            expect(result.current.loading).toBe(false);
+        });
+
+        it('drops a stale fetch error that arrives after a successful refresh', async () => {
+            // Same shape as the success-race test, but the older fetch
+            // rejects after a newer fetch resolves. The error must not
+            // leak onto the page-level error slot.
+            const slow = deferred<string[]>();
+            const fast = deferred<string[]>();
+            const fetchItems = vi.fn<() => Promise<string[]>>()
+                .mockImplementationOnce(() => slow.promise)
+                .mockImplementationOnce(() => fast.promise);
+
+            let dep = 'a';
+            const { result, rerender } = renderHook(
+                () => useCrudPanel<string>({ fetchItems, deps: [dep] }),
+            );
+
+            await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(1));
+
+            dep = 'b';
+            rerender();
+            await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(2));
+
+            await act(async () => {
+                fast.resolve(['fresh']);
+                await fast.promise;
+            });
+            await waitFor(() => expect(result.current.items).toEqual(['fresh']));
+
+            await act(async () => {
+                slow.reject(new Error('stale failure'));
+                await slow.promise.catch(() => {});
+            });
+
+            expect(result.current.error).toBeNull();
+            expect(result.current.items).toEqual(['fresh']);
+            expect(result.current.loading).toBe(false);
+        });
+
+        it('does not write state after unmount and logs no warning', async () => {
+            const consoleError = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+
+            const pending = deferred<string[]>();
+            const fetchItems = vi.fn<() => Promise<string[]>>(
+                () => pending.promise,
+            );
+
+            const { result, unmount } = renderHook(
+                () => useCrudPanel<string>({ fetchItems }),
+            );
+
+            // The initial fetch is in flight.
+            await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(1));
+            expect(result.current.loading).toBe(true);
+
+            // Unmount before the fetch resolves.
+            unmount();
+
+            // Resolve the pending fetch. The hook must drop the result;
+            // no setState-after-unmount warnings should appear.
+            await act(async () => {
+                pending.resolve(['after-unmount']);
+                await pending.promise;
+            });
+
+            const warnings = consoleError.mock.calls
+                .map((args) => String(args[0] ?? ''))
+                .filter((msg) =>
+                    msg.includes('unmounted')
+                    || msg.includes('memory leak'),
+                );
+            expect(warnings).toEqual([]);
+        });
+
+        it('still completes the loading transition on the happy path', async () => {
+            // Regression guard: with the generation/mount guards in place,
+            // a plain refresh() must still flip loading false and commit
+            // the result.
+            const fetchItems = vi.fn().mockResolvedValue(['only']);
+            const { result } = renderHook(() =>
+                useCrudPanel<string>({ fetchItems }),
+            );
+
+            await waitFor(() => expect(result.current.loading).toBe(false));
+            expect(result.current.items).toEqual(['only']);
+
+            fetchItems.mockResolvedValueOnce(['again']);
+            await act(async () => {
+                await result.current.refresh();
+            });
+            expect(result.current.items).toEqual(['again']);
+            expect(result.current.loading).toBe(false);
         });
     });
 });

--- a/client/src/components/AdminPanel/_shared/useCrudPanel.ts
+++ b/client/src/components/AdminPanel/_shared/useCrudPanel.ts
@@ -8,7 +8,7 @@
  *-------------------------------------------------------------------------
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { extractErrorMessage } from './errors';
 
 /**
@@ -163,24 +163,67 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
     const [deleteItem, setDeleteItem] = useState<T | null>(null);
     const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
 
+    // Generation counter for `refresh()`. Each invocation captures its
+    // own generation; only the most recent generation is allowed to
+    // commit results to state. This prevents an earlier, slower fetch
+    // from overwriting a later, faster one when `deps` change while a
+    // request is in flight.
+    const fetchGenerationRef = useRef<number>(0);
+
+    // Tracks whether the component is still mounted. State writes after
+    // unmount are silently dropped to avoid React's "setState on an
+    // unmounted component" dev-mode warning.
+    const isMountedRef = useRef<boolean>(true);
+
     const refresh = useCallback(async () => {
+        const generation = fetchGenerationRef.current + 1;
+        fetchGenerationRef.current = generation;
+        setLoading(true);
         try {
-            setLoading(true);
             const next = await fetchItems();
+            // Drop the result if a newer fetch started, or if the
+            // component unmounted while this request was in flight.
+            if (
+                !isMountedRef.current
+                || fetchGenerationRef.current !== generation
+            ) {
+                return;
+            }
             setItems(next);
         } catch (err: unknown) {
+            if (
+                !isMountedRef.current
+                || fetchGenerationRef.current !== generation
+            ) {
+                return;
+            }
             setError(extractErrorMessage(err));
         } finally {
-            setLoading(false);
+            // Only the latest in-flight generation owns the loading
+            // flag; earlier generations must not flip it back to
+            // false while a fresh request is still pending.
+            if (
+                isMountedRef.current
+                && fetchGenerationRef.current === generation
+            ) {
+                setLoading(false);
+            }
         }
     }, [fetchItems]);
 
     // Run refresh once on mount and whenever the caller's `deps` change.
     // `refresh` is included in the deps array; the eslint-disable below
     // is required because we spread caller-supplied `deps`, which the
-    // exhaustive-deps rule cannot statically verify.
+    // exhaustive-deps rule cannot statically verify. The cleanup hook
+    // flips `isMountedRef` so any in-flight fetch that resolves after
+    // unmount becomes a no-op. A deps-change does not unmount the
+    // component, so we also re-arm the ref each time the effect runs.
     useEffect(() => {
+        isMountedRef.current = true;
         void refresh();
+        return () => {
+            isMountedRef.current = false;
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [refresh, ...(deps ?? [])]);
 


### PR DESCRIPTION
## Summary

- Adds a monotonic generation counter and mount-tracking ref inside `useCrudPanel` so that an in-flight `refresh()` whose deps have already changed cannot overwrite list state with stale data.
- Drops `setState` calls when the component has unmounted, eliminating React 18 strict-mode "setState on unmounted" warnings.
- Public `CrudPanelApi` / `UseCrudPanelOptions` types are unchanged; no caller updates required.

Closes #213.

## Implementation

Option B from the issue (non-invasive). Each `refresh()` captures its own generation; results, errors, and `setLoading(false)` only commit when the captured generation is still current and the hook is still mounted. The existing `useEffect` cleanup flips the mount ref so post-unmount fetches no-op cleanly. `runMutation`'s `await refresh()` continues to work because `refresh` still resolves once the fetch settles — it just suppresses the state commit when stale.

## Test plan

- [x] New tests in `useCrudPanel.test.tsx` covering: stale-result race on deps change (fresh wins), stale-error race, unmount safety (no `console.error`), and happy-path regression.
- [x] `npm test -- useCrudPanel` — 27 tests pass (23 existing + 4 new).
- [x] `make test-all` from repo root — all subprojects green.
- [x] `useCrudPanel.ts` line coverage: 100% (74/74 lines, 31/31 branches, 11/11 functions).
- [x] `npm run lint` — 0 errors in modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race condition in AdminPanel where stale fetch results from earlier requests could overwrite newer data, ensuring users always see current information.
  * Fixed improper state updates occurring after component unmount, preventing stale callbacks and improving application stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/222)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->