### PR TITLE
docs: require TLS-terminating reverse proxy for network deployments (#234)

### DIFF
--- a/docs/admin-guide/index.md
+++ b/docs/admin-guide/index.md
@@ -10,6 +10,9 @@ access.
 
 The Administrator's Guide includes the following topics:
 
+- [TLS and Reverse Proxy Requirements](tls-and-reverse-proxy.md)
+  documents the mandatory TLS topology for any
+  network-accessible deployment.
 - [Authentication](authentication.md) covers user
   accounts, service accounts, API tokens, and
   role-based access control.

--- a/docs/admin-guide/tls-and-reverse-proxy.md
+++ b/docs/admin-guide/tls-and-reverse-proxy.md
@@ -1,0 +1,185 @@
+# TLS and Reverse Proxy Requirements
+
+Any network-accessible deployment of the pgEdge AI DBA
+Workbench must terminate TLS in front of the server.
+This page documents the supported deployment topology,
+the operator responsibilities, and the risks of
+ignoring the requirement.
+
+## Why TLS Is Mandatory
+
+The web client sends user credentials, session tokens,
+and API tokens to the server on every authenticated
+request. Plain HTTP transmits these credentials in
+cleartext over the network. Anyone on the path between
+the browser and the server can read or replay the
+captured credentials.
+
+The workbench therefore treats TLS as a hard
+requirement for any deployment that is reachable from a
+network other than the loopback interface of the host
+running the server. The requirement applies equally to
+production deployments, staging deployments, and shared
+development environments.
+
+## Recommended Topology
+
+The recommended topology places a TLS-terminating
+reverse proxy in front of the server. The reverse proxy
+accepts HTTPS connections from browsers and proxies
+plain HTTP to the server on the loopback interface or
+across a private network. The reverse proxy also serves
+the static web client assets that the build process
+emits into `client/dist/`.
+
+The recommended topology has the following properties:
+
+- The reverse proxy terminates TLS for browser
+  connections and the MCP transport.
+- The reverse proxy redirects HTTP requests to HTTPS so
+  that no credential ever travels over plain HTTP.
+- The reverse proxy issues an HTTP Strict Transport
+  Security (HSTS) header so browsers refuse to
+  downgrade subsequent requests.
+- The reverse proxy serves the static client bundle and
+  proxies `/api`, `/mcp`, and `/health` to the Go server
+  on port 8080.
+- The Go server listens on plain HTTP on a port that is
+  not exposed to the network; the reverse proxy is the
+  only client that connects to the server directly.
+
+The official Docker images follow this topology. The
+client container runs nginx as a non-root user, serves
+the bundled SPA, and proxies API and MCP traffic to the
+server container. See the
+[Docker deployment guide](../getting-started/docker.md)
+for the production Compose configuration and the
+[web client configuration page](../getting-started/configuration/client.md#nginx-configuration)
+for an annotated nginx configuration.
+
+## Operator Responsibilities
+
+A reverse proxy alone does not satisfy the requirement;
+the operator must also configure the proxy correctly.
+
+- The proxy must present a valid TLS certificate
+  issued by a certificate authority the browser
+  trusts.
+- The proxy must redirect every plain HTTP request to
+  the corresponding HTTPS URL with a `301` or `308`
+  response.
+- The proxy must set the `Strict-Transport-Security`
+  response header with a `max-age` of at least
+  `31536000` seconds (one year).
+- The proxy must forward the `X-Forwarded-For` and
+  `X-Forwarded-Proto` headers so the server records
+  the original client IP and scheme.
+- The proxy must restrict access to the server's
+  plain-HTTP listener; bind the listener to
+  `127.0.0.1` or to a private interface that the proxy
+  alone can reach.
+
+The server's `http.trusted_proxies` list pairs with
+the operator's network controls; configure the list
+with the CIDR ranges of the reverse proxies that send
+`X-Forwarded-For` headers. See the
+[server configuration reference](../getting-started/configuration/server.md#http-server-http)
+for details.
+
+## Direct TLS on the Server
+
+The Go server can terminate TLS directly when an
+operator chooses not to deploy a reverse proxy. The
+direct TLS path remains supported for environments
+where a reverse proxy is impractical, such as
+single-host appliance deployments or short-lived test
+deployments behind a corporate VPN.
+
+Configure direct TLS through the `http.tls` section of
+`ai-dba-server.yaml`:
+
+```yaml
+http:
+  address: ":8443"
+  tls:
+    enabled: true
+    cert_file: "/etc/pgedge/certs/cert.pem"
+    key_file: "/etc/pgedge/certs/key.pem"
+    chain_file: "/etc/pgedge/certs/chain.pem"
+```
+
+Operators who terminate TLS on the server must still
+serve the static web client bundle from a separate web
+server because the Go server is API-only. The Go
+server does not redirect plain HTTP to HTTPS and does
+not emit an HSTS header; the operator must rely on
+network controls to prevent plain-HTTP access to the
+server's listener.
+
+The recommended topology remains the reverse proxy in
+front of the server. Direct TLS is the exception
+rather than the rule.
+
+## The Vite Development Server
+
+The Vite development server at `http://localhost:5173`
+is a developer-only tool. The development server runs
+on plain HTTP, lacks the production hardening of the
+reverse proxy, and includes hot-reload tooling that is
+unsuitable for any shared environment. The development
+server is supported only for local development on the
+loopback interface.
+
+Do not expose port 5173 to a network of any kind. The
+development server transmits credentials over plain
+HTTP and provides no path to enable TLS. Deploy the
+production client bundle behind a reverse proxy
+instead, as described above.
+
+## Risks of Ignoring This Requirement
+
+A deployment that exposes the workbench over plain
+HTTP exposes every credential the user enters or the
+client sends. The concrete risks include the
+following items.
+
+- A passive attacker on the network path can capture
+  the user's password during login.
+- A passive attacker can capture a session token from
+  the `Authorization` header of any subsequent
+  request.
+- A passive attacker can capture API tokens that
+  scripts send through the REST API or the MCP
+  endpoint.
+- An active attacker can inject responses, replace
+  the SPA bundle, or intercept multi-factor
+  challenges.
+
+The workbench treats reports of plain-HTTP credential
+exposure on the development server as configuration
+issues rather than vulnerabilities, because the
+development server is documented as localhost-only.
+Reports of plain-HTTP credential exposure on a
+production deployment indicate a missing or
+misconfigured reverse proxy; review the topology
+above and the
+[Docker deployment guide](../getting-started/docker.md)
+to restore a supported configuration.
+
+## See Also
+
+- The
+  [installation guide](../getting-started/installation.md)
+  covers the standard production deployment.
+- The
+  [Docker deployment guide](../getting-started/docker.md)
+  documents the container topology that ships with
+  the project.
+- The
+  [server configuration reference](../getting-started/configuration/server.md#http-server-http)
+  lists every option for the `http` and `http.tls`
+  sections.
+- The
+  [web client configuration page](../getting-started/configuration/client.md#nginx-configuration)
+  shows an annotated nginx configuration for the
+  static SPA.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,23 @@ project adheres to
 
 ### Added
 
+- Document the TLS and reverse-proxy requirements for
+  any network-accessible deployment in a new
+  Administrator's Guide page at
+  `docs/admin-guide/tls-and-reverse-proxy.md`; the
+  page states explicitly that TLS termination, HTTP
+  to HTTPS redirection, and HSTS are operator
+  responsibilities at the reverse proxy layer, calls
+  out the Vite dev server on port 5173 as
+  localhost-only and unsupported for any
+  network-accessible use, notes that the server's
+  built-in TLS support remains available for
+  operators who choose to terminate at the
+  application, and enumerates the credential-exposure
+  risks of running the workbench over plain HTTP.
+  Cross-reference callouts now appear in the
+  installation, quick-start, Docker, and web-client
+  configuration pages. (#234)
 - Add a Playwright-based end-to-end smoke-test suite
   that drives the production client bundle in a real
   browser against a real server and Postgres on every

--- a/docs/getting-started/configuration/client.md
+++ b/docs/getting-started/configuration/client.md
@@ -19,6 +19,17 @@ npm run dev
 The application is available at
 `http://localhost:5173` after the server starts.
 
+!!! warning "Localhost only"
+    The Vite development server is a developer-only
+    tool that runs on plain HTTP and is supported only
+    on the loopback interface. Do not expose port
+    `5173` to any network; the development server
+    transmits credentials in cleartext and offers no
+    TLS option. For any network-accessible deployment,
+    build the production bundle and front it with a
+    TLS-terminating reverse proxy as described in the
+    [TLS and reverse proxy requirements](../../admin-guide/tls-and-reverse-proxy.md).
+
 ## API Proxy Configuration
 
 The development server proxies all API requests to the
@@ -110,6 +121,14 @@ For production deployments, serve the built files from
 the `dist` directory using a web server such as Nginx
 or Apache. The MCP server does not serve the web
 client files; a separate web server is required.
+
+!!! warning "TLS is required"
+    Any network-accessible deployment must terminate
+    TLS in front of the server. The reverse proxy is
+    responsible for TLS termination, HTTP-to-HTTPS
+    redirection, and HSTS. See the
+    [TLS and reverse proxy requirements](../../admin-guide/tls-and-reverse-proxy.md)
+    for the full operator checklist.
 
 ### Nginx Configuration
 

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -111,6 +111,21 @@ the GitHub Container Registry.
     [installation paths table](installation.md#installation-paths-by-method)
     for details.
 
+!!! warning "Add TLS before exposing the deployment"
+    The default Compose configuration publishes the
+    client container on plain HTTP at
+    `http://localhost:3000` for first-run convenience.
+    Any deployment that is reachable from a network
+    other than the loopback interface of the host must
+    terminate TLS in front of the client container.
+    Place an external reverse proxy (or a TLS sidecar)
+    in front of the published port, configure
+    HTTP-to-HTTPS redirection and HSTS on the proxy,
+    and restrict the published port to the proxy. See
+    the
+    [TLS and reverse proxy requirements](../admin-guide/tls-and-reverse-proxy.md)
+    for the full operator checklist.
+
 ## Image Variants
 
 Pre-built images are published to the GitHub Container

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -107,6 +107,17 @@ static file server such as Nginx. The web client
 consists of static HTML, CSS, and JavaScript files
 that require no server-side runtime.
 
+!!! warning "TLS is required"
+    Any network-accessible deployment must terminate
+    TLS in a reverse proxy in front of the server.
+    The reverse proxy is responsible for TLS
+    termination, HTTP-to-HTTPS redirection, and HSTS.
+    The Go server is API-only and does not serve the
+    static client bundle; the same reverse proxy that
+    terminates TLS also serves the SPA assets. See the
+    [TLS and reverse proxy requirements](../admin-guide/tls-and-reverse-proxy.md)
+    for the full operator checklist.
+
 !!! note
     To build the components from source instead,
     see the

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -237,6 +237,15 @@ client files from `/opt/ai-workbench/client` using
 a web server such as Nginx. Configure the web server
 to proxy API requests to the server on port 8080.
 
+!!! warning "TLS is required"
+    Any network-accessible deployment must terminate
+    TLS in the reverse proxy that fronts the server.
+    The reverse proxy is responsible for TLS
+    termination, HTTP-to-HTTPS redirection, and HSTS.
+    See the
+    [TLS and reverse proxy requirements](../admin-guide/tls-and-reverse-proxy.md)
+    for the full operator checklist.
+
 ## Verify the Setup
 
 After starting all components, follow these steps to

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
 
   - Administrator's Guide:
     - Overview: admin-guide/index.md
+    - TLS & Reverse Proxy: admin-guide/tls-and-reverse-proxy.md
     - Users & Authentication: admin-guide/authentication.md
     - Connection Management: admin-guide/connections.md
     - Alert Rules & Thresholds: admin-guide/alert-rules.md


### PR DESCRIPTION
## Summary

- New Administrator's Guide page `docs/admin-guide/tls-and-reverse-proxy.md` states the TLS and reverse-proxy requirements for any network-accessible deployment.
- Adds cross-link warning callouts to installation, quick-start, Docker, and web-client configuration pages.
- Updates `mkdocs.yml` nav and `docs/changelog.md`.

Issue #234 mistook the Vite dev server URL (`http://localhost:5173`) for a production deployment. The new docs make the deployment expectations unambiguous: the Vite dev server is localhost-only, and any network-accessible deployment must be fronted by a TLS-terminating reverse proxy (nginx for the official Docker images and enterprise package builds). The Go server's built-in `http.tls.*` direct-TLS support is documented as a supported-but-exceptional path.

Closes #234.

## Test plan

- [ ] `mkdocs build` is clean (verified in worktree before commit).
- [ ] New page renders correctly in the docs site preview.
- [ ] Cross-links resolve to the new page from installation, quick-start, Docker, and configuration/client pages.
- [ ] Nav entry appears under "Administrator's Guide" above "Users & Authentication".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive TLS and reverse-proxy requirements guide for operators deploying network-accessible instances.
  * Updated installation, quick-start, Docker, and client configuration guides with security warnings about mandatory TLS termination.
  * Updated changelog with TLS deployment notes and cross-references to security documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/237)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->