### PR TITLE
fix(client): decouple useCrudPanel busy flag from errorTarget (#216)

### DIFF
--- a/client/src/components/AdminPanel/AdminMessagingChannels.tsx
+++ b/client/src/components/AdminPanel/AdminMessagingChannels.tsx
@@ -257,10 +257,16 @@ const AdminMessagingChannels: React.FC<AdminMessagingChannelsProps> = ({ config 
 
     // --- Inline toggle enabled on main table ---
 
+    // The inline switch is not a delete and not a dialog save, so it
+    // must not flip `deleteLoading` (which would flicker any global
+    // delete spinner wired to it). We keep `errorTarget: 'page'` so a
+    // toggle failure still surfaces in the existing page-level banner,
+    // but pair it with `busyTarget: 'inline'` to decouple busy state.
+    // See issue #216.
     const handleToggleEnabled = async (channel: MessagingChannel) => {
         await crud.runMutation(
             () => apiPut(`/api/v1/notification-channels/${channel.id}`, { enabled: !channel.enabled }),
-            { errorTarget: 'page' },
+            { errorTarget: 'page', busyTarget: 'inline' },
         );
     };
 

--- a/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
@@ -375,7 +375,7 @@ describe('useCrudPanel', () => {
             expect(result.current.dialogError).toBe('Already exists.');
         });
 
-        it('returns { ok: false } when the mutation fails', async () => {
+        it('returns { ok: false, error } when the mutation fails', async () => {
             const fetchItems = vi.fn().mockResolvedValue(ITEMS);
             const { result } = renderHook(() =>
                 useCrudPanel<Item>({ fetchItems }),
@@ -387,7 +387,9 @@ describe('useCrudPanel', () => {
             await act(async () => {
                 returned = await result.current.runMutation(fn);
             });
-            expect(returned).toEqual({ ok: false });
+            // The failure branch carries the user-facing error message
+            // so inline callers can surface it without re-deriving it.
+            expect(returned).toEqual({ ok: false, error: 'nope' });
         });
 
         it(
@@ -499,6 +501,333 @@ describe('useCrudPanel', () => {
                 expect(result.current.deleteLoading).toBe(false),
             );
         });
+
+        // --- Issue #216: decouple errorTarget from busyTarget ---
+
+        it('inline errorTarget routes nowhere and returns the error', async () => {
+            // The inline target must not write to either shared error
+            // slot. The caller reads the message from the returned
+            // result and surfaces it itself (toast, row highlight, etc.).
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            const fn = vi.fn().mockRejectedValue(new Error('inline boom'));
+            let returned: unknown = 'sentinel';
+            await act(async () => {
+                returned = await result.current.runMutation(fn, {
+                    errorTarget: 'inline',
+                });
+            });
+            expect(returned).toEqual({ ok: false, error: 'inline boom' });
+            expect(result.current.error).toBeNull();
+            expect(result.current.dialogError).toBeNull();
+        });
+
+        it(
+            'inline errorTarget preserves an existing page error',
+            async () => {
+                // Regression guard: inline runMutation must not stomp on
+                // the page-level error slot. A prior page error stays
+                // untouched even when the inline mutation fails.
+                const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() =>
+                    expect(result.current.loading).toBe(false),
+                );
+
+                act(() => {
+                    result.current.setError('keep me');
+                });
+                const fn = vi.fn().mockRejectedValue(new Error('inline boom'));
+                await act(async () => {
+                    await result.current.runMutation(fn, {
+                        errorTarget: 'inline',
+                    });
+                });
+                expect(result.current.error).toBe('keep me');
+                expect(result.current.dialogError).toBeNull();
+            },
+        );
+
+        it('inline busyTarget leaves saving and deleteLoading false', async () => {
+            // The inline busy target must NOT toggle either of the two
+            // shared spinners, even while the mutation is mid-flight.
+            // A global indicator wired to `deleteLoading` would otherwise
+            // flicker on every inline toggle.
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            let resolver: ((value: string) => void) | null = null;
+            const fn = vi.fn(
+                () => new Promise<string>((res) => { resolver = res; }),
+            );
+            let mutationPromise: Promise<unknown> | undefined;
+            act(() => {
+                mutationPromise = result.current.runMutation(fn, {
+                    busyTarget: 'inline',
+                });
+            });
+            // Yield once so the mutation kicks off. With no busy flag
+            // toggled, there is nothing observable to wait on; instead
+            // assert both flags stay false across a microtask boundary.
+            await act(async () => {
+                await Promise.resolve();
+            });
+            expect(result.current.saving).toBe(false);
+            expect(result.current.deleteLoading).toBe(false);
+
+            act(() => resolver?.('done'));
+            await mutationPromise;
+            expect(result.current.saving).toBe(false);
+            expect(result.current.deleteLoading).toBe(false);
+        });
+
+        it('busyTarget save toggles saving only', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            let resolver: ((value: string) => void) | null = null;
+            const fn = vi.fn(
+                () => new Promise<string>((res) => { resolver = res; }),
+            );
+            let mutationPromise: Promise<unknown> | undefined;
+            act(() => {
+                mutationPromise = result.current.runMutation(fn, {
+                    errorTarget: 'inline',
+                    busyTarget: 'save',
+                });
+            });
+            await waitFor(() => expect(result.current.saving).toBe(true));
+            expect(result.current.deleteLoading).toBe(false);
+
+            act(() => resolver?.('done'));
+            await mutationPromise;
+            await waitFor(() => expect(result.current.saving).toBe(false));
+            expect(result.current.deleteLoading).toBe(false);
+        });
+
+        it('busyTarget delete toggles deleteLoading only', async () => {
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            let resolver: ((value: string) => void) | null = null;
+            const fn = vi.fn(
+                () => new Promise<string>((res) => { resolver = res; }),
+            );
+            let mutationPromise: Promise<unknown> | undefined;
+            act(() => {
+                mutationPromise = result.current.runMutation(fn, {
+                    errorTarget: 'inline',
+                    busyTarget: 'delete',
+                });
+            });
+            await waitFor(() =>
+                expect(result.current.deleteLoading).toBe(true),
+            );
+            expect(result.current.saving).toBe(false);
+
+            act(() => resolver?.('done'));
+            await mutationPromise;
+            await waitFor(() =>
+                expect(result.current.deleteLoading).toBe(false),
+            );
+            expect(result.current.saving).toBe(false);
+        });
+
+        it('defaults busyTarget=save when errorTarget=dialog (back-compat)', async () => {
+            // The previous coupled API toggled `saving` for dialog
+            // mutations; the default must preserve that.
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            let resolver: ((value: string) => void) | null = null;
+            const fn = vi.fn(
+                () => new Promise<string>((res) => { resolver = res; }),
+            );
+            let mutationPromise: Promise<unknown> | undefined;
+            act(() => {
+                mutationPromise = result.current.runMutation(fn, {
+                    errorTarget: 'dialog',
+                });
+            });
+            await waitFor(() => expect(result.current.saving).toBe(true));
+            expect(result.current.deleteLoading).toBe(false);
+
+            act(() => resolver?.('done'));
+            await mutationPromise;
+        });
+
+        it('defaults busyTarget=delete when errorTarget=page (back-compat)', async () => {
+            // The previous coupled API toggled `deleteLoading` for page
+            // mutations; the default must preserve that.
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            let resolver: ((value: string) => void) | null = null;
+            const fn = vi.fn(
+                () => new Promise<string>((res) => { resolver = res; }),
+            );
+            let mutationPromise: Promise<unknown> | undefined;
+            act(() => {
+                mutationPromise = result.current.runMutation(fn, {
+                    errorTarget: 'page',
+                });
+            });
+            await waitFor(() =>
+                expect(result.current.deleteLoading).toBe(true),
+            );
+            expect(result.current.saving).toBe(false);
+
+            act(() => resolver?.('done'));
+            await mutationPromise;
+        });
+
+        it('defaults busyTarget=inline when errorTarget=inline', async () => {
+            // Inline errorTarget with no busyTarget must default to
+            // inline busy, i.e. toggle nothing.
+            const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+            const { result } = renderHook(() =>
+                useCrudPanel<Item>({ fetchItems }),
+            );
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            let resolver: ((value: string) => void) | null = null;
+            const fn = vi.fn(
+                () => new Promise<string>((res) => { resolver = res; }),
+            );
+            let mutationPromise: Promise<unknown> | undefined;
+            act(() => {
+                mutationPromise = result.current.runMutation(fn, {
+                    errorTarget: 'inline',
+                });
+            });
+            await act(async () => {
+                await Promise.resolve();
+            });
+            expect(result.current.saving).toBe(false);
+            expect(result.current.deleteLoading).toBe(false);
+
+            act(() => resolver?.('done'));
+            await mutationPromise;
+            expect(result.current.saving).toBe(false);
+            expect(result.current.deleteLoading).toBe(false);
+        });
+
+        it(
+            'explicit busyTarget overrides the default from errorTarget',
+            async () => {
+                // errorTarget=page would default busyTarget=delete; the
+                // explicit busyTarget=inline must win and leave both
+                // shared busy flags untouched.
+                const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() =>
+                    expect(result.current.loading).toBe(false),
+                );
+
+                let resolver: ((value: string) => void) | null = null;
+                const fn = vi.fn(
+                    () => new Promise<string>((res) => { resolver = res; }),
+                );
+                let mutationPromise: Promise<unknown> | undefined;
+                act(() => {
+                    mutationPromise = result.current.runMutation(fn, {
+                        errorTarget: 'page',
+                        busyTarget: 'inline',
+                    });
+                });
+                await act(async () => {
+                    await Promise.resolve();
+                });
+                expect(result.current.saving).toBe(false);
+                expect(result.current.deleteLoading).toBe(false);
+
+                act(() => resolver?.('done'));
+                await mutationPromise;
+            },
+        );
+
+        it(
+            'errorTarget=page with busyTarget=inline still routes errors to the page',
+            async () => {
+                // The decoupling preserves error-routing: the failure
+                // message lands on the page banner even though the busy
+                // flag stays inline.
+                const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() =>
+                    expect(result.current.loading).toBe(false),
+                );
+
+                const fn = vi.fn().mockRejectedValue(new Error('toggle fail'));
+                let returned: unknown;
+                await act(async () => {
+                    returned = await result.current.runMutation(fn, {
+                        errorTarget: 'page',
+                        busyTarget: 'inline',
+                    });
+                });
+                expect(returned).toEqual({
+                    ok: false,
+                    error: 'toggle fail',
+                });
+                expect(result.current.error).toBe('toggle fail');
+                expect(result.current.deleteLoading).toBe(false);
+                expect(result.current.saving).toBe(false);
+            },
+        );
+
+        it(
+            'inline errorTarget uses errorFallback for non-Error rejections',
+            async () => {
+                // The fallback message path runs even when the target
+                // is inline; it surfaces via the returned result.
+                const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() =>
+                    expect(result.current.loading).toBe(false),
+                );
+
+                const fn = vi.fn().mockRejectedValue('weird');
+                let returned: unknown;
+                await act(async () => {
+                    returned = await result.current.runMutation(fn, {
+                        errorTarget: 'inline',
+                        errorFallback: 'fallback msg',
+                    });
+                });
+                expect(returned).toEqual({
+                    ok: false,
+                    error: 'fallback msg',
+                });
+            },
+        );
     });
 
     describe('stale-result protection', () => {

--- a/client/src/components/AdminPanel/_shared/index.ts
+++ b/client/src/components/AdminPanel/_shared/index.ts
@@ -19,7 +19,9 @@
 
 export {
     useCrudPanel,
+    type BusyTarget,
     type CrudPanelApi,
+    type ErrorTarget,
     type RunMutationOptions,
     type RunMutationResult,
     type UseCrudPanelOptions,

--- a/client/src/components/AdminPanel/_shared/useCrudPanel.ts
+++ b/client/src/components/AdminPanel/_shared/useCrudPanel.ts
@@ -35,6 +35,27 @@ import { extractErrorMessage } from './errors';
  */
 
 /**
+ * Where {@link runMutation} routes a mutation's error message.
+ *
+ * - `'page'`   writes to `crud.error` (page-level Alert above the table).
+ * - `'dialog'` writes to `crud.dialogError` (Alert inside the dialog).
+ * - `'inline'` writes nowhere; the caller reads the returned error
+ *   from {@link RunMutationResult} and surfaces it itself (toast, row
+ *   highlight, local state, etc.).
+ */
+export type ErrorTarget = 'page' | 'dialog' | 'inline';
+
+/**
+ * Which busy flag {@link runMutation} toggles while the mutation runs.
+ *
+ * - `'save'`   toggles `crud.saving` (dialog spinner / disabled state).
+ * - `'delete'` toggles `crud.deleteLoading` (delete dialog spinner).
+ * - `'inline'` toggles neither. The caller owns inline busy state, so
+ *   an inline toggle never flickers a global delete or save indicator.
+ */
+export type BusyTarget = 'save' | 'delete' | 'inline';
+
+/**
  * Tagged result returned by {@link CrudPanelApi.runMutation}.
  *
  * Callers must inspect the `ok` discriminant before reading `value`,
@@ -43,40 +64,40 @@ import { extractErrorMessage } from './errors';
  * `runMutation` returned `R | undefined`: an `apiDelete` that resolves
  * to `undefined` on HTTP 204 is now unambiguously distinguishable from
  * a rejection, regardless of the value of `R`.
+ *
+ * The failure branch carries the user-facing `error` message (after
+ * `mapError` / `errorFallback` are applied) so callers using
+ * `errorTarget: 'inline'` can surface it locally without re-deriving
+ * the message themselves.
  */
 export type RunMutationResult<R> =
     | { ok: true; value: R }
-    | { ok: false };
+    | { ok: false; error: string };
 
 /**
  * Options for a single mutation invocation.
+ *
+ * `errorTarget` and `busyTarget` are intentionally split: where the
+ * error message is shown is independent of which busy flag the hook
+ * toggles. When `busyTarget` is omitted it defaults from `errorTarget`
+ * for back-compat with the previous coupled API:
+ *
+ *   - `errorTarget: 'page'`   -> default `busyTarget: 'delete'`
+ *   - `errorTarget: 'dialog'` -> default `busyTarget: 'save'`
+ *   - `errorTarget: 'inline'` -> default `busyTarget: 'inline'`
  */
 export interface RunMutationOptions {
-    /**
-     * Toast to show on success. Omit to leave success state untouched.
-     */
+    /** Toast to show on success. Omit to leave success state untouched. */
     successMessage?: string;
-    /**
-     * Where to report errors. The default reports to the dialog-level
-     * `dialogError` slot, which matches the create/edit flow. Page-level
-     * mutations (delete, inline toggles, etc.) should pass `'page'`.
-     */
-    errorTarget?: 'page' | 'dialog';
-    /**
-     * Whether to refresh the list after a successful mutation. Defaults
-     * to `true` because the vast majority of mutations need it.
-     */
+    /** Where to route the error message. Defaults to `'dialog'`. */
+    errorTarget?: ErrorTarget;
+    /** Which busy flag to toggle. Defaults from `errorTarget`. */
+    busyTarget?: BusyTarget;
+    /** Whether to refresh the list on success. Defaults to `true`. */
     refresh?: boolean;
-    /**
-     * Custom fallback message for non-Error throws. Defaults to the
-     * shared {@link extractErrorMessage} fallback.
-     */
+    /** Fallback message for non-Error throws. */
     errorFallback?: string;
-    /**
-     * Maps the thrown value to a user-facing message before display.
-     * Useful for translating server constraint errors into friendlier
-     * wording (e.g. UNIQUE constraint -> "already exists").
-     */
+    /** Maps the thrown value to a user-facing message before display. */
     mapError?: (err: unknown) => string;
 }
 
@@ -288,19 +309,37 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
         const {
             successMessage,
             errorTarget = 'dialog',
+            busyTarget,
             refresh: shouldRefresh = true,
             errorFallback,
             mapError,
         } = opts;
 
-        const setBusy = errorTarget === 'dialog' ? setSaving : setDeleteLoading;
-        const writeError = errorTarget === 'dialog' ? setDialogError : setError;
+        // Default `busyTarget` from `errorTarget` so callers that
+        // pre-date the split keep their previous coupled behaviour.
+        const resolvedBusyTarget: BusyTarget = busyTarget
+            ?? (errorTarget === 'dialog'
+                ? 'save'
+                : errorTarget === 'page'
+                    ? 'delete'
+                    : 'inline');
+
+        // Inline mutations toggle no shared busy flag; the caller owns
+        // any local spinner. This prevents inline actions (e.g. a row
+        // toggle) from flickering a global delete or save indicator.
+        const setBusy: ((value: boolean) => void) | null = (() => {
+            if (resolvedBusyTarget === 'save') { return setSaving; }
+            if (resolvedBusyTarget === 'delete') { return setDeleteLoading; }
+            return null;
+        })();
 
         try {
-            setBusy(true);
+            setBusy?.(true);
+            // Clear only the slot we're about to write into. Inline
+            // targets write nowhere, so nothing to clear pre-emptively.
             if (errorTarget === 'dialog') {
                 setDialogError(null);
-            } else {
+            } else if (errorTarget === 'page') {
                 setError(null);
             }
             const value = await fn();
@@ -318,10 +357,17 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
             const message = mapError
                 ? mapError(err)
                 : extractErrorMessage(err, errorFallback);
-            writeError(message);
-            return { ok: false };
+            // Route the message based on `errorTarget`. Inline targets
+            // do NOT write to either shared slot; the caller reads the
+            // message from the returned result and surfaces it itself.
+            if (errorTarget === 'dialog') {
+                setDialogError(message);
+            } else if (errorTarget === 'page') {
+                setError(message);
+            }
+            return { ok: false, error: message };
         } finally {
-            setBusy(false);
+            setBusy?.(false);
         }
     }, [refresh]);
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -328,6 +328,19 @@ project adheres to
 
 ### Fixed
 
+- Fix the `AdminMessagingChannels` panel flipping the
+  `deleteLoading` busy flag when a user toggled a
+  channel's enabled state; the shared
+  `useCrudPanel.runMutation` helper gained an
+  independent `busyTarget` option
+  (`'save' | 'delete' | 'inline'`) that decouples the
+  busy-state flag from the `errorTarget`, and a new
+  `'inline'` error target routes errors only to the
+  caller through the returned result rather than to
+  `crud.error` or `crud.dialogError`. Defaults preserve
+  the previous behavior so existing call sites are
+  unchanged, and `handleToggleEnabled` now uses
+  `busyTarget: 'inline'`. (#216)
 - Fix the divergent error fallback wording shown by the
   Admin panels when a thrown value is not an `Error`
   instance. The `AdminUsers`, `AdminMemories`,


### PR DESCRIPTION
## Summary

- Add an independent `busyTarget` option (`'save' | 'delete' | 'inline'`) to `useCrudPanel.runMutation` so callers can pick which busy flag toggles independently of error routing.
- Add an `'inline'` `errorTarget` that returns the error only to the caller (via the existing `runMutation` result) rather than writing to `crud.error` or `crud.dialogError`.
- Defaults derive `busyTarget` from `errorTarget` (`'page' -> 'delete'`, `'dialog' -> 'save'`, `'inline' -> 'inline'`), so existing call sites need no changes.
- Update `AdminMessagingChannels.handleToggleEnabled` to use `busyTarget: 'inline'` so the inline toggle no longer flips `deleteLoading`.

Closes #216.

## Test plan

- [x] `make test-all` passes (client, collector, server, alerter).
- [x] Lint passes (`npm run lint`) with no new warnings.
- [x] `useCrudPanel` test file extended with 11 new cases covering: inline error routing, inline busy slot, explicit `busyTarget` overriding the default, and the three defaulting rules (`page->delete`, `dialog->save`, `inline->inline`).
- [x] `useCrudPanel.ts` line coverage: 100% (81/81).
- [x] `AdminMessagingChannels.tsx` line coverage: 90.82% (89/98), above the 90% floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Admin Messaging Channels panel: toggling a channel's enabled state no longer incorrectly triggers the delete loading indicator.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/225)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->