### PR TITLE
fix(client): add friendly titles for anomaly metrics and v3 alert rules

### DIFF
--- a/client/src/utils/__tests__/friendlyNames.test.ts
+++ b/client/src/utils/__tests__/friendlyNames.test.ts
@@ -1,0 +1,239 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    FRIENDLY_ALERT_TITLES,
+    FRIENDLY_PROBE_NAMES,
+    getFriendlyProbeName,
+    getFriendlyTitle,
+} from '../friendlyNames';
+
+describe('getFriendlyProbeName', () => {
+    it('returns the mapped name for a known probe', () => {
+        expect(getFriendlyProbeName('pg_stat_activity')).toBe(
+            'Database Activity',
+        );
+    });
+
+    it('returns the mapped name for a system probe', () => {
+        expect(getFriendlyProbeName('pg_sys_cpu_usage_info')).toBe(
+            'CPU Usage',
+        );
+    });
+
+    it('falls back to title-cased text for an unknown probe', () => {
+        expect(getFriendlyProbeName('custom_probe_name')).toBe(
+            'Custom Probe Name',
+        );
+    });
+
+    it('returns the raw value when given an empty string', () => {
+        expect(getFriendlyProbeName('')).toBe('');
+    });
+});
+
+describe('getFriendlyTitle', () => {
+    it('returns "Alert" for an empty string', () => {
+        expect(getFriendlyTitle('')).toBe('Alert');
+    });
+
+    it('preserves connection error prefixes verbatim', () => {
+        expect(getFriendlyTitle('Connection error: db1.example.com')).toBe(
+            'Connection Error: db1.example.com',
+        );
+    });
+
+    it('preserves a lowercase connection error prefix', () => {
+        expect(getFriendlyTitle('connection error: host')).toBe(
+            'Connection Error: host',
+        );
+    });
+
+    it('returns an exact mapped rule name', () => {
+        expect(getFriendlyTitle('high_max_connections')).toBe(
+            'High Max Connections',
+        );
+    });
+
+    it('matches case-insensitively', () => {
+        expect(getFriendlyTitle('HIGH_MAX_CONNECTIONS')).toBe(
+            'High Max Connections',
+        );
+    });
+
+    it('resolves partial matches that contain a known key', () => {
+        // "alert: cpu_usage_high - host1" contains "cpu_usage_high"
+        expect(getFriendlyTitle('alert: cpu_usage_high - host1')).toBe(
+            'High CPU Usage',
+        );
+    });
+
+    it('returns dotted metric names verbatim when not mapped', () => {
+        expect(getFriendlyTitle('pg_custom_probe.some_metric')).toBe(
+            'pg_custom_probe.some_metric',
+        );
+    });
+
+    it('title-cases unmapped underscore-separated names', () => {
+        expect(getFriendlyTitle('some_unknown_alert')).toBe(
+            'Some Unknown Alert',
+        );
+    });
+
+    // -----------------------------------------------------------------
+    // Anomaly metric-name entries (Status Panel display)
+    // -----------------------------------------------------------------
+
+    it('maps pg_replication_slots.max_retained_bytes', () => {
+        expect(getFriendlyTitle('pg_replication_slots.max_retained_bytes'))
+            .toBe('Replication Slot WAL Retention');
+    });
+
+    it('maps pg_replication_slots.retained_bytes', () => {
+        expect(getFriendlyTitle('pg_replication_slots.retained_bytes')).toBe(
+            'Replication Slot WAL Retention',
+        );
+    });
+
+    it('maps pg_replication_slots.inactive', () => {
+        expect(getFriendlyTitle('pg_replication_slots.inactive')).toBe(
+            'Replication Slot Inactive',
+        );
+    });
+
+    it('maps pg_replication_slots.inactive_count', () => {
+        expect(getFriendlyTitle('pg_replication_slots.inactive_count')).toBe(
+            'Inactive Replication Slots',
+        );
+    });
+
+    it('maps pg_settings.max_connections', () => {
+        expect(getFriendlyTitle('pg_settings.max_connections')).toBe(
+            'Max Connections',
+        );
+    });
+
+    it('maps pg_stat_replication.lag_bytes', () => {
+        expect(getFriendlyTitle('pg_stat_replication.lag_bytes')).toBe(
+            'Replication Lag',
+        );
+    });
+
+    it('maps pg_stat_replication.standby_disconnected', () => {
+        expect(
+            getFriendlyTitle('pg_stat_replication.standby_disconnected'),
+        ).toBe('Standby Disconnected');
+    });
+
+    it('maps pg_stat_activity.blocked_count', () => {
+        expect(getFriendlyTitle('pg_stat_activity.blocked_count')).toBe(
+            'Blocked Queries',
+        );
+    });
+
+    it('maps pg_stat_activity.max_lock_wait_seconds', () => {
+        expect(
+            getFriendlyTitle('pg_stat_activity.max_lock_wait_seconds'),
+        ).toBe('Lock Wait Time');
+    });
+
+    it('maps pg_stat_checkpointer.checkpoints_req_delta', () => {
+        expect(
+            getFriendlyTitle('pg_stat_checkpointer.checkpoints_req_delta'),
+        ).toBe('Checkpoint Requests');
+    });
+
+    it('maps pg_stat_archiver.failed_count_delta', () => {
+        expect(
+            getFriendlyTitle('pg_stat_archiver.failed_count_delta'),
+        ).toBe('WAL Archive Failures');
+    });
+
+    it('maps pg_sys_cpu_usage_info.processor_time_percent', () => {
+        expect(
+            getFriendlyTitle(
+                'pg_sys_cpu_usage_info.processor_time_percent',
+            ),
+        ).toBe('CPU Usage');
+    });
+
+    it('maps pg_sys_load_avg_info.load_avg_fifteen_minutes', () => {
+        expect(
+            getFriendlyTitle(
+                'pg_sys_load_avg_info.load_avg_fifteen_minutes',
+            ),
+        ).toBe('Load Average');
+    });
+
+    it('maps spock_exception_log.recent_count', () => {
+        expect(getFriendlyTitle('spock_exception_log.recent_count')).toBe(
+            'Spock Exceptions',
+        );
+    });
+
+    it('maps spock_resolutions.recent_count', () => {
+        expect(getFriendlyTitle('spock_resolutions.recent_count')).toBe(
+            'Spock Conflict Resolutions',
+        );
+    });
+
+    // -----------------------------------------------------------------
+    // New alert rule names from migration v3 (AdminAlertRules display)
+    // -----------------------------------------------------------------
+
+    it('maps the spock_recent_exceptions_present rule name', () => {
+        expect(getFriendlyTitle('spock_recent_exceptions_present')).toBe(
+            'Spock Exceptions (Warning)',
+        );
+    });
+
+    it('maps the spock_recent_exceptions_high rule name', () => {
+        expect(getFriendlyTitle('spock_recent_exceptions_high')).toBe(
+            'Spock Exceptions (Critical)',
+        );
+    });
+
+    it('maps the spock_recent_resolutions_present rule name', () => {
+        expect(getFriendlyTitle('spock_recent_resolutions_present')).toBe(
+            'Spock Conflict Resolutions (Warning)',
+        );
+    });
+
+    it('maps the spock_recent_resolutions_high rule name', () => {
+        expect(getFriendlyTitle('spock_recent_resolutions_high')).toBe(
+            'Spock Conflict Resolutions (Critical)',
+        );
+    });
+
+    it('maps the replication_slot_retention_warn rule name', () => {
+        expect(getFriendlyTitle('replication_slot_retention_warn')).toBe(
+            'Replication Slot WAL Retention (Warning)',
+        );
+    });
+
+    it('maps the replication_slot_retention_high rule name', () => {
+        expect(getFriendlyTitle('replication_slot_retention_high')).toBe(
+            'Replication Slot WAL Retention (Critical)',
+        );
+    });
+
+    // -----------------------------------------------------------------
+    // Map sanity checks
+    // -----------------------------------------------------------------
+
+    it('exports a non-empty FRIENDLY_ALERT_TITLES map', () => {
+        expect(Object.keys(FRIENDLY_ALERT_TITLES).length).toBeGreaterThan(0);
+    });
+
+    it('exports a non-empty FRIENDLY_PROBE_NAMES map', () => {
+        expect(Object.keys(FRIENDLY_PROBE_NAMES).length).toBeGreaterThan(0);
+    });
+});

--- a/client/src/utils/friendlyNames.ts
+++ b/client/src/utils/friendlyNames.ts
@@ -103,6 +103,8 @@ export const FRIENDLY_ALERT_TITLES: Record<string, string> = {
     'replication_lag_bytes': 'Replication Lag',
     'replication_slot_inactive': 'Replication Slot Inactive',
     'replication_standby_disconnected': 'Standby Disconnected',
+    'replication_slot_retention_warn': 'Replication Slot WAL Retention (Warning)',
+    'replication_slot_retention_high': 'Replication Slot WAL Retention (Critical)',
     'subscription_worker_down': 'Subscription Worker Down',
 
     // Resource alerts
@@ -135,6 +137,12 @@ export const FRIENDLY_ALERT_TITLES: Record<string, string> = {
     'cache_hit_ratio_low': 'Low Cache Hit Ratio',
     'temp_files_created': 'Temporary Files Created',
 
+    // Spock replication alerts
+    'spock_recent_exceptions_present': 'Spock Exceptions (Warning)',
+    'spock_recent_exceptions_high': 'Spock Exceptions (Critical)',
+    'spock_recent_resolutions_present': 'Spock Conflict Resolutions (Warning)',
+    'spock_recent_resolutions_high': 'Spock Conflict Resolutions (Critical)',
+
     // Staleness and anomaly alerts
     'metric_staleness': 'Metric Staleness',
     'session_count_anomaly': 'Session Count Anomaly',
@@ -144,12 +152,27 @@ export const FRIENDLY_ALERT_TITLES: Record<string, string> = {
     'pg_stat_activity.idle_in_transaction_seconds': 'Idle in Transaction',
     'pg_stat_activity.max_query_duration_seconds': 'Long Running Query',
     'pg_stat_activity.max_xact_duration_seconds': 'Long Running Transaction',
+    'pg_stat_activity.blocked_count': 'Blocked Queries',
+    'pg_stat_activity.max_lock_wait_seconds': 'Lock Wait Time',
     'pg_stat_all_tables.dead_tuple_percent': 'Dead Tuple Ratio',
+    'pg_stat_archiver.failed_count_delta': 'WAL Archive Failures',
+    'pg_stat_checkpointer.checkpoints_req_delta': 'Checkpoint Requests',
     'pg_stat_database.cache_hit_ratio': 'Cache Hit Ratio',
     'pg_stat_database.deadlocks_delta': 'Deadlocks',
     'pg_stat_database.temp_files_delta': 'Temporary Files',
+    'pg_stat_replication.lag_bytes': 'Replication Lag',
+    'pg_stat_replication.standby_disconnected': 'Standby Disconnected',
+    'pg_replication_slots.max_retained_bytes': 'Replication Slot WAL Retention',
+    'pg_replication_slots.retained_bytes': 'Replication Slot WAL Retention',
+    'pg_replication_slots.inactive_count': 'Inactive Replication Slots',
+    'pg_replication_slots.inactive': 'Replication Slot Inactive',
+    'pg_settings.max_connections': 'Max Connections',
+    'pg_sys_cpu_usage_info.processor_time_percent': 'CPU Usage',
+    'pg_sys_load_avg_info.load_avg_fifteen_minutes': 'Load Average',
     'pg_sys_memory_info.used_percent': 'Memory Usage',
     'pg_sys_disk_info.used_percent': 'Disk Usage',
+    'spock_exception_log.recent_count': 'Spock Exceptions',
+    'spock_resolutions.recent_count': 'Spock Conflict Resolutions',
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add curated entries to `FRIENDLY_ALERT_TITLES` so anomaly alerts no longer display raw internal metric names (e.g. `pg_replication_slots.max_retained_bytes`) in the Status Panel.
- Cover the six rule names added by collector migration v3 (`spock_recent_exceptions_*`, `spock_recent_resolutions_*`, `replication_slot_retention_*`) so AdminAlertRules shows curated labels instead of auto-title-cased fallbacks.
- Add a dedicated test file for `friendlyNames.ts` that locks in the new mappings (35 tests, 100% line/branch/function/statement coverage on the file).

The change is data-only — the `getFriendlyTitle()` lookup logic is unchanged. Affected entries include `pg_replication_slots.{max_retained_bytes,retained_bytes,inactive,inactive_count}`, `pg_stat_replication.{lag_bytes,standby_disconnected}`, `pg_stat_activity.{blocked_count,max_lock_wait_seconds}`, `pg_stat_checkpointer.checkpoints_req_delta`, `pg_stat_archiver.failed_count_delta`, `pg_sys_cpu_usage_info.processor_time_percent`, `pg_sys_load_avg_info.load_avg_fifteen_minutes`, `pg_settings.max_connections`, and `spock_{exception_log,resolutions}.recent_count`.

## Test plan

- [ ] `cd client && npx vitest run src/utils/__tests__/friendlyNames.test.ts` — 35/35 pass.
- [ ] `cd client && npx vitest run src/components/AdminPanel/__tests__/AdminAlertRules.test.tsx` — 19/19 pass (existing consumer of the map).
- [ ] `cd client && make coverage` — `friendlyNames.ts` reports 100% on all four metrics.
- [ ] Manual: trigger or seed an anomaly alert on `pg_replication_slots.max_retained_bytes` and confirm the Status Panel renders "Replication Slot WAL Retention" rather than the raw dotted name.
- [ ] Manual: open AdminAlertRules and confirm the six v3 rules show with their new curated labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for friendly name resolution logic across alert types and metrics.

* **Chores**
  * Extended friendly name mappings for additional alert and metric types to improve display readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/244)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->