### PR TITLE
feat(server): add get_timeline_events MCP tool (#250)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,22 @@ project adheres to
 
 ## [1.0.0-beta3] - Unreleased
 
+### Added
+
+- Add the `get_timeline_events` MCP tool, which exposes
+  the unified incident-investigation timeline that was
+  previously only reachable through the
+  `/api/v1/timeline/events` REST endpoint. The tool
+  returns configuration changes, HBA and ident edits,
+  server restarts, extension changes, alert
+  fired/cleared/acknowledged events, and blackout
+  start/end markers in a single TSV result ordered most
+  recent first. Ellie and other MCP clients can now
+  correlate alerts with the underlying changes that may
+  have caused them without falling back to direct REST
+  calls. The tool gates results through the same RBAC
+  checks as `get_alert_history`. (#250)
+
 ### Fixed
 
 - Fix the web client crashing into the "Something

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -165,6 +165,7 @@ builtins:
     get_alert_rules: true
     get_metric_baselines: true
     get_blackouts: true
+    get_timeline_events: true
     query_datastore: true
     generate_embedding: true
     search_knowledgebase: true
@@ -570,6 +571,7 @@ builtins:
     get_alert_rules: true
     get_metric_baselines: true
     get_blackouts: true
+    get_timeline_events: true
     query_datastore: true
     generate_embedding: true
     search_knowledgebase: true

--- a/docs/user-guide/ai/ask-ellie.md
+++ b/docs/user-guide/ai/ask-ellie.md
@@ -26,6 +26,9 @@ capabilities:
 - The assistant analyzes query execution plans.
 - The assistant reviews alert history and alert rule
   configuration.
+- The assistant correlates alerts with configuration
+  changes, restarts, HBA edits, extension changes, and
+  blackout windows through the unified event timeline.
 - The assistant stores and recalls persistent memories
   across conversations.
 
@@ -120,6 +123,7 @@ table describes the available tools:
 | `recall_memories` | Searches stored memories by semantic similarity. |
 | `delete_memory` | Removes a stored memory by its ID. |
 | `get_blackouts` | Queries blackout periods and recurring schedules. |
+| `get_timeline_events` | Queries the unified incident-investigation timeline of configuration changes, restarts, extension changes, alerts, and blackouts. |
 
 ## Chat Memory
 

--- a/docs/user-guide/mcp-tools.md
+++ b/docs/user-guide/mcp-tools.md
@@ -52,6 +52,7 @@ These tools query alert data from the monitoring system.
 | `get_alert_rules` | Queries alert rules and their effective thresholds. |
 | `get_metric_baselines` | Queries statistical baselines for anomaly detection. |
 | `get_blackouts` | Queries blackout periods and recurring schedules for monitored connections. |
+| `get_timeline_events` | Queries the unified incident-investigation timeline of configuration changes, restarts, extension changes, alerts, and blackouts. |
 
 ## Memory Tools
 

--- a/server/src/cmd/mcp-server/privileges.go
+++ b/server/src/cmd/mcp-server/privileges.go
@@ -360,6 +360,7 @@ func registerMCPPrivileges(store *auth.AuthStore) {
 		{"get_alert_history", "tool", "Query alert history for monitored connections", false},
 		{"get_alert_rules", "tool", "Query current alerting rules and effective thresholds", false},
 		{"get_metric_baselines", "tool", "Query statistical baselines for metrics used in anomaly detection", false},
+		{"get_timeline_events", "tool", "Query the incident-investigation timeline of significant events", false},
 
 		// Memory Tools - PUBLIC (have their own internal user-scoped authorization)
 		{"store_memory", "tool", "Store persistent memory", true},

--- a/server/src/internal/chat/llm.go
+++ b/server/src/internal/chat/llm.go
@@ -54,6 +54,7 @@ You have access to TWO types of database connections:
    - list_probes: List available metrics probes being collected
    - describe_probe: Get column details for a specific probe
    - query_metrics: Query historical metrics with time-based aggregation
+   - get_timeline_events: Query the unified incident-investigation timeline of configuration changes, HBA/ident edits, restarts, extension changes, alerts (fired/cleared/acknowledged), and blackout start/end markers. Prefer this over get_alert_history and get_blackouts when investigating "what happened" or "what changed" around an incident, because it returns config/HBA/restart/extension events those other tools cannot see.
    The datastore contains metrics collected from monitored servers over time.
 
 2. MONITORED DATABASES (live connections) - Use these tools for live queries:

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -87,6 +87,7 @@ type ToolsConfig struct {
 	GetAlertRules       *bool `yaml:"get_alert_rules"`      // Query alert rules and thresholds (default: true)
 	GetMetricBaselines  *bool `yaml:"get_metric_baselines"` // Query metric baselines for anomaly context (default: true)
 	QueryDatastore      *bool `yaml:"query_datastore"`      // Execute read-only SQL against the datastore (default: true)
+	GetTimelineEvents   *bool `yaml:"get_timeline_events"`  // Query the incident-investigation timeline (default: true)
 	StoreMemory         *bool `yaml:"store_memory"`         // Store chat memories for future recall (default: true)
 	RecallMemories      *bool `yaml:"recall_memories"`      // Recall stored chat memories by similarity (default: true)
 	DeleteMemory        *bool `yaml:"delete_memory"`        // Delete a stored chat memory by ID (default: true)
@@ -138,6 +139,8 @@ func (c *ToolsConfig) IsToolEnabled(toolName string) bool {
 		return c.GetMetricBaselines == nil || *c.GetMetricBaselines
 	case "query_datastore":
 		return c.QueryDatastore == nil || *c.QueryDatastore
+	case "get_timeline_events":
+		return c.GetTimelineEvents == nil || *c.GetTimelineEvents
 	case "store_memory":
 		return c.StoreMemory == nil || *c.StoreMemory
 	case "recall_memories":

--- a/server/src/internal/tools/context_aware_provider.go
+++ b/server/src/internal/tools/context_aware_provider.go
@@ -129,6 +129,9 @@ func (p *ContextAwareProvider) registerDatastoreTools(registry *Registry) {
 		if p.cfg.Builtins.Tools.IsToolEnabled("get_blackouts") {
 			registry.Register("get_blackouts", GetBlackoutsTool(datastorePool, p.rbacChecker, visibilityLister))
 		}
+		if p.cfg.Builtins.Tools.IsToolEnabled("get_timeline_events") {
+			registry.Register("get_timeline_events", GetTimelineEventsTool(p.datastore, p.rbacChecker, visibilityLister))
+		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("store_memory") && p.memoryStore != nil {
 			registry.Register("store_memory", StoreMemoryTool(p.memoryStore, p.cfg, p.rbacChecker))
 		}
@@ -168,6 +171,9 @@ func (p *ContextAwareProvider) registerDatastoreTools(registry *Registry) {
 		}
 		if p.cfg.Builtins.Tools.IsToolEnabled("get_blackouts") {
 			registry.Register("get_blackouts", GetBlackoutsTool(nil, p.rbacChecker, nil))
+		}
+		if p.cfg.Builtins.Tools.IsToolEnabled("get_timeline_events") {
+			registry.Register("get_timeline_events", GetTimelineEventsTool(nil, p.rbacChecker, nil))
 		}
 	}
 }
@@ -456,6 +462,7 @@ func (p *ContextAwareProvider) Execute(ctx context.Context, name string, args ma
 		"get_metric_baselines": true,                 // Datastore tool - uses shared datastore pool
 		"query_datastore":      true,                 // Datastore tool - uses shared datastore pool
 		"get_blackouts":        true,                 // Datastore tool - uses shared datastore pool
+		"get_timeline_events":  true,                 // Datastore tool - uses shared datastore pool
 		"store_memory":         p.memoryStore != nil, // Memory tool - requires memory store
 		"recall_memories":      p.memoryStore != nil, // Memory tool - requires memory store
 		"delete_memory":        p.memoryStore != nil, // Memory tool - requires memory store

--- a/server/src/internal/tools/context_aware_provider.go
+++ b/server/src/internal/tools/context_aware_provider.go
@@ -462,7 +462,7 @@ func (p *ContextAwareProvider) Execute(ctx context.Context, name string, args ma
 		"get_metric_baselines": true,                 // Datastore tool - uses shared datastore pool
 		"query_datastore":      true,                 // Datastore tool - uses shared datastore pool
 		"get_blackouts":        true,                 // Datastore tool - uses shared datastore pool
-		"get_timeline_events":  true,                 // Datastore tool - uses shared datastore pool
+		"get_timeline_events":  true,                 // Datastore tool - uses full Datastore for typed queries
 		"store_memory":         p.memoryStore != nil, // Memory tool - requires memory store
 		"recall_memories":      p.memoryStore != nil, // Memory tool - requires memory store
 		"delete_memory":        p.memoryStore != nil, // Memory tool - requires memory store

--- a/server/src/internal/tools/context_aware_provider_test.go
+++ b/server/src/internal/tools/context_aware_provider_test.go
@@ -67,7 +67,7 @@ func TestContextAwareProvider_List(t *testing.T) {
 		// List tools - should return all tools
 		tools := provider.List()
 
-		// Should have all 17 tools (no filtering)
+		// Should have all 18 tools (no filtering)
 		expectedTools := []string{
 			"read_resource",
 			"generate_embedding",
@@ -85,6 +85,7 @@ func TestContextAwareProvider_List(t *testing.T) {
 			"get_metric_baselines",
 			"query_datastore",
 			"get_blackouts",
+			"get_timeline_events",
 			"test_query",
 		}
 

--- a/server/src/internal/tools/get_timeline_events.go
+++ b/server/src/internal/tools/get_timeline_events.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/database"
 	"github.com/pgedge/ai-workbench/server/internal/mcp"
@@ -42,19 +43,12 @@ const (
 	timelineDefaultRange = 24 * time.Hour
 )
 
-// GetTimelineEventsTool creates the get_timeline_events tool for querying
-// the unified incident-investigation timeline.
-//
-// The tool wraps database.GetTimelineEvents and gates results behind the
-// same RBAC checks used by get_alert_history: callers may only see events
-// for connections they have access to. The visibilityLister argument may
-// be nil in unit tests; auth.RBACChecker.VisibleConnectionIDs tolerates a
-// nil lister by falling back to group/token-granted IDs only.
-func GetTimelineEventsTool(datastore *database.Datastore, rbacChecker *auth.RBACChecker, visibilityLister auth.ConnectionVisibilityLister) Tool {
-	return Tool{
-		Definition: mcp.Tool{
-			Name: "get_timeline_events",
-			Description: `Query the incident-investigation timeline of significant events.
+// timelineToolDescription is the long-form description shown to clients
+// when they introspect the get_timeline_events tool. It lives at package
+// scope so the schema builder stays short enough to fit under Lizard's
+// NLOC limit; the contents are unchanged from the previous in-function
+// literal.
+const timelineToolDescription = `Query the incident-investigation timeline of significant events.
 
 <database_context>
 This tool queries the DATASTORE for events that matter most when
@@ -106,180 +100,369 @@ Returns TSV data ordered by event time (most recent first):
 - get_timeline_events(start_time="7d") - last seven days
 - get_timeline_events(event_types="config_change,restart") - only restarts and config changes
 - get_timeline_events(start_time="2026-05-01T00:00:00Z", end_time="2026-05-02T00:00:00Z") - explicit window
-</examples>`,
-			CompactDescription: `Query the incident-investigation timeline of configuration changes, restarts, HBA/ident edits, extension changes, alerts, and blackouts across monitored connections. Defaults to the last 24 hours.`,
-			InputSchema: mcp.InputSchema{
-				Type: "object",
-				Properties: map[string]any{
-					"connection_id": map[string]any{
-						"type":        "integer",
-						"description": "ID of a monitored connection. Omit to return events across all accessible connections.",
-					},
-					"start_time": map[string]any{
-						"type":        "string",
-						"description": "Start of time range. Relative duration (e.g. '1h', '24h', '7d') or ISO 8601. Default: 24h.",
-						"default":     "24h",
-					},
-					"end_time": map[string]any{
-						"type":        "string",
-						"description": "End of time range. ISO 8601. Default: now.",
-					},
-					"event_types": map[string]any{
-						"type":        "string",
-						"description": "Comma-separated event types to include. Valid: config_change, hba_change, ident_change, restart, alert_fired, alert_cleared, alert_acknowledged, extension_change, blackout_started, blackout_ended.",
-					},
-					"limit": map[string]any{
-						"type":        "integer",
-						"description": "Maximum number of events to return (1-500). Default: 100.",
-						"default":     timelineDefaultLimit,
-						"minimum":     1,
-						"maximum":     timelineMaxLimit,
-					},
-				},
-				Required: []string{},
-			},
-		},
+</examples>`
+
+// timelineToolCompactDescription is the short single-line description.
+const timelineToolCompactDescription = `Query the incident-investigation timeline of configuration changes, restarts, HBA/ident edits, extension changes, alerts, and blackouts across monitored connections. Defaults to the last 24 hours.`
+
+// timelineRequest captures the parsed and RBAC-validated inputs for a
+// single get_timeline_events invocation. It is constructed by
+// buildTimelineRequest and consumed by the tool handler.
+type timelineRequest struct {
+	singleConnection bool
+	connectionID     int
+	connName         string
+	allConnections   bool
+	accessibleIDs    []int
+	startTime        time.Time
+	endTime          time.Time
+	eventTypes       []string
+	limit            int
+}
+
+// GetTimelineEventsTool creates the get_timeline_events tool for querying
+// the unified incident-investigation timeline.
+//
+// The tool wraps database.GetTimelineEvents and gates results behind the
+// same RBAC checks used by get_alert_history: callers may only see events
+// for connections they have access to. The visibilityLister argument may
+// be nil in unit tests; auth.RBACChecker.VisibleConnectionIDs tolerates a
+// nil lister by falling back to group/token-granted IDs only.
+func GetTimelineEventsTool(datastore *database.Datastore, rbacChecker *auth.RBACChecker, visibilityLister auth.ConnectionVisibilityLister) Tool {
+	return Tool{
+		Definition: timelineToolDefinition(),
 		Handler: func(args map[string]any) (mcp.ToolResponse, error) {
-			if datastore == nil {
-				return mcp.NewToolError("Datastore not configured. The get_timeline_events tool requires a datastore connection.")
-			}
-
-			ctx, ok := args["__context"].(context.Context)
-			if !ok {
-				ctx = context.Background()
-			}
-
-			// Single-connection vs multi-connection mode
-			singleConnection := false
-			var connectionID int
-			var connName string
-			pool := datastore.GetPool()
-			if _, hasConnID := args["connection_id"]; hasConnID {
-				cid, err := parseIntArg(args, "connection_id")
-				if err != nil {
-					return mcp.NewToolError("Invalid 'connection_id' parameter: must be an integer. Use list_connections to find available connection IDs.")
-				}
-				connectionID = cid
-				singleConnection = true
-
-				if pool != nil {
-					err = pool.QueryRow(ctx, "SELECT name FROM connections WHERE id = $1", connectionID).Scan(&connName)
-					if err != nil {
-						return mcp.NewToolError(fmt.Sprintf("Connection ID %d does not exist. Use list_connections to see available connections.", connectionID))
-					}
-				}
-
-				if rbacChecker != nil {
-					canAccess, _ := rbacChecker.CanAccessConnection(ctx, connectionID)
-					if !canAccess {
-						return mcp.NewToolError(fmt.Sprintf("Access denied: you do not have permission to access connection ID %d.", connectionID))
-					}
-				}
-			}
-
-			// Resolve accessible connections for multi-connection mode. The
-			// semantics mirror get_alert_history: superusers / wildcard
-			// tokens see allConnections=true; restricted users get an
-			// explicit set; a zero-length set with allConnections=false
-			// means "no access" and we short-circuit.
-			var accessibleIDs []int
-			allConnections := true
-			if !singleConnection && rbacChecker != nil {
-				ids, all, err := rbacChecker.VisibleConnectionIDs(ctx, visibilityLister)
-				if err != nil {
-					return mcp.NewToolError(fmt.Sprintf("Failed to resolve accessible connections: %v", err))
-				}
-				accessibleIDs = ids
-				allConnections = all
-				if !allConnections && len(accessibleIDs) == 0 {
-					return mcp.NewToolSuccess("No timeline events found. You do not have access to any connections.")
-				}
-			}
-
-			// Parse limit (default 100, clamped to [1, 500]).
-			limit := timelineDefaultLimit
-			if limitVal, ok := args["limit"]; ok && limitVal != nil {
-				l, err := parseIntArg(args, "limit")
-				if err != nil {
-					return mcp.NewToolError("Invalid 'limit' parameter: must be an integer between 1 and 500")
-				}
-				if l < 1 {
-					return mcp.NewToolError("Invalid 'limit' parameter: must be an integer between 1 and 500")
-				}
-				if l > timelineMaxLimit {
-					l = timelineMaxLimit
-				}
-				limit = l
-			}
-
-			// Parse end_time (default: now).
-			endTime := time.Now().UTC()
-			if endStr, ok := args["end_time"].(string); ok && endStr != "" && endStr != "now" {
-				parsed, err := parseTimeArg(endStr)
-				if err != nil {
-					return mcp.NewToolError("Invalid 'end_time' parameter: use ISO 8601 format")
-				}
-				endTime = parsed
-			}
-
-			// Parse start_time (default: end_time - 24h). Accept either a
-			// relative duration ("24h", "7d") or an absolute timestamp.
-			startTime := endTime.Add(-timelineDefaultRange)
-			if startStr, ok := args["start_time"].(string); ok && startStr != "" {
-				if dur, err := parseRelativeDuration(startStr); err == nil {
-					startTime = endTime.Add(-dur)
-				} else if parsed, err := parseTimeArg(startStr); err == nil {
-					startTime = parsed
-				} else {
-					return mcp.NewToolError("Invalid 'start_time' parameter: use relative duration (e.g., '24h', '7d') or ISO 8601 format")
-				}
-			}
-
-			if !startTime.Before(endTime) {
-				return mcp.NewToolError("Invalid time range: start_time must be before end_time")
-			}
-
-			// Parse and validate event_types filter.
-			var eventTypes []string
-			if etRaw, ok := args["event_types"].(string); ok && etRaw != "" {
-				valid := make(map[string]bool, len(timelineEventTypes))
-				for _, t := range timelineEventTypes {
-					valid[t] = true
-				}
-				for _, raw := range strings.Split(etRaw, ",") {
-					t := strings.TrimSpace(raw)
-					if t == "" {
-						continue
-					}
-					if !valid[t] {
-						return mcp.NewToolError(fmt.Sprintf("Invalid event_type %q. Valid values: %s",
-							t, strings.Join(timelineEventTypes, ", ")))
-					}
-					eventTypes = append(eventTypes, t)
-				}
-			}
-
-			filter := database.TimelineFilter{
-				StartTime:  startTime,
-				EndTime:    endTime,
-				EventTypes: eventTypes,
-				Limit:      limit,
-			}
-			if singleConnection {
-				cid := connectionID
-				filter.ConnectionID = &cid
-			} else if !allConnections {
-				filter.ConnectionIDs = accessibleIDs
-			}
-
-			result, err := datastore.GetTimelineEvents(ctx, filter)
-			if err != nil {
-				return mcp.NewToolError(fmt.Sprintf("Failed to query timeline events: %v", err))
-			}
-
-			return mcp.NewToolSuccess(formatTimelineEvents(result, singleConnection, connectionID, connName, startTime, endTime, limit))
+			return runTimelineHandler(args, datastore, rbacChecker, visibilityLister)
 		},
 	}
+}
+
+// timelineToolDefinition returns the mcp.Tool definition (name, schema,
+// and prose descriptions) for get_timeline_events. The prose lives in
+// timelineToolDescription / timelineToolCompactDescription so this
+// builder stays short enough to satisfy the Lizard NLOC limit.
+func timelineToolDefinition() mcp.Tool {
+	return mcp.Tool{
+		Name:               "get_timeline_events",
+		Description:        timelineToolDescription,
+		CompactDescription: timelineToolCompactDescription,
+		InputSchema:        timelineToolInputSchema(),
+	}
+}
+
+// timelineToolInputSchema describes the parameters accepted by
+// get_timeline_events. Each entry mirrors the documentation in
+// timelineToolDescription; both must stay in sync.
+func timelineToolInputSchema() mcp.InputSchema {
+	return mcp.InputSchema{
+		Type: "object",
+		Properties: map[string]any{
+			"connection_id": map[string]any{
+				"type":        "integer",
+				"description": "ID of a monitored connection. Omit to return events across all accessible connections.",
+			},
+			"start_time": map[string]any{
+				"type":        "string",
+				"description": "Start of time range. Relative duration (e.g. '1h', '24h', '7d') or ISO 8601. Default: 24h.",
+				"default":     "24h",
+			},
+			"end_time": map[string]any{
+				"type":        "string",
+				"description": "End of time range. ISO 8601. Default: now.",
+			},
+			"event_types": map[string]any{
+				"type":        "string",
+				"description": "Comma-separated event types to include. Valid: config_change, hba_change, ident_change, restart, alert_fired, alert_cleared, alert_acknowledged, extension_change, blackout_started, blackout_ended.",
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of events to return (1-500). Default: 100.",
+				"default":     timelineDefaultLimit,
+				"minimum":     1,
+				"maximum":     timelineMaxLimit,
+			},
+		},
+		Required: []string{},
+	}
+}
+
+// runTimelineHandler executes a single get_timeline_events call. It
+// validates the datastore, builds the parsed timelineRequest, runs the
+// query, and formats the result. All parse/RBAC errors short-circuit
+// here via the *mcp.ToolResponse returned by buildTimelineRequest.
+func runTimelineHandler(
+	args map[string]any,
+	datastore *database.Datastore,
+	rbacChecker *auth.RBACChecker,
+	visibilityLister auth.ConnectionVisibilityLister,
+) (mcp.ToolResponse, error) {
+	if datastore == nil {
+		return mcp.NewToolError("Datastore not configured. The get_timeline_events tool requires a datastore connection.")
+	}
+
+	ctx, ok := args["__context"].(context.Context)
+	if !ok {
+		ctx = context.Background()
+	}
+
+	req, earlyResp, err := buildTimelineRequest(ctx, args, datastore, rbacChecker, visibilityLister)
+	if earlyResp != nil {
+		return *earlyResp, err
+	}
+
+	filter := timelineFilterFromRequest(req)
+	result, qerr := datastore.GetTimelineEvents(ctx, filter)
+	if qerr != nil {
+		return mcp.NewToolError(fmt.Sprintf("Failed to query timeline events: %v", qerr))
+	}
+
+	return mcp.NewToolSuccess(formatTimelineEvents(result, req.singleConnection, req.connectionID, req.connName, req.startTime, req.endTime, req.limit))
+}
+
+// buildTimelineRequest parses and validates every argument map entry the
+// handler cares about. When a parse, RBAC, or short-circuit response is
+// required it returns that response (with the accompanying error from
+// the mcp helper, which is always nil today) so the caller can forward
+// it verbatim. On success it returns a populated timelineRequest and a
+// nil response pointer.
+func buildTimelineRequest(
+	ctx context.Context,
+	args map[string]any,
+	datastore *database.Datastore,
+	rbacChecker *auth.RBACChecker,
+	visibilityLister auth.ConnectionVisibilityLister,
+) (timelineRequest, *mcp.ToolResponse, error) {
+	var req timelineRequest
+
+	single, connID, connName, resp, err := resolveTimelineConnection(ctx, args, datastore.GetPool(), rbacChecker)
+	if resp != nil {
+		return req, resp, err
+	}
+	req.singleConnection = single
+	req.connectionID = connID
+	req.connName = connName
+
+	accessibleIDs, allConnections, resp, err := resolveTimelineAccessibleIDs(ctx, single, rbacChecker, visibilityLister)
+	if resp != nil {
+		return req, resp, err
+	}
+	req.accessibleIDs = accessibleIDs
+	req.allConnections = allConnections
+
+	limit, resp, err := parseTimelineLimit(args)
+	if resp != nil {
+		return req, resp, err
+	}
+	req.limit = limit
+
+	start, end, resp, err := parseTimelineWindow(args)
+	if resp != nil {
+		return req, resp, err
+	}
+	req.startTime = start
+	req.endTime = end
+
+	eventTypes, resp, err := parseTimelineEventTypes(args)
+	if resp != nil {
+		return req, resp, err
+	}
+	req.eventTypes = eventTypes
+
+	return req, nil, nil
+}
+
+// timelineFilterFromRequest projects a validated timelineRequest onto
+// the database.TimelineFilter struct used by GetTimelineEvents. The
+// connection scoping rules mirror the original handler: a single
+// connection populates ConnectionID; a restricted multi-connection mode
+// populates ConnectionIDs; an unrestricted multi-connection mode leaves
+// both unset so the underlying query sees no connection filter.
+func timelineFilterFromRequest(req timelineRequest) database.TimelineFilter {
+	filter := database.TimelineFilter{
+		StartTime:  req.startTime,
+		EndTime:    req.endTime,
+		EventTypes: req.eventTypes,
+		Limit:      req.limit,
+	}
+	if req.singleConnection {
+		cid := req.connectionID
+		filter.ConnectionID = &cid
+	} else if !req.allConnections {
+		filter.ConnectionIDs = req.accessibleIDs
+	}
+	return filter
+}
+
+// resolveTimelineConnection parses an optional connection_id argument,
+// looks up the connection name when a pool is available, and performs
+// the per-connection RBAC check. When connection_id is absent it
+// returns singleConnection=false and a nil short-circuit response. A
+// non-nil *mcp.ToolResponse indicates the caller should return that
+// response immediately.
+func resolveTimelineConnection(
+	ctx context.Context,
+	args map[string]any,
+	pool *pgxpool.Pool,
+	rbacChecker *auth.RBACChecker,
+) (bool, int, string, *mcp.ToolResponse, error) {
+	if _, hasConnID := args["connection_id"]; !hasConnID {
+		return false, 0, "", nil, nil
+	}
+
+	cid, err := parseIntArg(args, "connection_id")
+	if err != nil {
+		resp, rerr := mcp.NewToolError("Invalid 'connection_id' parameter: must be an integer. Use list_connections to find available connection IDs.")
+		return false, 0, "", &resp, rerr
+	}
+
+	var connName string
+	if pool != nil {
+		if qerr := pool.QueryRow(ctx, "SELECT name FROM connections WHERE id = $1", cid).Scan(&connName); qerr != nil {
+			resp, rerr := mcp.NewToolError(fmt.Sprintf("Connection ID %d does not exist. Use list_connections to see available connections.", cid))
+			return false, 0, "", &resp, rerr
+		}
+	}
+
+	if rbacChecker != nil {
+		canAccess, _ := rbacChecker.CanAccessConnection(ctx, cid)
+		if !canAccess {
+			resp, rerr := mcp.NewToolError(fmt.Sprintf("Access denied: you do not have permission to access connection ID %d.", cid))
+			return false, 0, "", &resp, rerr
+		}
+	}
+
+	return true, cid, connName, nil, nil
+}
+
+// resolveTimelineAccessibleIDs wraps RBACChecker.VisibleConnectionIDs
+// for the multi-connection mode. When singleConnection is true the
+// caller has already scoped the query, so this returns the "all
+// connections" default unchanged. When the caller has no visible
+// connections at all the function returns the explicit "no access"
+// success message used by the original handler; tests check for this
+// exact wording.
+func resolveTimelineAccessibleIDs(
+	ctx context.Context,
+	singleConnection bool,
+	rbacChecker *auth.RBACChecker,
+	visibilityLister auth.ConnectionVisibilityLister,
+) ([]int, bool, *mcp.ToolResponse, error) {
+	if singleConnection || rbacChecker == nil {
+		return nil, true, nil, nil
+	}
+
+	ids, all, err := rbacChecker.VisibleConnectionIDs(ctx, visibilityLister)
+	if err != nil {
+		resp, rerr := mcp.NewToolError(fmt.Sprintf("Failed to resolve accessible connections: %v", err))
+		return nil, false, &resp, rerr
+	}
+
+	if !all && len(ids) == 0 {
+		resp, rerr := mcp.NewToolSuccess("No timeline events found. You do not have access to any connections.")
+		return nil, false, &resp, rerr
+	}
+
+	return ids, all, nil, nil
+}
+
+// parseTimelineLimit parses, validates, and clamps the optional limit
+// argument. It rejects non-integer values and integers below 1 with
+// the exact error string the integration tests check for, and clamps
+// values above timelineMaxLimit to the maximum.
+func parseTimelineLimit(args map[string]any) (int, *mcp.ToolResponse, error) {
+	limitVal, ok := args["limit"]
+	if !ok || limitVal == nil {
+		return timelineDefaultLimit, nil, nil
+	}
+
+	l, err := parseIntArg(args, "limit")
+	if err != nil || l < 1 {
+		resp, rerr := mcp.NewToolError("Invalid 'limit' parameter: must be an integer between 1 and 500")
+		return 0, &resp, rerr
+	}
+	if l > timelineMaxLimit {
+		l = timelineMaxLimit
+	}
+	return l, nil, nil
+}
+
+// parseTimelineWindow parses optional end_time and start_time arguments
+// and validates the resulting range. end_time defaults to now and
+// accepts ISO 8601; start_time defaults to end_time - 24h and accepts
+// either a relative duration ("24h", "7d") or an ISO 8601 timestamp.
+// An inverted range yields the documented error.
+func parseTimelineWindow(args map[string]any) (time.Time, time.Time, *mcp.ToolResponse, error) {
+	endTime := time.Now().UTC()
+	if endStr, ok := args["end_time"].(string); ok && endStr != "" && endStr != "now" {
+		parsed, err := parseTimeArg(endStr)
+		if err != nil {
+			resp, rerr := mcp.NewToolError("Invalid 'end_time' parameter: use ISO 8601 format")
+			return time.Time{}, time.Time{}, &resp, rerr
+		}
+		endTime = parsed
+	}
+
+	startTime := endTime.Add(-timelineDefaultRange)
+	if startStr, ok := args["start_time"].(string); ok && startStr != "" {
+		parsed, perr := parseTimelineStart(startStr, endTime)
+		if perr != nil {
+			resp, rerr := mcp.NewToolError("Invalid 'start_time' parameter: use relative duration (e.g., '24h', '7d') or ISO 8601 format")
+			return time.Time{}, time.Time{}, &resp, rerr
+		}
+		startTime = parsed
+	}
+
+	if !startTime.Before(endTime) {
+		resp, rerr := mcp.NewToolError("Invalid time range: start_time must be before end_time")
+		return time.Time{}, time.Time{}, &resp, rerr
+	}
+	return startTime, endTime, nil, nil
+}
+
+// parseTimelineStart resolves the start_time string against the
+// already-parsed endTime anchor. It first tries to read the value as a
+// relative duration (e.g. "24h", "7d") which is subtracted from
+// endTime, then falls back to an absolute ISO 8601 timestamp. The
+// caller maps a non-nil error onto the documented error response.
+func parseTimelineStart(startStr string, endTime time.Time) (time.Time, error) {
+	if dur, err := parseRelativeDuration(startStr); err == nil {
+		return endTime.Add(-dur), nil
+	}
+	if parsed, err := parseTimeArg(startStr); err == nil {
+		return parsed, nil
+	}
+	return time.Time{}, fmt.Errorf("invalid start_time")
+}
+
+// parseTimelineEventTypes parses an optional comma-separated event_types
+// filter against the canonical timelineEventTypes set. Empty entries
+// (e.g. trailing commas or whitespace) are silently skipped; an
+// unrecognized entry produces the documented error.
+func parseTimelineEventTypes(args map[string]any) ([]string, *mcp.ToolResponse, error) {
+	etRaw, ok := args["event_types"].(string)
+	if !ok || etRaw == "" {
+		return nil, nil, nil
+	}
+
+	valid := make(map[string]bool, len(timelineEventTypes))
+	for _, t := range timelineEventTypes {
+		valid[t] = true
+	}
+
+	var eventTypes []string
+	for _, raw := range strings.Split(etRaw, ",") {
+		t := strings.TrimSpace(raw)
+		if t == "" {
+			continue
+		}
+		if !valid[t] {
+			resp, rerr := mcp.NewToolError(fmt.Sprintf("Invalid event_type %q. Valid values: %s",
+				t, strings.Join(timelineEventTypes, ", ")))
+			return nil, &resp, rerr
+		}
+		eventTypes = append(eventTypes, t)
+	}
+	return eventTypes, nil, nil
 }
 
 // formatTimelineEvents renders a TimelineResult as TSV with a header

--- a/server/src/internal/tools/get_timeline_events.go
+++ b/server/src/internal/tools/get_timeline_events.go
@@ -1,0 +1,331 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+	"github.com/pgedge/ai-workbench/server/internal/mcp"
+	"github.com/pgedge/ai-workbench/server/internal/tsv"
+)
+
+// timelineEventTypes lists the event types accepted by the tool. Values
+// match the constants in database/timeline_queries.go.
+var timelineEventTypes = []string{
+	database.EventTypeConfigChange,
+	database.EventTypeHBAChange,
+	database.EventTypeIdentChange,
+	database.EventTypeRestart,
+	database.EventTypeAlertFired,
+	database.EventTypeAlertCleared,
+	database.EventTypeAlertAcknowledged,
+	database.EventTypeExtensionChange,
+	database.EventTypeBlackoutStarted,
+	database.EventTypeBlackoutEnded,
+}
+
+const (
+	timelineDefaultLimit = 100
+	timelineMaxLimit     = 500
+	timelineDefaultRange = 24 * time.Hour
+)
+
+// GetTimelineEventsTool creates the get_timeline_events tool for querying
+// the unified incident-investigation timeline.
+//
+// The tool wraps database.GetTimelineEvents and gates results behind the
+// same RBAC checks used by get_alert_history: callers may only see events
+// for connections they have access to. The visibilityLister argument may
+// be nil in unit tests; auth.RBACChecker.VisibleConnectionIDs tolerates a
+// nil lister by falling back to group/token-granted IDs only.
+func GetTimelineEventsTool(datastore *database.Datastore, rbacChecker *auth.RBACChecker, visibilityLister auth.ConnectionVisibilityLister) Tool {
+	return Tool{
+		Definition: mcp.Tool{
+			Name: "get_timeline_events",
+			Description: `Query the incident-investigation timeline of significant events.
+
+<database_context>
+This tool queries the DATASTORE for events that matter most when
+investigating incidents: configuration changes, HBA edits, ident-mapping
+updates, server restarts, extension changes, blackout start and end
+markers, and alert fired/cleared/acknowledged events. Events from all
+sources are merged and returned in descending time order.
+</database_context>
+
+<important_behavior>
+ALWAYS check pg://connection_info first to find the current connection.
+
+If a connection IS selected (connected: true):
+- Specify connection_id to filter the timeline for that connection
+- "My database" or "the database" means the currently selected connection
+
+If NO connection is selected (connected: false):
+- Omit connection_id to see events across ALL accessible connections
+- The user can also specify a connection_id to filter to one connection
+
+Use this tool when the user asks what changed before an incident, what
+restarts or config changes have occurred, or to correlate alerts with
+the underlying changes that may have caused them.
+</important_behavior>
+
+<parameters>
+- connection_id: (optional) ID of a monitored connection. Omit to return events across all accessible connections.
+- start_time: Start of time range (default: 24h). Relative duration (1h, 24h, 7d) or ISO 8601 format.
+- end_time: End of time range (default: now). ISO 8601 format.
+- event_types: (optional) Comma-separated list of event types to include. Valid values: config_change, hba_change, ident_change, restart, alert_fired, alert_cleared, alert_acknowledged, extension_change, blackout_started, blackout_ended.
+- limit: Maximum number of events to return (1-500, default: 100).
+</parameters>
+
+<output>
+Returns TSV data ordered by event time (most recent first):
+- connection_id: Connection ID the event applies to (0 for non-server-scoped blackouts)
+- server_name: Connection or scope name
+- event_time: When the event occurred (RFC 3339)
+- event_type: One of the timeline event types
+- severity: info, warning, or critical
+- title: Short human-readable title
+- summary: One-line description of the event
+- id: Event identifier (composite, unique per row)
+</output>
+
+<examples>
+- get_timeline_events() - last 24 hours across all accessible connections
+- get_timeline_events(connection_id=5) - timeline for connection 5
+- get_timeline_events(start_time="7d") - last seven days
+- get_timeline_events(event_types="config_change,restart") - only restarts and config changes
+- get_timeline_events(start_time="2026-05-01T00:00:00Z", end_time="2026-05-02T00:00:00Z") - explicit window
+</examples>`,
+			CompactDescription: `Query the incident-investigation timeline of configuration changes, restarts, HBA/ident edits, extension changes, alerts, and blackouts across monitored connections. Defaults to the last 24 hours.`,
+			InputSchema: mcp.InputSchema{
+				Type: "object",
+				Properties: map[string]any{
+					"connection_id": map[string]any{
+						"type":        "integer",
+						"description": "ID of a monitored connection. Omit to return events across all accessible connections.",
+					},
+					"start_time": map[string]any{
+						"type":        "string",
+						"description": "Start of time range. Relative duration (e.g. '1h', '24h', '7d') or ISO 8601. Default: 24h.",
+						"default":     "24h",
+					},
+					"end_time": map[string]any{
+						"type":        "string",
+						"description": "End of time range. ISO 8601. Default: now.",
+					},
+					"event_types": map[string]any{
+						"type":        "string",
+						"description": "Comma-separated event types to include. Valid: config_change, hba_change, ident_change, restart, alert_fired, alert_cleared, alert_acknowledged, extension_change, blackout_started, blackout_ended.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Maximum number of events to return (1-500). Default: 100.",
+						"default":     timelineDefaultLimit,
+						"minimum":     1,
+						"maximum":     timelineMaxLimit,
+					},
+				},
+				Required: []string{},
+			},
+		},
+		Handler: func(args map[string]any) (mcp.ToolResponse, error) {
+			if datastore == nil {
+				return mcp.NewToolError("Datastore not configured. The get_timeline_events tool requires a datastore connection.")
+			}
+
+			ctx, ok := args["__context"].(context.Context)
+			if !ok {
+				ctx = context.Background()
+			}
+
+			// Single-connection vs multi-connection mode
+			singleConnection := false
+			var connectionID int
+			var connName string
+			pool := datastore.GetPool()
+			if _, hasConnID := args["connection_id"]; hasConnID {
+				cid, err := parseIntArg(args, "connection_id")
+				if err != nil {
+					return mcp.NewToolError("Invalid 'connection_id' parameter: must be an integer. Use list_connections to find available connection IDs.")
+				}
+				connectionID = cid
+				singleConnection = true
+
+				if pool != nil {
+					err = pool.QueryRow(ctx, "SELECT name FROM connections WHERE id = $1", connectionID).Scan(&connName)
+					if err != nil {
+						return mcp.NewToolError(fmt.Sprintf("Connection ID %d does not exist. Use list_connections to see available connections.", connectionID))
+					}
+				}
+
+				if rbacChecker != nil {
+					canAccess, _ := rbacChecker.CanAccessConnection(ctx, connectionID)
+					if !canAccess {
+						return mcp.NewToolError(fmt.Sprintf("Access denied: you do not have permission to access connection ID %d.", connectionID))
+					}
+				}
+			}
+
+			// Resolve accessible connections for multi-connection mode. The
+			// semantics mirror get_alert_history: superusers / wildcard
+			// tokens see allConnections=true; restricted users get an
+			// explicit set; a zero-length set with allConnections=false
+			// means "no access" and we short-circuit.
+			var accessibleIDs []int
+			allConnections := true
+			if !singleConnection && rbacChecker != nil {
+				ids, all, err := rbacChecker.VisibleConnectionIDs(ctx, visibilityLister)
+				if err != nil {
+					return mcp.NewToolError(fmt.Sprintf("Failed to resolve accessible connections: %v", err))
+				}
+				accessibleIDs = ids
+				allConnections = all
+				if !allConnections && len(accessibleIDs) == 0 {
+					return mcp.NewToolSuccess("No timeline events found. You do not have access to any connections.")
+				}
+			}
+
+			// Parse limit (default 100, clamped to [1, 500]).
+			limit := timelineDefaultLimit
+			if limitVal, ok := args["limit"]; ok && limitVal != nil {
+				l, err := parseIntArg(args, "limit")
+				if err != nil {
+					return mcp.NewToolError("Invalid 'limit' parameter: must be an integer between 1 and 500")
+				}
+				if l < 1 {
+					return mcp.NewToolError("Invalid 'limit' parameter: must be an integer between 1 and 500")
+				}
+				if l > timelineMaxLimit {
+					l = timelineMaxLimit
+				}
+				limit = l
+			}
+
+			// Parse end_time (default: now).
+			endTime := time.Now().UTC()
+			if endStr, ok := args["end_time"].(string); ok && endStr != "" && endStr != "now" {
+				parsed, err := parseTimeArg(endStr)
+				if err != nil {
+					return mcp.NewToolError("Invalid 'end_time' parameter: use ISO 8601 format")
+				}
+				endTime = parsed
+			}
+
+			// Parse start_time (default: end_time - 24h). Accept either a
+			// relative duration ("24h", "7d") or an absolute timestamp.
+			startTime := endTime.Add(-timelineDefaultRange)
+			if startStr, ok := args["start_time"].(string); ok && startStr != "" {
+				if dur, err := parseRelativeDuration(startStr); err == nil {
+					startTime = endTime.Add(-dur)
+				} else if parsed, err := parseTimeArg(startStr); err == nil {
+					startTime = parsed
+				} else {
+					return mcp.NewToolError("Invalid 'start_time' parameter: use relative duration (e.g., '24h', '7d') or ISO 8601 format")
+				}
+			}
+
+			if !startTime.Before(endTime) {
+				return mcp.NewToolError("Invalid time range: start_time must be before end_time")
+			}
+
+			// Parse and validate event_types filter.
+			var eventTypes []string
+			if etRaw, ok := args["event_types"].(string); ok && etRaw != "" {
+				valid := make(map[string]bool, len(timelineEventTypes))
+				for _, t := range timelineEventTypes {
+					valid[t] = true
+				}
+				for _, raw := range strings.Split(etRaw, ",") {
+					t := strings.TrimSpace(raw)
+					if t == "" {
+						continue
+					}
+					if !valid[t] {
+						return mcp.NewToolError(fmt.Sprintf("Invalid event_type %q. Valid values: %s",
+							t, strings.Join(timelineEventTypes, ", ")))
+					}
+					eventTypes = append(eventTypes, t)
+				}
+			}
+
+			filter := database.TimelineFilter{
+				StartTime:  startTime,
+				EndTime:    endTime,
+				EventTypes: eventTypes,
+				Limit:      limit,
+			}
+			if singleConnection {
+				cid := connectionID
+				filter.ConnectionID = &cid
+			} else if !allConnections {
+				filter.ConnectionIDs = accessibleIDs
+			}
+
+			result, err := datastore.GetTimelineEvents(ctx, filter)
+			if err != nil {
+				return mcp.NewToolError(fmt.Sprintf("Failed to query timeline events: %v", err))
+			}
+
+			return mcp.NewToolSuccess(formatTimelineEvents(result, singleConnection, connectionID, connName, startTime, endTime, limit))
+		},
+	}
+}
+
+// formatTimelineEvents renders a TimelineResult as TSV with a header
+// describing the request parameters and a trailing row count.
+func formatTimelineEvents(result *database.TimelineResult, singleConnection bool, connectionID int, connName string, startTime, endTime time.Time, limit int) string {
+	var sb strings.Builder
+
+	if singleConnection {
+		fmt.Fprintf(&sb, "Timeline Events | Connection: %d (%s) | Window: %s - %s | Limit: %d\n\n",
+			connectionID, connName,
+			startTime.Format(time.RFC3339), endTime.Format(time.RFC3339), limit)
+	} else {
+		fmt.Fprintf(&sb, "Timeline Events | All accessible connections | Window: %s - %s | Limit: %d\n\n",
+			startTime.Format(time.RFC3339), endTime.Format(time.RFC3339), limit)
+	}
+
+	sb.WriteString("connection_id\tserver_name\tevent_time\tevent_type\tseverity\ttitle\tsummary\tid\n")
+
+	rowCount := 0
+	if result != nil {
+		for i := range result.Events {
+			e := &result.Events[i]
+			fmt.Fprintf(&sb, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				e.ConnectionID,
+				tsv.FormatValue(e.ServerName),
+				e.OccurredAt.Format(time.RFC3339),
+				e.EventType,
+				e.Severity,
+				tsv.FormatValue(e.Title),
+				tsv.FormatValue(e.Summary),
+				tsv.FormatValue(e.ID))
+			rowCount++
+		}
+	}
+
+	if rowCount == 0 {
+		if singleConnection {
+			return fmt.Sprintf("No timeline events for connection %d (%s) in the specified time range.", connectionID, connName)
+		}
+		return "No timeline events found across accessible connections in the specified time range."
+	}
+
+	total := rowCount
+	if result != nil {
+		total = result.TotalCount
+	}
+	fmt.Fprintf(&sb, "\n(%d rows, %d total in window)\n", rowCount, total)
+	return sb.String()
+}

--- a/server/src/internal/tools/get_timeline_events_test.go
+++ b/server/src/internal/tools/get_timeline_events_test.go
@@ -1,0 +1,882 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ---------------------------------------------------------------------------
+// get_timeline_events tool definition tests
+// ---------------------------------------------------------------------------
+
+func TestGetTimelineEventsToolDefinition(t *testing.T) {
+	tool := GetTimelineEventsTool(nil, nil, nil)
+
+	if tool.Definition.Name != "get_timeline_events" {
+		t.Errorf("expected tool name 'get_timeline_events', got %q", tool.Definition.Name)
+	}
+	if tool.Definition.Description == "" {
+		t.Error("expected non-empty description")
+	}
+	if tool.Definition.CompactDescription == "" {
+		t.Error("expected non-empty compact description")
+	}
+	if len(tool.Definition.InputSchema.Required) != 0 {
+		t.Errorf("expected 0 required parameters, got %d", len(tool.Definition.InputSchema.Required))
+	}
+	for _, prop := range []string{"connection_id", "start_time", "end_time", "event_types", "limit"} {
+		if _, ok := tool.Definition.InputSchema.Properties[prop]; !ok {
+			t.Errorf("expected property %q in input schema", prop)
+		}
+	}
+
+	limitProp, ok := tool.Definition.InputSchema.Properties["limit"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'limit' property to be a map")
+	}
+	if limitProp["default"] != timelineDefaultLimit {
+		t.Errorf("expected limit default %d, got %v", timelineDefaultLimit, limitProp["default"])
+	}
+	if limitProp["maximum"] != timelineMaxLimit {
+		t.Errorf("expected limit maximum %d, got %v", timelineMaxLimit, limitProp["maximum"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_timeline_events nil datastore test
+// ---------------------------------------------------------------------------
+
+func TestGetTimelineEventsNilDatastore(t *testing.T) {
+	tool := GetTimelineEventsTool(nil, nil, nil)
+
+	response, err := tool.Handler(map[string]any{})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !response.IsError {
+		t.Error("expected error response when datastore is nil")
+	}
+	if len(response.Content) == 0 {
+		t.Fatal("expected error message in response content")
+	}
+	if !strings.Contains(response.Content[0].Text, "Datastore not configured") {
+		t.Errorf("expected 'Datastore not configured' error, got: %s", response.Content[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// formatTimelineEvents output shape
+// ---------------------------------------------------------------------------
+
+func TestFormatTimelineEventsHappyPath(t *testing.T) {
+	occurred := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	detailJSON := json.RawMessage(`{"change_count":2}`)
+	result := &database.TimelineResult{
+		Events: []database.TimelineEvent{
+			{
+				ID:           "config-7-2026-05-01T12:00:00Z",
+				EventType:    database.EventTypeConfigChange,
+				ConnectionID: 7,
+				ServerName:   "prod-1",
+				OccurredAt:   occurred,
+				Severity:     "info",
+				Title:        "Configuration Changed",
+				Summary:      "Changed 2 settings",
+				Details:      detailJSON,
+			},
+			{
+				ID:           "restart-7-2026-05-01T13:00:00Z",
+				EventType:    database.EventTypeRestart,
+				ConnectionID: 7,
+				ServerName:   "prod-1",
+				OccurredAt:   occurred.Add(time.Hour),
+				Severity:     "warning",
+				Title:        "Server Restart Detected",
+				Summary:      "Server started",
+			},
+		},
+		TotalCount: 2,
+	}
+
+	start := occurred.Add(-24 * time.Hour)
+	end := occurred.Add(2 * time.Hour)
+	out := formatTimelineEvents(result, true, 7, "prod-1", start, end, 100)
+
+	if !strings.Contains(out, "Timeline Events | Connection: 7 (prod-1)") {
+		t.Errorf("expected single-connection header, got: %s", out)
+	}
+	if !strings.Contains(out, "connection_id\tserver_name\tevent_time\tevent_type\tseverity\ttitle\tsummary\tid\n") {
+		t.Errorf("expected TSV header row, got: %s", out)
+	}
+	if !strings.Contains(out, database.EventTypeConfigChange) {
+		t.Errorf("expected config_change row, got: %s", out)
+	}
+	if !strings.Contains(out, database.EventTypeRestart) {
+		t.Errorf("expected restart row, got: %s", out)
+	}
+	if !strings.Contains(out, "(2 rows, 2 total in window)") {
+		t.Errorf("expected row count footer, got: %s", out)
+	}
+}
+
+func TestFormatTimelineEventsAllConnectionsHeader(t *testing.T) {
+	result := &database.TimelineResult{Events: []database.TimelineEvent{}, TotalCount: 0}
+	start := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	out := formatTimelineEvents(result, false, 0, "", start, end, 100)
+	if !strings.Contains(out, "No timeline events found across accessible connections") {
+		t.Errorf("expected multi-connection empty message, got: %s", out)
+	}
+}
+
+func TestFormatTimelineEventsSingleConnectionEmpty(t *testing.T) {
+	result := &database.TimelineResult{Events: []database.TimelineEvent{}, TotalCount: 0}
+	start := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	out := formatTimelineEvents(result, true, 9, "edge-2", start, end, 100)
+	if !strings.Contains(out, "No timeline events for connection 9 (edge-2)") {
+		t.Errorf("expected single-connection empty message, got: %s", out)
+	}
+}
+
+func TestFormatTimelineEventsNilResult(t *testing.T) {
+	start := time.Now().Add(-time.Hour)
+	end := time.Now()
+	out := formatTimelineEvents(nil, false, 0, "", start, end, 100)
+	if !strings.Contains(out, "No timeline events found across accessible connections") {
+		t.Errorf("expected empty message when result is nil, got: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests against a real Postgres instance
+// ---------------------------------------------------------------------------
+
+// timelineSchema mirrors the subset of production tables that the
+// timeline queries hit. We seed enough rows to exercise the alert_fired,
+// alert_cleared, alert_acknowledged, restart, blackout_started, and
+// blackout_ended subqueries; the config/HBA/extension/ident subqueries
+// also execute, but with no data they simply contribute zero rows.
+const timelineSchema = `
+DROP TABLE IF EXISTS alert_acknowledgments CASCADE;
+DROP TABLE IF EXISTS alerts CASCADE;
+DROP TABLE IF EXISTS alert_rules CASCADE;
+DROP TABLE IF EXISTS blackouts CASCADE;
+DROP TABLE IF EXISTS cluster_groups CASCADE;
+DROP TABLE IF EXISTS clusters CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+DROP SCHEMA IF EXISTS metrics CASCADE;
+
+CREATE SCHEMA metrics;
+
+CREATE TABLE cluster_groups (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE clusters (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    group_id INTEGER
+);
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    host VARCHAR(255) NOT NULL DEFAULT '',
+    port INTEGER NOT NULL DEFAULT 5432,
+    database_name VARCHAR(255) NOT NULL DEFAULT 'postgres',
+    is_shared BOOLEAN NOT NULL DEFAULT TRUE,
+    owner_username VARCHAR(255),
+    cluster_id INTEGER
+);
+
+CREATE TABLE alert_rules (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    metric_unit VARCHAR(64)
+);
+
+CREATE TABLE alerts (
+    id SERIAL PRIMARY KEY,
+    connection_id INTEGER NOT NULL,
+    rule_id INTEGER,
+    alert_type VARCHAR(64) NOT NULL DEFAULT 'threshold',
+    severity VARCHAR(32) NOT NULL DEFAULT 'warning',
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    metric_name VARCHAR(255),
+    metric_value DOUBLE PRECISION,
+    threshold_value DOUBLE PRECISION,
+    operator VARCHAR(8),
+    database_name VARCHAR(255),
+    probe_name VARCHAR(255),
+    triggered_at TIMESTAMPTZ NOT NULL,
+    cleared_at TIMESTAMPTZ,
+    status VARCHAR(32) NOT NULL DEFAULT 'active'
+);
+
+CREATE TABLE alert_acknowledgments (
+    id SERIAL PRIMARY KEY,
+    alert_id INTEGER NOT NULL,
+    acknowledged_at TIMESTAMPTZ NOT NULL,
+    acknowledged_by VARCHAR(255) NOT NULL,
+    acknowledge_type VARCHAR(32) NOT NULL DEFAULT 'manual',
+    false_positive BOOLEAN NOT NULL DEFAULT FALSE,
+    message TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE blackouts (
+    id SERIAL PRIMARY KEY,
+    scope VARCHAR(16) NOT NULL,
+    connection_id INTEGER,
+    cluster_id INTEGER,
+    group_id INTEGER,
+    reason TEXT,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ,
+    created_by VARCHAR(255) NOT NULL DEFAULT 'tester'
+);
+
+CREATE TABLE metrics.pg_settings (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    setting TEXT
+);
+
+CREATE TABLE metrics.pg_hba_file_rules (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    rule_number INTEGER NOT NULL,
+    type VARCHAR(64),
+    database VARCHAR(255),
+    user_name VARCHAR(255),
+    address VARCHAR(255),
+    auth_method VARCHAR(64)
+);
+
+CREATE TABLE metrics.pg_ident_file_mappings (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    map_number INTEGER,
+    map_name VARCHAR(255),
+    sys_name VARCHAR(255),
+    pg_username VARCHAR(255)
+);
+
+CREATE TABLE metrics.pg_node_role (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    postmaster_start_time TIMESTAMPTZ,
+    is_in_recovery BOOLEAN,
+    primary_role VARCHAR(64)
+);
+
+CREATE TABLE metrics.pg_extension (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    database_name VARCHAR(255),
+    extname VARCHAR(255),
+    extversion VARCHAR(64)
+);
+`
+
+const timelineTeardown = `
+DROP TABLE IF EXISTS alert_acknowledgments CASCADE;
+DROP TABLE IF EXISTS alerts CASCADE;
+DROP TABLE IF EXISTS alert_rules CASCADE;
+DROP TABLE IF EXISTS blackouts CASCADE;
+DROP TABLE IF EXISTS clusters CASCADE;
+DROP TABLE IF EXISTS cluster_groups CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+DROP SCHEMA IF EXISTS metrics CASCADE;
+`
+
+// newTimelineTestEnv prepares a Postgres instance with the timeline
+// schema and seed data. The returned cleanup drops the schema and closes
+// the pool. The test is skipped when TEST_AI_WORKBENCH_SERVER is unset.
+func newTimelineTestEnv(t *testing.T) (*pgxpool.Pool, *database.Datastore, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping timeline integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, timelineSchema); err != nil {
+		pool.Close()
+		t.Fatalf("create schema: %v", err)
+	}
+
+	ds := database.NewTestDatastore(pool)
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), timelineTeardown); err != nil {
+			t.Logf("teardown: %v", err)
+		}
+		pool.Close()
+	}
+	return pool, ds, cleanup
+}
+
+// seedTimelineFixtures inserts a small but representative set of timeline
+// events. It returns the connection ID so tests can target it and the
+// occurredAt time anchor used for the events so tests can compute the
+// window. Events are timed so the default 24h window includes them.
+func seedTimelineFixtures(t *testing.T, pool *pgxpool.Pool) (connID int, base time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	base = time.Now().UTC().Add(-2 * time.Hour)
+
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO connections (name, host, port, database_name, is_shared)
+         VALUES ('prod-edge', 'localhost', 5432, 'postgres', TRUE)
+         RETURNING id`,
+	).Scan(&connID); err != nil {
+		t.Fatalf("insert connection: %v", err)
+	}
+
+	// One fired + cleared + acknowledged alert.
+	var alertID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO alerts (connection_id, severity, title, description, triggered_at, cleared_at, status)
+         VALUES ($1, 'warning', 'CPU high', 'cpu over threshold', $2, $3, 'cleared')
+         RETURNING id`,
+		connID, base, base.Add(30*time.Minute),
+	).Scan(&alertID); err != nil {
+		t.Fatalf("insert alert: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO alert_acknowledgments (alert_id, acknowledged_at, acknowledged_by, message)
+         VALUES ($1, $2, 'oncall', 'investigated')`,
+		alertID, base.Add(45*time.Minute),
+	); err != nil {
+		t.Fatalf("insert acknowledgment: %v", err)
+	}
+
+	// A blackout that started and ended inside the window.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO blackouts (scope, connection_id, reason, start_time, end_time)
+         VALUES ('server', $1, 'maintenance', $2, $3)`,
+		connID, base.Add(time.Hour), base.Add(90*time.Minute),
+	); err != nil {
+		t.Fatalf("insert blackout: %v", err)
+	}
+
+	// Two pg_node_role rows so the restart subquery sees a transition.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO metrics.pg_node_role
+         (connection_id, collected_at, postmaster_start_time, is_in_recovery, primary_role)
+         VALUES ($1, $2, $3, FALSE, 'primary'),
+                ($1, $4, $5, FALSE, 'primary')`,
+		connID,
+		base.Add(-30*time.Minute), base.Add(-time.Hour),
+		base.Add(10*time.Minute), base.Add(5*time.Minute),
+	); err != nil {
+		t.Fatalf("insert pg_node_role: %v", err)
+	}
+
+	// Two pg_settings rows for the same parameter, with a changed value
+	// between the first and second snapshot. The LAG() detection in the
+	// config_change subquery requires at least two rows.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO metrics.pg_settings (connection_id, collected_at, name, setting)
+         VALUES ($1, $2, 'work_mem', '4MB'),
+                ($1, $3, 'work_mem', '8MB')`,
+		connID,
+		base.Add(-15*time.Minute), base.Add(20*time.Minute),
+	); err != nil {
+		t.Fatalf("insert pg_settings: %v", err)
+	}
+	return connID, base
+}
+
+func TestGetTimelineEventsIntegrationHappyPath(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	connID, _ := seedTimelineFixtures(t, pool)
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": float64(connID),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("unexpected error response: %s", resp.Content[0].Text)
+	}
+	body := resp.Content[0].Text
+	if !strings.Contains(body, "Timeline Events | Connection:") {
+		t.Errorf("expected single-connection header, got: %s", body)
+	}
+	for _, want := range []string{
+		database.EventTypeAlertFired,
+		database.EventTypeAlertCleared,
+		database.EventTypeAlertAcknowledged,
+		database.EventTypeBlackoutStarted,
+		database.EventTypeBlackoutEnded,
+		database.EventTypeRestart,
+		database.EventTypeConfigChange,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected event type %q in output: %s", want, body)
+		}
+	}
+}
+
+func TestGetTimelineEventsIntegrationEventTypeFilter(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	connID, _ := seedTimelineFixtures(t, pool)
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": float64(connID),
+		"event_types":   "restart, config_change",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("unexpected error response: %s", resp.Content[0].Text)
+	}
+	body := resp.Content[0].Text
+	if !strings.Contains(body, database.EventTypeRestart) {
+		t.Errorf("expected restart event, got: %s", body)
+	}
+	if !strings.Contains(body, database.EventTypeConfigChange) {
+		t.Errorf("expected config_change event, got: %s", body)
+	}
+	if strings.Contains(body, database.EventTypeAlertFired) {
+		t.Errorf("alert_fired must be excluded by filter, got: %s", body)
+	}
+	if strings.Contains(body, database.EventTypeBlackoutStarted) {
+		t.Errorf("blackout_started must be excluded by filter, got: %s", body)
+	}
+}
+
+func TestGetTimelineEventsIntegrationExplicitTimeRange(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	connID, base := seedTimelineFixtures(t, pool)
+
+	// Narrow window that excludes the seeded alert/blackout events. We
+	// pick a 1-minute slice ending right before "base" so all fixtures
+	// fall outside.
+	start := base.Add(-5 * time.Minute)
+	end := base.Add(-4 * time.Minute)
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": float64(connID),
+		"start_time":    start.Format(time.RFC3339),
+		"end_time":      end.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("unexpected error response: %s", resp.Content[0].Text)
+	}
+	body := resp.Content[0].Text
+	if !strings.Contains(body, "No timeline events for connection") {
+		t.Errorf("expected empty-window message, got: %s", body)
+	}
+}
+
+func TestGetTimelineEventsIntegrationDefaultRangeCoversFixtures(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	connID, _ := seedTimelineFixtures(t, pool)
+
+	// No start_time / end_time means default last 24h, which includes
+	// all fixtures (anchored at now-2h).
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": float64(connID),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("unexpected error response: %s", resp.Content[0].Text)
+	}
+	body := resp.Content[0].Text
+	if !strings.Contains(body, "rows,") {
+		t.Errorf("expected non-empty result with default range, got: %s", body)
+	}
+}
+
+func TestGetTimelineEventsIntegrationLimitClamped(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	connID, _ := seedTimelineFixtures(t, pool)
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": float64(connID),
+		"limit":         float64(timelineMaxLimit + 100),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("unexpected error response: %s", resp.Content[0].Text)
+	}
+	body := resp.Content[0].Text
+	// The advertised limit in the header should be clamped to the max.
+	want := fmt.Sprintf("Limit: %d", timelineMaxLimit)
+	if !strings.Contains(body, want) {
+		t.Errorf("expected header to advertise clamped limit %q, got: %s", want, body)
+	}
+}
+
+func TestGetTimelineEventsIntegrationLimitDefault(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	connID, _ := seedTimelineFixtures(t, pool)
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": float64(connID),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("unexpected error response: %s", resp.Content[0].Text)
+	}
+	if !strings.Contains(resp.Content[0].Text, fmt.Sprintf("Limit: %d", timelineDefaultLimit)) {
+		t.Errorf("expected default limit advertised in header: %s", resp.Content[0].Text)
+	}
+}
+
+func TestGetTimelineEventsIntegrationInvalidConnectionID(t *testing.T) {
+	_, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": "abc",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error response for string connection_id")
+	}
+	if !strings.Contains(resp.Content[0].Text, "connection_id") ||
+		!strings.Contains(resp.Content[0].Text, "integer") {
+		t.Errorf("expected connection_id integer error, got: %s", resp.Content[0].Text)
+	}
+}
+
+func TestGetTimelineEventsIntegrationUnknownConnectionID(t *testing.T) {
+	_, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": float64(99999),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error response for unknown connection_id")
+	}
+	if !strings.Contains(resp.Content[0].Text, "does not exist") {
+		t.Errorf("expected 'does not exist' error, got: %s", resp.Content[0].Text)
+	}
+}
+
+func TestGetTimelineEventsIntegrationInvalidEventType(t *testing.T) {
+	_, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"event_types": "config_change,bogus_event",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error response for invalid event_type")
+	}
+	if !strings.Contains(resp.Content[0].Text, "Invalid event_type") {
+		t.Errorf("expected 'Invalid event_type' error, got: %s", resp.Content[0].Text)
+	}
+}
+
+func TestGetTimelineEventsIntegrationInvalidLimit(t *testing.T) {
+	_, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	cases := []struct {
+		name string
+		val  any
+	}{
+		{"zero", float64(0)},
+		{"negative", float64(-1)},
+		{"string", "lots"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := tool.Handler(map[string]any{"limit": tc.val})
+			if err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			if !resp.IsError {
+				t.Fatalf("expected error response for limit=%v", tc.val)
+			}
+			if !strings.Contains(resp.Content[0].Text, "limit") {
+				t.Errorf("expected limit error message, got: %s", resp.Content[0].Text)
+			}
+		})
+	}
+}
+
+func TestGetTimelineEventsIntegrationInvalidStartTime(t *testing.T) {
+	_, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"start_time": "not-a-time",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error response for invalid start_time")
+	}
+	if !strings.Contains(resp.Content[0].Text, "Invalid 'start_time'") {
+		t.Errorf("expected start_time error, got: %s", resp.Content[0].Text)
+	}
+}
+
+func TestGetTimelineEventsIntegrationInvalidEndTime(t *testing.T) {
+	_, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"end_time": "not-a-time",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error response for invalid end_time")
+	}
+	if !strings.Contains(resp.Content[0].Text, "Invalid 'end_time'") {
+		t.Errorf("expected end_time error, got: %s", resp.Content[0].Text)
+	}
+}
+
+func TestGetTimelineEventsIntegrationInvertedTimeRange(t *testing.T) {
+	_, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"start_time": "2026-05-02T00:00:00Z",
+		"end_time":   "2026-05-01T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error for inverted range")
+	}
+	if !strings.Contains(resp.Content[0].Text, "start_time must be before end_time") {
+		t.Errorf("expected inverted-range error, got: %s", resp.Content[0].Text)
+	}
+}
+
+func TestGetTimelineEventsIntegrationMultiConnectionAllAccess(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	// Seed fixtures so the query yields at least one event and the
+	// multi-connection header is emitted instead of the empty-result
+	// short message. The seed connection is shared by default, so the
+	// nil RBACChecker path treats access as unrestricted.
+	seedTimelineFixtures(t, pool)
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("unexpected error response: %s", resp.Content[0].Text)
+	}
+	if !strings.Contains(resp.Content[0].Text, "Timeline Events | All accessible connections") {
+		t.Errorf("expected multi-connection header, got: %s", resp.Content[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RBAC-denial test using an in-process auth store and stub lister
+// ---------------------------------------------------------------------------
+
+// TestGetTimelineEventsRBACDeniesNoAccess mirrors the regression guards in
+// rbac_regression_test.go for the other monitored-data tools: a user with
+// zero visible connections must see the explicit "no access" message and
+// no leaked event data. The handler should short-circuit before any SQL
+// is issued, so a nil datastore would prevent us from reaching this code
+// path. We use an unreachable pool wrapped in a Datastore instead.
+func TestGetTimelineEventsRBACDeniesNoAccess(t *testing.T) {
+	pool, err := pgxpool.New(context.Background(), "postgres://nobody:nopass@127.0.0.1:1/nope")
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	defer pool.Close()
+	ds := database.NewTestDatastore(pool)
+
+	tmpDir, err := os.MkdirTemp("", "tools-timeline-rbac-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer store.Close()
+	store.SetBcryptCostForTesting(t, bcrypt.MinCost)
+
+	if err := store.CreateUser("bob", "Password1234", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := store.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	lister := &stubVisibilityLister{
+		connections: []auth.ConnectionVisibilityInfo{
+			{ID: 42, IsShared: false, OwnerUsername: "alice"},
+		},
+	}
+	rbac := auth.NewRBACChecker(store)
+	tool := GetTimelineEventsTool(ds, rbac, lister)
+
+	ctx := nonSuperuserContext(userID, "bob")
+	resp, err := tool.Handler(map[string]any{"__context": ctx})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("expected non-error response, got: %+v", resp.Content)
+	}
+	body := resp.Content[0].Text
+	if !strings.Contains(body, "No timeline events found") ||
+		!strings.Contains(body, "You do not have access to any connections") {
+		t.Errorf("expected RBAC denial message, got: %q", body)
+	}
+	if strings.Contains(body, "42") {
+		t.Errorf("response leaked unshared connection id 42: %q", body)
+	}
+}
+
+// TestGetTimelineEventsRBACDeniesExplicitConnectionID guards the case
+// where the caller asks for a specific connection_id they do not own and
+// is not shared with them. The tool must return an access-denied error
+// without revealing whether the connection exists, mirroring
+// get_alert_history's behavior.
+func TestGetTimelineEventsRBACDeniesExplicitConnectionID(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	// Seed a connection owned by alice, NOT shared.
+	var connID int
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO connections (name, host, port, database_name, is_shared, owner_username)
+         VALUES ('alice-only', 'localhost', 5432, 'postgres', FALSE, 'alice')
+         RETURNING id`,
+	).Scan(&connID); err != nil {
+		t.Fatalf("insert connection: %v", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "tools-timeline-rbac-conn-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		t.Fatalf("NewAuthStore: %v", err)
+	}
+	defer store.Close()
+	store.SetBcryptCostForTesting(t, bcrypt.MinCost)
+	if err := store.CreateUser("bob", "Password1234", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := store.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	rbac := auth.NewRBACCheckerForDatastore(store, ds)
+	tool := GetTimelineEventsTool(ds, rbac, database.NewVisibilityLister(ds))
+
+	ctx := nonSuperuserContext(userID, "bob")
+	resp, err := tool.Handler(map[string]any{
+		"__context":     ctx,
+		"connection_id": float64(connID),
+	})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatalf("expected access denied, got: %+v", resp.Content)
+	}
+	if !strings.Contains(resp.Content[0].Text, "Access denied") {
+		t.Errorf("expected access denied message, got: %s", resp.Content[0].Text)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a new `get_timeline_events` MCP tool that wraps `database.GetTimelineEvents`, exposing the unified event timeline (config/HBA/ident changes, restarts, extension changes, alert fired/cleared/acknowledged events, and blackout markers) to Ellie and other MCP clients.
- Registers the tool in `context_aware_provider.go` with the same RBAC gating as `get_alert_history`; restricted users see only events for connections they can access.
- Updates Ellie's system prompt to mention the new tool and when to prefer it over `get_alert_history`/`get_blackouts`.
- Adds documentation (`mcp-tools.md`, `ask-ellie.md`, `server.md` config example) and a `changelog.md` entry under `[1.0.0-beta3] - Unreleased`.

## Why

Today the timeline is REST-only. The React client renders it on the timeline view and feeds it into the AI Analysis (purple brain) flow, so the LLM does see it there. But Ellie cannot query the timeline during a chat: she can only piece together a partial picture from `get_alert_history` and `get_blackouts`, and is blind to config changes, HBA edits, extension changes, and restarts — which is where most incidents actually originate.

## Tool surface

- `connection_id` (optional integer) — filter to one monitored connection; omit for all accessible connections.
- `start_time` (string, default `24h`) — relative duration (`1h`, `24h`, `7d`) or ISO 8601.
- `end_time` (string, default `now`) — ISO 8601.
- `event_types` (string, optional) — comma-separated list of event-type values.
- `limit` (integer, default 100, max 500).

Returns TSV ordered most-recent-first; schema matches the REST endpoint.

## Test plan

- [x] `make lint` clean (server)
- [x] `make test-all` passes (server, alerter, collector, client — 3255 client tests)
- [x] `gofmt -l` clean on all modified Go files
- [x] CI will exercise the integration tests (`TestGetTimelineEventsIntegration*`, `TestGetTimelineEventsRBACDenies*`) against a real Postgres
- [ ] Verify CI coverage meets the 90% floor on `get_timeline_events.go`
- [ ] Confirm CodeRabbit and Codacy findings are addressed

Closes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified incident-investigation timeline tool that returns a single TSV of recent events (alerts, config/HBA edits, restarts, extension changes, blackouts) ordered newest-first, RBAC-gated, and integrated into Ellie for contextual investigations; enabled by default unless explicitly disabled.

* **Documentation**
  * Updated configuration and user guides to show the timeline tool and how to enable/use it.

* **Tests**
  * Added unit and integration tests covering behavior, filtering, time ranges, limits, and authorization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->