### PR TITLE
fix(server,client): stop ErrorBoundary crash on empty cluster delete

### DIFF
--- a/.claude/golang-expert/database-scan.md
+++ b/.claude/golang-expert/database-scan.md
@@ -81,6 +81,27 @@ The helper makes three guarantees that affect callers:
   for example
   `fmt.Errorf("failed to read cluster groups: %w", err)`.
 
+## Topology Response Slices
+
+The topology response tree built by `GetClusterTopology` in
+`topology_queries.go` carries the same non-nil-slice contract for
+fields encoded without `omitempty`:
+
+- `TopologyGroup.Clusters` must never be nil on the wire; a group
+  with zero clusters must marshal to `"clusters": []`, not
+  `"clusters": null`. The web client crashes on a JSON null here.
+- `TopologyCluster.Servers` follows the same rule.
+- `TopologyServerInfo.Children` and
+  `TopologyServerInfo.Relationships` use `omitempty`; nil is fine
+  there because it is omitted from JSON entirely.
+
+`GetClusterTopology` runs `normalizeTopologyGroups` as the final
+step before returning. The helper walks the tree and replaces nil
+`Clusters` or `Servers` slices with `make([]T, 0)`. New code paths
+that mutate the topology after that step must preserve the
+non-nil contract themselves, or feed back through the
+normalisation helper. Issue #242.
+
 ## When NOT To Use It
 
 Three categories of caller stay on the hand-written loop:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,7 +32,7 @@ import StatusPanel from './components/StatusPanel';
 import ChatPanel from './components/ChatPanel';
 import ChatFAB from './components/ChatPanel/ChatFAB';
 import { createPgedgeTheme, loginTheme } from './theme/pgedgeTheme';
-import { collectServers } from './utils/clusterHelpers';
+import { buildSelection } from './utils/buildSelection';
 import type { Selection } from './types/selection';
 
 // Style constants
@@ -168,96 +168,20 @@ const MainLayout: React.FC<MainLayoutProps> = ({ onToggleTheme }) => {
 
     // Build selection object based on current selection type.
     // Parent IDs are resolved from clusterData for blackout scope. #33
-    const selection = useMemo((): Selection | null => {
-        if (selectionType === 'server' && selectedServer) {
-            let clusterId: string | undefined;
-            let clusterName: string | undefined;
-            let isStandalone: boolean | undefined;
-            let groupId: string | undefined;
-            let groupName: string | undefined;
-
-            for (const group of clusterData) {
-                for (const cluster of group.clusters) {
-                    const allServers = collectServers(cluster.servers || []);
-                    if (allServers.some(s => s.id === selectedServer.id)) {
-                        clusterId = cluster.id;
-                        clusterName = cluster.name;
-                        isStandalone = cluster.isStandalone;
-                        groupId = group.id;
-                        groupName = group.name;
-                        break;
-                    }
-                }
-                if (groupId) {break;}
-            }
-
-            return {
-                type: 'server',
-                id: selectedServer.id,
-                name: selectedServer.name,
-                description: selectedServer.description ?? '',
-                status: selectedServer.status || 'unknown',
-                host: selectedServer.host ?? '',
-                port: selectedServer.port || 0,
-                role: selectedServer.role || '',
-                version: selectedServer.version || '',
-                database: selectedServer.database_name || selectedServer.database || '',
-                username: selectedServer.username ?? '',
-                os: selectedServer.os ?? '',
-                platform: selectedServer.platform ?? '',
-                spockNodeName: selectedServer.spock_node_name,
-                spockVersion: selectedServer.spock_version,
-                clusterId,
-                clusterName,
-                isStandalone,
-                groupId,
-                groupName,
-            };
-        }
-
-        if (selectionType === 'cluster' && selectedCluster) {
-            const servers = selectedCluster.servers ? collectServers(selectedCluster.servers) : [];
-            const serverIds = servers.map(s => s.id);
-
-            let groupId: string | undefined;
-            let groupName: string | undefined;
-
-            for (const group of clusterData) {
-                if (group.clusters.some(c => c.id === selectedCluster.id)) {
-                    groupId = group.id;
-                    groupName = group.name;
-                    break;
-                }
-            }
-
-            return {
-                type: 'cluster',
-                id: selectedCluster.id,
-                name: selectedCluster.name,
-                description: selectedCluster.description ?? '',
-                servers: servers,
-                serverIds: serverIds,
-                status: servers.every(s => s.status === 'offline') && servers.length > 0
-                    ? 'offline'
-                    : servers.some(s => s.status === 'offline' || s.status === 'warning')
-                        ? 'warning'
-                        : 'online',
-                groupId,
-                groupName,
-            };
-        }
-
-        if (selectionType === 'estate') {
-            return {
-                type: 'estate',
-                name: 'All Servers',
-                groups: clusterData,
-                status: 'online', // Will be calculated by StatusPanel
-            };
-        }
-
-        return null;
-    }, [selectionType, selectedServer, selectedCluster, clusterData]);
+    // The actual logic lives in buildSelection so it can be unit
+    // tested without rendering the full layout; the helper is also
+    // defensive about a group's clusters field being null (the server
+    // can emit `null` for an empty group, which would otherwise crash
+    // the layout into the ErrorBoundary, see issue #242).
+    const selection = useMemo<Selection | null>(
+        () => buildSelection(
+            selectionType,
+            selectedServer,
+            selectedCluster,
+            clusterData,
+        ),
+        [selectionType, selectedServer, selectedCluster, clusterData],
+    );
 
     return (
         <BlackoutProvider selection={selection}>

--- a/client/src/components/ClusterNavigator/GroupItem.tsx
+++ b/client/src/components/ClusterNavigator/GroupItem.tsx
@@ -121,7 +121,10 @@ interface GroupData {
     name: string;
     auto_group_key?: string;
     is_default?: boolean;
-    clusters?: (Cluster & { cluster_type?: string; replication_type?: string | null })[];
+    // The server may emit `clusters: null` for an empty group (Go
+    // nil-slice JSON marshaling). All consumers must tolerate null;
+    // see issue #242.
+    clusters?: (Cluster & { cluster_type?: string; replication_type?: string | null })[] | null;
 }
 
 interface GroupItemProps {

--- a/client/src/components/ClusterNavigator/index.tsx
+++ b/client/src/components/ClusterNavigator/index.tsx
@@ -253,7 +253,10 @@ const getSpinnerSx = (loading: boolean) => ({
 interface GroupData {
     id: string;
     name: string;
-    clusters?: Array<Cluster & { cluster_type?: string; replication_type?: string | null }>;
+    // The server may emit `clusters: null` for an empty group (Go
+    // nil-slice JSON marshaling). All consumers must tolerate null;
+    // see issue #242.
+    clusters?: Array<Cluster & { cluster_type?: string; replication_type?: string | null }> | null;
     [key: string]: unknown;
 }
 

--- a/client/src/contexts/ClusterDataContext.tsx
+++ b/client/src/contexts/ClusterDataContext.tsx
@@ -61,7 +61,10 @@ export interface ClusterEntry {
 export interface ClusterGroup {
     id: string;
     name: string;
-    clusters: ClusterEntry[];
+    // The server's GET /api/v1/clusters response can encode an empty
+    // group as `clusters: null` (Go nil-slice JSON marshaling). All
+    // consumers must guard against null; see issue #242.
+    clusters: ClusterEntry[] | null;
     [key: string]: unknown;
 }
 

--- a/client/src/contexts/__tests__/ClusterContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterContext.test.tsx
@@ -116,7 +116,8 @@ describe('ClusterContext', () => {
 
             // Data should be updated since fingerprint changed
             expect(result.current.clusterData).not.toBe(initialData);
-            expect(result.current.clusterData[0].clusters[0].servers[0].status).toBe('warning');
+            const clusters = result.current.clusterData[0].clusters ?? [];
+            expect(clusters[0].servers[0].status).toBe('warning');
         });
 
         it('updates lastRefresh even when data is unchanged', async () => {

--- a/client/src/contexts/__tests__/ClusterDataContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterDataContext.test.tsx
@@ -141,8 +141,9 @@ describe('ClusterDataContext', () => {
 
             expect(result).toHaveLength(1);
             expect(result[0].name).toBe('prod');
-            expect(result[0].clusters).toHaveLength(1);
-            expect(result[0].clusters[0].servers).toHaveLength(2);
+            const clusters = result[0].clusters ?? [];
+            expect(clusters).toHaveLength(1);
+            expect(clusters[0].servers).toHaveLength(2);
         });
 
         it('creates standalone clusters for connections without cluster_name', () => {
@@ -154,8 +155,9 @@ describe('ClusterDataContext', () => {
 
             expect(result).toHaveLength(1);
             expect(result[0].name).toBe('Ungrouped');
-            expect(result[0].clusters[0].isStandalone).toBe(true);
-            expect(result[0].clusters[0].servers[0].id).toBe(1);
+            const clusters = result[0].clusters ?? [];
+            expect(clusters[0].isStandalone).toBe(true);
+            expect(clusters[0].servers[0].id).toBe(1);
         });
 
         it('uses Ungrouped when cluster_group is missing', () => {

--- a/client/src/utils/__tests__/buildSelection.test.ts
+++ b/client/src/utils/__tests__/buildSelection.test.ts
@@ -1,0 +1,400 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildSelection } from '../buildSelection';
+import type {
+    ClusterEntry,
+    ClusterGroup,
+    ClusterServer,
+} from '../../contexts/ClusterDataContext';
+import type { Selection } from '../../types/selection';
+
+/**
+ * Asserts the selection is non-null and narrows the type. Used in
+ * place of a non-null assertion to satisfy
+ * `@typescript-eslint/no-non-null-assertion`.
+ */
+function assertSelection(sel: Selection | null): asserts sel is Selection {
+    expect(sel).not.toBeNull();
+    if (sel === null) {
+        throw new Error('expected selection to be non-null');
+    }
+}
+
+const makeServer = (id: number, overrides: Partial<ClusterServer> = {}): ClusterServer => ({
+    id,
+    name: `pg-${id}`,
+    status: 'online',
+    host: `10.0.0.${id}`,
+    port: 5432,
+    role: 'primary',
+    version: '17.0',
+    database_name: 'postgres',
+    username: 'postgres',
+    os: 'linux',
+    platform: 'amd64',
+    ...overrides,
+});
+
+const makeCluster = (id: string, servers: ClusterServer[]): ClusterEntry => ({
+    id,
+    name: `cluster-${id}`,
+    description: `cluster ${id} description`,
+    servers,
+});
+
+const makeGroup = (
+    id: string,
+    clusters: ClusterEntry[] | null,
+): ClusterGroup => ({
+    id,
+    name: `group-${id}`,
+    clusters,
+});
+
+describe('buildSelection', () => {
+    describe('null selection', () => {
+        it('returns null when selectionType is null', () => {
+            expect(buildSelection(null, null, null, [])).toBeNull();
+        });
+
+        it('returns null when selectionType is "server" but selectedServer is null', () => {
+            expect(buildSelection('server', null, null, [])).toBeNull();
+        });
+
+        it('returns null when selectionType is "cluster" but selectedCluster is null', () => {
+            expect(buildSelection('cluster', null, null, [])).toBeNull();
+        });
+    });
+
+    describe('estate selection', () => {
+        it('returns an EstateSelection that wraps the cluster data', () => {
+            const groups = [makeGroup('g1', [makeCluster('c1', [makeServer(1)])])];
+
+            const sel = buildSelection('estate', null, null, groups);
+
+            assertSelection(sel);
+            expect(sel.type).toBe('estate');
+            if (sel.type === 'estate') {
+                expect(sel.name).toBe('All Servers');
+                expect(sel.status).toBe('online');
+                expect(sel.groups).toBe(groups);
+            }
+        });
+
+        it('returns an EstateSelection even when groups contain null clusters', () => {
+            // Estate selection just passes groups through; it must not
+            // throw on null-clusters groups either.
+            const groups = [makeGroup('empty', null)];
+
+            const sel = buildSelection('estate', null, null, groups);
+
+            assertSelection(sel);
+            expect(sel.type).toBe('estate');
+        });
+    });
+
+    describe('cluster selection - happy path', () => {
+        it('resolves groupId and groupName when the cluster is present in clusterData', () => {
+            const server = makeServer(10);
+            const cluster = makeCluster('c1', [server]);
+            const group = makeGroup('g1', [cluster]);
+
+            const sel = buildSelection('cluster', null, cluster, [group]);
+
+            assertSelection(sel);
+            expect(sel.type).toBe('cluster');
+            if (sel.type === 'cluster') {
+                expect(sel.id).toBe('c1');
+                expect(sel.name).toBe('cluster-c1');
+                expect(sel.description).toBe('cluster c1 description');
+                expect(sel.groupId).toBe('g1');
+                expect(sel.groupName).toBe('group-g1');
+                expect(sel.serverIds).toEqual([10]);
+                expect(sel.servers).toHaveLength(1);
+            }
+        });
+
+        it('computes "online" status when all servers are online', () => {
+            const cluster = makeCluster('c1', [makeServer(1), makeServer(2)]);
+            const sel = buildSelection('cluster', null, cluster, [makeGroup('g1', [cluster])]);
+
+            assertSelection(sel);
+            expect(sel.status).toBe('online');
+        });
+
+        it('computes "warning" status when any server is offline or warning', () => {
+            const cluster = makeCluster('c1', [
+                makeServer(1),
+                makeServer(2, { status: 'warning' }),
+            ]);
+            const sel = buildSelection('cluster', null, cluster, [makeGroup('g1', [cluster])]);
+
+            assertSelection(sel);
+            expect(sel.status).toBe('warning');
+        });
+
+        it('computes "offline" status when every server is offline', () => {
+            const cluster = makeCluster('c1', [
+                makeServer(1, { status: 'offline' }),
+                makeServer(2, { status: 'offline' }),
+            ]);
+            const sel = buildSelection('cluster', null, cluster, [makeGroup('g1', [cluster])]);
+
+            assertSelection(sel);
+            expect(sel.status).toBe('offline');
+        });
+
+        it('handles clusters with no servers (servers field absent)', () => {
+            // Exercises the `selectedCluster.servers ?: []` branch:
+            // when the selected cluster carries no servers field at
+            // all, the helper must return an empty servers/serverIds
+            // pair rather than crashing.
+            const cluster: ClusterEntry = {
+                id: 'c-empty',
+                name: 'empty',
+                // servers omitted on purpose to drive the falsy branch.
+                servers: undefined as unknown as ClusterServer[],
+            };
+            const sel = buildSelection('cluster', null, cluster, [makeGroup('g1', [cluster])]);
+
+            assertSelection(sel);
+            if (sel.type === 'cluster') {
+                expect(sel.servers).toEqual([]);
+                expect(sel.serverIds).toEqual([]);
+                // No servers means the "every offline" branch is false
+                // and the "some offline/warning" branch is false; result
+                // is "online".
+                expect(sel.status).toBe('online');
+            }
+        });
+    });
+
+    describe('cluster selection - null clusters guard (issue #242 regression)', () => {
+        it('does not throw when clusterData contains a group whose clusters field is null', () => {
+            const cluster = makeCluster('c-orphan', [makeServer(99)]);
+            // The user has the cluster selected, but clusterData was
+            // refreshed and now contains a group with `clusters: null`.
+            // This is the exact shape that triggered issue #242.
+            const groups: ClusterGroup[] = [
+                makeGroup('g-empty', null),
+                makeGroup('g-other', [makeCluster('c-other', [makeServer(1)])]),
+            ];
+
+            // The selection should be built successfully (no TypeError).
+            expect(() =>
+                buildSelection('cluster', null, cluster, groups),
+            ).not.toThrow();
+        });
+
+        it('returns undefined groupId/groupName when the cluster is not located', () => {
+            const cluster = makeCluster('c-orphan', [makeServer(99)]);
+            const groups: ClusterGroup[] = [makeGroup('g-empty', null)];
+
+            const sel = buildSelection('cluster', null, cluster, groups);
+
+            assertSelection(sel);
+            if (sel.type === 'cluster') {
+                expect(sel.id).toBe('c-orphan');
+                expect(sel.groupId).toBeUndefined();
+                expect(sel.groupName).toBeUndefined();
+                // The cluster's own fields are still surfaced from the
+                // selectedCluster argument; only the parent group lookup
+                // returns undefined.
+                expect(sel.serverIds).toEqual([99]);
+            }
+        });
+
+        it('finds the cluster in a non-null group even when sibling groups are null', () => {
+            const cluster = makeCluster('c-real', [makeServer(7)]);
+            const groups: ClusterGroup[] = [
+                makeGroup('g-empty', null),
+                makeGroup('g-real', [cluster]),
+            ];
+
+            const sel = buildSelection('cluster', null, cluster, groups);
+
+            assertSelection(sel);
+            if (sel.type === 'cluster') {
+                expect(sel.groupId).toBe('g-real');
+                expect(sel.groupName).toBe('group-g-real');
+            }
+        });
+    });
+
+    describe('server selection - happy path', () => {
+        it('resolves clusterId, clusterName, groupId, and groupName for the owning cluster', () => {
+            const server = makeServer(42, { spock_node_name: 'node-a', spock_version: '5.0' });
+            const cluster: ClusterEntry = {
+                ...makeCluster('c-owner', [server]),
+                isStandalone: false,
+            };
+            const group = makeGroup('g-owner', [cluster]);
+
+            const sel = buildSelection('server', server, null, [group]);
+
+            assertSelection(sel);
+            expect(sel.type).toBe('server');
+            if (sel.type === 'server') {
+                expect(sel.id).toBe(42);
+                expect(sel.name).toBe('pg-42');
+                expect(sel.clusterId).toBe('c-owner');
+                expect(sel.clusterName).toBe('cluster-c-owner');
+                expect(sel.isStandalone).toBe(false);
+                expect(sel.groupId).toBe('g-owner');
+                expect(sel.groupName).toBe('group-g-owner');
+                expect(sel.spockNodeName).toBe('node-a');
+                expect(sel.spockVersion).toBe('5.0');
+                expect(sel.host).toBe('10.0.0.42');
+                expect(sel.port).toBe(5432);
+            }
+        });
+
+        it('falls back to "unknown" status and empty strings for missing optional server fields', () => {
+            // A bare-minimum server with no status, role, version, etc.
+            const server: ClusterServer = {
+                id: 1,
+                name: 'minimal',
+            };
+            const cluster = makeCluster('c1', [server]);
+            const group = makeGroup('g1', [cluster]);
+
+            const sel = buildSelection('server', server, null, [group]);
+
+            assertSelection(sel);
+            if (sel.type === 'server') {
+                expect(sel.status).toBe('unknown');
+                expect(sel.description).toBe('');
+                expect(sel.host).toBe('');
+                expect(sel.port).toBe(0);
+                expect(sel.role).toBe('');
+                expect(sel.version).toBe('');
+                expect(sel.database).toBe('');
+                expect(sel.username).toBe('');
+                expect(sel.os).toBe('');
+                expect(sel.platform).toBe('');
+            }
+        });
+
+        it('falls back to an empty server list when a candidate cluster has no servers field', () => {
+            // Exercises the `cluster.servers || []` branch in the
+            // server-lookup loop: a sibling cluster with an absent
+            // servers field must not cause the lookup to throw.
+            const server = makeServer(7);
+            const sparseCluster: ClusterEntry = {
+                id: 'c-sparse',
+                name: 'sparse',
+                // servers omitted on purpose; the runtime API has been
+                // observed to omit this field for empty clusters.
+                servers: undefined as unknown as ClusterServer[],
+            };
+            const realCluster = makeCluster('c-real', [server]);
+            const groups: ClusterGroup[] = [
+                makeGroup('g-sparse', [sparseCluster]),
+                makeGroup('g-real', [realCluster]),
+            ];
+
+            const sel = buildSelection('server', server, null, groups);
+
+            assertSelection(sel);
+            if (sel.type === 'server') {
+                expect(sel.clusterId).toBe('c-real');
+                expect(sel.groupId).toBe('g-real');
+            }
+        });
+
+        it('finds servers inside nested children', () => {
+            const child = makeServer(99, { name: 'child' });
+            const parent: ClusterServer = {
+                ...makeServer(98, { name: 'parent' }),
+                children: [child],
+            };
+            const cluster = makeCluster('c1', [parent]);
+            const sel = buildSelection('server', child, null, [makeGroup('g1', [cluster])]);
+
+            assertSelection(sel);
+            if (sel.type === 'server') {
+                expect(sel.clusterId).toBe('c1');
+                expect(sel.groupId).toBe('g1');
+            }
+        });
+
+        it('uses database_name in preference to database when both are present', () => {
+            const server = makeServer(1, { database_name: 'app_db', database: 'fallback' });
+            const cluster = makeCluster('c1', [server]);
+            const sel = buildSelection('server', server, null, [makeGroup('g1', [cluster])]);
+
+            assertSelection(sel);
+            if (sel.type === 'server') {
+                expect(sel.database).toBe('app_db');
+            }
+        });
+
+        it('falls back to database when database_name is absent', () => {
+            const server = makeServer(1, { database_name: undefined, database: 'legacy' });
+            const cluster = makeCluster('c1', [server]);
+            const sel = buildSelection('server', server, null, [makeGroup('g1', [cluster])]);
+
+            assertSelection(sel);
+            if (sel.type === 'server') {
+                expect(sel.database).toBe('legacy');
+            }
+        });
+    });
+
+    describe('server selection - null clusters guard (issue #242 regression)', () => {
+        it('does not throw when clusterData contains a group whose clusters field is null', () => {
+            const server = makeServer(7);
+            const groups: ClusterGroup[] = [
+                makeGroup('g-empty', null),
+                makeGroup('g-other', [makeCluster('c-other', [makeServer(99)])]),
+            ];
+
+            expect(() =>
+                buildSelection('server', server, null, groups),
+            ).not.toThrow();
+        });
+
+        it('returns undefined cluster/group fields when no group contains the server', () => {
+            const server = makeServer(7);
+            const groups: ClusterGroup[] = [makeGroup('g-empty', null)];
+
+            const sel = buildSelection('server', server, null, groups);
+
+            assertSelection(sel);
+            if (sel.type === 'server') {
+                expect(sel.id).toBe(7);
+                expect(sel.clusterId).toBeUndefined();
+                expect(sel.clusterName).toBeUndefined();
+                expect(sel.isStandalone).toBeUndefined();
+                expect(sel.groupId).toBeUndefined();
+                expect(sel.groupName).toBeUndefined();
+            }
+        });
+
+        it('locates the server in a non-null group even when sibling groups are null', () => {
+            const server = makeServer(7);
+            const cluster = makeCluster('c-real', [server]);
+            const groups: ClusterGroup[] = [
+                makeGroup('g-empty', null),
+                makeGroup('g-real', [cluster]),
+            ];
+
+            const sel = buildSelection('server', server, null, groups);
+
+            assertSelection(sel);
+            if (sel.type === 'server') {
+                expect(sel.clusterId).toBe('c-real');
+                expect(sel.groupId).toBe('g-real');
+            }
+        });
+    });
+});

--- a/client/src/utils/buildSelection.ts
+++ b/client/src/utils/buildSelection.ts
@@ -1,0 +1,135 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import type {
+    ClusterEntry,
+    ClusterGroup,
+    ClusterServer,
+} from '../contexts/ClusterDataContext';
+import type { Selection } from '../types/selection';
+import { collectServers } from './clusterHelpers';
+
+/**
+ * Selection type discriminator used by `useCluster`. Mirrors the
+ * runtime values produced by ClusterSelectionContext; kept local
+ * to avoid a circular import between contexts and utils.
+ */
+export type SelectionType = 'server' | 'cluster' | 'estate' | null;
+
+/**
+ * Build the canonical `Selection` object consumed by `BlackoutProvider`,
+ * `StatusPanel`, and downstream UI from the current selection state.
+ *
+ * The helper is defensive about `group.clusters` being nullish. The
+ * server's GET /api/v1/clusters response can return a group with a
+ * JSON `null` `clusters` field when a group has been emptied (for
+ * example, just after the user deletes its sole cluster). The
+ * server is being hardened to always emit `[]`, but the client must
+ * tolerate `null` regardless; otherwise the resulting TypeError
+ * crashes the MainLayout into the ErrorBoundary fallback. See
+ * issue #242.
+ */
+export const buildSelection = (
+    selectionType: SelectionType,
+    selectedServer: ClusterServer | null,
+    selectedCluster: ClusterEntry | null,
+    clusterData: ClusterGroup[],
+): Selection | null => {
+    if (selectionType === 'server' && selectedServer) {
+        let clusterId: string | undefined;
+        let clusterName: string | undefined;
+        let isStandalone: boolean | undefined;
+        let groupId: string | undefined;
+        let groupName: string | undefined;
+
+        for (const group of clusterData) {
+            for (const cluster of group.clusters ?? []) {
+                const allServers = collectServers(cluster.servers || []);
+                if (allServers.some(s => s.id === selectedServer.id)) {
+                    clusterId = cluster.id;
+                    clusterName = cluster.name;
+                    isStandalone = cluster.isStandalone;
+                    groupId = group.id;
+                    groupName = group.name;
+                    break;
+                }
+            }
+            if (groupId) {break;}
+        }
+
+        return {
+            type: 'server',
+            id: selectedServer.id,
+            name: selectedServer.name,
+            description: selectedServer.description ?? '',
+            status: selectedServer.status || 'unknown',
+            host: selectedServer.host ?? '',
+            port: selectedServer.port || 0,
+            role: selectedServer.role || '',
+            version: selectedServer.version || '',
+            database: selectedServer.database_name || selectedServer.database || '',
+            username: selectedServer.username ?? '',
+            os: selectedServer.os ?? '',
+            platform: selectedServer.platform ?? '',
+            spockNodeName: selectedServer.spock_node_name,
+            spockVersion: selectedServer.spock_version,
+            clusterId,
+            clusterName,
+            isStandalone,
+            groupId,
+            groupName,
+        };
+    }
+
+    if (selectionType === 'cluster' && selectedCluster) {
+        const servers = selectedCluster.servers
+            ? collectServers(selectedCluster.servers)
+            : [];
+        const serverIds = servers.map(s => s.id);
+
+        let groupId: string | undefined;
+        let groupName: string | undefined;
+
+        for (const group of clusterData) {
+            if ((group.clusters ?? []).some(c => c.id === selectedCluster.id)) {
+                groupId = group.id;
+                groupName = group.name;
+                break;
+            }
+        }
+
+        return {
+            type: 'cluster',
+            id: selectedCluster.id,
+            name: selectedCluster.name,
+            description: selectedCluster.description ?? '',
+            servers: servers,
+            serverIds: serverIds,
+            status: servers.every(s => s.status === 'offline') && servers.length > 0
+                ? 'offline'
+                : servers.some(s => s.status === 'offline' || s.status === 'warning')
+                    ? 'warning'
+                    : 'online',
+            groupId,
+            groupName,
+        };
+    }
+
+    if (selectionType === 'estate') {
+        return {
+            type: 'estate',
+            name: 'All Servers',
+            groups: clusterData,
+            status: 'online', // Will be calculated by StatusPanel
+        };
+    }
+
+    return null;
+};

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,26 @@ The format is based on
 project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta3] - Unreleased
+
+### Fixed
+
+- Fix the web client crashing into the "Something
+  went wrong" error boundary after the user deleted
+  an empty cluster. The server marshaled an empty
+  `clusters` list (and the nested `servers` list
+  inside each cluster) as JSON `null` rather than
+  `[]`, and `MainLayout`'s selection `useMemo` then
+  called `.some` on the null value without a guard.
+  The server's `GetClusterTopology` now normalises
+  both lists to a non-nil empty array, and the
+  client's selection logic guards every read of
+  `group.clusters` through a new `buildSelection`
+  helper. The `ClusterGroup.clusters` TypeScript
+  type is also tightened to `ClusterEntry[] | null`
+  so this regression class is caught by the type
+  system. (#242)
+
 ## [1.0.0-beta2] - 2026-05-14
 
 ### Added

--- a/server/src/internal/database/topology_queries.go
+++ b/server/src/internal/database/topology_queries.go
@@ -301,12 +301,14 @@ func (d *Datastore) GetClusterTopology(ctx context.Context, visibleConnectionIDs
 // already owned by the caller at this point.
 func normalizeTopologyGroups(groups []TopologyGroup) {
 	for i := range groups {
-		if groups[i].Clusters == nil {
-			groups[i].Clusters = make([]TopologyCluster, 0)
+		group := &groups[i]
+		if group.Clusters == nil {
+			group.Clusters = make([]TopologyCluster, 0)
 		}
-		for j := range groups[i].Clusters {
-			if groups[i].Clusters[j].Servers == nil {
-				groups[i].Clusters[j].Servers = make([]TopologyServerInfo, 0)
+		for j := range group.Clusters {
+			cluster := &group.Clusters[j]
+			if cluster.Servers == nil {
+				cluster.Servers = make([]TopologyServerInfo, 0)
 			}
 		}
 	}

--- a/server/src/internal/database/topology_queries.go
+++ b/server/src/internal/database/topology_queries.go
@@ -155,6 +155,11 @@ type ClusterSummary struct {
 // groups with no visible clusters are dropped. A nil slice means the
 // caller has unrestricted visibility (superuser or wildcard scope) and
 // the full topology is returned.
+//
+// Every returned TopologyGroup is guaranteed to have a non-nil Clusters
+// slice and every TopologyCluster a non-nil Servers slice, so the JSON
+// wire format is consistently "clusters": [] / "servers": [] rather than
+// null. Issue #242.
 func (d *Datastore) GetClusterTopology(ctx context.Context, visibleConnectionIDs []int) ([]TopologyGroup, error) {
 	// An explicit empty allow-list means no connections are visible;
 	// short-circuit before any datastore work.
@@ -165,7 +170,7 @@ func (d *Datastore) GetClusterTopology(ctx context.Context, visibleConnectionIDs
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	var result []TopologyGroup
+	result := make([]TopologyGroup, 0)
 
 	// Step 1: Get the default group info (database-backed since migration 16)
 	defaultGroup, err := d.getDefaultGroupInternal(ctx)
@@ -277,7 +282,34 @@ func (d *Datastore) GetClusterTopology(ctx context.Context, visibleConnectionIDs
 		result = pruneTopologyByVisibility(result, visibleConnectionIDs)
 	}
 
+	// Step 10: Normalize nil slices in the response tree so JSON encoding
+	// produces "clusters": [] / "servers": [] instead of null. This is
+	// the contract owned by the datastore: every TopologyGroup must carry
+	// a non-nil Clusters slice and every TopologyCluster a non-nil
+	// Servers slice. Issue #242.
+	normalizeTopologyGroups(result)
+
 	return result, nil
+}
+
+// normalizeTopologyGroups walks the topology tree and replaces any nil
+// Clusters slice on a TopologyGroup, and any nil Servers slice on a
+// TopologyCluster, with a non-nil empty slice. This guarantees the JSON
+// wire format never contains "clusters": null or "servers": null, which
+// the web client cannot defend against without per-call defensive
+// guards. The function mutates in place because the topology tree is
+// already owned by the caller at this point.
+func normalizeTopologyGroups(groups []TopologyGroup) {
+	for i := range groups {
+		if groups[i].Clusters == nil {
+			groups[i].Clusters = make([]TopologyCluster, 0)
+		}
+		for j := range groups[i].Clusters {
+			if groups[i].Clusters[j].Servers == nil {
+				groups[i].Clusters[j].Servers = make([]TopologyServerInfo, 0)
+			}
+		}
+	}
 }
 
 // pruneTopologyByVisibility removes servers, clusters, and groups that
@@ -554,8 +586,11 @@ func (d *Datastore) buildTopologyHierarchy(connections []connectionWithRole, clu
 	// pg18-spock1, pg18-spock2 -> another cluster
 	spockClusters := d.groupSpockNodesByClusters(spockNodes, childrenMap, connByID, assignedConnections, clusterOverrides)
 
-	// Build clusters list, filtering out claimed and dismissed clusters
-	var clusters []TopologyCluster
+	// Build clusters list, filtering out claimed and dismissed clusters.
+	// The slice is initialized non-nil so the default group always
+	// marshals to "clusters": [] when empty rather than "clusters":
+	// null. Issue #242.
+	clusters := make([]TopologyCluster, 0)
 	for _, cluster := range spockClusters {
 		// Skip clusters that have been moved to manual groups or dismissed
 		if cluster.AutoClusterKey != "" && (claimedKeys[cluster.AutoClusterKey] || dismissedKeys[cluster.AutoClusterKey]) {

--- a/server/src/internal/database/topology_visibility_test.go
+++ b/server/src/internal/database/topology_visibility_test.go
@@ -11,6 +11,8 @@ package database
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -339,5 +341,269 @@ func TestGetClusterTopology_EmptyFilterShortCircuits(t *testing.T) {
 	}
 	if len(result) != 0 {
 		t.Errorf("Expected empty topology, got %d groups", len(result))
+	}
+}
+
+// TestGetClusterTopology_EmptyFilterReturnsNonNilSlice is the regression
+// test for issue #242. The empty-filter short-circuit must return a
+// non-nil []TopologyGroup so that the JSON encoding is "[]" rather than
+// "null"; the web client crashes when the topology comes back as null.
+func TestGetClusterTopology_EmptyFilterReturnsNonNilSlice(t *testing.T) {
+	d := &Datastore{}
+	result, err := d.GetClusterTopology(context.Background(), []int{})
+	if err != nil {
+		t.Fatalf("GetClusterTopology: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected non-nil slice for empty filter; nil marshals to JSON null and crashes the client")
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if string(encoded) != "[]" {
+		t.Errorf("Expected JSON \"[]\", got %q", string(encoded))
+	}
+}
+
+// TestNormalizeTopologyGroups_ReplacesNilClustersWithEmpty is the unit
+// regression for issue #242. A TopologyGroup whose Clusters is nil must
+// be normalized to a non-nil empty slice so JSON encoding emits
+// "clusters": [] rather than "clusters": null. This is the exact bug the
+// web client crashed on after the only cluster in a group was deleted.
+func TestNormalizeTopologyGroups_ReplacesNilClustersWithEmpty(t *testing.T) {
+	groups := []TopologyGroup{
+		{
+			ID:       "g-empty",
+			Name:     "Default",
+			Clusters: nil, // The bug shape: nil after deletion.
+		},
+	}
+
+	normalizeTopologyGroups(groups)
+
+	if groups[0].Clusters == nil {
+		t.Fatal("Expected non-nil Clusters slice after normalization")
+	}
+	if len(groups[0].Clusters) != 0 {
+		t.Errorf("Expected empty Clusters slice, got %d", len(groups[0].Clusters))
+	}
+
+	encoded, err := json.Marshal(groups[0])
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"clusters":[]`) {
+		t.Errorf("Expected JSON to contain \"clusters\":[], got %s", string(encoded))
+	}
+	if strings.Contains(string(encoded), `"clusters":null`) {
+		t.Errorf("Expected JSON not to contain \"clusters\":null, got %s", string(encoded))
+	}
+}
+
+// TestNormalizeTopologyGroups_ReplacesNilServersWithEmpty verifies the
+// same nil-slice contract applies to TopologyCluster.Servers. A cluster
+// whose Servers field is nil must marshal to "servers": [] rather than
+// "servers": null.
+func TestNormalizeTopologyGroups_ReplacesNilServersWithEmpty(t *testing.T) {
+	groups := []TopologyGroup{
+		{
+			ID:   "g1",
+			Name: "Default",
+			Clusters: []TopologyCluster{
+				{
+					ID:          "c-empty",
+					Name:        "Empty Cluster",
+					ClusterType: "manual",
+					Servers:     nil,
+				},
+			},
+		},
+	}
+
+	normalizeTopologyGroups(groups)
+
+	if groups[0].Clusters[0].Servers == nil {
+		t.Fatal("Expected non-nil Servers slice after normalization")
+	}
+	if len(groups[0].Clusters[0].Servers) != 0 {
+		t.Errorf("Expected empty Servers slice, got %d", len(groups[0].Clusters[0].Servers))
+	}
+
+	encoded, err := json.Marshal(groups[0].Clusters[0])
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"servers":[]`) {
+		t.Errorf("Expected JSON to contain \"servers\":[], got %s", string(encoded))
+	}
+	if strings.Contains(string(encoded), `"servers":null`) {
+		t.Errorf("Expected JSON not to contain \"servers\":null, got %s", string(encoded))
+	}
+}
+
+// TestNormalizeTopologyGroups_PreservesNonNilSlices verifies that
+// normalization leaves already-initialized slices untouched. The function
+// must only replace nil slices, never overwrite existing data.
+func TestNormalizeTopologyGroups_PreservesNonNilSlices(t *testing.T) {
+	groups := []TopologyGroup{
+		{
+			ID:   "g1",
+			Name: "Group",
+			Clusters: []TopologyCluster{
+				{
+					ID:   "c1",
+					Name: "Cluster",
+					Servers: []TopologyServerInfo{
+						{ID: 42, Name: "node"},
+					},
+				},
+			},
+		},
+	}
+
+	normalizeTopologyGroups(groups)
+
+	if len(groups[0].Clusters) != 1 {
+		t.Fatalf("Expected 1 cluster preserved, got %d", len(groups[0].Clusters))
+	}
+	if len(groups[0].Clusters[0].Servers) != 1 {
+		t.Fatalf("Expected 1 server preserved, got %d", len(groups[0].Clusters[0].Servers))
+	}
+	if groups[0].Clusters[0].Servers[0].ID != 42 {
+		t.Errorf("Expected server ID 42, got %d", groups[0].Clusters[0].Servers[0].ID)
+	}
+}
+
+// TestNormalizeTopologyGroups_HandlesEmptyAndNilInput verifies the helper
+// is safe to call on edge inputs: a nil slice and an empty slice. Both
+// must return without panicking; the function has no return value, so
+// the assertion is simply that the call completes without panicking and
+// that the empty slice remains empty.
+func TestNormalizeTopologyGroups_HandlesEmptyAndNilInput(t *testing.T) {
+	// nil input: must not panic. There is nothing to assert on the
+	// returned slice because the function takes the slice by value;
+	// callers that need the nil-preserving guarantee can rely on the
+	// fact that the empty for-loop body never runs.
+	var nilGroups []TopologyGroup
+	normalizeTopologyGroups(nilGroups)
+
+	// empty input
+	emptyGroups := []TopologyGroup{}
+	normalizeTopologyGroups(emptyGroups)
+	if len(emptyGroups) != 0 {
+		t.Errorf("Expected empty input preserved, got %d groups", len(emptyGroups))
+	}
+}
+
+// TestBuildTopologyHierarchy_EmptyConnections_ReturnsNonNilClusters is
+// the producer-side regression for issue #242. When the connection list
+// is empty, buildTopologyHierarchy must still return a default group
+// whose Clusters slice is non-nil so that the topology marshals to JSON
+// with "clusters": [] rather than "clusters": null. This covers the
+// "after the only cluster is deleted" scenario that caused the bug.
+func TestBuildTopologyHierarchy_EmptyConnections_ReturnsNonNilClusters(t *testing.T) {
+	ds := &Datastore{}
+	defaultGroup := &defaultGroupInfo{ID: 1, Name: "Servers/Clusters"}
+
+	groups := ds.buildTopologyHierarchy(
+		nil, // no connections at all
+		make(map[string]clusterOverride),
+		make(map[string]bool),
+		make(map[string]bool),
+		defaultGroup,
+	)
+
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 default group, got %d", len(groups))
+	}
+	if groups[0].Clusters == nil {
+		t.Fatal("Expected non-nil Clusters slice; nil marshals to JSON null and crashes the client")
+	}
+	if len(groups[0].Clusters) != 0 {
+		t.Errorf("Expected empty Clusters slice for no-connections case, got %d",
+			len(groups[0].Clusters))
+	}
+
+	// Confirm the JSON wire shape.
+	encoded, err := json.Marshal(groups[0])
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"clusters":[]`) {
+		t.Errorf("Expected JSON to contain \"clusters\":[], got %s", string(encoded))
+	}
+	if strings.Contains(string(encoded), `"clusters":null`) {
+		t.Errorf("Expected JSON not to contain \"clusters\":null, got %s", string(encoded))
+	}
+}
+
+// TestNormalizeTopologyGroups_MixedNilAndNonNilSlices is a comprehensive
+// regression test that mixes the nil-clusters case (the issue #242 bug
+// shape) with adjacent groups whose Clusters slice is already populated.
+// Normalization must touch only the nil ones and leave the rest intact.
+func TestNormalizeTopologyGroups_MixedNilAndNonNilSlices(t *testing.T) {
+	groups := []TopologyGroup{
+		{
+			ID:       "g-empty",
+			Name:     "Empty Group",
+			Clusters: nil,
+		},
+		{
+			ID:   "g-populated",
+			Name: "Populated Group",
+			Clusters: []TopologyCluster{
+				{
+					ID:          "c1",
+					Name:        "With Servers",
+					ClusterType: "manual",
+					Servers: []TopologyServerInfo{
+						{ID: 1, Name: "n1"},
+					},
+				},
+				{
+					ID:          "c2",
+					Name:        "Empty Servers",
+					ClusterType: "manual",
+					Servers:     nil,
+				},
+			},
+		},
+	}
+
+	normalizeTopologyGroups(groups)
+
+	if groups[0].Clusters == nil {
+		t.Fatal("Expected first group's Clusters to be non-nil after normalization")
+	}
+	if len(groups[0].Clusters) != 0 {
+		t.Errorf("Expected first group's Clusters to be empty, got %d", len(groups[0].Clusters))
+	}
+
+	if len(groups[1].Clusters) != 2 {
+		t.Fatalf("Expected second group to have 2 clusters preserved, got %d", len(groups[1].Clusters))
+	}
+	if len(groups[1].Clusters[0].Servers) != 1 {
+		t.Errorf("Expected populated cluster's Servers preserved, got %d",
+			len(groups[1].Clusters[0].Servers))
+	}
+	if groups[1].Clusters[1].Servers == nil {
+		t.Fatal("Expected empty-servers cluster to be normalized to non-nil")
+	}
+	if len(groups[1].Clusters[1].Servers) != 0 {
+		t.Errorf("Expected empty-servers cluster Servers to be empty, got %d",
+			len(groups[1].Clusters[1].Servers))
+	}
+
+	// Encode the whole tree and confirm no "clusters":null / "servers":null leaks.
+	encoded, err := json.Marshal(groups)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), `"clusters":null`) {
+		t.Errorf("Expected no \"clusters\":null in JSON, got %s", string(encoded))
+	}
+	if strings.Contains(string(encoded), `"servers":null`) {
+		t.Errorf("Expected no \"servers\":null in JSON, got %s", string(encoded))
 	}
 }


### PR DESCRIPTION
## Summary

Fix for #242 — deleting an empty cluster sent the web client into the **Something went wrong** error boundary. Two compounding bugs, fixed in lockstep:

- **Server**: `TopologyGroup.Clusters` was a `[]TopologyCluster` with no `omitempty`; a nil Go slice marshals to JSON `null`. `GetClusterTopology`'s superuser path returned the topology straight from the datastore, so a group with zero clusters surfaced as `"clusters": null` on the wire. Now normalises both `Clusters` and the nested `Servers` slices to non-nil empties before returning.
- **Client**: `MainLayout`'s selection `useMemo` in `App.tsx` had two unguarded reads of `group.clusters` (iteration in the server branch, `.some` in the cluster branch), and the TypeScript type `ClusterGroup.clusters: ClusterEntry[]` lied about the runtime shape. Selection is extracted into a pure `buildSelection` helper that guards every read with `?? []`, and `ClusterGroup.clusters` is tightened to `ClusterEntry[] | null` so future unguarded reads trip the type checker.

Worth noting: the filtered (RBAC-pruned) path on the server already called `make([]TopologyCluster, 0, …)`, which is why the bug never surfaced for non-superusers in QA before. The fix puts the contract at the datastore layer so it holds on every path.

## Test plan

- [x] `make test-all` passes locally.
- [x] 7 new Go tests in `server/src/internal/database/topology_visibility_test.go` covering `normalizeTopologyGroups` and the empty-filter `Clusters` slice contract.
- [x] 22 new client tests in `client/src/utils/__tests__/buildSelection.test.ts` covering both the #242 regression (cluster + server branches with `clusters: null`) and the happy paths; 100% line coverage on the new helper.
- [x] Lint: no new warnings vs `main` baseline (39 pre-existing warnings, 0 errors).
- [x] Reproduced the original bug locally via `playwright-cli` against the broken build before the fix; flow now completes cleanly with the fix applied.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented client crash when clusters/servers are empty by ensuring API returns empty arrays and client selection logic tolerates missing lists.

* **New Features**
  * Added a shared selection builder to normalize and resolve estate/cluster/server selections reliably.

* **Documentation**
  * Clarified topology JSON shape contract: certain arrays are always serialized as empty arrays, and when omitting is allowed.

* **Tests**
  * Added regression and normalization tests to verify non-null JSON arrays and selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/247)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->