### PR TITLE
feat(server,alerter): add Gemini embedding support; bump default chat model

### DIFF
--- a/alerter/src/internal/config/config.go
+++ b/alerter/src/internal/config/config.go
@@ -256,7 +256,7 @@ func NewConfig() *Config {
 				EmbeddingModel: "voyage-3-lite",
 			},
 			Gemini: GeminiConfig{
-				ReasoningModel: "gemini-2.0-flash",
+				ReasoningModel: "gemini-2.5-flash",
 			},
 		},
 	}

--- a/alerter/src/internal/llm/gemini.go
+++ b/alerter/src/internal/llm/gemini.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	geminiBaseURL      = "https://generativelanguage.googleapis.com"
-	geminiDefaultModel = "gemini-2.0-flash"
+	geminiDefaultModel = "gemini-2.5-flash"
 )
 
 // GeminiReasoning implements ReasoningProvider using Google's Gemini API.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,20 @@ project adheres to
 
 ## [1.0.0-beta3] - Unreleased
 
+### Added
+
+- Add Gemini as a supported embedding provider in the
+  `embedding` and `knowledgebase` server configurations;
+  the provider supports `text-embedding-004` (default)
+  and `embedding-001`, both at 768 dimensions. (#246)
+
+### Changed
+
+- Update the default Gemini chat model in the alerter
+  and server configurations from `gemini-2.0-flash`,
+  which is no longer available to new API users, to
+  `gemini-2.5-flash`. (#246)
+
 ### Fixed
 
 - Fix the web client crashing into the "Something

--- a/docs/developer-guide/alerter/anomaly-detection.md
+++ b/docs/developer-guide/alerter/anomaly-detection.md
@@ -199,7 +199,7 @@ Configure the reasoning provider in the `llm` section:
 | Ollama | `qwen2.5:7b-instruct` |
 | OpenAI | `gpt-4o-mini` |
 | Anthropic | `claude-3-5-haiku-20241022` |
-| Gemini | `gemini-2.0-flash` |
+| Gemini | `gemini-2.5-flash` |
 
 ### Example Configuration
 

--- a/docs/getting-started/configuration/alerter.md
+++ b/docs/getting-started/configuration/alerter.md
@@ -284,13 +284,15 @@ provider.
 #### Gemini Configuration
 
 The `llm.gemini` section configures the Google Gemini
-provider.
+provider. Model availability varies by Gemini API key
+tier; run ListModels to verify which models a given
+key can access.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `api_key_file` | string | None | Path to API key file |
 | `base_url` | string | `https://generativelanguage.googleapis.com` | Gemini base URL |
-| `reasoning_model` | string | `gemini-2.0-flash` | Reasoning model |
+| `reasoning_model` | string | `gemini-2.5-flash` | Reasoning model |
 
 #### Voyage Configuration
 

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -114,6 +114,7 @@ embedding:
   ollama_url: "http://localhost:11434"
   # voyage_api_key_file: "~/.voyage-api-key"
   # openai_api_key_file: "~/.openai-api-key"
+  # gemini_api_key_file: "~/.gemini-api-key"
 
 #=====================================================
 # LLM CONFIGURATION (Web Client Chat Proxy)
@@ -364,6 +365,12 @@ protection for user-created database connections.
 
 ### Embedding (`embedding`)
 
+The `provider` option accepts `voyage`, `openai`, `gemini`, or
+`ollama`. The Gemini provider supports `text-embedding-004` (default,
+768 dimensions) and `embedding-001` (768 dimensions). Model
+availability varies by Gemini API key tier; run ListModels to verify
+which embedding models a given key can access.
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable embeddings |
@@ -372,8 +379,10 @@ protection for user-created database connections.
 | `ollama_url` | string | `http://localhost:11434` | Ollama URL |
 | `voyage_api_key_file` | string | | Voyage API key path |
 | `openai_api_key_file` | string | | OpenAI API key path |
+| `gemini_api_key_file` | string | | Gemini API key path |
 | `voyage_base_url` | string | `https://api.voyageai.com/v1/embeddings` | Voyage base URL |
 | `openai_base_url` | string | `https://api.openai.com/v1` | OpenAI base URL |
+| `gemini_base_url` | string | `https://generativelanguage.googleapis.com` | Gemini base URL |
 
 ### LLM Proxy (`llm`)
 
@@ -499,6 +508,12 @@ llm:
 
 ### Knowledgebase (`knowledgebase`)
 
+The `embedding_provider` option accepts `voyage`, `openai`, `gemini`,
+or `ollama`. The Gemini provider supports `text-embedding-004`
+(default, 768 dimensions) and `embedding-001` (768 dimensions). Model
+availability varies by Gemini API key tier; run ListModels to verify
+which embedding models a given key can access.
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable knowledgebase |
@@ -508,8 +523,10 @@ llm:
 | `embedding_ollama_url` | string | `http://localhost:11434` | Ollama URL |
 | `embedding_voyage_api_key_file` | string | | Voyage API key path |
 | `embedding_openai_api_key_file` | string | | OpenAI key path |
+| `embedding_gemini_api_key_file` | string | | Gemini key path |
 | `embedding_voyage_base_url` | string | `https://api.voyageai.com/v1/embeddings` | Voyage base URL |
 | `embedding_openai_base_url` | string | `https://api.openai.com/v1` | OpenAI base URL |
+| `embedding_gemini_base_url` | string | `https://generativelanguage.googleapis.com` | Gemini base URL |
 
 ### Memory (`memory`)
 

--- a/examples/ai-dba-alerter.yaml
+++ b/examples/ai-dba-alerter.yaml
@@ -344,8 +344,10 @@ llm:
     # base_url: https://generativelanguage.googleapis.com
 
     # Model to use for reasoning/classification
-    # Default: gemini-2.0-flash
-    reasoning_model: gemini-2.0-flash
+    # Model availability varies by Gemini API key tier; run
+    # ListModels to verify which models a given key can access.
+    # Default: gemini-2.5-flash
+    reasoning_model: gemini-2.5-flash
 
   #-------------------------------------------------------------------------
   # Voyage Settings (for embeddings only)

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -198,7 +198,7 @@ embedding:
   # Default: false
   enabled: false
 
-  # Embedding provider: "voyage", "openai", or "ollama"
+  # Embedding provider: "voyage", "openai", "gemini", or "ollama"
   # Default: ollama
   provider: "ollama"
 
@@ -206,6 +206,7 @@ embedding:
   # Default depends on provider:
   #   - voyage: voyage-3
   #   - openai: text-embedding-3-small
+  #   - gemini: text-embedding-004
   #   - ollama: nomic-embed-text
   model: "nomic-embed-text"
 
@@ -226,6 +227,22 @@ embedding:
   # containing the key via openai_api_key_file (raw keys cannot be
   # set inline for security).
   # openai_api_key_file: "~/.openai-api-key"
+
+  #-----------------------------------------------------------------------
+  # Gemini Configuration
+  #-----------------------------------------------------------------------
+  #
+  # Model availability varies by Gemini API key tier; run ListModels
+  # to verify which embedding models a given key can access.
+  #
+
+  # Google Gemini API key for embeddings — provide the path to a
+  # file containing the key via gemini_api_key_file (raw keys cannot
+  # be set inline for security).
+  # gemini_api_key_file: "~/.gemini-api-key"
+
+  # Base URL for the Gemini API
+  # gemini_base_url: "https://generativelanguage.googleapis.com"
 
   #-----------------------------------------------------------------------
   # Ollama Configuration
@@ -386,6 +403,17 @@ knowledgebase:
   # embedding_openai_api_key_file (raw keys cannot be set inline
   # for security).
   # embedding_openai_api_key_file: "~/.openai-api-key"
+
+  # Google Gemini API key for knowledgebase embeddings — provide
+  # the path to a file containing the key via
+  # embedding_gemini_api_key_file (raw keys cannot be set inline
+  # for security). Model availability varies by Gemini API key
+  # tier; run ListModels to verify which embedding models a given
+  # key can access.
+  # embedding_gemini_api_key_file: "~/.gemini-api-key"
+
+  # Base URL for the Gemini API used for knowledgebase embeddings
+  # embedding_gemini_base_url: "https://generativelanguage.googleapis.com"
 
 #=========================================================================
 # BUILT-IN TOOLS AND RESOURCES

--- a/examples/walkthrough/guide.sh
+++ b/examples/walkthrough/guide.sh
@@ -69,7 +69,7 @@ select_llm_provider() {
       ;;
     3)
       llm_provider="gemini"
-      llm_model="gemini-2.0-flash"
+      llm_model="gemini-2.5-flash"
       ;;
     *)
       llm_provider=""

--- a/pkg/embedding/README.md
+++ b/pkg/embedding/README.md
@@ -11,7 +11,8 @@ consistent API for generating vector representations of text.
 The package includes the following features:
 
 - A unified Provider interface supports multiple embedding backends.
-- OpenAI, Voyage AI, and Ollama providers are available out of the box.
+- OpenAI, Voyage AI, Gemini, and Ollama providers are available out of
+  the box.
 - Configurable logging tracks API calls, performance, and errors.
 - Automatic model dimension detection simplifies configuration.
 
@@ -45,6 +46,33 @@ The following models are supported:
 | `voyage-2-lite` | 1024 |
 
 The default model is `voyage-3-lite`.
+
+### Gemini
+
+The Gemini provider connects to Google's Generative Language
+embedding API.
+
+The following models are supported:
+
+| Model | Dimensions |
+|-------|------------|
+| `text-embedding-004` | 768 |
+| `embedding-001` | 768 |
+
+The default model is `text-embedding-004`. Model availability varies
+by Gemini API key tier; run ListModels to verify which embedding
+models a given key can access.
+
+In the following example, the server configuration selects the
+Gemini provider and reads the API key from a file on disk:
+
+```yaml
+embedding:
+  provider: "gemini"
+  model: "text-embedding-004"
+  gemini_api_key_file: "~/.gemini-api-key"
+  # gemini_base_url: "https://generativelanguage.googleapis.com"
+```
 
 ### Ollama
 
@@ -127,7 +155,7 @@ The `Config` struct holds configuration for embedding providers:
 
 ```go
 type Config struct {
-    Provider string // "voyage", "ollama", or "openai"
+    Provider string // "voyage", "openai", "gemini", or "ollama"
     Model    string // Model name (provider-specific)
 
     // Voyage AI-specific
@@ -135,6 +163,10 @@ type Config struct {
 
     // OpenAI-specific
     OpenAIAPIKey string
+
+    // Gemini-specific
+    GeminiAPIKey string
+    GeminiBaseURL string
 
     // Ollama-specific
     OllamaURL string

--- a/server/src/internal/api/server_info_handlers_test.go
+++ b/server/src/internal/api/server_info_handlers_test.go
@@ -344,7 +344,7 @@ func TestServerInfoCreateLLMClient(t *testing.T) {
 			llmConfig: &llmproxy.Config{
 				Provider:     "gemini",
 				GeminiAPIKey: "test-key",
-				Model:        "gemini-2.0-flash",
+				Model:        "gemini-2.5-flash",
 			},
 		}
 

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -251,7 +251,7 @@ func (cfg *DatabaseConfig) BuildConnectionString() string {
 // EmbeddingConfig holds embedding generation settings
 type EmbeddingConfig struct {
 	Enabled          bool   `yaml:"enabled"`             // Whether embedding generation is enabled (default: false)
-	Provider         string `yaml:"provider"`            // "voyage", "openai", or "ollama"
+	Provider         string `yaml:"provider"`            // "voyage", "openai", "gemini", or "ollama"
 	Model            string `yaml:"model"`               // Provider-specific model name
 	VoyageAPIKey     string `yaml:"-"`                   // API key for Voyage AI (loaded from file, not config)
 	VoyageAPIKeyFile string `yaml:"voyage_api_key_file"` // Path to file containing Voyage API key
@@ -259,6 +259,9 @@ type EmbeddingConfig struct {
 	OpenAIAPIKey     string `yaml:"-"`                   // API key for OpenAI (loaded from file, not config)
 	OpenAIAPIKeyFile string `yaml:"openai_api_key_file"` // Path to file containing OpenAI API key
 	OpenAIBaseURL    string `yaml:"openai_base_url"`     // Base URL for OpenAI API (default: https://api.openai.com/v1)
+	GeminiAPIKey     string `yaml:"-"`                   // API key for Gemini (loaded from file, not config)
+	GeminiAPIKeyFile string `yaml:"gemini_api_key_file"` // Path to file containing Gemini API key
+	GeminiBaseURL    string `yaml:"gemini_base_url"`     // Base URL for Gemini API (default: https://generativelanguage.googleapis.com)
 	OllamaURL        string `yaml:"ollama_url"`          // URL for Ollama service (default: http://localhost:11434)
 }
 
@@ -379,7 +382,7 @@ type KnowledgebaseConfig struct {
 	DatabasePath string `yaml:"database_path"` // Path to SQLite knowledgebase database
 
 	// Embedding provider configuration for KB similarity search (independent of generate_embeddings tool)
-	EmbeddingProvider         string `yaml:"embedding_provider"`            // "voyage", "openai", or "ollama"
+	EmbeddingProvider         string `yaml:"embedding_provider"`            // "voyage", "openai", "gemini", or "ollama"
 	EmbeddingModel            string `yaml:"embedding_model"`               // Provider-specific model name
 	EmbeddingVoyageAPIKey     string `yaml:"-"`                             // API key for Voyage AI (loaded from file, not config)
 	EmbeddingVoyageAPIKeyFile string `yaml:"embedding_voyage_api_key_file"` // Path to file containing Voyage API key
@@ -387,6 +390,9 @@ type KnowledgebaseConfig struct {
 	EmbeddingOpenAIAPIKey     string `yaml:"-"`                             // API key for OpenAI (loaded from file, not config)
 	EmbeddingOpenAIAPIKeyFile string `yaml:"embedding_openai_api_key_file"` // Path to file containing OpenAI API key
 	EmbeddingOpenAIBaseURL    string `yaml:"embedding_openai_base_url"`     // Base URL for OpenAI API (default: https://api.openai.com/v1)
+	EmbeddingGeminiAPIKey     string `yaml:"-"`                             // API key for Gemini (loaded from file, not config)
+	EmbeddingGeminiAPIKeyFile string `yaml:"embedding_gemini_api_key_file"` // Path to file containing Gemini API key
+	EmbeddingGeminiBaseURL    string `yaml:"embedding_gemini_base_url"`     // Base URL for Gemini API (default: https://generativelanguage.googleapis.com)
 	EmbeddingOllamaURL        string `yaml:"embedding_ollama_url"`          // URL for Ollama service (default: http://localhost:11434)
 }
 
@@ -643,6 +649,15 @@ func mergeConfig(dest, src *Config) {
 		if src.Embedding.OpenAIBaseURL != "" {
 			dest.Embedding.OpenAIBaseURL = src.Embedding.OpenAIBaseURL
 		}
+		if src.Embedding.GeminiAPIKey != "" {
+			dest.Embedding.GeminiAPIKey = src.Embedding.GeminiAPIKey
+		}
+		if src.Embedding.GeminiAPIKeyFile != "" {
+			dest.Embedding.GeminiAPIKeyFile = src.Embedding.GeminiAPIKeyFile
+		}
+		if src.Embedding.GeminiBaseURL != "" {
+			dest.Embedding.GeminiBaseURL = src.Embedding.GeminiBaseURL
+		}
 		if src.Embedding.OllamaURL != "" {
 			dest.Embedding.OllamaURL = src.Embedding.OllamaURL
 		}
@@ -730,6 +745,15 @@ func mergeConfig(dest, src *Config) {
 		}
 		if src.Knowledgebase.EmbeddingOpenAIBaseURL != "" {
 			dest.Knowledgebase.EmbeddingOpenAIBaseURL = src.Knowledgebase.EmbeddingOpenAIBaseURL
+		}
+		if src.Knowledgebase.EmbeddingGeminiAPIKey != "" {
+			dest.Knowledgebase.EmbeddingGeminiAPIKey = src.Knowledgebase.EmbeddingGeminiAPIKey
+		}
+		if src.Knowledgebase.EmbeddingGeminiAPIKeyFile != "" {
+			dest.Knowledgebase.EmbeddingGeminiAPIKeyFile = src.Knowledgebase.EmbeddingGeminiAPIKeyFile
+		}
+		if src.Knowledgebase.EmbeddingGeminiBaseURL != "" {
+			dest.Knowledgebase.EmbeddingGeminiBaseURL = src.Knowledgebase.EmbeddingGeminiBaseURL
 		}
 		if src.Knowledgebase.EmbeddingOllamaURL != "" {
 			dest.Knowledgebase.EmbeddingOllamaURL = src.Knowledgebase.EmbeddingOllamaURL
@@ -836,6 +860,11 @@ func loadAPIKeysFromFiles(cfg *Config) {
 			cfg.Embedding.OpenAIAPIKey = key
 		}
 	}
+	if cfg.Embedding.GeminiAPIKey == "" && cfg.Embedding.GeminiAPIKeyFile != "" {
+		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Embedding.GeminiAPIKeyFile); err == nil && key != "" {
+			cfg.Embedding.GeminiAPIKey = key
+		}
+	}
 
 	// LLM API keys
 	if cfg.LLM.AnthropicAPIKey == "" && cfg.LLM.AnthropicAPIKeyFile != "" {
@@ -863,6 +892,11 @@ func loadAPIKeysFromFiles(cfg *Config) {
 	if cfg.Knowledgebase.EmbeddingOpenAIAPIKey == "" && cfg.Knowledgebase.EmbeddingOpenAIAPIKeyFile != "" {
 		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Knowledgebase.EmbeddingOpenAIAPIKeyFile); err == nil && key != "" {
 			cfg.Knowledgebase.EmbeddingOpenAIAPIKey = key
+		}
+	}
+	if cfg.Knowledgebase.EmbeddingGeminiAPIKey == "" && cfg.Knowledgebase.EmbeddingGeminiAPIKeyFile != "" {
+		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Knowledgebase.EmbeddingGeminiAPIKeyFile); err == nil && key != "" {
+			cfg.Knowledgebase.EmbeddingGeminiAPIKey = key
 		}
 	}
 }

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -740,3 +740,222 @@ data_dir: ./relative/path
 		})
 	}
 }
+
+// TestMergeConfigGeminiEmbedding verifies that the merge logic copies
+// the new Gemini fields from the source EmbeddingConfig to the
+// destination, mirroring the behavior for Voyage and OpenAI.
+func TestMergeConfigGeminiEmbedding(t *testing.T) {
+	dest := defaultConfig()
+	src := &Config{
+		Embedding: EmbeddingConfig{
+			Enabled:          true,
+			Provider:         "gemini",
+			Model:            "text-embedding-004",
+			GeminiAPIKey:     "test-gemini-key",
+			GeminiAPIKeyFile: "/path/to/gemini-key",
+			GeminiBaseURL:    "https://gemini.example.com",
+		},
+	}
+
+	mergeConfig(dest, src)
+
+	if dest.Embedding.Provider != "gemini" {
+		t.Errorf("expected provider 'gemini', got %q", dest.Embedding.Provider)
+	}
+	if dest.Embedding.Model != "text-embedding-004" {
+		t.Errorf("expected model 'text-embedding-004', got %q", dest.Embedding.Model)
+	}
+	if dest.Embedding.GeminiAPIKey != "test-gemini-key" {
+		t.Errorf("expected GeminiAPIKey 'test-gemini-key', got %q",
+			dest.Embedding.GeminiAPIKey)
+	}
+	if dest.Embedding.GeminiAPIKeyFile != "/path/to/gemini-key" {
+		t.Errorf("expected GeminiAPIKeyFile '/path/to/gemini-key', got %q",
+			dest.Embedding.GeminiAPIKeyFile)
+	}
+	if dest.Embedding.GeminiBaseURL != "https://gemini.example.com" {
+		t.Errorf("expected GeminiBaseURL 'https://gemini.example.com', got %q",
+			dest.Embedding.GeminiBaseURL)
+	}
+}
+
+// TestMergeConfigGeminiKnowledgebase verifies that the merge logic
+// copies the new Gemini fields from the source KnowledgebaseConfig to
+// the destination.
+func TestMergeConfigGeminiKnowledgebase(t *testing.T) {
+	dest := defaultConfig()
+	src := &Config{
+		Knowledgebase: KnowledgebaseConfig{
+			Enabled:                   true,
+			DatabasePath:              "/tmp/kb.db",
+			EmbeddingProvider:         "gemini",
+			EmbeddingModel:            "text-embedding-004",
+			EmbeddingGeminiAPIKey:     "kb-gemini-key",
+			EmbeddingGeminiAPIKeyFile: "/path/to/kb-gemini-key",
+			EmbeddingGeminiBaseURL:    "https://gemini.example.com",
+		},
+	}
+
+	mergeConfig(dest, src)
+
+	if dest.Knowledgebase.EmbeddingProvider != "gemini" {
+		t.Errorf("expected provider 'gemini', got %q",
+			dest.Knowledgebase.EmbeddingProvider)
+	}
+	if dest.Knowledgebase.EmbeddingGeminiAPIKey != "kb-gemini-key" {
+		t.Errorf("expected EmbeddingGeminiAPIKey 'kb-gemini-key', got %q",
+			dest.Knowledgebase.EmbeddingGeminiAPIKey)
+	}
+	if dest.Knowledgebase.EmbeddingGeminiAPIKeyFile != "/path/to/kb-gemini-key" {
+		t.Errorf("expected EmbeddingGeminiAPIKeyFile '/path/to/kb-gemini-key', got %q",
+			dest.Knowledgebase.EmbeddingGeminiAPIKeyFile)
+	}
+	if dest.Knowledgebase.EmbeddingGeminiBaseURL != "https://gemini.example.com" {
+		t.Errorf("expected EmbeddingGeminiBaseURL 'https://gemini.example.com', got %q",
+			dest.Knowledgebase.EmbeddingGeminiBaseURL)
+	}
+}
+
+// TestLoadAPIKeysFromFilesGeminiEmbedding verifies the secret-loading
+// path picks up the Gemini key from disk when GeminiAPIKey is unset
+// and GeminiAPIKeyFile points at a readable file.
+func TestLoadAPIKeysFromFilesGeminiEmbedding(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "gemini.key")
+	if err := os.WriteFile(keyPath, []byte("  file-loaded-gemini-key  \n"), 0600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+
+	cfg := &Config{
+		Embedding: EmbeddingConfig{
+			GeminiAPIKeyFile: keyPath,
+		},
+	}
+
+	loadAPIKeysFromFiles(cfg)
+
+	if cfg.Embedding.GeminiAPIKey != "file-loaded-gemini-key" {
+		t.Errorf("expected GeminiAPIKey 'file-loaded-gemini-key', got %q",
+			cfg.Embedding.GeminiAPIKey)
+	}
+}
+
+// TestLoadAPIKeysFromFilesGeminiKnowledgebase verifies the
+// knowledgebase secret-loading path picks up the Gemini key from disk.
+func TestLoadAPIKeysFromFilesGeminiKnowledgebase(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "kb-gemini.key")
+	if err := os.WriteFile(keyPath, []byte("kb-file-gemini-key\n"), 0600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+
+	cfg := &Config{
+		Knowledgebase: KnowledgebaseConfig{
+			EmbeddingGeminiAPIKeyFile: keyPath,
+		},
+	}
+
+	loadAPIKeysFromFiles(cfg)
+
+	if cfg.Knowledgebase.EmbeddingGeminiAPIKey != "kb-file-gemini-key" {
+		t.Errorf("expected EmbeddingGeminiAPIKey 'kb-file-gemini-key', got %q",
+			cfg.Knowledgebase.EmbeddingGeminiAPIKey)
+	}
+}
+
+// TestLoadAPIKeysFromFilesGeminiPreservesExisting verifies the
+// secret-loading code does not overwrite an explicit Gemini API key.
+func TestLoadAPIKeysFromFilesGeminiPreservesExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "gemini.key")
+	if err := os.WriteFile(keyPath, []byte("file-key\n"), 0600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+
+	cfg := &Config{
+		Embedding: EmbeddingConfig{
+			GeminiAPIKey:     "preset-key",
+			GeminiAPIKeyFile: keyPath,
+		},
+		Knowledgebase: KnowledgebaseConfig{
+			EmbeddingGeminiAPIKey:     "preset-kb-key",
+			EmbeddingGeminiAPIKeyFile: keyPath,
+		},
+	}
+
+	loadAPIKeysFromFiles(cfg)
+
+	if cfg.Embedding.GeminiAPIKey != "preset-key" {
+		t.Errorf("expected existing Embedding key to be preserved, got %q",
+			cfg.Embedding.GeminiAPIKey)
+	}
+	if cfg.Knowledgebase.EmbeddingGeminiAPIKey != "preset-kb-key" {
+		t.Errorf("expected existing Knowledgebase key to be preserved, got %q",
+			cfg.Knowledgebase.EmbeddingGeminiAPIKey)
+	}
+}
+
+// TestLoadConfigGeminiFromYAML verifies the full LoadConfig pipeline
+// correctly unmarshals Gemini embedding fields from YAML, including
+// the api-key-from-file indirection.
+func TestLoadConfigGeminiFromYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "gemini.key")
+	if err := os.WriteFile(keyPath, []byte("yaml-gemini-key"), 0600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	kbKeyPath := filepath.Join(tmpDir, "kb-gemini.key")
+	if err := os.WriteFile(kbKeyPath, []byte("yaml-kb-gemini-key"), 0600); err != nil {
+		t.Fatalf("failed to write kb key file: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	configContent := `
+embedding:
+    enabled: true
+    provider: gemini
+    model: text-embedding-004
+    gemini_api_key_file: ` + keyPath + `
+    gemini_base_url: https://gemini.example.com
+knowledgebase:
+    enabled: true
+    database_path: /tmp/kb.db
+    embedding_provider: gemini
+    embedding_model: text-embedding-004
+    embedding_gemini_api_key_file: ` + kbKeyPath + `
+    embedding_gemini_base_url: https://gemini.example.com
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath, CLIFlags{ConfigFileSet: true, ConfigFile: configPath})
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if cfg.Embedding.Provider != "gemini" {
+		t.Errorf("expected Embedding.Provider 'gemini', got %q",
+			cfg.Embedding.Provider)
+	}
+	if cfg.Embedding.GeminiAPIKey != "yaml-gemini-key" {
+		t.Errorf("expected Embedding.GeminiAPIKey 'yaml-gemini-key', got %q",
+			cfg.Embedding.GeminiAPIKey)
+	}
+	if cfg.Embedding.GeminiBaseURL != "https://gemini.example.com" {
+		t.Errorf("expected Embedding.GeminiBaseURL 'https://gemini.example.com', got %q",
+			cfg.Embedding.GeminiBaseURL)
+	}
+	if cfg.Knowledgebase.EmbeddingProvider != "gemini" {
+		t.Errorf("expected Knowledgebase.EmbeddingProvider 'gemini', got %q",
+			cfg.Knowledgebase.EmbeddingProvider)
+	}
+	if cfg.Knowledgebase.EmbeddingGeminiAPIKey != "yaml-kb-gemini-key" {
+		t.Errorf("expected Knowledgebase.EmbeddingGeminiAPIKey 'yaml-kb-gemini-key', got %q",
+			cfg.Knowledgebase.EmbeddingGeminiAPIKey)
+	}
+	if cfg.Knowledgebase.EmbeddingGeminiBaseURL != "https://gemini.example.com" {
+		t.Errorf("expected Knowledgebase.EmbeddingGeminiBaseURL 'https://gemini.example.com', got %q",
+			cfg.Knowledgebase.EmbeddingGeminiBaseURL)
+	}
+}

--- a/server/src/internal/tools/generate_embedding.go
+++ b/server/src/internal/tools/generate_embedding.go
@@ -69,6 +69,8 @@ func GenerateEmbeddingTool(cfg *config.Config) Tool {
 				VoyageBaseURL: cfg.Embedding.VoyageBaseURL,
 				OpenAIAPIKey:  cfg.Embedding.OpenAIAPIKey,
 				OpenAIBaseURL: cfg.Embedding.OpenAIBaseURL,
+				GeminiAPIKey:  cfg.Embedding.GeminiAPIKey,
+				GeminiBaseURL: cfg.Embedding.GeminiBaseURL,
 				OllamaURL:     cfg.Embedding.OllamaURL,
 			}
 

--- a/server/src/internal/tools/generate_embedding_test.go
+++ b/server/src/internal/tools/generate_embedding_test.go
@@ -10,6 +10,8 @@
 package tools
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -199,5 +201,89 @@ func TestGenerateEmbeddingTool_InvalidProvider(t *testing.T) {
 	// Should fail to initialize the embedding provider
 	if !strings.Contains(response.Content[0].Text, "Failed to initialize") {
 		t.Errorf("expected 'Failed to initialize' error, got: %s", response.Content[0].Text)
+	}
+}
+
+// TestGenerateEmbeddingTool_GeminiMissingAPIKey verifies that the
+// factory rejects a Gemini configuration that lacks an API key, which
+// confirms the new config plumbing reaches the embedding provider.
+func TestGenerateEmbeddingTool_GeminiMissingAPIKey(t *testing.T) {
+	cfg := &config.Config{
+		Embedding: config.EmbeddingConfig{
+			Enabled:  true,
+			Provider: "gemini",
+			Model:    "text-embedding-004",
+		},
+	}
+	tool := GenerateEmbeddingTool(cfg)
+
+	response, err := tool.Handler(map[string]any{"text": "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Error("expected error response when Gemini API key is missing")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response")
+	}
+	if !strings.Contains(response.Content[0].Text, "Gemini API key is required") {
+		t.Errorf("expected 'Gemini API key is required' error, got: %s",
+			response.Content[0].Text)
+	}
+}
+
+// TestGenerateEmbeddingTool_GeminiSuccess exercises the full Gemini
+// happy path through the new config plumbing, including GeminiAPIKey
+// and GeminiBaseURL. A local httptest server stands in for the Gemini
+// embedContent endpoint, returning a fixed vector that the tool must
+// echo back in its success response.
+func TestGenerateEmbeddingTool_GeminiSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/v1beta/models/text-embedding-004:embedContent") {
+			t.Errorf("unexpected request path %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("key") != "test-gemini-key" {
+			t.Errorf("expected API key in query string, got %q", r.URL.Query().Get("key"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// 768-element response would be ideal but a short one suffices to
+		// exercise the decoder and the success-path formatting.
+		_, _ = w.Write([]byte(`{"embedding":{"values":[0.1,0.2,0.3]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Embedding: config.EmbeddingConfig{
+			Enabled:       true,
+			Provider:      "gemini",
+			Model:         "text-embedding-004",
+			GeminiAPIKey:  "test-gemini-key",
+			GeminiBaseURL: srv.URL,
+		},
+	}
+	tool := GenerateEmbeddingTool(cfg)
+
+	response, err := tool.Handler(map[string]any{"text": "hello gemini"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response.IsError {
+		t.Fatalf("expected success response, got error: %s",
+			response.Content[0].Text)
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected non-empty response content")
+	}
+	body := response.Content[0].Text
+	if !strings.Contains(body, "Provider: gemini") {
+		t.Errorf("expected 'Provider: gemini' in response, got: %s", body)
+	}
+	if !strings.Contains(body, "Model: text-embedding-004") {
+		t.Errorf("expected 'Model: text-embedding-004' in response, got: %s", body)
+	}
+	if !strings.Contains(body, "0.1") || !strings.Contains(body, "0.3") {
+		t.Errorf("expected embedding vector in response, got: %s", body)
 	}
 }

--- a/server/src/internal/tools/recall_memories.go
+++ b/server/src/internal/tools/recall_memories.go
@@ -113,6 +113,8 @@ func RecallMemoriesTool(memoryStore *memory.Store, cfg *config.Config) Tool {
 					VoyageBaseURL: cfg.Embedding.VoyageBaseURL,
 					OpenAIAPIKey:  cfg.Embedding.OpenAIAPIKey,
 					OpenAIBaseURL: cfg.Embedding.OpenAIBaseURL,
+					GeminiAPIKey:  cfg.Embedding.GeminiAPIKey,
+					GeminiBaseURL: cfg.Embedding.GeminiBaseURL,
 					OllamaURL:     cfg.Embedding.OllamaURL,
 				}
 

--- a/server/src/internal/tools/search_knowledgebase.go
+++ b/server/src/internal/tools/search_knowledgebase.go
@@ -277,6 +277,8 @@ func generateKBQueryEmbedding(ctx context.Context, serverCfg *config.Config, que
 		VoyageBaseURL: kbCfg.EmbeddingVoyageBaseURL,
 		OpenAIAPIKey:  kbCfg.EmbeddingOpenAIAPIKey,
 		OpenAIBaseURL: kbCfg.EmbeddingOpenAIBaseURL,
+		GeminiAPIKey:  kbCfg.EmbeddingGeminiAPIKey,
+		GeminiBaseURL: kbCfg.EmbeddingGeminiBaseURL,
 		OllamaURL:     kbCfg.EmbeddingOllamaURL,
 	}
 

--- a/server/src/internal/tools/search_knowledgebase_test.go
+++ b/server/src/internal/tools/search_knowledgebase_test.go
@@ -10,12 +10,17 @@
 package tools
 
 import (
+	"context"
 	"database/sql"
 	"encoding/binary"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/pgedge/ai-workbench/server/internal/config"
 	_ "modernc.org/sqlite"
 )
 
@@ -547,4 +552,67 @@ func findInString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestGenerateKBQueryEmbedding_NoProvider verifies the helper returns
+// an explicit error when no knowledgebase embedding provider is set.
+func TestGenerateKBQueryEmbedding_NoProvider(t *testing.T) {
+	cfg := &config.Config{}
+	_, _, err := generateKBQueryEmbedding(context.Background(), cfg, "hello")
+	if err == nil {
+		t.Fatal("expected error when KB embedding provider is unset")
+	}
+	if !strings.Contains(err.Error(), "provider not configured") {
+		t.Errorf("expected 'provider not configured' error, got: %v", err)
+	}
+}
+
+// TestGenerateKBQueryEmbedding_Gemini exercises the full Gemini code
+// path for the knowledgebase helper, confirming the new
+// EmbeddingGeminiAPIKey / EmbeddingGeminiBaseURL config fields wire
+// through to the embedding factory.
+func TestGenerateKBQueryEmbedding_Gemini(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embedding":{"values":[0.5,0.6,0.7]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Knowledgebase: config.KnowledgebaseConfig{
+			EmbeddingProvider:      "gemini",
+			EmbeddingModel:         "text-embedding-004",
+			EmbeddingGeminiAPIKey:  "kb-test-key",
+			EmbeddingGeminiBaseURL: srv.URL,
+		},
+	}
+
+	vec, provider, err := generateKBQueryEmbedding(context.Background(), cfg, "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider != "gemini" {
+		t.Errorf("expected provider 'gemini', got %q", provider)
+	}
+	if len(vec) != 3 {
+		t.Errorf("expected 3-element vector, got %d elements", len(vec))
+	}
+	if vec[0] != float32(0.5) {
+		t.Errorf("expected first element 0.5, got %v", vec[0])
+	}
+}
+
+// TestGenerateKBQueryEmbedding_InvalidProvider verifies factory errors
+// are propagated for unsupported provider values.
+func TestGenerateKBQueryEmbedding_InvalidProvider(t *testing.T) {
+	cfg := &config.Config{
+		Knowledgebase: config.KnowledgebaseConfig{
+			EmbeddingProvider: "unknown",
+		},
+	}
+	_, _, err := generateKBQueryEmbedding(context.Background(), cfg, "hello")
+	if err == nil {
+		t.Fatal("expected error for invalid KB provider, got nil")
+	}
 }

--- a/server/src/internal/tools/similarity_search.go
+++ b/server/src/internal/tools/similarity_search.go
@@ -724,6 +724,8 @@ func generateQueryEmbeddingWithConfig(ctx context.Context, serverCfg *config.Con
 		VoyageBaseURL: serverCfg.Embedding.VoyageBaseURL,
 		OpenAIAPIKey:  serverCfg.Embedding.OpenAIAPIKey,
 		OpenAIBaseURL: serverCfg.Embedding.OpenAIBaseURL,
+		GeminiAPIKey:  serverCfg.Embedding.GeminiAPIKey,
+		GeminiBaseURL: serverCfg.Embedding.GeminiBaseURL,
 		OllamaURL:     serverCfg.Embedding.OllamaURL,
 	}
 

--- a/server/src/internal/tools/similarity_search_test.go
+++ b/server/src/internal/tools/similarity_search_test.go
@@ -10,10 +10,14 @@
 package tools
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/pgedge/ai-workbench/server/internal/config"
 	"github.com/pgedge/ai-workbench/server/internal/database"
 )
 
@@ -594,5 +598,66 @@ func TestFindTableInMetadataMap(t *testing.T) {
 				t.Errorf("findTableInMetadataMap() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestGenerateQueryEmbeddingWithConfig_Disabled verifies the helper
+// returns an error when embedding generation is disabled.
+func TestGenerateQueryEmbeddingWithConfig_Disabled(t *testing.T) {
+	cfg := &config.Config{
+		Embedding: config.EmbeddingConfig{Enabled: false},
+	}
+	_, err := generateQueryEmbeddingWithConfig(context.Background(), cfg, "hello")
+	if err == nil {
+		t.Fatal("expected error when embedding is disabled, got nil")
+	}
+	if !strings.Contains(err.Error(), "not enabled") {
+		t.Errorf("expected 'not enabled' error, got: %v", err)
+	}
+}
+
+// TestGenerateQueryEmbeddingWithConfig_Gemini exercises the full
+// Gemini code path through the new GeminiAPIKey/GeminiBaseURL config
+// plumbing, ensuring the helper builds an embedding provider that
+// reaches the Gemini API.
+func TestGenerateQueryEmbeddingWithConfig_Gemini(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embedding":{"values":[0.1,0.2,0.3]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Embedding: config.EmbeddingConfig{
+			Enabled:       true,
+			Provider:      "gemini",
+			Model:         "text-embedding-004",
+			GeminiAPIKey:  "test-key",
+			GeminiBaseURL: srv.URL,
+		},
+	}
+
+	vec, err := generateQueryEmbeddingWithConfig(context.Background(), cfg, "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vec) != 3 {
+		t.Errorf("expected 3-element vector, got %d elements", len(vec))
+	}
+}
+
+// TestGenerateQueryEmbeddingWithConfig_InvalidProvider verifies the
+// helper surfaces factory errors when the provider is unsupported.
+func TestGenerateQueryEmbeddingWithConfig_InvalidProvider(t *testing.T) {
+	cfg := &config.Config{
+		Embedding: config.EmbeddingConfig{
+			Enabled:  true,
+			Provider: "unknown",
+		},
+	}
+	_, err := generateQueryEmbeddingWithConfig(context.Background(), cfg, "hello")
+	if err == nil {
+		t.Fatal("expected error for invalid provider, got nil")
 	}
 }

--- a/server/src/internal/tools/store_memory.go
+++ b/server/src/internal/tools/store_memory.go
@@ -128,6 +128,8 @@ func StoreMemoryTool(memoryStore *memory.Store, cfg *config.Config, rbacChecker 
 					VoyageBaseURL: cfg.Embedding.VoyageBaseURL,
 					OpenAIAPIKey:  cfg.Embedding.OpenAIAPIKey,
 					OpenAIBaseURL: cfg.Embedding.OpenAIBaseURL,
+					GeminiAPIKey:  cfg.Embedding.GeminiAPIKey,
+					GeminiBaseURL: cfg.Embedding.GeminiBaseURL,
 					OllamaURL:     cfg.Embedding.OllamaURL,
 				}
 


### PR DESCRIPTION
## Summary

- Expose Gemini as a fourth embedding provider in `server`/`knowledgebase`
  config (the underlying `pkg/embedding/gemini.go` provider already existed
  but was unreachable from YAML). Supports `text-embedding-004` and
  `embedding-001` (both 768 dims).
- Bump the default Gemini chat model from `gemini-2.0-flash` (no longer
  available to new API tier keys, returns 404) to `gemini-2.5-flash` in
  alerter code, server test fixtures, and example configs.
- Document Gemini as an embedding provider in `pkg/embedding/README.md`
  and the server configuration guide; note that model availability
  varies by Gemini API key tier and recommend running ListModels.

## Test plan

- [x] `make test-all` passes (server, alerter, collector, client)
- [x] `go vet ./...` clean in `server/src` and `alerter/src`
- [x] `gofmt -l` clean
- [x] `golangci-lint` reports 0 issues in server and alerter
- [x] New unit tests added for Gemini config merge, secret-file loading,
      and Gemini-provider construction via `generate_embeddings`,
      `similarity_search`, and `search_knowledgebase` tools (httptest-stubbed
      Gemini endpoint).
- [x] `grep -rn "gemini-2.0-flash"` clean except for the changelog entry
      that intentionally records the bump.

Closes #246