### PR TITLE
fix(client): unambiguous runMutation result (#214)

### DIFF
--- a/client/src/components/AdminPanel/AdminAlertRules.tsx
+++ b/client/src/components/AdminPanel/AdminAlertRules.tsx
@@ -144,7 +144,7 @@ const AdminAlertRules: React.FC = () => {
                 successMessage: `Alert rule "${getFriendlyTitle(editRule.name)}" updated successfully.`,
             },
         );
-        if (result !== undefined) {
+        if (result.ok) {
             crud.closeDialog();
         }
     };

--- a/client/src/components/AdminPanel/AdminGroups.tsx
+++ b/client/src/components/AdminPanel/AdminGroups.tsx
@@ -189,7 +189,7 @@ const AdminGroups: React.FC = () => {
                     description: formDesc.trim(),
                 }),
         );
-        if (result !== undefined) {
+        if (result.ok) {
             crud.closeDialog();
         }
     };
@@ -212,7 +212,7 @@ const AdminGroups: React.FC = () => {
                     description: formDesc.trim(),
                 }),
         );
-        if (result !== undefined) {
+        if (result.ok) {
             crud.closeDialog();
             if (expandedGroup === target.id) {
                 void fetchGroupDetail(target.id);
@@ -230,20 +230,15 @@ const AdminGroups: React.FC = () => {
         const target = crud.deleteItem;
         if (!target) { return; }
         // The groups DELETE endpoint returns 204 No Content, which the
-        // API client surfaces as `undefined`. `runMutation` uses
-        // `undefined` as its failure sentinel, so a bare apiDelete call
-        // would make a successful delete indistinguishable from a
-        // failure and leave the confirm dialog open (see issue from
-        // PR #209 manual QA). Returning an explicit success token lets
-        // `result !== undefined` correctly gate the close + cleanup.
+        // API client surfaces as `undefined`. `runMutation` now returns
+        // a tagged `{ ok: true | false }` result, so a successful void
+        // mutation is unambiguously distinguishable from a failure
+        // (see issue #214). The bare apiDelete call is therefore safe.
         const result = await crud.runMutation(
-            async () => {
-                await apiDelete(`/api/v1/rbac/groups/${target.id}`);
-                return true as const;
-            },
+            () => apiDelete(`/api/v1/rbac/groups/${target.id}`),
             { errorTarget: 'page' },
         );
-        if (result !== undefined) {
+        if (result.ok) {
             if (expandedGroup === target.id) {
                 setExpandedGroup(null);
                 setGroupDetail(null);

--- a/client/src/components/AdminPanel/AdminMessagingChannels.tsx
+++ b/client/src/components/AdminPanel/AdminMessagingChannels.tsx
@@ -228,7 +228,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                 ? `Channel "${successName}" updated successfully.`
                 : `Channel "${successName}" created successfully.`,
         });
-        if (result !== undefined) {
+        if (result.ok) {
             crud.closeDialog();
         }
     };
@@ -250,7 +250,7 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
                 successMessage: `Channel "${target.name}" deleted successfully.`,
             },
         );
-        if (result !== undefined) {
+        if (result.ok) {
             crud.closeDelete();
         }
     };

--- a/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
@@ -367,14 +367,17 @@ describe('AdminGroups', () => {
         });
 
         it('closes the confirmation dialog after a successful delete and does not re-issue the request', async () => {
-            // Regression test for the PR #209 bug: the rbac/groups DELETE
-            // endpoint returns 204 No Content, which apiClient surfaces
-            // as `undefined`. The earlier `runMutation` consumer keyed
-            // its `closeDelete()` call on `result !== undefined`, treating
+            // Regression test for the PR #209 bug, retained after the
+            // issue #214 fix: the rbac/groups DELETE endpoint returns
+            // 204 No Content, which apiClient surfaces as `undefined`.
+            // The original `runMutation` consumer keyed its
+            // `closeDelete()` call on `result !== undefined`, treating
             // a 204 success identically to a thrown error. The dialog
-            // stayed open with the just-deleted target still selected, so
-            // a second confirm click 404'd the now-missing group and the
-            // user saw "Failed to delete group".
+            // stayed open with the just-deleted target still selected,
+            // so a second confirm click 404'd the now-missing group and
+            // the user saw "Failed to delete group". `runMutation` now
+            // returns a tagged `{ ok: true | false }` result, so the
+            // void-success / failure distinction is unambiguous.
             setupApiGetRouter({
                 '/api/v1/rbac/groups': { groups: GROUPS },
             });

--- a/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
@@ -264,7 +264,7 @@ describe('useCrudPanel', () => {
                     successMessage: 'created',
                 });
             });
-            expect(returned).toBe('ok');
+            expect(returned).toEqual({ ok: true, value: 'ok' });
             expect(result.current.success).toBe('created');
             expect(fetchItems).toHaveBeenCalledTimes(1);
         });
@@ -357,7 +357,7 @@ describe('useCrudPanel', () => {
             expect(result.current.dialogError).toBe('Already exists.');
         });
 
-        it('returns undefined when the mutation fails', async () => {
+        it('returns { ok: false } when the mutation fails', async () => {
             const fetchItems = vi.fn().mockResolvedValue(ITEMS);
             const { result } = renderHook(() =>
                 useCrudPanel<Item>({ fetchItems }),
@@ -369,8 +369,38 @@ describe('useCrudPanel', () => {
             await act(async () => {
                 returned = await result.current.runMutation(fn);
             });
-            expect(returned).toBeUndefined();
+            expect(returned).toEqual({ ok: false });
         });
+
+        it(
+            'returns { ok: true, value: undefined } for a void-returning success',
+            async () => {
+                // Regression guard for issue #214: an `apiDelete` that
+                // resolves to `undefined` on HTTP 204 must be reported
+                // as a success, NOT a failure. With the previous
+                // `R | undefined` return type, callers could not tell
+                // the two cases apart and the AdminGroups delete dialog
+                // never closed. The tagged result removes the ambiguity
+                // at the type level, and this test pins the runtime
+                // behaviour so a future refactor cannot regress it.
+                const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+                fetchItems.mockClear();
+
+                const fn = vi.fn().mockResolvedValue(undefined);
+                let returned: unknown;
+                await act(async () => {
+                    returned = await result.current.runMutation(fn);
+                });
+                expect(returned).toEqual({ ok: true, value: undefined });
+                // The success branch must still trigger a refresh by
+                // default, just like any other successful mutation.
+                expect(fetchItems).toHaveBeenCalledTimes(1);
+            },
+        );
 
         it('clears prior dialog error before each mutation', async () => {
             const fetchItems = vi.fn().mockResolvedValue(ITEMS);

--- a/client/src/components/AdminPanel/_shared/index.ts
+++ b/client/src/components/AdminPanel/_shared/index.ts
@@ -21,6 +21,7 @@ export {
     useCrudPanel,
     type CrudPanelApi,
     type RunMutationOptions,
+    type RunMutationResult,
     type UseCrudPanelOptions,
 } from './useCrudPanel';
 export { extractErrorMessage, DEFAULT_ERROR_MESSAGE } from './errors';

--- a/client/src/components/AdminPanel/_shared/useCrudPanel.ts
+++ b/client/src/components/AdminPanel/_shared/useCrudPanel.ts
@@ -35,6 +35,20 @@ import { extractErrorMessage } from './errors';
  */
 
 /**
+ * Tagged result returned by {@link CrudPanelApi.runMutation}.
+ *
+ * Callers must inspect the `ok` discriminant before reading `value`,
+ * which is only present on the success branch. The discriminated union
+ * prevents the "void success vs. failure" ambiguity that existed when
+ * `runMutation` returned `R | undefined`: an `apiDelete` that resolves
+ * to `undefined` on HTTP 204 is now unambiguously distinguishable from
+ * a rejection, regardless of the value of `R`.
+ */
+export type RunMutationResult<R> =
+    | { ok: true; value: R }
+    | { ok: false };
+
+/**
  * Options for a single mutation invocation.
  */
 export interface RunMutationOptions {
@@ -98,7 +112,10 @@ export interface CrudPanelApi<T> {
     closeDelete: () => void;
 
     // --- Mutation helper ---
-    runMutation: <R>(fn: () => Promise<R>, options?: RunMutationOptions) => Promise<R | undefined>;
+    runMutation: <R>(
+        fn: () => Promise<R>,
+        options?: RunMutationOptions,
+    ) => Promise<RunMutationResult<R>>;
 }
 
 /**
@@ -136,11 +153,13 @@ export interface UseCrudPanelOptions<T> {
  *   });
  *
  *   const handleSave = async () => {
- *       await crud.runMutation(
+ *       const result = await crud.runMutation(
  *           () => apiPost('/api/v1/things', body),
  *           { successMessage: 'Created!' },
  *       );
- *       crud.closeDialog();
+ *       if (result.ok) {
+ *           crud.closeDialog();
+ *       }
  *   };
  */
 export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T> {
@@ -222,7 +241,7 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
     const runMutation = useCallback(async function runMutationInner<R>(
         fn: () => Promise<R>,
         opts: RunMutationOptions = {},
-    ): Promise<R | undefined> {
+    ): Promise<RunMutationResult<R>> {
         const {
             successMessage,
             errorTarget = 'dialog',
@@ -241,20 +260,23 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
             } else {
                 setError(null);
             }
-            const result = await fn();
+            const value = await fn();
             if (successMessage) {
                 setSuccess(successMessage);
             }
             if (shouldRefresh) {
                 await refresh();
             }
-            return result;
+            // Wrap the success value in the tagged result so callers can
+            // distinguish a void-returning success (`apiDelete` on HTTP
+            // 204) from a failure without inspecting `value` at all.
+            return { ok: true, value };
         } catch (err: unknown) {
             const message = mapError
                 ? mapError(err)
                 : extractErrorMessage(err, errorFallback);
             writeError(message);
-            return undefined;
+            return { ok: false };
         } finally {
             setBusy(false);
         }


### PR DESCRIPTION
## Summary

- Closes #214.
- Change `useCrudPanel.runMutation<R>()` to return a tagged
  `{ ok: true; value: R } | { ok: false }` result so a void-returning
  success (e.g. `apiDelete` on HTTP 204) is unambiguously distinguishable
  from failure regardless of `R`.
- Migrate the three current callers (`AdminAlertRules`, `AdminGroups`,
  `AdminMessagingChannels`) to the `result.ok` style and unwind the
  `true as const` sentinel workaround in `AdminGroups.handleDeleteGroup`.

The PR #209 regression test in `AdminGroups.test.tsx` still passes
unchanged against the new shape; its explanatory comment is updated to
reference the issue #214 fix. A new unit test pins the tagged result at
the hook level: a void-returning success reports
`{ ok: true, value: undefined }` rather than being indistinguishable
from a failure.

## Test plan

- [x] `cd client && npm run lint` — clean on touched files
- [x] `cd client && make coverage` — 100% on `useCrudPanel.ts`; touched
      panel components stay above the 90% floor
- [x] `make test-all` from repo root — passes
- [ ] CI green
- [ ] CodeRabbit review clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved admin panel dialog handling to more reliably detect operation success and failure, ensuring dialogs only close when operations complete successfully.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/223)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->