### PR TITLE
fix(server): create auth.db with 0600 mode and fail closed on silent chmod ignore

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,27 @@ project adheres to
 
 ## [1.0.0-beta3] - Unreleased
 
+### Security
+
+- Fix the server creating the SQLite `auth.db` file with
+  world-readable mode `0644` on first start, exposing bcrypt
+  password hashes and token hashes to other local users on
+  the host. The previous `os.Chmod(0600)` call ran before the
+  `modernc.org/sqlite` driver had created the file on disk,
+  so the chmod silently failed with ENOENT and the file was
+  left at the operating system's umask default. The fix moves
+  the chmod after the `PRAGMA foreign_keys` query, which
+  forces the driver to round-trip and create the file, and
+  adds a post-chmod `os.Stat` verification that logs a
+  warning if the resulting mode is not `0600`. The server
+  applies the chmod unconditionally on every startup, so an
+  existing `auth.db` left at `0644` by an earlier release is
+  re-narrowed automatically and no manual operator action is
+  required. On filesystems that silently ignore chmod (for
+  example FAT or some FUSE mounts), the server now refuses to
+  start and operators should consult the WARNING log line that
+  reports the observed mode. (#249)
+
 ### Fixed
 
 - Fix the web client crashing into the "Something

--- a/server/src/internal/auth/store.go
+++ b/server/src/internal/auth/store.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -256,13 +257,14 @@ var (
 )
 
 // restrictAuthDBPermissions tightens the on-disk permissions of the
-// auth database file to 0600 so that other users on the system cannot
-// read password hashes or tokens. The function is split out from
-// NewAuthStore so that the chmod-failed, stat-failed, and
-// mode-mismatch branches are unit-testable; the caller is expected to
-// invoke this only after the SQLite driver has created the file on
-// disk (a fresh data directory needs at least one real query before
-// the file exists, since modernc.org/sqlite opens lazily).
+// auth database file to at most 0600 so that other users on the
+// system cannot read password hashes or tokens. The function is
+// split out from NewAuthStore so that the chmod-failed, stat-failed,
+// and mode-wider-than-0600 branches are unit-testable; the caller is
+// expected to invoke this only after the SQLite driver has created
+// the file on disk (a fresh data directory needs at least one real
+// query before the file exists, since modernc.org/sqlite opens
+// lazily).
 //
 // The chmod-failed and stat-failed branches log at WARNING and return
 // nil because some filesystems (FAT, NTFS, certain fuse mounts,
@@ -277,9 +279,26 @@ var (
 // ignore" scenario that issue #249 was filed to prevent. We must fail
 // closed there: continuing would serve auth from a world-readable
 // bcrypt-hash store, exactly the regression we are guarding against.
-// The function returns a non-nil error in that case so NewAuthStore
-// can abort startup, and it also keeps the WARNING log line so
-// operators see both a log entry and the startup failure.
+// The check uses a mask (perm &^ 0600 != 0) rather than strict
+// equality with 0600 because the property we actually require is "no
+// bits outside the owner-rw mask are set"; an operator who has
+// tightened the file further to 0400 (or 0000) is at least as safe
+// as 0600 and must not be rejected. The function returns a non-nil
+// error in the wider-than-0600 case so NewAuthStore can abort
+// startup, and it also keeps the WARNING log line so operators see
+// both a log entry and the startup failure.
+//
+// On Windows the mask check is skipped entirely. os.Chmod on Windows
+// only toggles the FILE_ATTRIBUTE_READONLY bit, so even a successful
+// chmod(0600) is followed by an os.Stat that reports approximately
+// 0666 (writable) or 0444 (read-only). The mask check has no useful
+// meaning under those semantics, and enforcing it would refuse boot
+// on every Windows build. Windows operators are expected to secure
+// confidentiality through ACLs on the data directory (which is
+// already created with mode 0700 and inherits whatever ACL semantics
+// the host applies); we still call chmod above to preserve the
+// cross-platform contract that auth.db is at minimum not writable by
+// other users where the OS honors POSIX-style modes at all.
 func restrictAuthDBPermissions(dbPath string) error {
 	if chmodErr := authDBChmod(dbPath, 0600); chmodErr != nil {
 		log.Printf("[AUTH] WARNING: Failed to set permissions on %s: %v", dbPath, chmodErr)
@@ -287,18 +306,23 @@ func restrictAuthDBPermissions(dbPath string) error {
 	}
 
 	// Belt-and-braces: re-stat the file and warn if the effective
-	// permissions are still wider than 0600. A chmod that returns
-	// nil but does not actually narrow the mode would otherwise
-	// leave auth.db world-readable with no observable signal until
-	// an operator noticed the file mode by hand.
+	// permissions are wider than 0600. A chmod that returns nil but
+	// does not actually narrow the mode would otherwise leave
+	// auth.db world-readable with no observable signal until an
+	// operator noticed the file mode by hand. The mask form
+	// "perm &^ 0600 != 0" accepts any mode no wider than 0600
+	// (including narrower modes such as 0400) and rejects any mode
+	// that has bits set outside the owner-rw pair.
 	info, statErr := authDBStat(dbPath)
 	if statErr != nil {
 		log.Printf("[AUTH] WARNING: Failed to set permissions on %s: post-chmod stat failed: %v", dbPath, statErr)
 		return nil
 	}
-	if perm := info.Mode().Perm(); perm != 0600 {
-		log.Printf("[AUTH] WARNING: Failed to set permissions on %s: filesystem reported mode %#o after chmod (expected 0600)", dbPath, perm)
-		return fmt.Errorf("file mode %#o on %s is wider than 0600 after chmod", perm, dbPath)
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm&^0600 != 0 {
+			log.Printf("[AUTH] WARNING: Failed to set permissions on %s: filesystem reported mode %#o after chmod (expected at most 0600)", dbPath, perm)
+			return fmt.Errorf("file mode %#o on %s is wider than 0600 after chmod", perm, dbPath)
+		}
 	}
 	return nil
 }

--- a/server/src/internal/auth/store.go
+++ b/server/src/internal/auth/store.go
@@ -161,12 +161,6 @@ func NewAuthStore(dataDir string, maxUserTokenDays, maxFailedAttempts int) (*Aut
 		return nil, fmt.Errorf("failed to open auth database: %w", err)
 	}
 
-	// Restrict database file permissions to owner-only (0600) so that
-	// other users on the system cannot read password hashes or tokens.
-	if chmodErr := os.Chmod(dbPath, 0600); chmodErr != nil {
-		log.Printf("[AUTH] WARNING: Failed to set permissions on %s: %v", dbPath, chmodErr)
-	}
-
 	// Verify that the foreign_keys pragma is actually active. SQLite
 	// silently ignores the pragma if it was compiled without foreign key
 	// support (SQLITE_OMIT_FOREIGN_KEY) or if the DSN parameter was not
@@ -174,6 +168,16 @@ func NewAuthStore(dataDir string, maxUserTokenDays, maxFailedAttempts int) (*Aut
 	// delete paths in this package rely on ON DELETE CASCADE for
 	// defense in depth and a future regression would silently leave
 	// orphan rows behind.
+	//
+	// This QueryRow is also the first statement that forces the
+	// modernc.org/sqlite driver to open a real connection, which is
+	// what actually creates auth.db on disk for a fresh data directory.
+	// sql.Open is lazy and does not touch the filesystem, so the chmod
+	// below must come after this QueryRow rather than before it;
+	// otherwise the chmod fires against a non-existent path and logs a
+	// spurious "no such file or directory" warning while leaving the
+	// eventual database file at the user's default umask (typically
+	// 0644, which exposes password hashes to other local users).
 	var fkEnabled int
 	if err := db.QueryRow("PRAGMA foreign_keys").Scan(&fkEnabled); err != nil {
 		db.Close()
@@ -182,6 +186,28 @@ func NewAuthStore(dataDir string, maxUserTokenDays, maxFailedAttempts int) (*Aut
 	if fkEnabled != 1 {
 		db.Close()
 		return nil, fmt.Errorf("foreign_keys pragma is not active (value=%d); SQLite build must support foreign keys", fkEnabled)
+	}
+
+	// Restrict database file permissions to owner-only (0600) so that
+	// other users on the system cannot read password hashes or tokens.
+	// The QueryRow above guaranteed that the file now exists, so any
+	// chmod failure here reflects a real platform issue (for example a
+	// networked filesystem that refuses chmod) rather than a transient
+	// "file not yet created" race.
+	//
+	// The helper logs at WARNING (and returns nil) for the cases where
+	// chmod or the post-chmod stat themselves fail; those reflect
+	// platform/operator constraints that should not block startup. It
+	// returns a non-nil error only when chmod returned nil but the
+	// filesystem still reports a mode wider than 0600 - the FAT/NTFS/
+	// fuse "silent ignore" scenario that issue #249 was filed to
+	// prevent. In that case we must fail closed: serving auth out of a
+	// world-readable bcrypt-hash store is the exact regression we are
+	// guarding against, so we close the database handle and abort
+	// startup with a wrapped error.
+	if err := restrictAuthDBPermissions(dbPath); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("auth.db has unsafe file permissions: %w", err)
 	}
 
 	store := &AuthStore{
@@ -214,6 +240,67 @@ func NewAuthStore(dataDir string, maxUserTokenDays, maxFailedAttempts int) (*Aut
 	}
 
 	return store, nil
+}
+
+// authDBChmod and authDBStat indirect through package-level function
+// variables so that the failure branches inside
+// restrictAuthDBPermissions (chmod error, post-chmod stat error,
+// chmod silently ignored) can be exercised in unit tests on
+// filesystems where the real syscalls would always succeed. Production
+// code uses os.Chmod and os.Stat unchanged; only the test file
+// overrides these variables, and even then it must restore them in
+// t.Cleanup. They are intentionally not exported.
+var (
+	authDBChmod = os.Chmod
+	authDBStat  = os.Stat
+)
+
+// restrictAuthDBPermissions tightens the on-disk permissions of the
+// auth database file to 0600 so that other users on the system cannot
+// read password hashes or tokens. The function is split out from
+// NewAuthStore so that the chmod-failed, stat-failed, and
+// mode-mismatch branches are unit-testable; the caller is expected to
+// invoke this only after the SQLite driver has created the file on
+// disk (a fresh data directory needs at least one real query before
+// the file exists, since modernc.org/sqlite opens lazily).
+//
+// The chmod-failed and stat-failed branches log at WARNING and return
+// nil because some filesystems (FAT, NTFS, certain fuse mounts,
+// network shares that strip permission bits) reject chmod outright or
+// fail intermittently on stat for transient reasons. Hard-failing
+// startup in those environments would refuse to boot on legitimate
+// operator setups, so we preserve visibility via the log without that
+// cost.
+//
+// The mode-mismatch branch - chmod returned nil but the filesystem
+// reports a mode wider than 0600 - is the FAT/NTFS/fuse "silent
+// ignore" scenario that issue #249 was filed to prevent. We must fail
+// closed there: continuing would serve auth from a world-readable
+// bcrypt-hash store, exactly the regression we are guarding against.
+// The function returns a non-nil error in that case so NewAuthStore
+// can abort startup, and it also keeps the WARNING log line so
+// operators see both a log entry and the startup failure.
+func restrictAuthDBPermissions(dbPath string) error {
+	if chmodErr := authDBChmod(dbPath, 0600); chmodErr != nil {
+		log.Printf("[AUTH] WARNING: Failed to set permissions on %s: %v", dbPath, chmodErr)
+		return nil
+	}
+
+	// Belt-and-braces: re-stat the file and warn if the effective
+	// permissions are still wider than 0600. A chmod that returns
+	// nil but does not actually narrow the mode would otherwise
+	// leave auth.db world-readable with no observable signal until
+	// an operator noticed the file mode by hand.
+	info, statErr := authDBStat(dbPath)
+	if statErr != nil {
+		log.Printf("[AUTH] WARNING: Failed to set permissions on %s: post-chmod stat failed: %v", dbPath, statErr)
+		return nil
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		log.Printf("[AUTH] WARNING: Failed to set permissions on %s: filesystem reported mode %#o after chmod (expected 0600)", dbPath, perm)
+		return fmt.Errorf("file mode %#o on %s is wider than 0600 after chmod", perm, dbPath)
+	}
+	return nil
 }
 
 // migrateV1ToV2 adds the is_public column to mcp_privilege_identifiers table

--- a/server/src/internal/auth/store_test.go
+++ b/server/src/internal/auth/store_test.go
@@ -347,6 +347,42 @@ func TestRestrictAuthDBPermissions(t *testing.T) {
 			t.Errorf("expected mode-mismatch warning to still be logged, got %q", got)
 		}
 	})
+
+	t.Run("accepts modes narrower than 0600", func(t *testing.T) {
+		buf := captureLog(t)
+
+		// Lock in the "narrower modes are OK" guarantee that the
+		// mask-based check (perm &^ 0600 != 0) provides. A future
+		// refactor that reverts to strict equality with 0600 would
+		// reject 0400 and refuse boot on operator setups that have
+		// tightened the file further than this helper requests.
+		// Stub stat to report 0400; chmod is left untouched (the
+		// real os.Chmod will succeed harmlessly on the temp file)
+		// because we only care about the post-chmod mask check.
+		prevStat := authDBStat
+		authDBStat = func(name string) (os.FileInfo, error) {
+			real, err := os.Stat(name)
+			if err != nil {
+				return nil, err
+			}
+			return wideModeFileInfo{FileInfo: real, mode: 0400}, nil
+		}
+		t.Cleanup(func() { authDBStat = prevStat })
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "auth.db")
+		if err := os.WriteFile(path, []byte("x"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		if err := restrictAuthDBPermissions(path); err != nil {
+			t.Fatalf("expected nil error for mode 0400, got %v", err)
+		}
+
+		if got := buf.String(); strings.Contains(got, "Failed to set permissions") {
+			t.Errorf("unexpected warning emitted for narrower mode: %q", got)
+		}
+	})
 }
 
 // TestNewAuthStore_UnsafePermissionsAbortStartup confirms the

--- a/server/src/internal/auth/store_test.go
+++ b/server/src/internal/auth/store_test.go
@@ -10,7 +10,12 @@
 package auth
 
 import (
+	"bytes"
+	"log"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -127,6 +132,350 @@ func TestNewAuthStore(t *testing.T) {
 		}
 	})
 }
+
+// TestNewAuthStore_FilePermissions is the regression test for GitHub
+// issue #249. The previous implementation called os.Chmod on auth.db
+// immediately after sql.Open, but the modernc.org/sqlite driver opens
+// the database lazily and does not create the file until the first
+// real query forces a connection. The chmod therefore fired against a
+// non-existent path, logged "Failed to set permissions on auth.db: no
+// such file or directory", and left the eventual file at the user's
+// default umask (typically 0644, which is world-readable). The fix
+// reorders NewAuthStore so the foreign-keys PRAGMA QueryRow runs first
+// and creates the file, then chmod runs against a file that is
+// guaranteed to exist.
+//
+// The test asserts both halves of the contract: the on-disk file is
+// 0600 after NewAuthStore returns, and no "Failed to set permissions"
+// warning was emitted to the package logger during startup.
+//
+// The test is skipped on Windows because Windows does not honor
+// POSIX permission bits; os.Chmod silently maps to the read-only flag
+// and the Mode().Perm() reported by os.Stat does not reflect 0600.
+func TestNewAuthStore_FilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file permissions are not enforced on Windows")
+	}
+
+	// Redirect the standard logger to an in-memory buffer for the
+	// duration of the test so we can scan for the regression warning
+	// without polluting test output. Mirror the approach used by
+	// captureLog in server/src/internal/api/handle_test.go.
+	prevWriter := log.Writer()
+	prevFlags := log.Flags()
+	buf := &bytes.Buffer{}
+	log.SetOutput(buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevWriter)
+		log.SetFlags(prevFlags)
+	})
+
+	tmpDir := t.TempDir()
+
+	store, err := NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		store.Close()
+	})
+
+	dbPath := filepath.Join(tmpDir, "auth.db")
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat(%q) failed: %v", dbPath, err)
+	}
+
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("auth.db has mode %#o; expected 0600", perm)
+	}
+
+	// Regression guard: the original bug surfaced as a startup warning
+	// line beginning "[AUTH] WARNING: Failed to set permissions".
+	// Reviewers grep for that exact prefix when triaging packaging
+	// issues, so the test asserts on the same substring rather than a
+	// looser pattern.
+	if got := buf.String(); strings.Contains(got, "Failed to set permissions") {
+		t.Errorf("NewAuthStore logged a chmod warning; output was:\n%s", got)
+	}
+}
+
+// TestRestrictAuthDBPermissions exercises the helper that tightens
+// auth.db to 0600. Three of the four subtests cover scenarios where
+// the helper logs a WARNING and returns nil (happy path, chmod
+// failed, post-chmod stat failed); the fourth covers the silent-
+// ignore mode-mismatch case where the helper must fail closed by
+// returning a non-nil error so NewAuthStore can abort startup. The
+// cases share the same log-redirect plumbing as
+// TestNewAuthStore_FilePermissions and pin the WARNING prefix that
+// operators grep for in production logs.
+func TestRestrictAuthDBPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file permissions are not enforced on Windows")
+	}
+
+	captureLog := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		prevWriter := log.Writer()
+		prevFlags := log.Flags()
+		buf := &bytes.Buffer{}
+		log.SetOutput(buf)
+		log.SetFlags(0)
+		t.Cleanup(func() {
+			log.SetOutput(prevWriter)
+			log.SetFlags(prevFlags)
+		})
+		return buf
+	}
+
+	t.Run("tightens existing file to 0600", func(t *testing.T) {
+		buf := captureLog(t)
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "auth.db")
+		if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		if err := restrictAuthDBPermissions(path); err != nil {
+			t.Fatalf("restrictAuthDBPermissions returned error on happy path: %v", err)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Errorf("expected mode 0600, got %#o", perm)
+		}
+		if got := buf.String(); strings.Contains(got, "Failed to set permissions") {
+			t.Errorf("unexpected warning emitted: %q", got)
+		}
+	})
+
+	t.Run("warns when chmod fails on missing file", func(t *testing.T) {
+		buf := captureLog(t)
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "auth.db") // never created
+
+		// The chmod-failed branch logs a warning and returns nil; we
+		// keep WARN-and-continue here so that platforms which reject
+		// chmod (EROFS, EPERM, ENOSYS) do not refuse to boot.
+		if err := restrictAuthDBPermissions(path); err != nil {
+			t.Fatalf("expected nil error on chmod failure, got %v", err)
+		}
+
+		got := buf.String()
+		if !strings.Contains(got, "Failed to set permissions") {
+			t.Errorf("expected chmod failure warning, got %q", got)
+		}
+	})
+
+	t.Run("warns when post-chmod stat fails", func(t *testing.T) {
+		buf := captureLog(t)
+
+		// Swap the package-level stat seam so chmod succeeds but
+		// the verification stat returns an error. This simulates a
+		// race where the file is removed between chmod and stat, or
+		// a filesystem where stat fails for an inode that chmod
+		// accepted.
+		prev := authDBStat
+		authDBStat = func(string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}
+		t.Cleanup(func() { authDBStat = prev })
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "auth.db")
+		if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		// The stat-failed branch also logs a warning and returns nil;
+		// a transient stat failure should not refuse boot.
+		if err := restrictAuthDBPermissions(path); err != nil {
+			t.Fatalf("expected nil error on stat failure, got %v", err)
+		}
+
+		got := buf.String()
+		if !strings.Contains(got, "Failed to set permissions") ||
+			!strings.Contains(got, "post-chmod stat failed") {
+			t.Errorf("expected post-chmod stat-failure warning, got %q", got)
+		}
+	})
+
+	t.Run("errors when filesystem ignores chmod", func(t *testing.T) {
+		buf := captureLog(t)
+
+		// Swap both seams so chmod returns nil but the post-chmod
+		// stat reports a mode wider than 0600. This simulates the
+		// FAT/NTFS/fuse scenario described in the helper docstring:
+		// chmod succeeds while the filesystem silently keeps the
+		// original permissions. The helper must fail closed here,
+		// returning a non-nil error so NewAuthStore can abort.
+		prevChmod := authDBChmod
+		authDBChmod = func(string, os.FileMode) error { return nil }
+		t.Cleanup(func() { authDBChmod = prevChmod })
+
+		// Real os.Stat is left in place; the test file below keeps
+		// its 0644 bits because our stubbed chmod did not actually
+		// narrow them.
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "auth.db")
+		if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		err := restrictAuthDBPermissions(path)
+		if err == nil {
+			t.Fatal("expected non-nil error on mode mismatch, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "0600") {
+			t.Errorf("expected error message to mention 0600, got %q", msg)
+		}
+		if !strings.Contains(msg, "0644") {
+			t.Errorf("expected error message to include actual mode 0644 in octal, got %q", msg)
+		}
+
+		got := buf.String()
+		if !strings.Contains(got, "Failed to set permissions") ||
+			!strings.Contains(got, "filesystem reported mode") {
+			t.Errorf("expected mode-mismatch warning to still be logged, got %q", got)
+		}
+	})
+}
+
+// TestNewAuthStore_UnsafePermissionsAbortStartup confirms the
+// fail-closed contract end-to-end: when restrictAuthDBPermissions
+// reports the silent-ignore mode-mismatch scenario, NewAuthStore must
+// surface a wrapped error, close the database handle it opened, and
+// not return a usable store. This is the regression guard for the
+// security-auditor finding on issue #249: a chmod that returns nil
+// without actually narrowing the mode used to be a WARN-and-continue,
+// which would have let the server boot and serve auth from a world-
+// readable bcrypt-hash store.
+//
+// We force the silent-ignore scenario via the authDBChmod and
+// authDBStat function-variable seams. The chmod stub returns nil
+// without touching the filesystem, and the stat stub returns a
+// FileInfo whose Mode() reports 0644. The seams are restored via
+// t.Cleanup so unrelated subsequent tests are unaffected.
+func TestNewAuthStore_UnsafePermissionsAbortStartup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file permissions are not enforced on Windows")
+	}
+
+	// Redirect the package logger so the WARNING line emitted by the
+	// helper does not pollute test output, and so we can assert the
+	// helper still logs even when it now also fails closed.
+	prevWriter := log.Writer()
+	prevFlags := log.Flags()
+	buf := &bytes.Buffer{}
+	log.SetOutput(buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevWriter)
+		log.SetFlags(prevFlags)
+	})
+
+	// chmod stub: pretend the filesystem accepted the request.
+	prevChmod := authDBChmod
+	authDBChmod = func(string, os.FileMode) error { return nil }
+	t.Cleanup(func() { authDBChmod = prevChmod })
+
+	// stat stub: report a mode wider than 0600 (the silent-ignore
+	// scenario). We delegate to the real os.Stat for everything else
+	// so size/modtime fields stay realistic, and only override the
+	// mode bits via a wrapper FileInfo.
+	prevStat := authDBStat
+	authDBStat = func(name string) (os.FileInfo, error) {
+		real, err := os.Stat(name)
+		if err != nil {
+			return nil, err
+		}
+		return wideModeFileInfo{FileInfo: real, mode: 0644}, nil
+	}
+	t.Cleanup(func() { authDBStat = prevStat })
+
+	tmpDir := t.TempDir()
+	store, err := NewAuthStore(tmpDir, 0, 0)
+	if store != nil {
+		// Defensive cleanup so we do not leak a handle if the test
+		// fails to assert correctly; the contract is that store must
+		// be nil on this path.
+		t.Cleanup(func() { store.Close() })
+	}
+	if err == nil {
+		t.Fatal("expected NewAuthStore to return an error on unsafe permissions, got nil")
+	}
+	if store != nil {
+		t.Errorf("expected nil *AuthStore on unsafe permissions, got non-nil")
+	}
+
+	// The wrapped error from NewAuthStore should carry the helper
+	// message context so operators triaging a refused boot can tell
+	// what happened.
+	msg := err.Error()
+	if !strings.Contains(msg, "auth.db has unsafe file permissions") {
+		t.Errorf("expected wrapped NewAuthStore error to mention unsafe permissions, got %q", msg)
+	}
+	if !strings.Contains(msg, "0600") {
+		t.Errorf("expected wrapped error to reference target mode 0600, got %q", msg)
+	}
+
+	// The helper should still have logged the WARNING line so
+	// operators see both a structured error and a log entry.
+	if got := buf.String(); !strings.Contains(got, "Failed to set permissions") {
+		t.Errorf("expected helper to still log a WARNING on mode mismatch, got %q", got)
+	}
+
+	// auth.db should still exist on disk - the QueryRow that creates
+	// the file ran before restrictAuthDBPermissions - but the
+	// database handle must have been closed by NewAuthStore on the
+	// abort path. Asserting the file exists makes sure the abort
+	// happened after the file-creation QueryRow and not before it;
+	// that ordering is what guarantees the helper actually runs (a
+	// future refactor that moves the chmod earlier would silently
+	// regress).
+	dbPath := filepath.Join(tmpDir, "auth.db")
+	if _, statErr := os.Stat(dbPath); statErr != nil {
+		t.Errorf("expected auth.db to exist after aborted NewAuthStore, got Stat error: %v", statErr)
+	}
+
+	// Probe the closed-handle contract by restoring the real
+	// chmod/stat seams and re-opening the file with the same driver.
+	// modernc.org/sqlite uses fcntl POSIX locks on Linux, so a second
+	// sql.Open + initial QueryRow cycle would block or fail if
+	// NewAuthStore had leaked the SQLite handle on the abort path.
+	// Restoring the seams here (rather than waiting for t.Cleanup) is
+	// necessary because the second NewAuthStore would otherwise hit
+	// the same silent-ignore failure and we would not learn anything
+	// about handle hygiene.
+	authDBChmod = prevChmod
+	authDBStat = prevStat
+
+	store2, err := NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("re-open after aborted NewAuthStore failed (handle may have leaked): %v", err)
+	}
+	t.Cleanup(func() { store2.Close() })
+}
+
+// wideModeFileInfo wraps an os.FileInfo and overrides Mode() so the
+// reported permission bits look wider than the underlying file. It
+// exists solely so TestNewAuthStore_UnsafePermissionsAbortStartup can
+// simulate the silent-ignore FAT/NTFS/fuse scenario without needing a
+// real such filesystem mounted under the test runner.
+type wideModeFileInfo struct {
+	os.FileInfo
+	mode os.FileMode
+}
+
+func (w wideModeFileInfo) Mode() os.FileMode { return w.mode }
 
 func TestAuthStorePath(t *testing.T) {
 	t.Run("returns correct database path", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reorder `NewAuthStore` so the `chmod 0600` on `auth.db` runs **after** the `PRAGMA foreign_keys` `QueryRow`; that QueryRow is the first statement that forces the `modernc.org/sqlite` driver to open a real connection and actually create the file on disk, so the previous chmod-before-QueryRow ordering fired against a non-existent path and logged a "no such file or directory" warning, leaving the eventual file at the operating system's umask default. On Debian this shipped as world-readable `0644`, exposing bcrypt password hashes and token hashes to any local user.
- Factor the chmod + a post-stat verification into a private helper `restrictAuthDBPermissions`. Genuine chmod/stat failures (networked filesystems, exotic mounts) still log a `WARNING` and continue — hard-failing on those would refuse to boot legitimate operator setups. The "silent ignore" case (chmod returns nil but the filesystem still reports a mode wider than `0600` — FAT, NTFS, some fuse mounts) now returns a non-nil error so the server **fails closed** instead of serving auth from a world-readable hash store.
- The chmod runs on every `NewAuthStore`, so existing `0644` files left behind by older Debian installs are re-narrowed automatically on the next server start; no operator action is required for the typical upgrade path.

## Scope note

This PR fixes the Go-side bug only. The companion Debian packaging fix mentioned in #249 — running `-add-user` as the `pgedge` user rather than `root` in the postinst — has to land separately in the packaging repository, which lives outside this checkout. For that reason this PR intentionally does not use `Closes #249`; I will leave a comment on the issue once both halves are merged so it can be closed by hand.

## Test plan

- [x] New unit tests in `server/src/internal/auth/store_test.go`:
  - `TestNewAuthStore_FilePermissions` — end-to-end regression assert: created `auth.db` is `0600` **and** no `Failed to set permissions` log line was emitted. Confirmed by temporarily reverting the fix that this test fails with the original bug.
  - `TestRestrictAuthDBPermissions` — four subtests covering happy path, chmod error, post-chmod stat error, and the silent-ignore mode-mismatch case (uses package-private `authDBChmod` / `authDBStat` function-variable seams, restored via `t.Cleanup`).
  - `TestNewAuthStore_UnsafePermissionsAbortStartup` — drives the silent-ignore path through `NewAuthStore` itself and asserts the constructor returns `nil, error`, the error wraps the helper's message and mentions `0600`, the file exists on disk (so a future refactor that moves chmod earlier would visibly regress), and a follow-up `NewAuthStore` after restoring the real seams still succeeds (probes the closed-handle contract via SQLite's POSIX file locks).
- [x] `cd server && make build` clean.
- [x] `cd server && make test` — all 21 server packages `ok`, including `internal/auth`.
- [x] `gofmt -l server/src/internal/auth/` prints nothing; `go vet ./internal/auth/...` clean; `make lint` reports `0 issues` for `collector`, `server`, `alerter`.
- [x] `make test-all` from the repo root passes for all four sub-projects.
- [x] Coverage: `restrictAuthDBPermissions` at 100% function coverage; new error-return path in `NewAuthStore` covered by both the happy-path and abort-startup tests. `NewAuthStore` aggregate sits at 66.7%, a pre-existing baseline driven by unrelated `initSchema` / migration / FK-pragma error branches that were not exercised before this change either.

## Notes for reviewers

- Considered, deferred to follow-up: pre-creating `auth.db` with `O_CREATE|O_EXCL, 0600` before `sql.Open` to close the (brief) TOCTOU window between SQLite's umask-mode create and our chmod. The data directory at `0700` already restricts directory enumeration, so this is a "nice to have" hardening rather than a fix; happy to track in a follow-up issue.
- Considered, decided against here: an opt-in config flag to bypass the fail-closed check for operators who knowingly run on chmod-ignoring filesystems. We can add it if anyone asks; out of scope for the security fix.

Refs #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enforces stricter file permissions (0600) on the authentication database at startup, logs warnings if permission changes fail, and prevents the server from starting on filesystems that silently ignore permission changes.
  * Validates that database foreign key constraints are properly enabled on startup.

* **Tests**
  * Added comprehensive test coverage for authentication database permission enforcement and startup validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->