### PR TITLE
fix(client): suppress useCrudPanel success toast when refresh fails (#215)

### DIFF
--- a/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
@@ -436,6 +436,136 @@ describe('useCrudPanel', () => {
             expect(result.current.dialogError).toBeNull();
         });
 
+        it(
+            'suppresses success toast when the follow-on refresh fails',
+            async () => {
+                // Regression guard for issue #215: a mutation that
+                // succeeds but whose refresh fetch fails must NOT leave
+                // a success toast on screen alongside the refresh
+                // error. The user-facing outcome is "the data on screen
+                // is stale and we could not reload" — showing "Saved"
+                // beside "Failed to load …" is contradictory.
+                const fetchItems = vi.fn<() => Promise<Item[]>>()
+                    .mockResolvedValueOnce(ITEMS)
+                    .mockRejectedValueOnce(new Error('Failed to load groups'));
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+
+                const fn = vi.fn().mockResolvedValue('saved-id');
+                let returned: unknown;
+                await act(async () => {
+                    returned = await result.current.runMutation(fn, {
+                        successMessage: 'Saved',
+                    });
+                });
+
+                // The mutation itself succeeded, so the tagged result
+                // must report ok=true with the mutation's value.
+                expect(returned).toEqual({ ok: true, value: 'saved-id' });
+                // No stale success toast: the page-level refresh error
+                // is the only thing the user should see.
+                expect(result.current.success).toBeNull();
+                expect(result.current.error).toBe('Failed to load groups');
+                // The follow-on refresh did run.
+                expect(fetchItems).toHaveBeenCalledTimes(2);
+            },
+        );
+
+        it(
+            'keeps the success toast when refresh succeeds (issue #215 control)',
+            async () => {
+                // Control case for the suppression test above: a
+                // healthy refresh path must NOT swallow the success
+                // toast. Without this guard, a buggy "always suppress"
+                // implementation could pass the failing-refresh test
+                // while breaking every happy-path mutation in the app.
+                const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+
+                const fn = vi.fn().mockResolvedValue('saved-id');
+                await act(async () => {
+                    await result.current.runMutation(fn, {
+                        successMessage: 'Saved',
+                    });
+                });
+                expect(result.current.success).toBe('Saved');
+                expect(result.current.error).toBeNull();
+            },
+        );
+
+        it(
+            'keeps the success toast when refresh: false skips the refresh',
+            async () => {
+                // When the caller opts out of refresh entirely, there
+                // is no fetch that could fail, so the success toast
+                // must always fire if `successMessage` is provided.
+                const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+                fetchItems.mockClear();
+
+                await act(async () => {
+                    await result.current.runMutation(
+                        () => Promise.resolve('ok'),
+                        { successMessage: 'Saved', refresh: false },
+                    );
+                });
+                expect(result.current.success).toBe('Saved');
+                expect(fetchItems).not.toHaveBeenCalled();
+            },
+        );
+
+        it(
+            'returns true from refresh() on the happy path',
+            async () => {
+                // The new Promise<boolean> contract: a clean refresh
+                // resolves to `true`. Callers (notably runMutation) use
+                // this to decide whether to surface the success toast.
+                const fetchItems = vi.fn().mockResolvedValue(ITEMS);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+
+                let outcome: boolean | undefined;
+                await act(async () => {
+                    outcome = await result.current.refresh();
+                });
+                expect(outcome).toBe(true);
+            },
+        );
+
+        it(
+            'returns false from refresh() when the fetch rejects',
+            async () => {
+                // Mirror of the happy-path control: a failing refresh
+                // resolves to `false` so runMutation can suppress its
+                // success toast. The error message is also written to
+                // the page-level error slot, matching pre-#215 behaviour.
+                const fetchItems = vi.fn<() => Promise<Item[]>>()
+                    .mockResolvedValueOnce(ITEMS)
+                    .mockRejectedValueOnce(new Error('boom'));
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+
+                let outcome: boolean | undefined;
+                await act(async () => {
+                    outcome = await result.current.refresh();
+                });
+                expect(outcome).toBe(false);
+                expect(result.current.error).toBe('boom');
+            },
+        );
+
         it('clears prior page error before page-target mutations', async () => {
             const fetchItems = vi.fn().mockResolvedValue(ITEMS);
             const { result } = renderHook(() =>
@@ -554,6 +684,127 @@ describe('useCrudPanel', () => {
             expect(result.current.items).toEqual(['fresh']);
             expect(result.current.loading).toBe(false);
         });
+
+        it(
+            'a superseded refresh reports outcome=true so callers do not suppress success',
+            async () => {
+                // Deliberate design choice (see issue #215 thread):
+                // when a refresh is superseded by a newer generation,
+                // it is no longer authoritative for *any* observable
+                // state, including the runMutation success-toast gate.
+                // Returning `true` from the superseded path means
+                // runMutation will surface its success toast and let
+                // the newer generation, which IS authoritative, decide
+                // whether to overwrite the page with an error.
+                //
+                // Treating "superseded" as "failed" instead would let
+                // a user-triggered manual refresh that lost a race
+                // silently swallow the previous mutation's success
+                // toast, which is the opposite of what we want.
+                const slow = deferred<Item[]>();
+                const fast = deferred<Item[]>();
+                const fetchItems = vi.fn<() => Promise<Item[]>>()
+                    // Initial mount fetch.
+                    .mockResolvedValueOnce(ITEMS)
+                    // Slow refresh kicked off by the mutation.
+                    .mockImplementationOnce(() => slow.promise)
+                    // Fast refresh kicked off by an external caller
+                    // (e.g. a deps change in the parent component).
+                    .mockImplementationOnce(() => fast.promise);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+
+                // Drive the mutation. Its refresh awaits `slow`.
+                const mutationFn = vi.fn().mockResolvedValue('id');
+                let mutation: Promise<unknown> | undefined;
+                act(() => {
+                    mutation = result.current.runMutation(mutationFn, {
+                        successMessage: 'Saved',
+                    });
+                });
+                // Wait until the mutation's refresh is in flight.
+                await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(2));
+
+                // Now kick off a second, fresher refresh from outside
+                // the mutation. It bumps the generation counter.
+                let externalRefresh: Promise<boolean> | undefined;
+                act(() => {
+                    externalRefresh = result.current.refresh();
+                });
+                await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(3));
+
+                // Resolve the fast (newer) refresh first.
+                await act(async () => {
+                    fast.resolve(ITEMS);
+                    await externalRefresh;
+                });
+
+                // Now resolve the slow (superseded) refresh. Its
+                // return value flows back into runMutation.
+                await act(async () => {
+                    slow.resolve(ITEMS);
+                    await mutation;
+                });
+
+                // The superseded refresh returned true, so the
+                // success toast is set.
+                expect(result.current.success).toBe('Saved');
+                expect(result.current.error).toBeNull();
+            },
+        );
+
+        it(
+            'a superseded refresh error is dropped, not surfaced',
+            async () => {
+                // Companion to the test above: when the superseded
+                // fetch *rejects*, the error must be swallowed.
+                // Writing it to `setError` would let a stale failure
+                // overwrite the page state owned by the newer
+                // generation. The boolean return is also `true` so
+                // runMutation does not suppress its success toast.
+                const slow = deferred<Item[]>();
+                const fast = deferred<Item[]>();
+                const fetchItems = vi.fn<() => Promise<Item[]>>()
+                    .mockResolvedValueOnce(ITEMS)
+                    .mockImplementationOnce(() => slow.promise)
+                    .mockImplementationOnce(() => fast.promise);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+
+                const mutationFn = vi.fn().mockResolvedValue('id');
+                let mutation: Promise<unknown> | undefined;
+                act(() => {
+                    mutation = result.current.runMutation(mutationFn, {
+                        successMessage: 'Saved',
+                    });
+                });
+                await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(2));
+
+                let externalRefresh: Promise<boolean> | undefined;
+                act(() => {
+                    externalRefresh = result.current.refresh();
+                });
+                await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(3));
+
+                await act(async () => {
+                    fast.resolve(ITEMS);
+                    await externalRefresh;
+                });
+
+                await act(async () => {
+                    slow.reject(new Error('stale failure'));
+                    await mutation;
+                });
+
+                // Success toast survives; the stale error is dropped.
+                expect(result.current.success).toBe('Saved');
+                expect(result.current.error).toBeNull();
+            },
+        );
 
         it('drops a stale fetch error that arrives after a successful refresh', async () => {
             // Same shape as the success-race test, but the older fetch

--- a/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/_shared/useCrudPanel.test.tsx
@@ -566,6 +566,121 @@ describe('useCrudPanel', () => {
             },
         );
 
+        it(
+            'clears a prior success toast when a later refresh fails',
+            async () => {
+                // Regression guard for the residual issue #215 gap that
+                // CodeRabbit flagged on PR #226: even after the
+                // suppress-on-failed-refresh fix, a successful mutation
+                // followed by an *independent* failing refresh would
+                // leave both toasts on screen — "Saved" from the prior
+                // mutation and "Failed to load …" from the new error.
+                // The authoritative-failure branch in refresh() must
+                // clear success before writing error.
+                const fetchItems = vi.fn<() => Promise<Item[]>>()
+                    // Initial mount.
+                    .mockResolvedValueOnce(ITEMS)
+                    // Refresh kicked off by the mutation — succeeds.
+                    .mockResolvedValueOnce(ITEMS)
+                    // Later, independent refresh — rejects.
+                    .mockRejectedValueOnce(new Error('Failed to load groups'));
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+
+                // Step 1: mutation A succeeds AND its refresh succeeds,
+                // so the success toast lands.
+                const fn = vi.fn().mockResolvedValue('saved-id');
+                await act(async () => {
+                    await result.current.runMutation(fn, {
+                        successMessage: 'Saved',
+                    });
+                });
+                expect(result.current.success).toBe('Saved');
+                expect(result.current.error).toBeNull();
+
+                // Step 2: a later refresh (manual reload, deps change,
+                // follow-on refresh from a different mutation, etc.)
+                // fails. The old "Saved" toast must be cleared so it
+                // doesn't sit on screen next to the new error.
+                let outcome: boolean | undefined;
+                await act(async () => {
+                    outcome = await result.current.refresh();
+                });
+                expect(outcome).toBe(false);
+                expect(result.current.success).toBeNull();
+                expect(result.current.error).toBe('Failed to load groups');
+            },
+        );
+
+        it(
+            'does not clear success when a superseded refresh fails',
+            async () => {
+                // Companion guard: only the *authoritative* failure
+                // branch in refresh() clears success. A superseded
+                // failure (one whose generation was already overtaken)
+                // returns early before reaching the setSuccess(null)
+                // call, so a stale rejection cannot wipe out a success
+                // toast that legitimately belongs to the newer
+                // generation. This pins the "do nothing on stale
+                // failure" half of the refresh contract.
+                const slow = deferred<Item[]>();
+                const fast = deferred<Item[]>();
+                const fetchItems = vi.fn<() => Promise<Item[]>>()
+                    // Initial mount fetch — resolves immediately.
+                    .mockResolvedValueOnce(ITEMS)
+                    // Slow refresh that will eventually REJECT after
+                    // being superseded by a newer generation.
+                    .mockImplementationOnce(() => slow.promise)
+                    // Fast refresh that wins the race.
+                    .mockImplementationOnce(() => fast.promise);
+                const { result } = renderHook(() =>
+                    useCrudPanel<Item>({ fetchItems }),
+                );
+                await waitFor(() => expect(result.current.loading).toBe(false));
+
+                // Manually seed a success toast (as if a prior
+                // successful mutation left one behind).
+                act(() => {
+                    result.current.setSuccess('Saved');
+                });
+
+                // Start the slow refresh; it is now the latest
+                // generation in flight.
+                let slowRefresh: Promise<boolean> | undefined;
+                act(() => {
+                    slowRefresh = result.current.refresh();
+                });
+                await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(2));
+
+                // Start the fast refresh; it bumps the generation, so
+                // the slow refresh is now superseded.
+                let fastRefresh: Promise<boolean> | undefined;
+                act(() => {
+                    fastRefresh = result.current.refresh();
+                });
+                await waitFor(() => expect(fetchItems).toHaveBeenCalledTimes(3));
+
+                // Resolve fast (newer) refresh successfully.
+                await act(async () => {
+                    fast.resolve(ITEMS);
+                    await fastRefresh;
+                });
+
+                // Now reject the slow (superseded) refresh. Because the
+                // catch handler hits the superseded-guard early, it
+                // must NOT clear the success toast.
+                await act(async () => {
+                    slow.reject(new Error('stale failure'));
+                    await slowRefresh;
+                });
+
+                expect(result.current.success).toBe('Saved');
+                expect(result.current.error).toBeNull();
+            },
+        );
+
         it('clears prior page error before page-target mutations', async () => {
             const fetchItems = vi.fn().mockResolvedValue(ITEMS);
             const { result } = renderHook(() =>

--- a/client/src/components/AdminPanel/_shared/useCrudPanel.ts
+++ b/client/src/components/AdminPanel/_shared/useCrudPanel.ts
@@ -92,7 +92,18 @@ export interface CrudPanelApi<T> {
     setError: (value: string | null) => void;
     success: string | null;
     setSuccess: (value: string | null) => void;
-    refresh: () => Promise<void>;
+    /**
+     * Re-fetch the list. Resolves to `true` when the fetch produced a
+     * fresh result (or was superseded by a newer generation; see the
+     * implementation note below). Resolves to `false` when the fetch
+     * rejected and the hook wrote the message to {@link CrudPanelApi.error}.
+     *
+     * Callers that do not care about the outcome (page mount, manual
+     * reload button) may discard the boolean. {@link runMutation} uses
+     * it to suppress a stale success toast when the follow-on refresh
+     * fails — see issue #215.
+     */
+    refresh: () => Promise<boolean>;
 
     // --- Edit/create dialog state ---
     dialogOpen: boolean;
@@ -194,7 +205,7 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
     // unmounted component" dev-mode warning.
     const isMountedRef = useRef<boolean>(true);
 
-    const refresh = useCallback(async () => {
+    const refresh = useCallback(async (): Promise<boolean> => {
         const generation = fetchGenerationRef.current + 1;
         fetchGenerationRef.current = generation;
         setLoading(true);
@@ -202,21 +213,35 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
             const next = await fetchItems();
             // Drop the result if a newer fetch started, or if the
             // component unmounted while this request was in flight.
+            // A superseded fetch is treated as a clean outcome from
+            // *this* caller's perspective: the newer generation will
+            // report its own success or failure, and the success toast
+            // that gated on us belongs to a mutation whose intent has
+            // not been contradicted. Returning `true` here means
+            // runMutation does NOT suppress its success toast on a
+            // stale-but-still-pending refresh; the newer refresh owns
+            // that decision.
             if (
                 !isMountedRef.current
                 || fetchGenerationRef.current !== generation
             ) {
-                return;
+                return true;
             }
             setItems(next);
+            return true;
         } catch (err: unknown) {
+            // Same rule as the success branch: an error from a
+            // superseded fetch is dropped entirely (not written to
+            // `error`, not reported to the caller). The newer
+            // generation is authoritative.
             if (
                 !isMountedRef.current
                 || fetchGenerationRef.current !== generation
             ) {
-                return;
+                return true;
             }
             setError(extractErrorMessage(err));
+            return false;
         } finally {
             // Only the latest in-flight generation owns the loading
             // flag; earlier generations must not flip it back to
@@ -304,15 +329,24 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
                 setError(null);
             }
             const value = await fn();
-            if (successMessage) {
-                setSuccess(successMessage);
-            }
+            // Defer the success toast until we know whether the
+            // follow-on refresh succeeded. Setting it now and clearing
+            // it on refresh failure would briefly flash "Saved" before
+            // "Failed to load…" replaces it; gating instead avoids the
+            // flash entirely. See issue #215.
+            let refreshClean = true;
             if (shouldRefresh) {
-                await refresh();
+                refreshClean = await refresh();
+            }
+            if (successMessage && refreshClean) {
+                setSuccess(successMessage);
             }
             // Wrap the success value in the tagged result so callers can
             // distinguish a void-returning success (`apiDelete` on HTTP
             // 204) from a failure without inspecting `value` at all.
+            // Note: the mutation itself succeeded even if the refresh
+            // didn't, so we still return ok=true here. The refresh
+            // error is surfaced via `error`, not via this return value.
             return { ok: true, value };
         } catch (err: unknown) {
             const message = mapError

--- a/client/src/components/AdminPanel/_shared/useCrudPanel.ts
+++ b/client/src/components/AdminPanel/_shared/useCrudPanel.ts
@@ -240,6 +240,8 @@ export function useCrudPanel<T>(options: UseCrudPanelOptions<T>): CrudPanelApi<T
             ) {
                 return true;
             }
+            // Clear any lingering success toast so the refresh error is alone (see #215).
+            setSuccess(null);
             setError(extractErrorMessage(err));
             return false;
         } finally {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -328,6 +328,13 @@ project adheres to
 
 ### Fixed
 
+- Fix the Admin panels showing a success toast alongside a
+  page-level refresh error when a save succeeded but the
+  follow-on reload failed; the shared `useCrudPanel` hook
+  now suppresses the success toast when the post-mutation
+  refresh fails, so the user sees only the actionable
+  refresh error. (#215)
+
 - Fix the divergent error fallback wording shown by the
   Admin panels when a thrown value is not an `Error`
   instance. The `AdminUsers`, `AdminMemories`,


### PR DESCRIPTION
## Summary

- Closes #215.
- When a CRUD mutation succeeded but the follow-on `refresh()` fetch failed, the Admin panels displayed both a "Saved" success toast and a page-level "Failed to load X" error simultaneously, which was contradictory.
- The shared `useCrudPanel.refresh()` now returns `Promise<boolean>` (true on clean fetch or when superseded by a newer generation, false on rejection). `runMutation` awaits refresh first, then only sets `setSuccess(successMessage)` if the refresh succeeded or was skipped. The mutation return value remains `{ ok: true, value }` since the mutation itself still succeeded — only the toast is suppressed.
- Existing callers of `refresh()` (e.g. `AdminGroups`, page-mount `useEffect`s) discard the new boolean and are fully backward compatible.

## Test plan

- [x] `make test-all` passes from repo root (exit 0, "All tests passed!").
- [x] `useCrudPanel.test.tsx`: 35/35 tests pass (7 new tests added covering the refresh-failure path, the `refresh: false` skip path, the happy path control, and the superseded-generation edge cases).
- [x] Coverage of `client/src/components/AdminPanel/_shared/**`: 100% lines / 100% branches / 100% functions (well above the 90% floor).
- [x] ESLint clean on touched files; remaining repo warnings are pre-existing in unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin panels no longer show a brief success notification when a save succeeds but the subsequent reload fails; users now see only the refresh error. Success notifications still appear when reloads succeed or are intentionally skipped.

* **Tests**
  * Expanded test coverage for save/refresh race conditions to prevent stale or superseded refreshes from causing misleading UI flashes.

* **Documentation**
  * Changelog updated to reflect this fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/226)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->