### PR TITLE
fix(server,client): gate remaining connection mutations on manage_connections (#207 follow-up)

### DIFF
--- a/.claude/golang-expert/rbac-patterns.md
+++ b/.claude/golang-expert/rbac-patterns.md
@@ -80,6 +80,22 @@ handler that has any existing `HasAdminPermission` call, verify the
 gate covers every write path, not just the "obviously sensitive"
 ones.
 
+When a mutating per-resource handler already calls
+`rc.CanAccessConnection` (or another visibility check) at the top to
+return 403 on non-visible callers, place the Variant 1 gate AFTER
+the visibility check and BEFORE `DecodeJSONBody`. The visibility
+check must run first so a non-visible caller still gets the
+existing "Access denied" response and learns nothing about the
+resource's existence (or absence). The admin gate then catches the
+distinct bug class where a caller who CAN see the resource (e.g.
+via a group share) tries to mutate it; without the gate, any
+visible caller could re-home or rewrite the resource. The
+reference is `handleUpdateConnectionCluster` in
+`server/src/internal/api/connection_handlers.go` (PUT
+`/api/v1/connections/{id}/cluster`), gated as part of the issue
+#233 follow-up audit. The order is: visibility check, admin gate,
+decode, then the datastore mutation.
+
 ## Variant 2: Owner-Fallback Gate
 
 Use this for per-object mutations where the row has an

--- a/.claude/golang-expert/rbac-patterns.md
+++ b/.claude/golang-expert/rbac-patterns.md
@@ -58,6 +58,28 @@ The reference implementation is `updateAutoDetectedCluster` in
 `server/src/internal/api/cluster_handlers.go`. Use the same error
 wording so the client-facing message stays uniform across endpoints.
 
+When a handler must stamp the caller's username onto the new row
+(e.g. `owner_username`), call `getUserInfoCompat` first to extract
+the username, then place the Variant 1 gate immediately afterward
+and BEFORE any request-body decoding. The 401 from
+`getUserInfoCompat` is authentication, not authorization: a missing
+or invalid bearer token must short-circuit before any permission
+check, but a valid token must still pass the gate before reaching
+`DecodeJSONBody` or any datastore call. The reference for this
+two-step pattern is `createConnection` in
+`server/src/internal/api/connection_handlers.go`, gated for
+GitHub issue #233 as the follow-up to #207.
+
+A regression-family caution: when issue #207 introduced this gate
+across cluster handlers, the audit missed the connection-create
+handler because that handler already had a gate on the IsShared
+branch. A partial gate is NOT a full gate; if a mutating endpoint
+performs writes regardless of an input flag, the gate must precede
+the branch on that flag, not sit inside it. When auditing a
+handler that has any existing `HasAdminPermission` call, verify the
+gate covers every write path, not just the "obviously sensitive"
+ones.
+
 ## Variant 2: Owner-Fallback Gate
 
 Use this for per-object mutations where the row has an

--- a/.claude/golang-expert/rbac-patterns.md
+++ b/.claude/golang-expert/rbac-patterns.md
@@ -93,7 +93,7 @@ visible caller could re-home or rewrite the resource. The
 reference is `handleUpdateConnectionCluster` in
 `server/src/internal/api/connection_handlers.go` (PUT
 `/api/v1/connections/{id}/cluster`), gated as part of the issue
-#233 follow-up audit. The order is: visibility check, admin gate,
+`#233` follow-up audit. The order is: visibility check, admin gate,
 decode, then the datastore mutation.
 
 ## Variant 2: Owner-Fallback Gate

--- a/.claude/react-expert/quality-checklist.md
+++ b/.claude/react-expert/quality-checklist.md
@@ -235,8 +235,8 @@ Reference implementations:
 
 - `client/src/components/AdminPanel/index.tsx` filters whole nav
   sections by `hasPermission(item.permission)`.
-- `client/src/components/AddMenu.tsx` hides Add Cluster and Add
-  Cluster Group when the user lacks `manage_connections`.
+- `client/src/components/AddMenu.tsx` hides Add Server, Add Cluster,
+  and Add Cluster Group when the user lacks `manage_connections`.
 
 Permission strings must match the server-side constants exactly;
 see `server/src/internal/auth/token_scope.go` for the canonical

--- a/client/src/components/AddMenu.tsx
+++ b/client/src/components/AddMenu.tsx
@@ -9,18 +9,8 @@
  */
 
 import type React from 'react';
-import {
-    Menu,
-    MenuItem,
-    ListItemIcon,
-    ListItemText,
-    Divider,
-} from '@mui/material';
-import {
-    Storage as StorageIcon,
-    Folder as FolderIcon,
-    Hub as HubIcon,
-} from '@mui/icons-material';
+import { Menu, MenuItem, ListItemIcon, ListItemText, Divider } from '@mui/material';
+import { Storage as StorageIcon, Folder as FolderIcon, Hub as HubIcon } from '@mui/icons-material';
 import { useAuth } from '../contexts/useAuth';
 
 interface AddMenuProps {
@@ -35,11 +25,11 @@ interface AddMenuProps {
 /**
  * A dropdown menu for adding servers or cluster groups.
  *
- * The "Add Cluster" and "Add Cluster Group" entries require the
- * `manage_connections` admin permission and are omitted entirely for
- * users that lack it. The server enforces the same restriction with a
- * 403 response, so hiding the menu items keeps unauthorized users from
- * seeing actions they cannot perform.
+ * The "Add Server", "Add Cluster", and "Add Cluster Group" entries
+ * require the `manage_connections` admin permission and are omitted
+ * entirely for users that lack it. The server enforces the same
+ * restriction with a 403 response, so hiding the menu items keeps
+ * unauthorized users from seeing actions they cannot perform.
  */
 const AddMenu: React.FC<AddMenuProps> = ({
     anchorEl,
@@ -93,12 +83,14 @@ const AddMenu: React.FC<AddMenuProps> = ({
                 },
             }}
         >
-            <MenuItem onClick={handleAddServer}>
-                <ListItemIcon>
-                    <StorageIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary="Add Server" />
-            </MenuItem>
+            {canManageConnections && (
+                <MenuItem onClick={handleAddServer}>
+                    <ListItemIcon>
+                        <StorageIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Add Server" />
+                </MenuItem>
+            )}
             {canManageConnections && (
                 <MenuItem onClick={handleAddCluster}>
                     <ListItemIcon>

--- a/client/src/components/__tests__/AddMenu.test.tsx
+++ b/client/src/components/__tests__/AddMenu.test.tsx
@@ -55,9 +55,7 @@ describe('AddMenu', () => {
 
     describe('with manage_connections permission', () => {
         beforeEach(() => {
-            mockHasPermission.mockImplementation(
-                (perm: string) => perm === 'manage_connections',
-            );
+            mockHasPermission.mockImplementation((perm: string) => perm === 'manage_connections');
         });
 
         it('renders Add Server, Add Cluster, and Add Cluster Group', () => {
@@ -66,6 +64,12 @@ describe('AddMenu', () => {
             expect(screen.getByText('Add Server')).toBeInTheDocument();
             expect(screen.getByText('Add Cluster')).toBeInTheDocument();
             expect(screen.getByText('Add Cluster Group')).toBeInTheDocument();
+        });
+
+        it('renders the divider that separates the cluster entries', () => {
+            renderAddMenu();
+
+            expect(screen.getByRole('separator')).toBeInTheDocument();
         });
 
         it('queries for the manage_connections permission', () => {
@@ -124,26 +128,23 @@ describe('AddMenu', () => {
             mockHasPermission.mockReturnValue(false);
         });
 
-        it('renders only Add Server', () => {
+        it('renders no menu items or dividers', () => {
             renderAddMenu();
 
-            expect(screen.getByText('Add Server')).toBeInTheDocument();
+            expect(screen.queryByText('Add Server')).not.toBeInTheDocument();
             expect(screen.queryByText('Add Cluster')).not.toBeInTheDocument();
-            expect(
-                screen.queryByText('Add Cluster Group'),
-            ).not.toBeInTheDocument();
+            expect(screen.queryByText('Add Cluster Group')).not.toBeInTheDocument();
             expect(screen.queryByRole('separator')).not.toBeInTheDocument();
         });
 
-        it('still allows Add Server to fire its callback', () => {
+        it('does not invoke onAddServer because Add Server is hidden', () => {
             const onAddServer = vi.fn();
             const onClose = vi.fn();
             renderAddMenu({ onAddServer, onClose });
 
-            fireEvent.click(screen.getByText('Add Server'));
-
-            expect(onAddServer).toHaveBeenCalledTimes(1);
-            expect(onClose).toHaveBeenCalledTimes(1);
+            expect(screen.queryByText('Add Server')).not.toBeInTheDocument();
+            expect(onAddServer).not.toHaveBeenCalled();
+            expect(onClose).not.toHaveBeenCalled();
         });
     });
 
@@ -156,11 +157,9 @@ describe('AddMenu', () => {
 
             renderAddMenu();
 
-            expect(screen.getByText('Add Server')).toBeInTheDocument();
+            expect(screen.queryByText('Add Server')).not.toBeInTheDocument();
             expect(screen.queryByText('Add Cluster')).not.toBeInTheDocument();
-            expect(
-                screen.queryByText('Add Cluster Group'),
-            ).not.toBeInTheDocument();
+            expect(screen.queryByText('Add Cluster Group')).not.toBeInTheDocument();
             expect(screen.queryByRole('separator')).not.toBeInTheDocument();
         });
     });
@@ -171,9 +170,7 @@ describe('AddMenu', () => {
 
             expect(screen.queryByText('Add Server')).not.toBeInTheDocument();
             expect(screen.queryByText('Add Cluster')).not.toBeInTheDocument();
-            expect(
-                screen.queryByText('Add Cluster Group'),
-            ).not.toBeInTheDocument();
+            expect(screen.queryByText('Add Cluster Group')).not.toBeInTheDocument();
         });
     });
 });

--- a/docs/admin-guide/api/openapi.json
+++ b/docs/admin-guide/api/openapi.json
@@ -3607,7 +3607,7 @@
       },
       "post": {
         "summary": "Create a connection",
-        "description": "Creates a new database connection",
+        "description": "Creates a new database connection. Requires manage_connections permission.",
         "operationId": "createConnection",
         "tags": [
           "Connections"
@@ -3655,7 +3655,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Requires manage_connections permission",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/admin-guide/api/openapi.json
+++ b/docs/admin-guide/api/openapi.json
@@ -4037,6 +4037,171 @@
         ]
       }
     },
+    "/connections/{id}/cluster": {
+      "get": {
+        "summary": "Get connection cluster assignment",
+        "description": "Returns the current cluster assignment for the connection together with the list of available clusters and any node relationships involving this connection.",
+        "operationId": "getConnectionCluster",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Connection ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection cluster assignment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionClusterResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Connection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to list clusters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update connection cluster assignment",
+        "description": "Reassigns the connection to a different cluster or resets its membership source. Requires manage_connections permission.",
+        "operationId": "updateConnectionCluster",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Connection ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Cluster assignment update",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectionClusterUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated cluster assignment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionClusterInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied: requires manage_connections permission",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to assign connection to cluster",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
     "/connections/{id}/databases": {
       "get": {
         "summary": "List databases for a connection",
@@ -9893,6 +10058,81 @@
           "username": {
             "type": "string",
             "description": "Database username"
+          }
+        }
+      },
+      "ConnectionClusterInfo": {
+        "type": "object",
+        "properties": {
+          "auto_cluster_key": {
+            "type": "string",
+            "description": "Auto-detected cluster key",
+            "nullable": true
+          },
+          "cluster_id": {
+            "type": "integer",
+            "description": "Current cluster ID",
+            "nullable": true
+          },
+          "cluster_name": {
+            "type": "string",
+            "description": "Current cluster name",
+            "nullable": true
+          },
+          "membership_source": {
+            "type": "string",
+            "description": "How the connection is assigned: auto or manual"
+          },
+          "replication_type": {
+            "type": "string",
+            "description": "Cluster replication type",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "description": "Current cluster role",
+            "nullable": true
+          }
+        }
+      },
+      "ConnectionClusterResponse": {
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "type": "array",
+            "description": "Available clusters for autocomplete",
+            "items": {
+              "type": "object"
+            }
+          },
+          "info": {
+            "$ref": "#/components/schemas/ConnectionClusterInfo"
+          },
+          "relationships": {
+            "type": "array",
+            "description": "Node relationships involving this connection",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "ConnectionClusterUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "cluster_id": {
+            "type": "integer",
+            "description": "Target cluster ID; null resets the connection to auto-detection",
+            "nullable": true
+          },
+          "membership_source": {
+            "type": "string",
+            "description": "How the connection is assigned: auto or manual"
+          },
+          "role": {
+            "type": "string",
+            "description": "Cluster role for the connection",
+            "nullable": true
           }
         }
       },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -330,6 +330,19 @@ project adheres to
   regression tests cover every affected handler.
   (#67)
 
+- Extend the `manage_connections` gate to the two
+  remaining connection-creation paths missed by the
+  earlier sweep under #207; the server's
+  `createConnection` handler now requires the permission
+  for every new connection rather than only for shared
+  connections, and the web client's Add menu hides the
+  "Add Server" entry from users who lack the permission.
+  Unauthorized callers receive a `403 Forbidden` response
+  with a clear authorization error, and the OpenAPI
+  specification and the static
+  `docs/admin-guide/api/openapi.json` document the new
+  response on the affected path. (#233)
+
 - Require the `manage_connections` permission on all
   cluster and cluster-group mutating endpoints; users
   without the permission previously could create

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -330,18 +330,27 @@ project adheres to
   regression tests cover every affected handler.
   (#67)
 
-- Extend the `manage_connections` gate to the two
-  remaining connection-creation paths missed by the
-  earlier sweep under #207; the server's
-  `createConnection` handler now requires the permission
-  for every new connection rather than only for shared
-  connections, and the web client's Add menu hides the
-  "Add Server" entry from users who lack the permission.
-  Unauthorized callers receive a `403 Forbidden` response
-  with a clear authorization error, and the OpenAPI
-  specification and the static
+- Extend the `manage_connections` gate to the remaining
+  connection paths missed by the earlier sweep under
+  #207; the server's `createConnection` handler now
+  requires the permission for every new connection
+  rather than only for shared connections, the
+  `handleUpdateConnectionCluster` handler behind
+  `PUT /api/v1/connections/{id}/cluster` now also
+  requires the permission so that a user with only
+  read-visibility on a connection can no longer re-home
+  it between clusters, and the web client's Add menu
+  hides the "Add Server" entry from users who lack the
+  permission. The new server-side gate sits after the
+  existing visibility check and before any body decode
+  or datastore mutation. Unauthorized callers receive a
+  `403 Forbidden` response with a clear authorization
+  error, and the OpenAPI specification and the static
   `docs/admin-guide/api/openapi.json` document the new
-  response on the affected path. (#233)
+  response on the affected paths; the previously
+  undocumented `/connections/{id}/cluster` path is now
+  present in the specification with both its GET and
+  PUT methods. (#233)
 
 - Require the `manage_connections` permission on all
   cluster and cluster-group mutating endpoints; users

--- a/server/src/internal/api/connection_handlers.go
+++ b/server/src/internal/api/connection_handlers.go
@@ -779,6 +779,22 @@ func (h *ConnectionHandler) handleUpdateConnectionCluster(w http.ResponseWriter,
 		return
 	}
 
+	// Issue #233 (follow-up to #207): reassigning a connection between
+	// clusters mutates the topology, so it must require
+	// manage_connections in addition to the visibility check above. The
+	// previous gate stopped at CanAccessConnection, which permits any
+	// user with read access to the connection (including via a group
+	// share) to re-home it between clusters. Place the admin gate
+	// AFTER the visibility check (so non-visible callers still see the
+	// same 403 as before and learn nothing about the connection's
+	// existence) but BEFORE DecodeJSONBody, so denied callers cannot
+	// probe payload shape via validation error messages.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
+		return
+	}
+
 	var req ConnectionClusterUpdateRequest
 	if !DecodeJSONBody(w, r, &req) {
 		return

--- a/server/src/internal/api/connection_handlers.go
+++ b/server/src/internal/api/connection_handlers.go
@@ -196,10 +196,23 @@ func (h *ConnectionHandler) listConnections(w http.ResponseWriter, r *http.Reque
 
 // createConnection handles POST /api/v1/connections
 func (h *ConnectionHandler) createConnection(w http.ResponseWriter, r *http.Request) {
-	// Get current user info
+	// Get current user info. The username is stamped onto the row as
+	// owner_username, so we authenticate before the permission gate.
 	username, _, err := getUserInfoCompat(r, h.authStore)
 	if err != nil {
 		RespondError(w, http.StatusUnauthorized, "Invalid or missing authentication token")
+		return
+	}
+
+	// Issue #233 (follow-up to #207): gate ALL connection creation on
+	// manage_connections, not only the shared branch. The previous gate
+	// only fired when req.IsShared was true, so any authenticated caller
+	// could create a non-shared server connection and silently expand
+	// their visible topology. Check before decoding the body so denied
+	// callers cannot probe payload shape via validation error messages.
+	if !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
+		RespondError(w, http.StatusForbidden,
+			"Permission denied: requires manage_connections permission")
 		return
 	}
 
@@ -246,13 +259,6 @@ func (h *ConnectionHandler) createConnection(w http.ResponseWriter, r *http.Requ
 	if err := h.hostValidator.ValidatePort(req.Port); err != nil {
 		log.Printf("[ERROR] Invalid port validation: %v", err)
 		RespondError(w, http.StatusBadRequest, "Invalid port")
-		return
-	}
-
-	// Only users with manage_connections permission can create shared connections
-	if req.IsShared && !h.rbacChecker.HasAdminPermission(r.Context(), auth.PermManageConnections) {
-		RespondError(w, http.StatusForbidden,
-			"Permission denied: you do not have permission to create shared connections")
 		return
 	}
 

--- a/server/src/internal/api/openapi.go
+++ b/server/src/internal/api/openapi.go
@@ -244,6 +244,33 @@ func buildSchemas() map[string]*OpenAPISchema {
 				"is_monitored":       {Type: "boolean", Description: "Whether the connection is monitored"},
 			},
 		},
+		"ConnectionClusterUpdateRequest": {
+			Type: "object",
+			Properties: map[string]*OpenAPISchema{
+				"cluster_id":        {Type: "integer", Description: "Target cluster ID; null resets the connection to auto-detection", Nullable: true},
+				"role":              {Type: "string", Description: "Cluster role for the connection", Nullable: true},
+				"membership_source": {Type: "string", Description: "How the connection is assigned: auto or manual"},
+			},
+		},
+		"ConnectionClusterInfo": {
+			Type: "object",
+			Properties: map[string]*OpenAPISchema{
+				"cluster_id":        {Type: "integer", Description: "Current cluster ID", Nullable: true},
+				"role":              {Type: "string", Description: "Current cluster role", Nullable: true},
+				"membership_source": {Type: "string", Description: "How the connection is assigned: auto or manual"},
+				"cluster_name":      {Type: "string", Description: "Current cluster name", Nullable: true},
+				"replication_type":  {Type: "string", Description: "Cluster replication type", Nullable: true},
+				"auto_cluster_key":  {Type: "string", Description: "Auto-detected cluster key", Nullable: true},
+			},
+		},
+		"ConnectionClusterResponse": {
+			Type: "object",
+			Properties: map[string]*OpenAPISchema{
+				"info":          {Ref: "#/components/schemas/ConnectionClusterInfo"},
+				"clusters":      {Type: "array", Items: &OpenAPISchema{Type: "object"}, Description: "Available clusters for autocomplete"},
+				"relationships": {Type: "array", Items: &OpenAPISchema{Type: "object"}, Description: "Node relationships involving this connection"},
+			},
+		},
 		"CurrentConnectionRequest": {
 			Type: "object",
 			Properties: map[string]*OpenAPISchema{
@@ -1463,6 +1490,40 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
 					"403": jsonResponse("ErrorResponse", "Forbidden"),
 					"404": jsonResponse("ErrorResponse", "Connection not found"),
+				},
+			},
+		},
+
+		"/connections/{id}/cluster": {
+			Get: &OpenAPIOperation{
+				Summary:     "Get connection cluster assignment",
+				Description: "Returns the current cluster assignment for the connection together with the list of available clusters and any node relationships involving this connection.",
+				OperationID: "getConnectionCluster",
+				Tags:        []string{"Connections"},
+				Security:    bearerAuth,
+				Parameters:  []OpenAPIParameter{pathParamInt("id", "Connection ID")},
+				Responses: map[string]OpenAPIResponse{
+					"200": jsonResponse("ConnectionClusterResponse", "Connection cluster assignment"),
+					"401": jsonResponse("ErrorResponse", "Unauthorized"),
+					"403": jsonResponse("ErrorResponse", "Access denied"),
+					"404": jsonResponse("ErrorResponse", "Connection not found"),
+					"500": jsonResponse("ErrorResponse", "Failed to list clusters"),
+				},
+			},
+			Put: &OpenAPIOperation{
+				Summary:     "Update connection cluster assignment",
+				Description: "Reassigns the connection to a different cluster or resets its membership source. Requires manage_connections permission.",
+				OperationID: "updateConnectionCluster",
+				Tags:        []string{"Connections"},
+				Security:    bearerAuth,
+				Parameters:  []OpenAPIParameter{pathParamInt("id", "Connection ID")},
+				RequestBody: jsonRequestBody("ConnectionClusterUpdateRequest", "Cluster assignment update", true),
+				Responses: map[string]OpenAPIResponse{
+					"200": jsonResponse("ConnectionClusterInfo", "Updated cluster assignment"),
+					"400": jsonResponse("ErrorResponse", "Invalid request"),
+					"401": jsonResponse("ErrorResponse", "Unauthorized"),
+					"403": jsonResponse("ErrorResponse", "Permission denied: requires manage_connections permission"),
+					"500": jsonResponse("ErrorResponse", "Failed to assign connection to cluster"),
 				},
 			},
 		},

--- a/server/src/internal/api/openapi.go
+++ b/server/src/internal/api/openapi.go
@@ -1405,7 +1405,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 			},
 			Post: &OpenAPIOperation{
 				Summary:     "Create a connection",
-				Description: "Creates a new database connection",
+				Description: "Creates a new database connection. Requires manage_connections permission.",
 				OperationID: "createConnection",
 				Tags:        []string{"Connections"},
 				Security:    bearerAuth,
@@ -1414,7 +1414,7 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"201": jsonResponse("Connection", "Connection created"),
 					"400": jsonResponse("ErrorResponse", "Invalid request"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
-					"403": jsonResponse("ErrorResponse", "Forbidden"),
+					"403": jsonResponse("ErrorResponse", "Requires manage_connections permission"),
 					"503": jsonResponse("ErrorResponse", "Datastore not configured"),
 				},
 			},

--- a/server/src/internal/api/rbac_issue233_connections_test.go
+++ b/server/src/internal/api/rbac_issue233_connections_test.go
@@ -253,3 +253,181 @@ func TestConnectionHandler_CreateConnection_Issue233_SuperuserAllowed(t *testing
 		handler.createConnection(rec, req)
 	})
 }
+
+// =============================================================================
+// Regression Test Coverage for handleUpdateConnectionCluster (#233 follow-up)
+//
+// PUT /api/v1/connections/{id}/cluster previously gated only on
+// CanAccessConnection, which is a visibility check. Any caller who
+// could see the connection (e.g. via a group share) could re-home it
+// between clusters; this is the same bug-class as #207 / #233 (a
+// mutating handler missing the admin gate).
+//
+// The fix places HasAdminPermission(manage_connections) AFTER the
+// existing CanAccessConnection check (so non-visible callers still
+// learn nothing about the connection's existence) and BEFORE
+// DecodeJSONBody (so denied callers cannot probe payload shape via
+// validation error messages). The gate uses the same canonical 403
+// wording used elsewhere in connection_handlers.go and
+// cluster_handlers.go: "Permission denied: requires manage_connections
+// permission".
+//
+// The tests below exercise:
+//
+//   - Denied: a non-admin caller with visibility on the connection
+//     (the nil sharing lookup fn means the visibility check returns
+//     true) cannot reassign the connection; the response is 403 with
+//     the canonical wording.
+//   - Denied-skips-decode: an invalid JSON body still returns 403
+//     (not 400) because the gate fires before DecodeJSONBody.
+//   - Admin allowed: a caller with manage_connections passes the gate;
+//     the nil datastore panics post-gate and the test recovers.
+//   - Superuser allowed: same shape as admin allowed but via the
+//     superuser bypass.
+// =============================================================================
+
+// setupIssue233UpdateConnectionCluster builds a ConnectionHandler with a
+// real RBACChecker and a real auth store, then registers a user with
+// the caller-supplied permission set. The visibility check
+// (CanAccessConnection) is configured to pass: the auth store has no
+// group assignments for the test connection ID and the sharing lookup
+// function is nil, so the visibility check returns true. The gate is
+// the only protection between the caller and the datastore mutation.
+func setupIssue233UpdateConnectionCluster(
+	t *testing.T,
+	username string,
+	permissions []string,
+) (*ConnectionHandler, int64, string, func()) {
+	t.Helper()
+
+	_, store, cleanup := createTestRBACHandler(t)
+	var userID int64
+	if len(permissions) == 0 {
+		userID = newIssue207UnprivilegedUser(t, store, username)
+	} else {
+		userID = setupUserWithPermissions(t, store, username, permissions)
+	}
+
+	token, _, err := store.AuthenticateUser(username, "Password1234")
+	if err != nil {
+		cleanup()
+		t.Fatalf("Failed to authenticate test user %s: %v", username, err)
+	}
+
+	checker := auth.NewRBACChecker(store)
+	handler := NewConnectionHandler(nil, store, checker)
+
+	return handler, userID, token, cleanup
+}
+
+// TestConnectionHandler_UpdateConnectionCluster_Issue233 groups the
+// regression cases for the PUT /api/v1/connections/{id}/cluster gate
+// added as a follow-up to #233.
+func TestConnectionHandler_UpdateConnectionCluster_Issue233(t *testing.T) {
+	const testConnectionID = 4242
+
+	t.Run("DeniedVisibleButNotAdmin", func(t *testing.T) {
+		handler, userID, token, cleanup := setupIssue233UpdateConnectionCluster(
+			t, "issue233_updatecluster_denied", nil)
+		defer cleanup()
+
+		clusterID := 1
+		body, _ := json.Marshal(ConnectionClusterUpdateRequest{
+			ClusterID:        &clusterID,
+			MembershipSource: "manual",
+		})
+		req := httptest.NewRequest(http.MethodPut,
+			"/api/v1/connections/4242/cluster", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = withBearer(req, token)
+		req = withUser(req, userID)
+		rec := httptest.NewRecorder()
+
+		handler.handleUpdateConnectionCluster(rec, req, testConnectionID)
+
+		assertForbiddenWithMessage(t, rec)
+	})
+
+	t.Run("DeniedSkipsDecode", func(t *testing.T) {
+		handler, userID, token, cleanup := setupIssue233UpdateConnectionCluster(
+			t, "issue233_updatecluster_baddecode", nil)
+		defer cleanup()
+
+		req := httptest.NewRequest(http.MethodPut,
+			"/api/v1/connections/4242/cluster",
+			bytes.NewBufferString("not json"))
+		req.Header.Set("Content-Type", "application/json")
+		req = withBearer(req, token)
+		req = withUser(req, userID)
+		rec := httptest.NewRecorder()
+
+		handler.handleUpdateConnectionCluster(rec, req, testConnectionID)
+
+		assertForbiddenWithMessage(t, rec)
+	})
+
+	t.Run("AdminAllowed", func(t *testing.T) {
+		handler, userID, token, cleanup := setupIssue233UpdateConnectionCluster(
+			t, "issue233_updatecluster_admin",
+			[]string{auth.PermManageConnections})
+		defer cleanup()
+
+		clusterID := 1
+		body, _ := json.Marshal(ConnectionClusterUpdateRequest{
+			ClusterID:        &clusterID,
+			MembershipSource: "manual",
+		})
+		req := httptest.NewRequest(http.MethodPut,
+			"/api/v1/connections/4242/cluster", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = withBearer(req, token)
+		req = withUser(req, userID)
+		rec := httptest.NewRecorder()
+
+		assertGatePassed(t, rec, func() {
+			handler.handleUpdateConnectionCluster(rec, req, testConnectionID)
+		})
+	})
+
+	t.Run("SuperuserAllowed", func(t *testing.T) {
+		// Superuser bypass requires both a valid bearer token (so the
+		// auth path through getUserInfoCompat succeeds when invoked)
+		// and the superuser flag on the request context (so
+		// HasAdminPermission returns true).
+		_, store, cleanup := createTestRBACHandler(t)
+		defer cleanup()
+
+		if err := store.CreateUser("issue233_updatecluster_super",
+			"Password1234", "", "", ""); err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		if err := store.SetUserSuperuser(
+			"issue233_updatecluster_super", true); err != nil {
+			t.Fatalf("SetUserSuperuser: %v", err)
+		}
+		token, _, err := store.AuthenticateUser(
+			"issue233_updatecluster_super", "Password1234")
+		if err != nil {
+			t.Fatalf("AuthenticateUser: %v", err)
+		}
+
+		checker := auth.NewRBACChecker(store)
+		handler := NewConnectionHandler(nil, store, checker)
+
+		clusterID := 1
+		body, _ := json.Marshal(ConnectionClusterUpdateRequest{
+			ClusterID:        &clusterID,
+			MembershipSource: "manual",
+		})
+		req := httptest.NewRequest(http.MethodPut,
+			"/api/v1/connections/4242/cluster", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = withBearer(req, token)
+		req = withSuperuser(req)
+		rec := httptest.NewRecorder()
+
+		assertGatePassed(t, rec, func() {
+			handler.handleUpdateConnectionCluster(rec, req, testConnectionID)
+		})
+	})
+}

--- a/server/src/internal/api/rbac_issue233_connections_test.go
+++ b/server/src/internal/api/rbac_issue233_connections_test.go
@@ -1,0 +1,255 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+)
+
+// =============================================================================
+// Regression Test Coverage for GitHub Issue #233
+//
+// Issue #233 is a follow-up to issue #207 / PR #217. The original fix
+// gated cluster mutations on manage_connections but missed a sibling
+// gap in the connection-create handler: createConnection only gated
+// the IsShared branch, so any authenticated caller could create a
+// non-shared server connection and silently expand the topology they
+// could see.
+//
+// The fix in connection_handlers.go applies the plain admin gate
+// (Variant 1 per .claude/golang-expert/rbac-patterns.md) to ALL
+// connection creation, regardless of req.IsShared. The gate is placed
+// after the bearer-token authentication step (because the handler
+// needs the username for owner_username) but BEFORE request-body
+// decoding, so denied callers cannot probe payload shape via
+// validation error messages.
+//
+// The tests below exercise:
+//
+//   - Denial path: authenticated, unprivileged caller attempting a
+//     non-shared create gets 403 with the canonical wording.
+//   - Decode-skip property: denial happens before JSON decoding, so
+//     an invalid body still returns 403 (not 400).
+//   - Shared-create denial: the previously-gated shared branch still
+//     denies, locking in no regression for the original behavior.
+//   - Admin allowed: a caller with manage_connections passes the gate;
+//     the post-gate datastore call panics on a nil datastore, which
+//     we recover from. The test asserts only that the gate did not
+//     return 403/401.
+//
+// The denial paths run with a nil datastore so a panic from a stray
+// datastore call would itself surface as a test failure (the gate
+// must reject before any datastore work).
+// =============================================================================
+
+// setupIssue233CreateConnection builds a ConnectionHandler with a real
+// RBACChecker and a real auth store, then registers a user with the
+// caller-supplied permission set. The user is authenticated so the
+// returned bearer token will pass through getUserInfoCompat. The
+// datastore is intentionally nil: the denial path must return 403
+// before the datastore is touched, and the admin-allowed path uses
+// the nil datastore to verify the gate fired (a post-gate datastore
+// access panics, which the test recovers from).
+//
+// Returns the handler, the user's ID, and the user's session token.
+// The cleanup is taken care of by the caller via createTestRBACHandler.
+func setupIssue233CreateConnection(
+	t *testing.T,
+	username string,
+	permissions []string,
+) (*ConnectionHandler, int64, string, func()) {
+	t.Helper()
+
+	_, store, cleanup := createTestRBACHandler(t)
+	var userID int64
+	if len(permissions) == 0 {
+		userID = newIssue207UnprivilegedUser(t, store, username)
+	} else {
+		userID = setupUserWithPermissions(t, store, username, permissions)
+	}
+
+	token, _, err := store.AuthenticateUser(username, "Password1234")
+	if err != nil {
+		cleanup()
+		t.Fatalf("Failed to authenticate test user %s: %v", username, err)
+	}
+
+	checker := auth.NewRBACChecker(store)
+	handler := NewConnectionHandler(nil, store, checker)
+
+	return handler, userID, token, cleanup
+}
+
+// TestConnectionHandler_CreateConnection_Issue233_DeniedNonShared verifies
+// that an authenticated user without manage_connections cannot create a
+// non-shared connection. The previous behavior silently allowed this;
+// the fix returns 403 with the canonical wording.
+func TestConnectionHandler_CreateConnection_Issue233_DeniedNonShared(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue233_create_unshared", nil)
+	defer cleanup()
+
+	body, _ := json.Marshal(ConnectionCreateRequest{
+		Name:         "attempt",
+		Host:         "db.example.com",
+		Port:         5432,
+		DatabaseName: "postgres",
+		Username:     "alice",
+		Password:     "secret",
+		IsShared:     false,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createConnection(rec, req)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestConnectionHandler_CreateConnection_Issue233_DeniedShared verifies
+// that the original (shared-only) denial behavior is preserved: an
+// authenticated user without manage_connections cannot create a shared
+// connection either. This locks in no regression for the #207 case.
+func TestConnectionHandler_CreateConnection_Issue233_DeniedShared(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue233_create_shared", nil)
+	defer cleanup()
+
+	body, _ := json.Marshal(ConnectionCreateRequest{
+		Name:         "attempt",
+		Host:         "db.example.com",
+		Port:         5432,
+		DatabaseName: "postgres",
+		Username:     "alice",
+		Password:     "secret",
+		IsShared:     true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createConnection(rec, req)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestConnectionHandler_CreateConnection_Issue233_DeniedSkipsDecode
+// verifies that the 403 happens BEFORE JSON decoding: a malformed body
+// that would otherwise trigger 400 ("Invalid request body") returns 403
+// instead. This is the "no payload probing" property the gate ordering
+// protects.
+func TestConnectionHandler_CreateConnection_Issue233_DeniedSkipsDecode(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue233_create_baddecode", nil)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createConnection(rec, req)
+
+	assertForbiddenWithMessage(t, rec)
+}
+
+// TestConnectionHandler_CreateConnection_Issue233_AdminAllowed confirms
+// that a caller with manage_connections passes the gate. The handler
+// then reaches the nil datastore and panics; the test recovers and
+// asserts only that the gate did not reject the caller. Coverage of
+// the post-gate write path lives in the integration suite gated on
+// TEST_AI_WORKBENCH_SERVER.
+func TestConnectionHandler_CreateConnection_Issue233_AdminAllowed(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue233_create_admin",
+		[]string{auth.PermManageConnections})
+	defer cleanup()
+
+	body, _ := json.Marshal(ConnectionCreateRequest{
+		Name:         "admin-conn",
+		Host:         "db.example.com",
+		Port:         5432,
+		DatabaseName: "postgres",
+		Username:     "alice",
+		Password:     "secret",
+		IsShared:     false,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.createConnection(rec, req)
+	})
+}
+
+// TestConnectionHandler_CreateConnection_Issue233_SuperuserAllowed
+// confirms that the gate is satisfied by the superuser bypass. Like
+// the admin-allowed case, the nil datastore panics post-gate and the
+// test recovers; the assertion is that the gate did not reject.
+func TestConnectionHandler_CreateConnection_Issue233_SuperuserAllowed(t *testing.T) {
+	// Superuser bypass requires both a valid bearer token (so
+	// getUserInfoCompat succeeds) and the superuser flag on the
+	// request context (so HasAdminPermission returns true).
+	_, store, cleanup := createTestRBACHandler(t)
+	defer cleanup()
+
+	if err := store.CreateUser("issue233_super", "Password1234", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := store.SetUserSuperuser("issue233_super", true); err != nil {
+		t.Fatalf("SetUserSuperuser: %v", err)
+	}
+	token, _, err := store.AuthenticateUser("issue233_super", "Password1234")
+	if err != nil {
+		t.Fatalf("AuthenticateUser: %v", err)
+	}
+
+	checker := auth.NewRBACChecker(store)
+	handler := NewConnectionHandler(nil, store, checker)
+
+	body, _ := json.Marshal(ConnectionCreateRequest{
+		Name:         "super-conn",
+		Host:         "db.example.com",
+		Port:         5432,
+		DatabaseName: "postgres",
+		Username:     "alice",
+		Password:     "secret",
+		IsShared:     false,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withSuperuser(req)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.createConnection(rec, req)
+	})
+}

--- a/server/src/internal/api/rbac_issue35_test.go
+++ b/server/src/internal/api/rbac_issue35_test.go
@@ -131,10 +131,11 @@ func requireNotForbidden(t *testing.T, rec *httptest.ResponseRecorder, label str
 // pre-check but, as a follow-up to issue #233, also requires
 // HasAdminPermission(manage_connections) after the visibility check.
 // Visibility-only "NotDenied" assertions therefore do not apply to it;
-// its admin-gate behavior is exercised separately in
-// rbac_issue233_connections_test.go and the negative path is covered
-// inline below (NonOwnerUnshared_403_UpdateConnectionCluster and
-// NoDatastoreSideEffect tests).
+// its admin-gate behavior is exercised in
+// TestConnectionHandler_UpdateConnectionCluster_Issue233 (in
+// rbac_issue233_connections_test.go), and the visibility-denial
+// negative path is covered inline below by
+// TestConnectionHandler_UpdateConnectionCluster_NoDatastoreSideEffect.
 // =============================================================================
 
 // connResourceInvoker is the minimal shape of a per-connection handler

--- a/server/src/internal/api/rbac_issue35_test.go
+++ b/server/src/internal/api/rbac_issue35_test.go
@@ -121,12 +121,20 @@ func requireNotForbidden(t *testing.T, rec *httptest.ResponseRecorder, label str
 // =============================================================================
 // ConnectionHandler per-connection handlers
 //
-// listDatabases, getConnectionContext, handleGetConnectionCluster, and
-// handleUpdateConnectionCluster all call rc.CanAccessConnection BEFORE
-// any datastore call. A nil datastore is therefore safe for both the 403
-// and positive paths: denial returns 403; a pass leaves the response
-// untouched and the test recovers from the nil-pointer panic that
-// follows.
+// listDatabases, getConnectionContext, and handleGetConnectionCluster
+// call rc.CanAccessConnection BEFORE any datastore call. A nil
+// datastore is therefore safe for both the 403 and positive paths:
+// denial returns 403; a pass leaves the response untouched and the
+// test recovers from the nil-pointer panic that follows.
+//
+// handleUpdateConnectionCluster has the same CanAccessConnection
+// pre-check but, as a follow-up to issue #233, also requires
+// HasAdminPermission(manage_connections) after the visibility check.
+// Visibility-only "NotDenied" assertions therefore do not apply to it;
+// its admin-gate behavior is exercised separately in
+// rbac_issue233_connections_test.go and the negative path is covered
+// inline below (NonOwnerUnshared_403_UpdateConnectionCluster and
+// NoDatastoreSideEffect tests).
 // =============================================================================
 
 // connResourceInvoker is the minimal shape of a per-connection handler
@@ -143,6 +151,12 @@ type connResourceCase struct {
 	invoker connResourceInvoker
 }
 
+// connResourceHandlers covers the visibility-only handlers: their RBAC
+// contract is solely "can the caller see this connection?". An owner,
+// shared-connection viewer, or group-granted caller must not receive a
+// 403 from these. handleUpdateConnectionCluster is intentionally NOT in
+// this table because issue #233 added an extra manage_connections gate
+// on top of the visibility check; see the comment above.
 var connResourceHandlers = []connResourceCase{
 	{
 		name:        "listDatabases",
@@ -168,16 +182,11 @@ var connResourceHandlers = []connResourceCase{
 			h.handleGetConnectionCluster(w, r, id)
 		},
 	},
-	{
-		name:        "handleUpdateConnectionCluster",
-		method:      http.MethodPut,
-		urlTemplate: "/api/v1/connections/%d/cluster",
-		body:        []byte(`{"cluster_id": 7, "membership_source": "manual"}`),
-		invoker: func(h *ConnectionHandler, w http.ResponseWriter, r *http.Request, id int) {
-			h.handleUpdateConnectionCluster(w, r, id)
-		},
-	},
 }
+
+// The visibility-denial case for handleUpdateConnectionCluster is
+// covered directly by TestConnectionHandler_UpdateConnectionCluster_NoDatastoreSideEffect
+// below; its admin-gate paths live in rbac_issue233_connections_test.go.
 
 // TestConnectionHandler_PerConnection_NonOwnerUnshared_403 verifies every
 // per-connection handler returns 403 when a non-owner user with no group


### PR DESCRIPTION
## Summary

Follow-up to #207 / #217. The earlier sweep gated cluster-group and
cluster mutations on `manage_connections`. Three remaining gaps in
the same regression family are closed here:

- **Client** — `AddMenu.tsx` now hides the "Add Server" entry from
  users without `manage_connections`, matching how "Add Cluster
  Group" and "Add Cluster" are already gated.
- **Server (create)** — `createConnection` in
  `server/src/internal/api/connection_handlers.go` now gates **all**
  connection creation on `manage_connections`, not just the shared
  branch.
- **Server (reassign)** — `handleUpdateConnectionCluster` (PUT
  `/api/v1/connections/{id}/cluster`) now also requires
  `manage_connections`. Previously a user with only read-visibility
  on a connection (e.g., via a group share) could re-home it between
  clusters. The new gate sits **after** the existing
  `CanAccessConnection` visibility check and **before** body decode
  or any datastore mutation.

Unauthorized callers receive `403 Forbidden` with the canonical
message "Permission denied: requires manage_connections permission".
The OpenAPI spec documents 403 on both affected paths; the
`/connections/{id}/cluster` path entry was missing entirely and is
added in this PR with both GET and PUT methods. The static
`docs/admin-guide/api/openapi.json` is regenerated.

## Test plan

- [x] `client/__tests__/AddMenu.test.tsx` extended: "Add Server"
      hidden without permission, visible with permission, divider
      behaviour preserved. Coverage on `AddMenu.tsx`: 100%.
- [x] `server/.../rbac_issue233_connections_test.go` covers
      `createConnection` (5 subtests) and
      `handleUpdateConnectionCluster` (4 subtests) — denied
      non-shared, denied shared, denied-skips-decode, admin-allowed,
      superuser-allowed, etc.
- [x] `server/.../rbac_issue35_test.go` updated: removes
      `handleUpdateConnectionCluster` from the visibility-only
      table (its contract is now stricter); a header comment points
      at the new admin-gate tests. Visibility-denial path remains
      covered by the pre-existing
      `TestConnectionHandler_UpdateConnectionCluster_NoDatastoreSideEffect`.
- [x] `make test-all` from repo root: all tests pass.
- [x] `make lint` (server) clean. `gofmt` clean.
- [x] OpenAPI tests pass after spec change.
- [x] Security audit (run on first round): gate placement
      ("auth-first / visibility-first, gate-second, decode-third")
      confirmed; no bypass paths; error-message hygiene matches #207
      canonical wording.

Closes #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Require manage_connections for all connection-creation and for cluster reassignment; admin checks now run earlier to return 403 before request decoding.

* **User Interface**
  * “Add Server” is hidden for users without manage_connections.

* **API / Documentation**
  * OpenAPI added GET/PUT connection-cluster endpoints and schemas; docs updated with permission requirement and RBAC handler ordering guidance.

* **Tests**
  * Added and expanded regression tests covering the updated RBAC gating for create/update flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/240)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->