### PR TITLE
perf(tests): speed up test-all by ~65% (10m49s → 3m49s)

### DIFF
--- a/.claude/golang-expert/testing-strategy.md
+++ b/.claude/golang-expert/testing-strategy.md
@@ -68,17 +68,17 @@ func TestFunctionName_Error(t *testing.T)        // Error case
 
 ```bash
 # Per sub-project
-cd collector && make test        # Unit tests
-cd collector && make coverage    # Tests with coverage
+cd collector && make test        # Fast unit tests (no coverage)
+cd collector && make coverage    # Verbose tests with coverage profile
 cd collector && make lint        # Linter
-cd collector && make test-all    # Test + coverage + lint
+cd collector && make test-all    # fmt-check + coverage + lint
 
-cd server && make test           # Unit + integration tests
+cd server && make test           # Fast unit + integration tests
 cd server && make coverage
 cd server && make lint
 cd server && make test-all
 
-cd alerter && make test          # Unit tests
+cd alerter && make test          # Fast unit tests
 cd alerter && make coverage
 cd alerter && make lint
 cd alerter && make test-all
@@ -86,6 +86,22 @@ cd alerter && make test-all
 # All projects from root
 make test-all
 ```
+
+`test-all` runs the full Go suite **once** with
+`go test -race -v -coverprofile=coverage.out ./...` (via the
+`coverage` target) and then runs `lint`; `fmt-check` runs first. An
+earlier shape ran the suite twice — once for `test`, once for
+`coverage` — which doubled CI wall-clock for no extra signal. Do
+not re-introduce a duplicate `test` step inside `test-all`.
+
+`make test` (without `-all`) remains as a fast developer-only loop:
+no coverage instrumentation, no HTML report. Use it for iterative
+TDD; use `make test-all` (or `make coverage` standalone) before
+handing work back.
+
+Both `test` and `coverage` bracket the test invocation with `killall`
+so stray probe/server processes from earlier runs cannot interfere
+with the next package's tests.
 
 ### Environment Variables
 
@@ -196,6 +212,50 @@ func TestUserRepository_GetUser(t *testing.T) {
     assert.Equal(t, "Test User", user.Name)
 }
 ```
+
+### HTTP Handler Tests: Never Point at Unreachable URLs
+
+Handlers in `internal/llmproxy/`, `internal/chat/`, and related
+packages issue real outbound HTTP requests when their configured
+endpoint is reachable. Pointing such a handler at an unreachable
+URL (for example `http://localhost:8080/v1` when nothing is
+listening) blocks for the duration of the shared HTTP client's
+timeout. The LLM client at `internal/chat/llm.go` uses a 120-second
+`defaultLLMHTTPTimeout` deliberately, to accommodate large-context
+chat completions; that 120 s applies to test code too, so a single
+hung handler test costs two minutes per `make test-all` run — and
+runs twice (once via the `test` target, once via `coverage`) on
+older Makefile shapes.
+
+The fix is to mock the endpoint with `httptest.NewServer` and
+return a minimal valid response. For OpenAI-compatible model
+listings, an empty `data` array is enough:
+
+```go
+server := httptest.NewServer(http.HandlerFunc(
+    func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        if _, err := w.Write([]byte(`{"data": []}`)); err != nil {
+            t.Errorf("mock server failed to write body: %v", err)
+        }
+    }))
+defer server.Close()
+
+config := &Config{
+    OpenAIBaseURL: server.URL,
+    Model:         "local-model",
+}
+HandleModels(w, req, config)
+```
+
+See `TestHandleModels_OpenAIBaseURLOnly` in
+`server/src/internal/llmproxy/proxy_test.go` for the canonical
+pattern, and the sibling tests in `server/src/internal/chat/llm_test.go`
+for other shapes (chat completion bodies, error responses).
+
+When auditing a slow test, grep for `OpenAIBaseURL` and
+`AnthropicAPIURL` set to literal `http://localhost:...` or
+`https://api.openai.com` strings; those are the smell.
 
 ### Testing Without Database
 
@@ -461,6 +521,26 @@ without panicking. It mutates the per-store `bcryptCost` field under
 `s.mu`, so the next `CreateUser`, `UpdateUser`, or `UpdateUserAtomic`
 call uses the override. Production behavior is unaffected; the default
 cost stays at `DefaultBcryptCost` unless a test explicitly lowers it.
+
+The helper also regenerates the per-store `dummyHash` (the
+timing-equalizer used in `AuthenticateUser` when a username is not
+found) at the lowered cost. Without this, every "nonexistent user"
+code path performs a cost-12 `bcrypt.CompareHashAndPassword` against
+the package-level `defaultDummyHash`, which costs ~250 ms in plain
+runs and ~1-2 s under the race detector — visible as
+multi-second `TestAuthenticateUserNonExistent` and
+`TestAuthHandler_HandleLogin` runtimes. Production AuthStores share
+`defaultDummyHash` (computed once at package load), so production
+timing equalization is unchanged.
+
+If you add a test that simulates a missing user and the runtime is
+still seconds rather than milliseconds, confirm
+`SetBcryptCostForTesting` ran *before* the AuthenticateUser call.
+The dummy hash is read from the store struct on every authenticate,
+so a later cost-lowering call would also work — but the test helper
+pattern in `createTestAuthStoreForStore` / `createTestRBACHandler`
+already does this immediately after `NewAuthStore`, and new helpers
+should follow the same order.
 
 The matching `AuthStore.Close()` method stops the session cleanup
 goroutine as well as closing the database, so pairing

--- a/alerter/Makefile
+++ b/alerter/Makefile
@@ -60,9 +60,15 @@ fmt-check:
 # Run tests with coverage
 # Use -p=1 to serialize per-package test binaries (see note on the test target).
 # -race enables the data-race detector; CI runs the same target.
-coverage:
+# -v emits per-test output so this single invocation can replace the
+# separate `test` target inside `test-all` and halve total test time.
+# killall brackets the run because the test suite may leave stray
+# processes that interfere with subsequent test binaries (same
+# rationale as the `test` target).
+coverage: killall
 	@echo "Running tests with coverage..."
-	cd src && go test -race -p=1 -coverprofile=coverage.out ./...
+	cd src && go test -race -p=1 -v -coverprofile=coverage.out ./...
+	@$(MAKE) --no-print-directory killall
 	cd src && go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: src/coverage.html"
 
@@ -82,8 +88,11 @@ deps:
 check: fmt vet test lint
 	@echo "All checks passed!"
 
-# Run all tests (fmt-check, test, coverage, lint)
-test-all: fmt-check test coverage lint
+# Run all tests (fmt-check, coverage, lint)
+# coverage now emits verbose output and runs the full suite once, so
+# the separate `test` target is no longer included; this halves the
+# wall-clock time previously spent running every package twice.
+test-all: fmt-check coverage lint
 	@echo "All tests passed!"
 
 # Help target
@@ -97,7 +106,7 @@ help:
 	@echo "  fmt       - Format code with gofmt"
 	@echo "  fmt-check - Check code formatting (fails if not formatted)"
 	@echo "  coverage  - Generate test coverage report"
-	@echo "  test-all  - Run fmt-check, test, coverage, and lint"
+	@echo "  test-all  - Run fmt-check, coverage, and lint (verbose, single pass)"
 	@echo "  clean     - Remove build artifacts"
 	@echo "  deps      - Install/update dependencies"
 	@echo "  check     - Run all checks (fmt, vet, test, lint)"

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -56,9 +56,15 @@ fmt-check:
 
 # Run tests with coverage
 # -race enables the data-race detector; CI runs the same target.
-coverage:
+# -v emits per-test output so this single invocation can replace the
+# separate `test` target inside `test-all` and halve total test time.
+# killall brackets the run because the test suite may leave stray
+# processes that interfere with subsequent test binaries (same
+# rationale as the `test` target).
+coverage: killall
 	@echo "Running tests with coverage..."
-	cd src && go test -race -coverprofile=coverage.out ./...
+	cd src && go test -race -v -coverprofile=coverage.out ./...
+	@$(MAKE) --no-print-directory killall
 	cd src && go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: src/coverage.html"
 
@@ -78,8 +84,11 @@ deps:
 check: fmt vet test lint
 	@echo "All checks passed!"
 
-# Run all tests (fmt-check, test, coverage, lint)
-test-all: fmt-check test coverage lint
+# Run all tests (fmt-check, coverage, lint)
+# coverage now emits verbose output and runs the full suite once, so
+# the separate `test` target is no longer included; this halves the
+# wall-clock time previously spent running every package twice.
+test-all: fmt-check coverage lint
 	@echo "All tests passed!"
 
 # Help target
@@ -93,7 +102,7 @@ help:
 	@echo "  fmt       - Format code with gofmt"
 	@echo "  fmt-check - Check code formatting (fails if not formatted)"
 	@echo "  coverage  - Generate test coverage report"
-	@echo "  test-all  - Run fmt-check, test, coverage, and lint"
+	@echo "  test-all  - Run fmt-check, coverage, and lint (verbose, single pass)"
 	@echo "  clean     - Remove build artifacts"
 	@echo "  deps      - Install/update dependencies"
 	@echo "  check     - Run all checks (fmt, vet, test, lint)"

--- a/server/Makefile
+++ b/server/Makefile
@@ -66,9 +66,15 @@ fmt-check:
 # Run tests with coverage
 # Use -p=1 to serialize per-package test binaries (see note on the test target).
 # -race enables the data-race detector; CI runs the same target.
-coverage:
+# -v emits per-test output so this single invocation can replace the
+# separate `test` target inside `test-all` and halve total test time.
+# killall brackets the run because the test suite may leave stray
+# processes that interfere with subsequent test binaries (same
+# rationale as the `test` target).
+coverage: killall
 	@echo "Running tests with coverage..."
-	cd src && go test -race -p=1 -coverprofile=coverage.out ./...
+	cd src && go test -race -p=1 -v -coverprofile=coverage.out ./...
+	@$(MAKE) --no-print-directory killall
 	cd src && go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: src/coverage.html"
 
@@ -88,8 +94,11 @@ deps:
 check: fmt vet test lint
 	@echo "All checks passed!"
 
-# Run all tests (fmt-check, test, coverage, lint)
-test-all: fmt-check test coverage lint
+# Run all tests (fmt-check, coverage, lint)
+# coverage now emits verbose output and runs the full suite once, so
+# the separate `test` target is no longer included; this halves the
+# wall-clock time previously spent running every package twice.
+test-all: fmt-check coverage lint
 	@echo "All tests passed!"
 
 # Help target
@@ -104,7 +113,7 @@ help:
 	@echo "  fmt       - Format code with gofmt"
 	@echo "  fmt-check - Check code formatting (fails if not formatted)"
 	@echo "  coverage  - Generate test coverage report"
-	@echo "  test-all  - Run fmt-check, test, coverage, and lint"
+	@echo "  test-all  - Run fmt-check, coverage, and lint (verbose, single pass)"
 	@echo "  clean     - Remove build artifacts"
 	@echo "  deps      - Install/update dependencies"
 	@echo "  check     - Run all checks (fmt, vet, test, lint)"

--- a/server/src/internal/auth/store.go
+++ b/server/src/internal/auth/store.go
@@ -46,13 +46,18 @@ const (
 	maxSessionsPerUser = 10
 )
 
-// dummyHash is a pre-computed bcrypt hash used during authentication
-// to prevent timing side-channel attacks that could reveal whether a
-// username exists. When a lookup returns no rows, we compare against
-// this hash so the response time is consistent with a real comparison.
+// defaultDummyHash is a pre-computed bcrypt hash used during
+// authentication to prevent timing side-channel attacks that could
+// reveal whether a username exists. When a user lookup returns no
+// rows, the AuthStore compares against this hash so the response
+// time is consistent with a real comparison. Production AuthStores
+// share this package-level hash to avoid recomputing the cost-12
+// hash on every NewAuthStore call. Test AuthStores get a per-store
+// hash at the lowered cost so they do not pay the production
+// timing cost on every "nonexistent user" code path.
 //
 //nolint:errcheck // bcrypt.GenerateFromPassword with a valid cost never fails
-var dummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-timing-equalizer"), DefaultBcryptCost)
+var defaultDummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-timing-equalizer"), DefaultBcryptCost)
 
 const (
 	// DefaultSessionExpiry is the default duration for session tokens
@@ -77,6 +82,14 @@ type AuthStore struct {
 	// SetBcryptCostForTesting to avoid dominating suite runtime with
 	// hashing work. Reads of this field are guarded by s.mu.
 	bcryptCost int
+	// dummyHash is the timing-equalizer hash this AuthStore compares
+	// against when a user lookup returns no rows. Production stores
+	// share the package-level defaultDummyHash (computed once at
+	// cost DefaultBcryptCost); SetBcryptCostForTesting replaces it
+	// with a cheaper per-store hash so the "nonexistent user" path
+	// runs in microseconds rather than the ~250 ms a cost-12 compare
+	// takes under the race detector. Guarded by s.mu.
+	dummyHash []byte
 	// Created indicates whether this AuthStore instance created a new
 	// auth.db file (true) or opened an existing one (false). Callers
 	// can use this to provide appropriate startup messages.
@@ -177,6 +190,7 @@ func NewAuthStore(dataDir string, maxUserTokenDays, maxFailedAttempts int) (*Aut
 		maxUserTokenDays:  maxUserTokenDays,
 		maxFailedAttempts: maxFailedAttempts,
 		bcryptCost:        DefaultBcryptCost,
+		dummyHash:         defaultDummyHash,
 		Created:           !dbExisted,
 	}
 
@@ -569,9 +583,22 @@ func (s *AuthStore) SetBcryptCostForTesting(t interface{ Helper() }, cost int) {
 			"this hook is test-only and must never run in production")
 	}
 	t.Helper()
+	// Regenerate the timing-equalizer hash at the lowered cost so the
+	// "nonexistent user" code path in AuthenticateUser no longer pays
+	// a cost-12 bcrypt compare on every call. Compute outside the
+	// store lock; the input is a constant string and the cost is
+	// already validated by the GenerateFromPassword call.
+	dummy, err := bcrypt.GenerateFromPassword([]byte("dummy-timing-equalizer"), cost)
+	if err != nil {
+		// An invalid cost is a programmer error in the test; surface
+		// it loudly rather than silently leaving the production
+		// dummy hash in place.
+		panic(fmt.Sprintf("SetBcryptCostForTesting: invalid bcrypt cost %d: %v", cost, err))
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.bcryptCost = cost
+	s.dummyHash = dummy
 }
 
 // =============================================================================
@@ -1152,9 +1179,11 @@ func (s *AuthStore) AuthenticateUser(username, password string) (string, time.Ti
 	if err == sql.ErrNoRows {
 		// Perform a dummy bcrypt comparison to ensure consistent response
 		// timing regardless of whether the username exists, preventing
-		// user enumeration via timing side-channel.
+		// user enumeration via timing side-channel. s.dummyHash is set
+		// in NewAuthStore (production cost) and may be lowered by
+		// SetBcryptCostForTesting; s.mu is held by AuthenticateUser.
 		//nolint:errcheck // Result is intentionally ignored
-		bcrypt.CompareHashAndPassword(dummyHash, []byte(password))
+		bcrypt.CompareHashAndPassword(s.dummyHash, []byte(password))
 		return "", time.Time{}, fmt.Errorf("invalid username or password")
 	}
 	if err != nil {

--- a/server/src/internal/llmproxy/proxy_test.go
+++ b/server/src/internal/llmproxy/proxy_test.go
@@ -276,8 +276,28 @@ func TestHandleModels_GeminiNotConfigured(t *testing.T) {
 }
 
 func TestHandleModels_OpenAIBaseURLOnly(t *testing.T) {
+	// Use httptest.NewServer to mock the OpenAI-compatible models
+	// endpoint. Without this the handler issues a real outbound HTTP
+	// request and blocks waiting for the OS-level TCP connect timeout
+	// (~120s on macOS), which dominates `make test-all` wall clock.
+	// The purpose of this test is only to confirm that the "OpenAI
+	// API key not configured" gate is passed when OpenAIBaseURL is
+	// set; the request must reach the network layer, but we do not
+	// care about the network response itself.
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			// Return an empty data array so ListModels parses
+			// successfully and the handler returns 200. The body shape
+			// matches the OpenAI /v1/models response contract.
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`{"data": []}`)); err != nil {
+				t.Errorf("mock server failed to write body: %v", err)
+			}
+		}))
+	defer server.Close()
+
 	config := &Config{
-		OpenAIBaseURL: "http://localhost:8080/v1",
+		OpenAIBaseURL: server.URL,
 		Model:         "local-model",
 	}
 
@@ -286,9 +306,8 @@ func TestHandleModels_OpenAIBaseURLOnly(t *testing.T) {
 
 	HandleModels(w, req, config)
 
-	// Should not get a 400 "not configured" error; it will fail at
-	// the actual API call level (500) since the URL is not real,
-	// but the configuration check should pass.
+	// Must not return the 400 "not configured" gate; reaching the
+	// mock server means the configuration check passed.
 	if w.Code == http.StatusBadRequest {
 		body := w.Body.String()
 		if body == "OpenAI API key not configured\n" {


### PR DESCRIPTION
## Summary

Three independent fixes to the test suite that compound to cut `make test-all` wall clock from ~10m49s to ~3m49s.

- **Deduplicate Go `test-all`.** Each of `collector`, `server`, and `alerter` previously ran the full Go test suite **twice** — once via the `test` target with `-race -v`, then again via `coverage` with `-race -coverprofile`. The new `coverage` target adds `-v` and is the sole invocation; `test-all` is now `fmt-check + coverage + lint`. Standalone `make test` is unchanged for fast iterative TDD.
- **Mock a hung llmproxy handler test.** `TestHandleModels_OpenAIBaseURLOnly` pointed `OpenAIBaseURL` at an unreachable `http://localhost:8080/v1` and blocked on the shared LLM HTTP client's 120-second timeout. It now uses `httptest.NewServer` returning a minimal valid `{"data": []}` body — runtime 120.00s → 0.00s, doubled across the duplicate test+coverage shape for ~240s wall-clock saved.
- **Lower bcrypt cost on the AuthStore timing-equalizer in tests.** `SetBcryptCostForTesting` only adjusted the per-store `bcryptCost`; the package-level `dummyHash` (compared against when a username does not exist) was still computed at `DefaultBcryptCost = 12`. Every "nonexistent user" code path in tests paid ~250 ms plain / 1–2 s under `-race`. `dummyHash` is now a per-store field that `SetBcryptCostForTesting` regenerates at the lowered cost. **Production stores share the package-level default — no production behavior change.**

## Results

| Sub-project | Before | After | Reduction |
|---|---:|---:|---:|
| collector | 36.4 s | 18.5 s | 49 % |
| server | 484.5 s | 109.0 s | 77 % |
| alerter | 48.5 s | 21.2 s | 56 % |
| client | 79.8 s | 79.8 s | — |
| **Total sequential** | **649 s** | **229 s** | **65 %** |

Individual test wins:
- `TestHandleModels_OpenAIBaseURLOnly`: 120.00 s → 0.00 s
- `TestAuthenticateUserNonExistent`: 2.47 s → 0.06 s
- `TestAuthHandler_HandleLogin`: 2.51 s → 0.09 s

## Files changed

- `collector/Makefile`, `server/Makefile`, `alerter/Makefile` — single coverage pass replaces test+coverage in `test-all`; `coverage` target adds `-v` and brackets with `killall`.
- `server/src/internal/llmproxy/proxy_test.go` — `httptest.NewServer` mock for `TestHandleModels_OpenAIBaseURLOnly`.
- `server/src/internal/auth/store.go` — per-store `dummyHash` field; `SetBcryptCostForTesting` regenerates it; `defaultDummyHash` (package-level, cost 12) preserved for production.
- `.claude/golang-expert/testing-strategy.md` — KB updates: new `test-all` shape, httptest pattern for handler tests, per-store `dummyHash` semantics.

## Out of scope (documented as follow-ups)

- `TestRBACEnforcement_AdminPermissions` (~4 s) is **not** bcrypt-bound — it's SQLite schema-init overhead repeated across ~50 sub-stores. Separate change if we want to address it.
- Three sibling tests in `proxy_test.go` (`TestHandleChat_OpenAIBaseURLOnly`, `TestHandleChat_OverrideProvider`, `TestHandleChat_OverrideProviderWithBaseURL`) follow the same anti-pattern but currently happen to complete fast in CI; flagged for follow-up to apply the same `httptest.NewServer` treatment defensively.
- Top-level `make test-all` still runs sub-projects sequentially; parallelizing would bring wall clock down further (server dominates).

## Test plan

- [ ] CI passes on all four sub-project workflows.
- [ ] `make -C collector test-all` reports each Go package exactly once under `ok` lines.
- [ ] `make -C server test-all` likewise; `TestHandleModels_OpenAIBaseURLOnly` reports `(0.00s)`.
- [ ] `make -C alerter test-all` likewise.
- [ ] `make -C client test-all` unchanged (no edits to client).
- [ ] `make test` (standalone, without `-all`) still works for fast iteration on each Go sub-project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated testing strategy documentation with clarified guidance on test execution workflows and best practices.

* **Tests**
  * Improved test infrastructure with enhanced process cleanup and mock-based HTTP testing to reduce external dependencies.

* **Chores**
  * Refined build system test targets for more efficient and consistent test execution across modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/239)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->