### PR TITLE
fix(client): prevent copy/run icons overlapping SQL text (#221)

### DIFF
--- a/client/src/components/shared/MarkdownContent.tsx
+++ b/client/src/components/shared/MarkdownContent.tsx
@@ -202,7 +202,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
                         style={cleanTheme}
                         language={language || 'sql'}
                         PreTag="div"
-                        customStyle={getCodeBlockCustomStyle(customBackground)}
+                        customStyle={getCodeBlockCustomStyle(customBackground, 1)}
                         {...props}
                     >
                         {codeString}

--- a/client/src/components/shared/MarkdownExports.ts
+++ b/client/src/components/shared/MarkdownExports.ts
@@ -41,6 +41,7 @@ export {
     getInlineCodeSx,
     getCodeBlockWrapperSx,
     getCodeBlockCustomStyle,
+    getCodeBlockRightPadding,
     getLinkSx,
     getBlockquoteSx,
     getTableSx,

--- a/client/src/components/shared/RunnableCodeBlock.tsx
+++ b/client/src/components/shared/RunnableCodeBlock.tsx
@@ -247,7 +247,10 @@ const RunnableCodeBlock: React.FC<RunnableCodeBlockProps> = ({
                     style={syntaxTheme}
                     language={language || 'sql'}
                     PreTag="div"
-                    customStyle={getCodeBlockCustomStyle(customBackground)}
+                    customStyle={getCodeBlockCustomStyle(
+                        customBackground,
+                        isSql ? 2 : 1,
+                    )}
                     {...props}
                 >
                     {codeContent}

--- a/client/src/components/shared/__tests__/RunnableCodeBlock.test.tsx
+++ b/client/src/components/shared/__tests__/RunnableCodeBlock.test.tsx
@@ -1,0 +1,552 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Regression coverage for issue #221 plus broader unit coverage for
+// RunnableCodeBlock. The component previously had only integration
+// coverage through analysis dialogs because the heavyweight query
+// runner is normally exercised end-to-end. The issue #221 fix touched
+// the SyntaxHighlighter call site, so these tests now anchor every
+// behavioural branch (layout, success, confirmation, error, dismiss).
+//
+// SyntaxHighlighter is mocked with a stub that surfaces the
+// `customStyle` prop as JSON so we can assert layout decisions without
+// pulling in the real prismjs grammar. apiFetch is mocked per test to
+// drive the query-execution branches.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createTheme } from '@mui/material/styles';
+import RunnableCodeBlock from '../RunnableCodeBlock';
+import { renderWithTheme } from '../../../test/renderWithTheme';
+
+vi.mock('react-syntax-highlighter', () => ({
+    Prism: ({
+        children,
+        customStyle,
+    }: {
+        children: React.ReactNode;
+        customStyle?: Record<string, unknown>;
+        [key: string]: unknown;
+    }) => (
+        <div
+            data-testid="syntax-highlighter"
+            data-custom-style={JSON.stringify(customStyle ?? {})}
+            style={customStyle as React.CSSProperties}
+        >
+            {children}
+        </div>
+    ),
+}));
+
+const mockApiFetch = vi.fn();
+vi.mock('../../../utils/apiClient', () => ({
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+const theme = createTheme();
+
+const baseProps = {
+    codeContent: 'SELECT * FROM spock.exception_status WHERE status = $1;',
+    language: 'sql',
+    isDark: false,
+    connectionId: 1,
+    syntaxTheme: {},
+    customBackground: '#fafafa',
+    theme,
+    props: {},
+};
+
+const readCustomStyle = (): Record<string, unknown> => {
+    const node = screen.getByTestId('syntax-highlighter');
+    return JSON.parse(node.dataset.customStyle || '{}');
+};
+
+/**
+ * The run icon's MUI Tooltip wraps the IconButton in a <span> that carries
+ * the `aria-label` (so disabled buttons still announce their purpose).
+ * Tests that need to click the underlying IconButton walk through the
+ * labelled span to find the actual <button>.
+ */
+const getRunButton = (label = 'Run query'): HTMLElement => {
+    const labelled = screen.getByLabelText(label);
+    const button = labelled.querySelector('button');
+    if (!button) {
+        throw new Error(`No <button> inside labelled element "${label}"`);
+    }
+    return button as HTMLElement;
+};
+
+const makeOkResponse = (body: unknown) => ({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(''),
+});
+
+const makeErrorResponse = ({
+    status = 500,
+    json,
+    text,
+}: {
+    status?: number;
+    json?: unknown;
+    text?: string;
+} = {}) => ({
+    ok: false,
+    status,
+    json: vi.fn(
+        json === undefined
+            ? () => Promise.reject(new Error('not-json'))
+            : () => Promise.resolve(json),
+    ),
+    text: vi.fn().mockResolvedValue(text ?? ''),
+});
+
+beforeEach(() => {
+    mockApiFetch.mockReset();
+});
+
+describe('RunnableCodeBlock layout (issue #221 fix)', () => {
+    it('reserves room for both copy and run icons on SQL blocks', () => {
+        renderWithTheme(<RunnableCodeBlock {...baseProps} isSql={true} />);
+
+        // Two action buttons (copy + run) need 74px of clearance on the
+        // right of the code area; without this, long SQL lines hide
+        // underneath the icons.
+        const customStyle = readCustomStyle();
+        expect(customStyle.paddingRight).toBe('74px');
+        expect(customStyle.padding).toBe('1rem');
+        expect(customStyle.background).toBe('#fafafa');
+    });
+
+    it('reserves room for only the copy icon when the block is not runnable', () => {
+        renderWithTheme(<RunnableCodeBlock {...baseProps} isSql={false} />);
+
+        // Non-SQL code blocks only ever show the copy icon, so a single
+        // 42px clearance is enough.
+        const customStyle = readCustomStyle();
+        expect(customStyle.paddingRight).toBe('42px');
+    });
+
+    it('falls back to the "sql" language when none is provided', () => {
+        renderWithTheme(
+            <RunnableCodeBlock {...baseProps} isSql={true} language="" />,
+        );
+
+        // The component defaults the SyntaxHighlighter language prop to
+        // 'sql' to keep the highlighter happy and the contract stable;
+        // exercise this branch so future changes keep it intact.
+        expect(screen.getByTestId('syntax-highlighter')).toBeInTheDocument();
+    });
+});
+
+describe('RunnableCodeBlock run button', () => {
+    it('renders the run action icon for SQL blocks', () => {
+        renderWithTheme(<RunnableCodeBlock {...baseProps} isSql={true} />);
+
+        expect(screen.getByLabelText('Run query')).toBeInTheDocument();
+    });
+
+    it('omits the run action icon when isSql is false', () => {
+        renderWithTheme(<RunnableCodeBlock {...baseProps} isSql={false} />);
+
+        expect(screen.queryByLabelText('Run query')).not.toBeInTheDocument();
+    });
+
+    it('builds a server-and-database aware tooltip for the run icon', () => {
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                serverName="alpha"
+                databaseName="prod"
+            />,
+        );
+
+        expect(
+            screen.getByLabelText('Run on alpha/prod'),
+        ).toBeInTheDocument();
+    });
+
+    it('falls back to a server-only tooltip when no database name is supplied', () => {
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                serverName="alpha"
+            />,
+        );
+
+        expect(screen.getByLabelText('Run on alpha')).toBeInTheDocument();
+    });
+});
+
+describe('RunnableCodeBlock query execution', () => {
+    it('flags a code block with no executable SQL', async () => {
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="-- only a comment"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/No executable SQL found/i),
+            ).toBeInTheDocument();
+        });
+        // The fetch should never run for a block that contains no SQL.
+        expect(mockApiFetch).not.toHaveBeenCalled();
+    });
+
+    it('renders the result table on success and posts the cleaned SQL', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            makeOkResponse({
+                total_statements: 1,
+                results: [
+                    {
+                        query: 'SELECT 1;',
+                        columns: ['col_a'],
+                        rows: [['v1']],
+                        row_count: 1,
+                    },
+                ],
+            }),
+        );
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="SELECT 1;"
+                databaseName="prod"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        // Result header + table content for the single statement.
+        await waitFor(() =>
+            expect(screen.getByText('1 statement')).toBeInTheDocument(),
+        );
+        expect(screen.getByText('col_a')).toBeInTheDocument();
+        expect(screen.getByText('v1')).toBeInTheDocument();
+        expect(screen.getByText('1 row')).toBeInTheDocument();
+
+        // The fetch should carry the database name when supplied.
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+        const callBody = JSON.parse(
+            (mockApiFetch.mock.calls[0][1] as { body: string }).body,
+        );
+        expect(callBody).toEqual({
+            query: 'SELECT 1;',
+            database_name: 'prod',
+        });
+    });
+
+    it('renders pluralised row counts and the truncation notice', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            makeOkResponse({
+                total_statements: 2,
+                results: [
+                    {
+                        query: 'SELECT * FROM a;',
+                        columns: ['c'],
+                        rows: [['x'], ['y'], ['z']],
+                        row_count: 3,
+                        truncated: true,
+                    },
+                    {
+                        query: 'SELECT 2;',
+                        error: 'boom',
+                    },
+                ],
+            }),
+        );
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="SELECT * FROM a; SELECT 2;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(screen.getByText('2 statements')).toBeInTheDocument(),
+        );
+        expect(
+            screen.getByText('Results limited to 3 rows'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('boom')).toBeInTheDocument();
+    });
+
+    it('shows a confirmation prompt and re-runs with confirmed=true', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            makeOkResponse({
+                requires_confirmation: true,
+                write_statements: ['DELETE FROM t;'],
+            }),
+        );
+        mockApiFetch.mockResolvedValueOnce(
+            makeOkResponse({
+                total_statements: 1,
+                results: [{ query: 'DELETE FROM t;', row_count: 0 }],
+            }),
+        );
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="DELETE FROM t;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(
+                screen.getByText(/contains statements that modify/i),
+            ).toBeInTheDocument(),
+        );
+        // The confirmation panel lists the write statements as bulleted
+        // paragraphs. At least one paragraph must echo the DELETE so the
+        // operator can confirm what is about to run.
+        const stmtParagraphs = screen
+            .getAllByText(/DELETE FROM t;/)
+            .filter((el) => el.tagName === 'P');
+        expect(stmtParagraphs.length).toBeGreaterThan(0);
+
+        // Execute the confirmation; the second call must include confirmed=true.
+        await user.click(screen.getByRole('button', { name: /execute/i }));
+        await waitFor(() =>
+            expect(screen.getByText('1 statement')).toBeInTheDocument(),
+        );
+
+        const secondBody = JSON.parse(
+            (mockApiFetch.mock.calls[1][1] as { body: string }).body,
+        );
+        expect(secondBody).toMatchObject({
+            confirmed: true,
+            query: 'DELETE FROM t;',
+        });
+    });
+
+    it('dismisses the confirmation prompt when Cancel is clicked', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            makeOkResponse({
+                requires_confirmation: true,
+                write_statements: ['DROP TABLE t;'],
+            }),
+        );
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="DROP TABLE t;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(
+                screen.getByText(/contains statements that modify/i),
+            ).toBeInTheDocument(),
+        );
+
+        await user.click(screen.getByRole('button', { name: /cancel/i }));
+        await waitFor(() =>
+            expect(
+                screen.queryByText(/contains statements that modify/i),
+            ).not.toBeInTheDocument(),
+        );
+    });
+
+    it('surfaces the JSON error payload when the server returns non-2xx', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            makeErrorResponse({ json: { error: 'forbidden: ro-token' } }),
+        );
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="SELECT 1;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(
+                screen.getByText('forbidden: ro-token'),
+            ).toBeInTheDocument(),
+        );
+    });
+
+    it('falls back to the plain text body when the error response is not JSON', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            makeErrorResponse({ text: 'plain text failure' }),
+        );
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="SELECT 1;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(
+                screen.getByText('plain text failure'),
+            ).toBeInTheDocument(),
+        );
+    });
+
+    it('uses the status-based fallback when both JSON and text bodies are empty', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            makeErrorResponse({ status: 503, text: '' }),
+        );
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="SELECT 1;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(
+                screen.getByText('Query failed with status 503'),
+            ).toBeInTheDocument(),
+        );
+    });
+
+    it('captures network failures from the apiFetch call', async () => {
+        mockApiFetch.mockRejectedValueOnce(new Error('network down'));
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="SELECT 1;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(screen.getByText('network down')).toBeInTheDocument(),
+        );
+    });
+
+    it('clears the error banner when the dismiss icon is clicked', async () => {
+        mockApiFetch.mockRejectedValueOnce(new Error('temporary glitch'));
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="SELECT 1;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(screen.getByText('temporary glitch')).toBeInTheDocument(),
+        );
+
+        // The dismiss IconButton is the only button rendered inside the
+        // error banner.
+        const errorText = screen.getByText('temporary glitch');
+        const banner = errorText.closest('div');
+        if (!banner) {
+            throw new Error('error banner not found');
+        }
+        const dismissButton = banner.querySelector('button');
+        if (!dismissButton) {
+            throw new Error('dismiss button not found');
+        }
+        await act(async () => {
+            await user.click(dismissButton);
+        });
+
+        await waitFor(() =>
+            expect(
+                screen.queryByText('temporary glitch'),
+            ).not.toBeInTheDocument(),
+        );
+    });
+
+    it('clears the result panel when the dismiss icon is clicked', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            makeOkResponse({
+                total_statements: 1,
+                results: [
+                    {
+                        query: 'SELECT 1;',
+                        columns: ['c'],
+                        rows: [['v']],
+                        row_count: 1,
+                    },
+                ],
+            }),
+        );
+        renderWithTheme(
+            <RunnableCodeBlock
+                {...baseProps}
+                isSql={true}
+                codeContent="SELECT 1;"
+            />,
+        );
+
+        const user = userEvent.setup();
+        await user.click(getRunButton());
+
+        await waitFor(() =>
+            expect(screen.getByText('1 statement')).toBeInTheDocument(),
+        );
+
+        const header = screen.getByText('1 statement').closest('div');
+        if (!header) {
+            throw new Error('result header not found');
+        }
+        const headerDismiss = header.querySelector('button');
+        if (!headerDismiss) {
+            throw new Error('header dismiss button not found');
+        }
+        await act(async () => {
+            await user.click(headerDismiss);
+        });
+
+        await waitFor(() =>
+            expect(
+                screen.queryByText('1 statement'),
+            ).not.toBeInTheDocument(),
+        );
+    });
+});

--- a/client/src/components/shared/__tests__/markdownStyles.test.ts
+++ b/client/src/components/shared/__tests__/markdownStyles.test.ts
@@ -1,0 +1,92 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Regression coverage for issue #221. The Remediation Steps panel rendered
+// SQL code blocks with absolutely positioned copy/run icons in the
+// top-right corner, but the code area had a uniform 1rem padding which let
+// long SQL lines slide underneath the icons. The fix reserves horizontal
+// space on the right of the code area sized to the number of action
+// buttons that overlay it. These tests pin down the padding calculation
+// and the customStyle shape that feeds SyntaxHighlighter.
+
+import { describe, it, expect } from 'vitest';
+import {
+    getCodeBlockRightPadding,
+    getCodeBlockCustomStyle,
+} from '../markdownStyles';
+
+describe('getCodeBlockRightPadding (issue #221)', () => {
+    it('returns the default 1rem when no action buttons overlay the block', () => {
+        // A non-decorated code block keeps the original symmetric padding so
+        // we do not introduce a visible right-side gutter without reason.
+        expect(getCodeBlockRightPadding(0)).toBe('1rem');
+    });
+
+    it('reserves enough room for a single 28px action button', () => {
+        // Layout: 6px offset + one 28px button + 8px gutter = 42px.
+        expect(getCodeBlockRightPadding(1)).toBe('42px');
+    });
+
+    it('reserves enough room for two action buttons with the inter-button gap', () => {
+        // Layout: 6px offset + 2 * 28px buttons + 1 * 4px gap + 8px gutter
+        // = 74px. This is the case that issue #221 originally regressed:
+        // both the copy and run icons sit over the right edge of the SQL.
+        expect(getCodeBlockRightPadding(2)).toBe('74px');
+    });
+
+    it('scales linearly with additional buttons', () => {
+        // Defensive: future panels may add more action buttons. The helper
+        // must keep clearing each extra 28px button and its preceding gap.
+        expect(getCodeBlockRightPadding(3)).toBe('106px');
+    });
+
+    it('clamps negative button counts to the no-button default', () => {
+        // Treat a nonsensical caller value as zero rather than computing a
+        // negative padding that would shrink the code area.
+        expect(getCodeBlockRightPadding(-1)).toBe('1rem');
+    });
+});
+
+describe('getCodeBlockCustomStyle (issue #221)', () => {
+    it('preserves the existing padding and font defaults', () => {
+        const style = getCodeBlockCustomStyle('#fff');
+        expect(style.margin).toBe(0);
+        expect(style.padding).toBe('1rem');
+        expect(style.fontSize).toBe('1rem');
+        expect(style.fontFamily).toBe(
+            '"JetBrains Mono", "SF Mono", monospace',
+        );
+        expect(style.background).toBe('#fff');
+    });
+
+    it('defaults paddingRight to 1rem when no button count is supplied', () => {
+        // Callers that never had action buttons (legacy paths) must keep
+        // their symmetric padding so this change is a no-op for them.
+        const style = getCodeBlockCustomStyle('#fff');
+        expect(style.paddingRight).toBe('1rem');
+    });
+
+    it('uses the single-button clearance when one button overlays the block', () => {
+        const style = getCodeBlockCustomStyle('#fff', 1);
+        expect(style.paddingRight).toBe('42px');
+    });
+
+    it('uses the two-button clearance for SQL code blocks (the issue #221 case)', () => {
+        const style = getCodeBlockCustomStyle('#fff', 2);
+        expect(style.paddingRight).toBe('74px');
+    });
+
+    it('forwards the supplied background colour verbatim', () => {
+        // The background colour is theme-driven and must not be touched by
+        // the padding logic.
+        const style = getCodeBlockCustomStyle('rgb(10, 20, 30)', 2);
+        expect(style.background).toBe('rgb(10, 20, 30)');
+    });
+});

--- a/client/src/components/shared/__tests__/markdownStyles.test.ts
+++ b/client/src/components/shared/__tests__/markdownStyles.test.ts
@@ -17,9 +17,13 @@
 // and the customStyle shape that feeds SyntaxHighlighter.
 
 import { describe, it, expect } from 'vitest';
+import { createTheme } from '@mui/material/styles';
 import {
     getCodeBlockRightPadding,
     getCodeBlockCustomStyle,
+    getCodeBlockButtonGroupSx,
+    getCopyButtonSx,
+    getRunButtonSx,
 } from '../markdownStyles';
 
 describe('getCodeBlockRightPadding (issue #221)', () => {
@@ -88,5 +92,45 @@ describe('getCodeBlockCustomStyle (issue #221)', () => {
         // the padding logic.
         const style = getCodeBlockCustomStyle('rgb(10, 20, 30)', 2);
         expect(style.background).toBe('rgb(10, 20, 30)');
+    });
+});
+
+describe('code block button geometry (issue #221)', () => {
+    // The button group is absolutely positioned in the top-right of the
+    // code block and its geometry must agree with getCodeBlockRightPadding
+    // so long SQL lines never slide under the copy/run icons. These tests
+    // pin down the constants the padding helper relies on; if they change,
+    // getCodeBlockRightPadding's expected values change with them.
+    it('positions the button group 6px from the top-right corner', () => {
+        const sx = getCodeBlockButtonGroupSx();
+        expect(sx.position).toBe('absolute');
+        expect(sx.top).toBe(6);
+        expect(sx.right).toBe(6);
+        expect(sx.display).toBe('flex');
+    });
+
+    it('separates buttons with the 4px gap assumed by the padding helper', () => {
+        // Use an explicit pixel string instead of a theme-spacing unit so a
+        // future change to theme.spacing cannot drift the gap away from
+        // CODE_BLOCK_BUTTON_GAP and reintroduce the issue #221 overlap.
+        const sx = getCodeBlockButtonGroupSx();
+        expect(sx.gap).toBe('4px');
+    });
+
+    it('sizes the copy button to the 28px square that padding reserves for it', () => {
+        const theme = createTheme();
+        const sx = getCopyButtonSx(theme);
+        expect(sx.width).toBe(28);
+        expect(sx.height).toBe(28);
+    });
+
+    it('sizes the run button to the 28px square and anchors it top-right', () => {
+        const theme = createTheme();
+        const sx = getRunButtonSx(theme);
+        expect(sx.width).toBe(28);
+        expect(sx.height).toBe(28);
+        expect(sx.position).toBe('absolute');
+        expect(sx.top).toBe(6);
+        expect(sx.right).toBe(6);
     });
 });

--- a/client/src/components/shared/markdownStyles.ts
+++ b/client/src/components/shared/markdownStyles.ts
@@ -130,9 +130,37 @@ export const getCodeBlockWrapperSx = (theme: Theme) => ({
     },
 });
 
-export const getCodeBlockCustomStyle = (customBackground) => ({
+// Width allowance reserved on the right of the code area so the action
+// buttons (copy, run) do not overlap long, non-wrapping SQL lines (see
+// issue #221). The button group is absolutely positioned at top: 6px /
+// right: 6px with 28px buttons separated by a 4px gap, so for `n`
+// buttons the minimum clearance is 6 + n * 28 + (n - 1) * 4. We add a
+// small visual gutter on top of that so glyphs never touch the icons.
+const CODE_BLOCK_BUTTON_WIDTH = 28;
+const CODE_BLOCK_BUTTON_GAP = 4;
+const CODE_BLOCK_BUTTON_OFFSET = 6;
+const CODE_BLOCK_BUTTON_GUTTER = 8;
+
+export const getCodeBlockRightPadding = (buttonCount: number): string => {
+    const count = Math.max(0, buttonCount);
+    if (count === 0) {
+        return '1rem';
+    }
+    const px =
+        CODE_BLOCK_BUTTON_OFFSET +
+        count * CODE_BLOCK_BUTTON_WIDTH +
+        Math.max(0, count - 1) * CODE_BLOCK_BUTTON_GAP +
+        CODE_BLOCK_BUTTON_GUTTER;
+    return `${px}px`;
+};
+
+export const getCodeBlockCustomStyle = (
+    customBackground: string,
+    buttonCount: number = 0,
+) => ({
     margin: 0,
     padding: '1rem',
+    paddingRight: getCodeBlockRightPadding(buttonCount),
     fontSize: '1rem',
     fontFamily: '"JetBrains Mono", "SF Mono", monospace',
     background: customBackground,

--- a/client/src/components/shared/markdownStyles.ts
+++ b/client/src/components/shared/markdownStyles.ts
@@ -241,16 +241,16 @@ export const getTableSx = (theme: Theme) => ({
 
 export const getCodeBlockButtonGroupSx = () => ({
     position: 'absolute',
-    top: 6,
-    right: 6,
+    top: CODE_BLOCK_BUTTON_OFFSET,
+    right: CODE_BLOCK_BUTTON_OFFSET,
     display: 'flex',
-    gap: 0.5,
+    gap: `${CODE_BLOCK_BUTTON_GAP}px`,
 });
 
 const getCodeBlockActionButtonSx = (theme: Theme) => ({
     minWidth: 0,
-    width: 28,
-    height: 28,
+    width: CODE_BLOCK_BUTTON_WIDTH,
+    height: CODE_BLOCK_BUTTON_WIDTH,
     p: 0,
     borderRadius: 0.75,
     bgcolor: alpha(
@@ -277,8 +277,8 @@ export const getCopyButtonSx = (theme: Theme) => ({
 export const getRunButtonSx = (theme: Theme) => ({
     ...getCodeBlockActionButtonSx(theme),
     position: 'absolute',
-    top: 6,
-    right: 6,
+    top: CODE_BLOCK_BUTTON_OFFSET,
+    right: CODE_BLOCK_BUTTON_OFFSET,
 });
 
 export const getQueryResultWrapperSx = (theme: Theme) => ({

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -328,6 +328,13 @@ project adheres to
 
 ### Fixed
 
+- Fix long, non-wrapping SQL queries flowing underneath the
+  copy and run icons in the Remediation Steps panel of the
+  alert AI analysis view; the shared markdown styles now
+  reserve right-side padding on each code block sized to the
+  number of overlaid action buttons, so the SQL text never
+  collides with the icons. (#221)
+
 - Fix the Admin panels showing a success toast alongside a
   page-level refresh error when a save succeeded but the
   follow-on reload failed; the shared `useCrudPanel` hook


### PR DESCRIPTION
## Summary

- Fixes #221: copy and run icons overlapping query text in the Remediation Steps panel.
- Long, non-wrapping SQL queries previously flowed underneath the absolutely-positioned action icons; the shared markdown styles now reserve right-side padding sized to the number of overlaid buttons (42 px for one, 74 px for two).
- Adds unit tests covering the new padding helper and the `RunnableCodeBlock` layout and behavior; touched files measure 100% line coverage.

## Test plan

- [x] `npm run lint` (no new warnings)
- [x] `npm run typecheck` (no new errors)
- [x] `npm test` — 3132 tests pass
- [x] Targeted coverage for touched files (100%)
- [x] `make test-all` from repo root (exit 0)
- [ ] Visual verification of the Remediation Steps panel against a real Spock alert (recommended for reviewers; the dev server is not reachable from the agent sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code-block layout so long, non-wrapping SQL no longer collides with overlaid copy/run icons by reserving right-side padding.

* **Improvements**
  * Code-block styling now adapts right-side padding based on action button count and content type (e.g., SQL) and uses shared sizing constants for consistent button placement.
  * Exposed a utility to compute code-block right padding for layout consistency.

* **Tests**
  * Added regression tests covering padding logic, button geometry, and SQL execution UI/behavior.

* **Documentation**
  * Added changelog entry describing the UI fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/232)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->