### PR TITLE
fix(alerter): fire replication_slot_inactive alert (#224)

### DIFF
--- a/alerter/src/internal/database/metric_registry.go
+++ b/alerter/src/internal/database/metric_registry.go
@@ -208,22 +208,28 @@ var metricRegistry = map[string]metricQueryConfig{
 		historicalScan: historicalScanBasic,
 	},
 
+	// pg_replication_slots.inactive emits a single row per connection with
+	// value=1 whenever at least one replication slot recorded in the last
+	// five minutes has active=false. No row is emitted for connections
+	// whose slots are all active, which clears the matching `==` alert.
+	//
+	// The earlier implementation read from metrics.pg_stat_replication_slots
+	// (a table that no migration creates) and inferred inactivity by an
+	// application_name join against metrics.pg_stat_replication. That join
+	// is unnecessary because metrics.pg_replication_slots.active mirrors
+	// the source pg_replication_slots.active column directly, so the query
+	// can decide inactivity from a single table.
 	"pg_replication_slots.inactive": {
 		latestSQL: `
 			WITH slot_status AS (
-				SELECT DISTINCT connection_id, 1 as has_inactive
-				FROM metrics.pg_stat_replication_slots s
+				SELECT DISTINCT connection_id, 1 AS has_inactive
+				FROM metrics.pg_replication_slots s
 				WHERE s.collected_at > NOW() - INTERVAL '5 minutes'
-				  AND NOT EXISTS (
-				      SELECT 1 FROM metrics.pg_stat_replication r
-				      WHERE r.connection_id = s.connection_id
-				        AND r.collected_at > NOW() - INTERVAL '5 minutes'
-				        AND r.application_name = s.slot_name
-				  )
+				  AND s.active = false
 			)
 			SELECT connection_id,
-			       has_inactive::float as value,
-			       NOW() as collected_at
+			       has_inactive::float AS value,
+			       NOW() AS collected_at
 			FROM slot_status
 		`,
 		historicalSQL:  "",

--- a/alerter/src/internal/database/metric_registry.go
+++ b/alerter/src/internal/database/metric_registry.go
@@ -209,9 +209,19 @@ var metricRegistry = map[string]metricQueryConfig{
 	},
 
 	// pg_replication_slots.inactive emits a single row per connection with
-	// value=1 whenever at least one replication slot recorded in the last
-	// five minutes has active=false. No row is emitted for connections
-	// whose slots are all active, which clears the matching `==` alert.
+	// value=1 whenever the most recent sample for at least one replication
+	// slot recorded in the last five minutes has active=false. No row is
+	// emitted for connections whose slots are all currently active, which
+	// clears the matching `==` alert as soon as every slot recovers.
+	//
+	// The latest-sample-per-slot reduction is essential: without it, a slot
+	// that was inactive at t-4m but active at t-1m would still match the
+	// active=false predicate against its older row and keep the alert
+	// firing after recovery. DISTINCT ON (connection_id, slot_name) ordered
+	// by collected_at DESC inside the freshness window selects exactly the
+	// most recent sample for every slot, and a single connection with N
+	// slots is reduced to one row regardless of how many of those slots
+	// are inactive (the alert engine consumes one row per connection_id).
 	//
 	// The earlier implementation read from metrics.pg_stat_replication_slots
 	// (a table that no migration creates) and inferred inactivity by an
@@ -221,16 +231,19 @@ var metricRegistry = map[string]metricQueryConfig{
 	// can decide inactivity from a single table.
 	"pg_replication_slots.inactive": {
 		latestSQL: `
-			WITH slot_status AS (
-				SELECT DISTINCT connection_id, 1 AS has_inactive
-				FROM metrics.pg_replication_slots s
-				WHERE s.collected_at > NOW() - INTERVAL '5 minutes'
-				  AND s.active = false
+			WITH latest_per_slot AS (
+				SELECT DISTINCT ON (connection_id, slot_name)
+				       connection_id, slot_name, active, collected_at
+				FROM metrics.pg_replication_slots
+				WHERE collected_at > NOW() - INTERVAL '5 minutes'
+				ORDER BY connection_id, slot_name, collected_at DESC
 			)
 			SELECT connection_id,
-			       has_inactive::float AS value,
-			       NOW() AS collected_at
-			FROM slot_status
+			       1::float AS value,
+			       MAX(collected_at) AS collected_at
+			FROM latest_per_slot
+			WHERE active = false
+			GROUP BY connection_id
 		`,
 		historicalSQL:  "",
 		scan:           scanBasic,

--- a/alerter/src/internal/database/metric_registry_integration_test.go
+++ b/alerter/src/internal/database/metric_registry_integration_test.go
@@ -582,6 +582,127 @@ func TestMetricRegistry_PgReplicationSlotsInactive_StaleSampleExcluded(t *testin
 	}
 }
 
+// TestMetricRegistry_PgReplicationSlotsInactive_RecoveryClears verifies
+// that the metric stops emitting a row for a slot once the most recent
+// sample reports active=true, even if an older sample inside the
+// freshness window is still inactive. This is the alert-recovery
+// scenario: without the latest-sample-per-slot reduction, the older
+// active=false row would keep the `==` alert firing after the slot
+// reconnected and the operator would never see the alert clear.
+//
+// A second "still-inactive" connection is seeded so the query exercises
+// the success path of GetLatestMetricValues (which returns a sentinel
+// error when the entire result set is empty). The recovered connection
+// must be absent and the still-inactive connection must appear with
+// value=1.
+func TestMetricRegistry_PgReplicationSlotsInactive_RecoveryClears(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	recoveredConnID := insertConnection(t, pool, "slot-inactive-recovered")
+	stillInactiveConnID := insertConnection(t, pool, "slot-inactive-stillinactive")
+
+	older := time.Now().UTC().Add(-3 * time.Minute)
+	newer := time.Now().UTC().Add(-1 * time.Minute)
+
+	// Recovered slot: older sample is inactive, newer sample is active.
+	// The new query must evaluate inactivity only against the newer
+	// sample and therefore emit no row for this connection.
+	insertReplicationSlotRow(t, pool, recoveredConnID, older, "slot_a", false, 100)
+	insertReplicationSlotRow(t, pool, recoveredConnID, newer, "slot_a", true, 100)
+
+	// Still-inactive slot: only sample is inactive.
+	insertReplicationSlotRow(t, pool, stillInactiveConnID, newer, "slot_a", false, 100)
+
+	results, err := ds.GetLatestMetricValues(ctx, "pg_replication_slots.inactive")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(pg_replication_slots.inactive) "+
+			"returned unexpected error: %v", err)
+	}
+
+	var sawStillInactive bool
+	for _, mv := range results {
+		switch mv.ConnectionID {
+		case recoveredConnID:
+			t.Errorf("pg_replication_slots.inactive emitted a row for "+
+				"connection %d whose slot recovered (latest sample at %s "+
+				"has active=true); the metric must evaluate inactivity "+
+				"only against the most recent sample per slot so the "+
+				"alert clears after recovery (got value=%v)",
+				recoveredConnID, newer.Format(time.RFC3339), mv.Value)
+		case stillInactiveConnID:
+			sawStillInactive = true
+			if mv.Value != 1 {
+				t.Errorf("pg_replication_slots.inactive value for "+
+					"still-inactive connection %d = %v; want 1",
+					stillInactiveConnID, mv.Value)
+			}
+		}
+	}
+	if !sawStillInactive {
+		t.Errorf("pg_replication_slots.inactive did not return the "+
+			"still-inactive connection %d; results=%+v",
+			stillInactiveConnID, results)
+	}
+}
+
+// TestMetricRegistry_PgReplicationSlotsInactive_PerSlotLatest verifies
+// that the metric evaluates inactivity per slot, not per connection.
+// When a connection has two slots whose most recent samples were
+// collected at different times, the query must inspect each slot's
+// latest sample independently before deciding whether any slot is
+// currently inactive.
+//
+// Slot A: older sample active, newer sample inactive (latest = inactive).
+// Slot B: only one sample, active (latest = active).
+//
+// The expected output is a single row with value=1 because at least one
+// slot (slot A) is currently inactive. A query that collapsed samples
+// per connection rather than per slot would either miss slot A's most
+// recent state entirely (because slot B's sample is newer overall) or
+// pick the wrong slot's active flag.
+func TestMetricRegistry_PgReplicationSlotsInactive_PerSlotLatest(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "slot-inactive-perslot")
+
+	earliest := time.Now().UTC().Add(-4 * time.Minute)
+	middle := time.Now().UTC().Add(-2 * time.Minute)
+	latest := time.Now().UTC().Add(-1 * time.Minute)
+
+	// slot_a: older active, newer inactive -> latest sample is inactive.
+	insertReplicationSlotRow(t, pool, connID, earliest, "slot_a", true, 100)
+	insertReplicationSlotRow(t, pool, connID, middle, "slot_a", false, 100)
+	// slot_b: single sample, active, collected after slot_a's last sample.
+	insertReplicationSlotRow(t, pool, connID, latest, "slot_b", true, 200)
+
+	results, err := ds.GetLatestMetricValues(ctx, "pg_replication_slots.inactive")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(pg_replication_slots.inactive) failed: %v", err)
+	}
+
+	var matches int
+	for _, mv := range results {
+		if mv.ConnectionID == connID {
+			matches++
+			if mv.Value != 1 {
+				t.Errorf("pg_replication_slots.inactive value for "+
+					"connection %d with one inactive slot and one "+
+					"active slot = %v; want 1", connID, mv.Value)
+			}
+		}
+	}
+	if matches != 1 {
+		t.Errorf("pg_replication_slots.inactive emitted %d rows for "+
+			"connection %d; want exactly 1 (one row per connection "+
+			"because at least one slot's latest sample is inactive)",
+			matches, connID)
+	}
+}
+
 // TestMetricRegistry_PgReplicationSlotsMaxRetainedBytes verifies that the
 // pg_replication_slots.max_retained_bytes metric returns the maximum
 // retained_bytes value across slots in the latest sample.

--- a/alerter/src/internal/database/metric_registry_integration_test.go
+++ b/alerter/src/internal/database/metric_registry_integration_test.go
@@ -401,6 +401,187 @@ func TestMetricRegistry_PgReplicationSlotsInactiveCount(t *testing.T) {
 	}
 }
 
+// TestMetricRegistry_PgReplicationSlotsInactive verifies that the
+// pg_replication_slots.inactive metric returns exactly one row with
+// value=1 for a connection whose latest sample contains at least one
+// inactive slot. The metric must NOT inspect metrics.pg_stat_replication
+// because the active column on metrics.pg_replication_slots is the
+// authoritative signal for slot inactivity.
+//
+// Three slots are seeded in the freshness window: two active and one
+// inactive. The expected output is a single row with value=1 because
+// the metric is consumed by an "==" alert rule.
+func TestMetricRegistry_PgReplicationSlotsInactive(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "slot-inactive-emit")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_a", true, 100)
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_b", false, 200)
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_c", true, 300)
+
+	results, err := ds.GetLatestMetricValues(ctx, "pg_replication_slots.inactive")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(pg_replication_slots.inactive) failed: %v", err)
+	}
+
+	got := findValueForConnection(t, results, connID)
+	if got != 1 {
+		t.Errorf("pg_replication_slots.inactive = %v; want 1", got)
+	}
+}
+
+// TestMetricRegistry_PgReplicationSlotsInactive_AllActive verifies that
+// the pg_replication_slots.inactive metric returns no row for a
+// connection whose slots are all active. The alert rule fires on "==
+// 1"; emitting any row for an all-active connection would cause false
+// positives or block the alert from clearing once a slot reactivates.
+//
+// A second "with-inactive" connection is seeded so the query exercises
+// the success path of GetLatestMetricValues (which returns a sentinel
+// error when the entire result set is empty). The assertion then
+// proves the all-active connection is absent and the inactive
+// connection is present with value=1.
+func TestMetricRegistry_PgReplicationSlotsInactive_AllActive(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	allActiveID := insertConnection(t, pool, "slot-inactive-allactive")
+	hasInactiveID := insertConnection(t, pool, "slot-inactive-withinactive")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+
+	insertReplicationSlotRow(t, pool, allActiveID, sample, "slot_a", true, 100)
+	insertReplicationSlotRow(t, pool, allActiveID, sample, "slot_b", true, 200)
+	insertReplicationSlotRow(t, pool, hasInactiveID, sample, "slot_a", false, 100)
+
+	results, err := ds.GetLatestMetricValues(ctx, "pg_replication_slots.inactive")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(pg_replication_slots.inactive) "+
+			"returned unexpected error: %v", err)
+	}
+
+	var sawInactive bool
+	for _, mv := range results {
+		switch mv.ConnectionID {
+		case allActiveID:
+			t.Errorf("pg_replication_slots.inactive emitted a row for "+
+				"connection %d whose slots are all active (value=%v); "+
+				"the metric must only emit rows when at least one slot "+
+				"is inactive", allActiveID, mv.Value)
+		case hasInactiveID:
+			sawInactive = true
+			if mv.Value != 1 {
+				t.Errorf("pg_replication_slots.inactive value for "+
+					"connection %d with an inactive slot = %v; want 1",
+					hasInactiveID, mv.Value)
+			}
+		}
+	}
+	if !sawInactive {
+		t.Errorf("pg_replication_slots.inactive did not return the "+
+			"connection %d with an inactive slot; results=%+v",
+			hasInactiveID, results)
+	}
+}
+
+// TestMetricRegistry_PgReplicationSlotsInactive_DeduplicatesSlots
+// verifies that the metric emits at most one row per connection even
+// when several slots in the latest sample are inactive. The alert
+// engine consumes one row per connection-id, so duplicate rows would
+// cause the same alert to fire multiple times for the same connection.
+func TestMetricRegistry_PgReplicationSlotsInactive_DeduplicatesSlots(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertConnection(t, pool, "slot-inactive-dedupe")
+	sample := time.Now().UTC().Add(-1 * time.Minute)
+
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_a", false, 100)
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_b", false, 200)
+	insertReplicationSlotRow(t, pool, connID, sample, "slot_c", false, 300)
+
+	results, err := ds.GetLatestMetricValues(ctx, "pg_replication_slots.inactive")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(pg_replication_slots.inactive) failed: %v", err)
+	}
+
+	var matches int
+	for _, mv := range results {
+		if mv.ConnectionID == connID {
+			matches++
+			if mv.Value != 1 {
+				t.Errorf("pg_replication_slots.inactive value = %v; want 1",
+					mv.Value)
+			}
+		}
+	}
+	if matches != 1 {
+		t.Errorf("pg_replication_slots.inactive emitted %d rows for "+
+			"connection %d; want exactly 1 (one row per connection "+
+			"regardless of how many inactive slots are present)",
+			matches, connID)
+	}
+}
+
+// TestMetricRegistry_PgReplicationSlotsInactive_StaleSampleExcluded
+// verifies that the 5-minute freshness cutoff excludes inactive slots
+// whose sample is older than the cutoff. A stale connection (sample
+// outside the cutoff) is paired with a fresh connection (sample inside
+// the cutoff) so the query exercises the success path; the assertion
+// then proves the stale connection is absent and the fresh connection
+// is present.
+func TestMetricRegistry_PgReplicationSlotsInactive_StaleSampleExcluded(t *testing.T) {
+	ds, pool, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	staleConnID := insertConnection(t, pool, "slot-inactive-stale")
+	freshConnID := insertConnection(t, pool, "slot-inactive-fresh")
+
+	stale := time.Now().UTC().Add(-6 * time.Minute)
+	fresh := time.Now().UTC().Add(-1 * time.Minute)
+	insertReplicationSlotRow(t, pool, staleConnID, stale, "slot_a", false, 100)
+	insertReplicationSlotRow(t, pool, freshConnID, fresh, "slot_a", false, 100)
+
+	results, err := ds.GetLatestMetricValues(ctx, "pg_replication_slots.inactive")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(pg_replication_slots.inactive) "+
+			"returned unexpected error: %v", err)
+	}
+
+	var sawFresh bool
+	for _, mv := range results {
+		switch mv.ConnectionID {
+		case staleConnID:
+			t.Errorf("pg_replication_slots.inactive returned a value "+
+				"for stale connection %d whose only sample (at %s) was "+
+				"outside the 5-minute freshness cutoff: got value %v",
+				staleConnID, stale.Format(time.RFC3339), mv.Value)
+		case freshConnID:
+			sawFresh = true
+			if mv.Value != 1 {
+				t.Errorf("pg_replication_slots.inactive value for fresh "+
+					"connection %d = %v; want 1",
+					freshConnID, mv.Value)
+			}
+		default:
+			t.Errorf("pg_replication_slots.inactive returned an "+
+				"unexpected connection_id=%d (value %v); only the fresh "+
+				"connection (%d) should appear in the result set",
+				mv.ConnectionID, mv.Value, freshConnID)
+		}
+	}
+	if !sawFresh {
+		t.Errorf("pg_replication_slots.inactive did not return the "+
+			"fresh connection %d; results=%+v", freshConnID, results)
+	}
+}
+
 // TestMetricRegistry_PgReplicationSlotsMaxRetainedBytes verifies that the
 // pg_replication_slots.max_retained_bytes metric returns the maximum
 // retained_bytes value across slots in the latest sample.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -328,6 +328,17 @@ project adheres to
 
 ### Fixed
 
+- Fix the alerter's `replication_slot_inactive` critical
+  alert never firing because its metric query selected
+  from a non-existent `metrics.pg_stat_replication_slots`
+  table; the `pg_replication_slots.inactive` metric now
+  reads directly from `metrics.pg_replication_slots` (the
+  table the collector probe writes to) and derives the
+  inactive state from the `active` column. New integration
+  tests cover the happy path, the no-row case when every
+  slot is active, slot deduplication per connection, and
+  the 5-minute freshness cutoff. (#224)
+
 - Fix the Admin panels showing a success toast alongside a
   page-level refresh error when a save succeeded but the
   follow-on reload failed; the shared `useCrudPanel` hook


### PR DESCRIPTION
## Summary

- Fix the `pg_replication_slots.inactive` metric query in
  `alerter/src/internal/database/metric_registry.go`. The previous
  query selected `FROM metrics.pg_stat_replication_slots`, a table
  that no migration creates and no probe writes to, so the query
  errored silently and the `replication_slot_inactive` critical
  alert never fired.
- The metric now reads directly from `metrics.pg_replication_slots`
  (the table the collector probe writes to) and derives inactivity
  from the `active` boolean column, removing the fragile
  `application_name`-to-`slot_name` `NOT EXISTS` join.
- Add four integration tests: happy path, no-row case when every
  slot is active, per-connection deduplication, and the 5-minute
  freshness cutoff.

Fixes #224.

## Test plan

- [x] `cd alerter && make coverage` — all alerter packages pass, 0 lint issues.
- [x] `cd client && npm test` — 3104 client tests pass.
- [x] `make test-all` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the replication_slot_inactive metric to correctly detect inactive PostgreSQL replication slots using a 5-minute freshness window and per-connection deduplication.

* **Tests**
  * Added integration tests for inactive/active states, deduplication, freshness cutoff, per-slot latest evaluation, and recovery behavior.

* **Documentation**
  * Updated changelog entry describing the fix and new test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/228)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->