### PR TITLE
fix(server): enrich timeline alert_cleared summary

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,29 @@ project adheres to
 
 ### Fixed
 
+- Fix the `get_timeline_events` MCP tool emitting a
+  flat "Alert condition no longer active" summary on
+  `alert_cleared` rows, which left a reviewer
+  scanning the timeline to read the vivid
+  `alert_fired` summary (carrying the alert's frozen
+  `description` text) and risk misreading an already
+  resolved alert as still active. Cleared rows now
+  carry a self-contained summary of the form
+  `Resolved after <duration>. Fired: <original alert
+  description>`, where `<duration>` renders as
+  `Ns`, `Nm Ms`, or `Nh Mm`; the underlying
+  `alerts.description` column is preserved unchanged,
+  so this is a presentation change in the timeline
+  tool rather than a rewrite of historical alert
+  text. The tool description visible to MCP clients
+  now also states that `alert_fired.summary`
+  describes the firing condition and not the current
+  state, and instructs clients to pair each
+  `alert_fired` row with its corresponding
+  `alert_cleared` row (matching title prefix
+  `'Alert Cleared: '`) before treating an alert as
+  ongoing.
+
 - Fix the collector entering a restart loop when its
   consolidated schema migration ran against a partially
   populated datastore. PostgreSQL has no

--- a/server/src/internal/database/queries_test.go
+++ b/server/src/internal/database/queries_test.go
@@ -1655,6 +1655,73 @@ func TestBuildAlertClearedQuery(t *testing.T) {
 	if !strings.Contains(query, "Alert Cleared:") {
 		t.Error("expected query to contain 'Alert Cleared:' in title")
 	}
+	// The enriched summary must reference both the resolution prefix
+	// and the original a.description so the cleared row is
+	// self-contained and the historical text is preserved verbatim.
+	if !strings.Contains(query, "'Resolved after '") {
+		t.Error("expected query summary to start with 'Resolved after '")
+	}
+	if !strings.Contains(query, "|| '. Fired: ' || a.description") {
+		t.Error("expected query summary to append '. Fired: ' || a.description")
+	}
+	if strings.Contains(query, "'Alert condition no longer active'") {
+		t.Error("legacy summary literal must no longer appear in cleared query")
+	}
+	// The duration expression must defend against negative diffs and
+	// branch on the documented thresholds (< 60, < 3600).
+	if !strings.Contains(query, "GREATEST(EXTRACT(EPOCH FROM (a.cleared_at - a.triggered_at))::BIGINT, 0)") {
+		t.Error("expected query to clamp negative durations to zero")
+	}
+	if !strings.Contains(query, "< 60 THEN") {
+		t.Error("expected query to branch on the < 60s threshold")
+	}
+	if !strings.Contains(query, "< 3600 THEN") {
+		t.Error("expected query to branch on the < 3600s threshold")
+	}
+}
+
+// TestBuildAlertFiredQuerySummaryUnchanged ensures the alert_fired
+// summary continues to carry a.description verbatim. The cleared row
+// summary was enriched; the fired row must not be touched because it
+// remains the historical record of the firing condition.
+func TestBuildAlertFiredQuerySummaryUnchanged(t *testing.T) {
+	query := buildAlertFiredQuery("")
+
+	if !strings.Contains(query, "a.description AS summary") {
+		t.Error("expected alert_fired summary to remain 'a.description AS summary' verbatim")
+	}
+	if strings.Contains(query, "'Resolved after '") {
+		t.Error("alert_fired query must not contain the cleared-row resolution prefix")
+	}
+}
+
+// TestFormatAlertClearedDuration exercises the boundary cases of the
+// duration formatter: short (< 60s), medium (< 1h), long (>= 1h), and
+// the negative/zero edges that the SQL companion expression clamps.
+func TestFormatAlertClearedDuration(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{"zero", 0, "0s"},
+		{"one_second", time.Second, "1s"},
+		{"just_under_a_minute", 59 * time.Second, "59s"},
+		{"exact_minute", 60 * time.Second, "1m 0s"},
+		{"two_minutes_fifteen", 2*time.Minute + 15*time.Second, "2m 15s"},
+		{"just_under_an_hour", 59*time.Minute + 59*time.Second, "59m 59s"},
+		{"exact_hour", time.Hour, "1h 0m"},
+		{"one_hour_twenty_three", time.Hour + 23*time.Minute, "1h 23m"},
+		{"long_duration", 5*time.Hour + 7*time.Minute + 42*time.Second, "5h 7m"},
+		{"negative_clamped_to_zero", -3 * time.Second, "0s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatAlertClearedDuration(tc.in); got != tc.want {
+				t.Errorf("formatAlertClearedDuration(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestBuildAlertAcknowledgedQuery(t *testing.T) {

--- a/server/src/internal/database/timeline_alert_cleared_integration_test.go
+++ b/server/src/internal/database/timeline_alert_cleared_integration_test.go
@@ -1,0 +1,298 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// timelineAlertClearedSchema mirrors the minimum subset of tables that
+// the buildAlertClearedQuery subquery touches. We intentionally keep
+// this independent from the schema in the tools-package integration
+// test so a future change to that file cannot silently break us.
+const timelineAlertClearedSchema = `
+DROP TABLE IF EXISTS alerts CASCADE;
+DROP TABLE IF EXISTS alert_rules CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE alert_rules (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    metric_unit VARCHAR(64)
+);
+
+CREATE TABLE alerts (
+    id SERIAL PRIMARY KEY,
+    connection_id INTEGER NOT NULL REFERENCES connections(id) ON DELETE CASCADE,
+    rule_id INTEGER,
+    alert_type VARCHAR(64) NOT NULL DEFAULT 'threshold',
+    severity VARCHAR(32) NOT NULL DEFAULT 'warning',
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    metric_name VARCHAR(255),
+    metric_value DOUBLE PRECISION,
+    threshold_value DOUBLE PRECISION,
+    operator VARCHAR(8),
+    database_name VARCHAR(255),
+    probe_name VARCHAR(255),
+    triggered_at TIMESTAMPTZ NOT NULL,
+    cleared_at TIMESTAMPTZ,
+    status VARCHAR(32) NOT NULL DEFAULT 'active'
+);
+`
+
+const timelineAlertClearedTeardown = `
+DROP TABLE IF EXISTS alerts CASCADE;
+DROP TABLE IF EXISTS alert_rules CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+`
+
+// newAlertClearedTestEnv brings up the minimum Postgres state needed to
+// drive the alert_cleared subquery end-to-end. It skips when no test DB
+// is configured so unit-test runs that lack TEST_AI_WORKBENCH_SERVER
+// still pass.
+func newAlertClearedTestEnv(t *testing.T) (*pgxpool.Pool, *Datastore, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping alert_cleared integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+	if _, err := pool.Exec(ctx, timelineAlertClearedSchema); err != nil {
+		pool.Close()
+		t.Fatalf("create schema: %v", err)
+	}
+
+	ds := NewTestDatastore(pool)
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), timelineAlertClearedTeardown); err != nil {
+			t.Logf("teardown: %v", err)
+		}
+		pool.Close()
+	}
+	return pool, ds, cleanup
+}
+
+// insertClearedAlert seeds a fired-then-cleared alert with the given
+// description and elapsed duration between triggered_at and cleared_at.
+// It returns the cleared_at time anchor so callers can build a time
+// window that includes the resulting row.
+func insertClearedAlert(t *testing.T, pool *pgxpool.Pool, connID int, description string, elapsed time.Duration) time.Time {
+	t.Helper()
+	cleared := time.Now().UTC().Add(-30 * time.Minute)
+	triggered := cleared.Add(-elapsed)
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO alerts (
+            connection_id, severity, title, description, triggered_at, cleared_at, status
+        ) VALUES ($1, 'warning', 'Staleness', $2, $3, $4, 'cleared')`,
+		connID, description, triggered, cleared,
+	); err != nil {
+		t.Fatalf("insert cleared alert: %v", err)
+	}
+	return cleared
+}
+
+// fetchClearedSummary runs GetTimelineEvents with the alert_cleared
+// filter and returns the summary string of the single expected row.
+// It fails the test if the row count is not exactly one.
+func fetchClearedSummary(t *testing.T, ds *Datastore, connID int, cleared time.Time) string {
+	t.Helper()
+	cid := connID
+	result, err := ds.GetTimelineEvents(context.Background(), TimelineFilter{
+		ConnectionID: &cid,
+		StartTime:    cleared.Add(-2 * time.Hour),
+		EndTime:      cleared.Add(time.Hour),
+		EventTypes:   []string{EventTypeAlertCleared},
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("GetTimelineEvents: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("expected exactly one cleared row, got %d", len(result.Events))
+	}
+	if result.Events[0].EventType != EventTypeAlertCleared {
+		t.Fatalf("expected alert_cleared event, got %q", result.Events[0].EventType)
+	}
+	return result.Events[0].Summary
+}
+
+// TestAlertClearedSummaryShortDuration verifies the < 60s branch of
+// the SQL CASE expression. The Ellie regression involved a 27-second
+// gap between triggered_at and cleared_at, so the short branch is the
+// most important one to cover.
+func TestAlertClearedSummaryShortDuration(t *testing.T) {
+	pool, ds, cleanup := newAlertClearedTestEnv(t)
+	defer cleanup()
+
+	var connID int
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO connections (name) VALUES ('short') RETURNING id`,
+	).Scan(&connID); err != nil {
+		t.Fatalf("insert connection: %v", err)
+	}
+
+	desc := "has not collected data for 154 minutes (threshold: 15 minutes)"
+	cleared := insertClearedAlert(t, pool, connID, desc, 27*time.Second)
+	summary := fetchClearedSummary(t, ds, connID, cleared)
+
+	want := fmt.Sprintf("Resolved after 27s. Fired: %s", desc)
+	if summary != want {
+		t.Errorf("cleared summary mismatch\n got: %q\nwant: %q", summary, want)
+	}
+}
+
+// TestAlertClearedSummaryMediumDuration verifies the < 1h branch.
+func TestAlertClearedSummaryMediumDuration(t *testing.T) {
+	pool, ds, cleanup := newAlertClearedTestEnv(t)
+	defer cleanup()
+
+	var connID int
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO connections (name) VALUES ('medium') RETURNING id`,
+	).Scan(&connID); err != nil {
+		t.Fatalf("insert connection: %v", err)
+	}
+
+	desc := "replication lag exceeded threshold"
+	cleared := insertClearedAlert(t, pool, connID, desc, 2*time.Minute+15*time.Second)
+	summary := fetchClearedSummary(t, ds, connID, cleared)
+
+	want := fmt.Sprintf("Resolved after 2m 15s. Fired: %s", desc)
+	if summary != want {
+		t.Errorf("cleared summary mismatch\n got: %q\nwant: %q", summary, want)
+	}
+}
+
+// TestAlertClearedSummaryLongDuration verifies the >= 1h branch.
+func TestAlertClearedSummaryLongDuration(t *testing.T) {
+	pool, ds, cleanup := newAlertClearedTestEnv(t)
+	defer cleanup()
+
+	var connID int
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO connections (name) VALUES ('long') RETURNING id`,
+	).Scan(&connID); err != nil {
+		t.Fatalf("insert connection: %v", err)
+	}
+
+	desc := "CPU saturation"
+	cleared := insertClearedAlert(t, pool, connID, desc, time.Hour+23*time.Minute+5*time.Second)
+	summary := fetchClearedSummary(t, ds, connID, cleared)
+
+	want := fmt.Sprintf("Resolved after 1h 23m. Fired: %s", desc)
+	if summary != want {
+		t.Errorf("cleared summary mismatch\n got: %q\nwant: %q", summary, want)
+	}
+}
+
+// TestAlertClearedSummaryNegativeClampedToZero exercises the
+// GREATEST(...,0) guard against clock skew or out-of-order timestamps.
+// When cleared_at < triggered_at the summary must report "0s" rather
+// than a negative or oddly formatted duration.
+func TestAlertClearedSummaryNegativeClampedToZero(t *testing.T) {
+	pool, ds, cleanup := newAlertClearedTestEnv(t)
+	defer cleanup()
+
+	var connID int
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO connections (name) VALUES ('skew') RETURNING id`,
+	).Scan(&connID); err != nil {
+		t.Fatalf("insert connection: %v", err)
+	}
+
+	// Insert an alert with cleared_at deliberately earlier than
+	// triggered_at to simulate clock skew between collector and server.
+	cleared := time.Now().UTC().Add(-30 * time.Minute)
+	triggered := cleared.Add(5 * time.Second) // 5s after cleared_at
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO alerts (
+            connection_id, severity, title, description, triggered_at, cleared_at, status
+        ) VALUES ($1, 'warning', 'Staleness', 'clock skew probe', $2, $3, 'cleared')`,
+		connID, triggered, cleared,
+	); err != nil {
+		t.Fatalf("insert cleared alert: %v", err)
+	}
+
+	summary := fetchClearedSummary(t, ds, connID, cleared)
+	if !strings.HasPrefix(summary, "Resolved after 0s. Fired: ") {
+		t.Errorf("expected negative duration to clamp to 0s, got: %q", summary)
+	}
+}
+
+// TestAlertFiredSummaryPreservesDescription confirms the alert_fired
+// summary continues to be a.description verbatim. The Ellie investigation
+// established that the fired-row summary is the immutable historical
+// record and must not be rewritten alongside the cleared-row enrichment.
+func TestAlertFiredSummaryPreservesDescription(t *testing.T) {
+	pool, ds, cleanup := newAlertClearedTestEnv(t)
+	defer cleanup()
+
+	var connID int
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO connections (name) VALUES ('fired-only') RETURNING id`,
+	).Scan(&connID); err != nil {
+		t.Fatalf("insert connection: %v", err)
+	}
+
+	desc := "exact text that must survive verbatim"
+	triggered := time.Now().UTC().Add(-30 * time.Minute)
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO alerts (
+            connection_id, severity, title, description, triggered_at, status
+        ) VALUES ($1, 'warning', 'Probe', $2, $3, 'active')`,
+		connID, desc, triggered,
+	); err != nil {
+		t.Fatalf("insert fired alert: %v", err)
+	}
+
+	cid := connID
+	result, err := ds.GetTimelineEvents(context.Background(), TimelineFilter{
+		ConnectionID: &cid,
+		StartTime:    triggered.Add(-time.Hour),
+		EndTime:      triggered.Add(time.Hour),
+		EventTypes:   []string{EventTypeAlertFired},
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("GetTimelineEvents: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("expected exactly one fired row, got %d", len(result.Events))
+	}
+	if result.Events[0].Summary != desc {
+		t.Errorf("fired summary mismatch\n got: %q\nwant: %q", result.Events[0].Summary, desc)
+	}
+}

--- a/server/src/internal/database/timeline_queries.go
+++ b/server/src/internal/database/timeline_queries.go
@@ -812,7 +812,17 @@ func buildAlertFiredCountQuery(whereClause string) string {
     `, tableWhere)
 }
 
-// buildAlertClearedQuery creates the subquery for cleared alerts
+// buildAlertClearedQuery creates the subquery for cleared alerts.
+//
+// The summary column is a self-contained record of resolution: a
+// reader who sees only the cleared row should know the alert has
+// been resolved AND what the original firing condition described.
+// The duration between triggered_at and cleared_at is rendered in
+// human-readable form ("Ns", "Nm Ms", "Nh Mm") so it reads naturally
+// in tool output and chat replies. The original a.description is
+// appended verbatim, preserving the historical alert text without
+// rewriting it. The corresponding alert_fired row continues to carry
+// a.description on its own as the historical record.
 func buildAlertClearedQuery(whereClause string) string {
 	tableWhere := strings.ReplaceAll(whereClause, "event_time", "cleared_at")
 
@@ -833,7 +843,7 @@ func buildAlertClearedQuery(whereClause string) string {
             a.cleared_at AS event_time,
             'info' AS severity,
             'Alert Cleared: ' || a.title AS title,
-            'Alert condition no longer active' AS summary,
+            'Resolved after ' || %s || '. Fired: ' || a.description AS summary,
             jsonb_build_object(
                 'alert_id', a.id,
                 'original_severity', a.severity,
@@ -843,7 +853,58 @@ func buildAlertClearedQuery(whereClause string) string {
         FROM alerts a
         JOIN connections c ON a.connection_id = c.id
         %s
-    `, EventTypeAlertCleared, tableWhere)
+    `, EventTypeAlertCleared, alertClearedDurationSQL, tableWhere)
+}
+
+// alertClearedDurationSQL renders the elapsed time between a fired
+// alert's triggered_at and cleared_at columns as a human-readable
+// string for use in the cleared-row summary.
+//
+// The expression uses GREATEST(...,0) to defend against clock skew or
+// out-of-order timestamps where cleared_at < triggered_at; in that
+// case the duration is treated as zero seconds rather than producing
+// a negative or oddly formatted string. The thresholds match the
+// Go-side helper formatAlertClearedDuration so unit-tested expectations
+// match SQL output exactly:
+//
+//   - diff < 60       -> "Ns"
+//   - diff < 3600     -> "Nm Ms"
+//   - diff >= 3600    -> "Nh Mm"
+const alertClearedDurationSQL = `
+            CASE
+                WHEN GREATEST(EXTRACT(EPOCH FROM (a.cleared_at - a.triggered_at))::BIGINT, 0) < 60 THEN
+                    GREATEST(EXTRACT(EPOCH FROM (a.cleared_at - a.triggered_at))::BIGINT, 0)::TEXT || 's'
+                WHEN GREATEST(EXTRACT(EPOCH FROM (a.cleared_at - a.triggered_at))::BIGINT, 0) < 3600 THEN
+                    (GREATEST(EXTRACT(EPOCH FROM (a.cleared_at - a.triggered_at))::BIGINT, 0) / 60)::TEXT
+                    || 'm '
+                    || (GREATEST(EXTRACT(EPOCH FROM (a.cleared_at - a.triggered_at))::BIGINT, 0) % 60)::TEXT
+                    || 's'
+                ELSE
+                    (GREATEST(EXTRACT(EPOCH FROM (a.cleared_at - a.triggered_at))::BIGINT, 0) / 3600)::TEXT
+                    || 'h '
+                    || ((GREATEST(EXTRACT(EPOCH FROM (a.cleared_at - a.triggered_at))::BIGINT, 0) % 3600) / 60)::TEXT
+                    || 'm'
+            END
+        `
+
+// formatAlertClearedDuration renders the same human-readable duration
+// string that alertClearedDurationSQL produces, but in Go. It exists
+// so unit tests can verify the SQL output without a live database and
+// so any future caller that needs to render the same string can share
+// a single definition. The two implementations must stay in sync.
+func formatAlertClearedDuration(d time.Duration) string {
+	secs := int64(d.Seconds())
+	if secs < 0 {
+		secs = 0
+	}
+	switch {
+	case secs < 60:
+		return fmt.Sprintf("%ds", secs)
+	case secs < 3600:
+		return fmt.Sprintf("%dm %ds", secs/60, secs%60)
+	default:
+		return fmt.Sprintf("%dh %dm", secs/3600, (secs%3600)/60)
+	}
 }
 
 // buildAlertClearedCountQuery creates the count query for cleared alerts

--- a/server/src/internal/tools/get_timeline_events.go
+++ b/server/src/internal/tools/get_timeline_events.go
@@ -72,6 +72,12 @@ If NO connection is selected (connected: false):
 Use this tool when the user asks what changed before an incident, what
 restarts or config changes have occurred, or to correlate alerts with
 the underlying changes that may have caused them.
+
+When reporting on alerts from this timeline, always check whether an
+alert_fired row has a corresponding alert_cleared row before treating
+it as ongoing; two rows describe the same underlying alert when the
+cleared row's title equals 'Alert Cleared: ' followed by the fired
+row's title.
 </important_behavior>
 
 <parameters>
@@ -90,7 +96,7 @@ Returns TSV data ordered by event time (most recent first):
 - event_type: One of the timeline event types
 - severity: info, warning, or critical
 - title: Short human-readable title
-- summary: One-line description of the event
+- summary: One-line description of the event. For alert_fired rows the summary describes the condition AT THE MOMENT THE ALERT FIRED and is not a statement about the current state. For alert_cleared rows the summary begins with 'Resolved after <duration>. Fired: ...' so the resolution is explicit.
 - id: Event identifier (composite, unique per row)
 </output>
 

--- a/server/src/internal/tools/get_timeline_events_test.go
+++ b/server/src/internal/tools/get_timeline_events_test.go
@@ -61,6 +61,40 @@ func TestGetTimelineEventsToolDefinition(t *testing.T) {
 	}
 }
 
+// TestGetTimelineEventsToolDescriptionMentionsAlertSemantics enforces the
+// long-form tool description includes the two pieces of guidance added
+// to prevent models from quoting historical alert text as live state.
+// The description ships on every tool listing, so future edits must keep
+// both of these signals in place for the model to interpret cleared
+// alerts correctly.
+func TestGetTimelineEventsToolDescriptionMentionsAlertSemantics(t *testing.T) {
+	desc := timelineToolDescription
+
+	// Output-section guidance: alert_fired summary describes the
+	// condition at firing time, and alert_cleared summary begins with
+	// 'Resolved after '.
+	wantOutputPhrases := []string{
+		"AT THE MOMENT THE ALERT FIRED",
+		"Resolved after <duration>. Fired:",
+	}
+	for _, want := range wantOutputPhrases {
+		if !strings.Contains(desc, want) {
+			t.Errorf("expected description to mention %q in <output> section", want)
+		}
+	}
+
+	// Behavior-section guidance: check for cleared-row pairing rule.
+	wantBehaviorPhrases := []string{
+		"alert_fired row has a corresponding alert_cleared row",
+		"'Alert Cleared: '",
+	}
+	for _, want := range wantBehaviorPhrases {
+		if !strings.Contains(desc, want) {
+			t.Errorf("expected description to mention %q in <important_behavior>", want)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // get_timeline_events nil datastore test
 // ---------------------------------------------------------------------------
@@ -455,6 +489,55 @@ func TestGetTimelineEventsIntegrationHappyPath(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("expected event type %q in output: %s", want, body)
 		}
+	}
+}
+
+// TestGetTimelineEventsIntegrationClearedSummaryEnrichment confirms that
+// the alert_cleared row emitted by the tool carries the enriched
+// "Resolved after <duration>. Fired: <description>" summary and that
+// the paired alert_fired row still carries the raw description. This is
+// the end-to-end version of the SQL-level coverage in
+// timeline_alert_cleared_integration_test.go.
+func TestGetTimelineEventsIntegrationClearedSummaryEnrichment(t *testing.T) {
+	pool, ds, cleanup := newTimelineTestEnv(t)
+	defer cleanup()
+
+	// Seed a single alert that fired and cleared 30 minutes later. The
+	// seedTimelineFixtures helper inserts the alert with description
+	// "cpu over threshold"; we re-use it so the expectations below
+	// mirror what the helper actually writes.
+	connID, base := seedTimelineFixtures(t, pool)
+
+	tool := GetTimelineEventsTool(ds, nil, nil)
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": float64(connID),
+		"event_types":   "alert_fired,alert_cleared",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("unexpected error response: %s", resp.Content[0].Text)
+	}
+	body := resp.Content[0].Text
+
+	// Cleared row: 30-minute gap formats as "30m 0s" and the
+	// description is appended verbatim.
+	wantCleared := "Resolved after 30m 0s. Fired: cpu over threshold"
+	if !strings.Contains(body, wantCleared) {
+		t.Errorf("expected cleared-row summary %q, got: %s", wantCleared, body)
+	}
+	// Fired row: description still appears verbatim somewhere in the
+	// TSV output (the cleared row contains it after 'Fired: ', so the
+	// fired row's presence is asserted by counting occurrences).
+	if strings.Count(body, "cpu over threshold") < 2 {
+		t.Errorf("expected description to appear in both fired and cleared rows, got body: %s", body)
+	}
+	// Sanity check the base anchor was not somehow elided from the
+	// emitted window, which would suggest the time filter was broken
+	// by the new summary expression.
+	if !strings.Contains(body, base.Format("2006")) {
+		t.Errorf("expected event timestamps in body, got: %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `alert_cleared` rows in the `get_timeline_events` MCP tool now carry a self-contained summary of the form `Resolved after <duration>. Fired: <original description>` instead of the flat `Alert condition no longer active`.
- Tool description tells clients that `alert_fired.summary` is the firing condition (not current state) and to pair each fired row with its corresponding `alert_cleared` row before treating an alert as ongoing.
- `alerts.description` is **not** modified — the firing text is preserved verbatim as the historical record.

## Background

While investigating an apparent "multiple probes haven't collected data for 150+ minutes" report from Ellie on the long-term test host, we found no current staleness — all enabled+available probes were collecting within their intervals. Ellie was quoting the `summary` field of an `alert_fired` row from a burst of staleness alerts that fired and cleared (27 seconds apart) ~3.5 hours earlier. The `alerts.description` column is frozen at create time, so the fired-row summary still read "...has not collected data for 154 minutes...", and the matching `alert_cleared` row's bland summary did not balance it. Both Ellie and a human skim-reader are vulnerable to the same misread.

## Test plan

- [x] `make test-all` green (server + collector + alerter + client).
- [x] Added unit tests for `formatAlertClearedDuration` covering `<60s`, `<3600s`, `>=3600s`, and clock-skew clamp.
- [x] Added integration tests exercising the SQL CASE for short (27s), medium (2m 15s), long (1h 23m 5s) durations and the negative-diff clamp.
- [x] Added tool-description string-match test and an end-to-end TSV assertion.
- [x] 100% per-function coverage on `buildAlertClearedQuery`, `buildAlertFiredQuery`, `formatAlertClearedDuration`, `buildAlertClearedCountQuery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Alert cleared events now display "Resolved after [duration]. Fired: [condition]" to clearly show how long the alert was active and what condition triggered it.

* **Documentation**
  * Clarified alert event correlation semantics in timeline tool documentation, including how to match fired and cleared alert events and what their summaries represent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/ai-dba-workbench/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->