### PR TITLE
fix(alerter): make LLM decision parsing deterministic

### DIFF
--- a/alerter/src/internal/engine/llm_parser.go
+++ b/alerter/src/internal/engine/llm_parser.go
@@ -22,15 +22,26 @@ type llmDecisionResponse struct {
 	Reasoning  string  `json:"reasoning"`
 }
 
+// decisionKeywords associates a canonical decision with the natural-language
+// keyword phrases that indicate it. Keyword groups are evaluated in slice
+// order so that matching is deterministic and has a well-defined precedence.
+type decisionKeywords struct {
+	// Decision is the canonical decision returned when a keyword matches.
+	Decision string
+
+	// Keywords are the lowercase phrases that indicate the decision.
+	Keywords []string
+}
+
 // llmDecisionConfig defines the keywords and fallback behavior for parsing
 // an LLM decision response.
 type llmDecisionConfig struct {
 	// ValidDecisions maps lowercase decision strings to their canonical form.
 	ValidDecisions map[string]string
 
-	// TextKeywords maps canonical decisions to keyword phrases that indicate
-	// that decision in natural language.
-	TextKeywords map[string][]string
+	// TextKeywords lists keyword groups in precedence order. The first group
+	// with a matching keyword wins, so fail-safe decisions must come first.
+	TextKeywords []decisionKeywords
 
 	// DefaultDecision is returned when the response cannot be parsed.
 	DefaultDecision string
@@ -42,26 +53,98 @@ type llmDecisionConfig struct {
 	FallbackConfidence float64
 }
 
-// parseLLMDecision parses an LLM response string into a decision and
-// confidence score using the provided configuration. It first attempts
-// JSON parsing, then falls back to keyword matching in the response text.
-func parseLLMDecision(response string, cfg llmDecisionConfig) (string, float64) {
-	// Try JSON parsing first
-	var result llmDecisionResponse
-	if err := json.Unmarshal([]byte(response), &result); err == nil {
-		canonical, ok := cfg.ValidDecisions[strings.ToLower(result.Decision)]
-		if ok {
-			return canonical, result.Confidence
+// extractJSONObject returns the substring spanning the first '{' to the last
+// '}' in s, or the empty string if no such span exists. This recovers a JSON
+// object embedded in surrounding prose.
+func extractJSONObject(s string) string {
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start < 0 || end < 0 || end < start {
+		return ""
+	}
+	return s[start : end+1]
+}
+
+// stripCodeFence removes a leading markdown code fence (```json or ```) and a
+// trailing fence from s, returning the trimmed inner content. If s is not
+// fenced, the whitespace-trimmed input is returned unchanged.
+func stripCodeFence(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+
+	// Drop the opening fence line (e.g. "```json" or "```").
+	trimmed = strings.TrimPrefix(trimmed, "```")
+	if idx := strings.IndexByte(trimmed, '\n'); idx >= 0 {
+		trimmed = trimmed[idx+1:]
+	} else {
+		trimmed = ""
+	}
+
+	// Drop the trailing closing fence if present.
+	trimmed = strings.TrimSpace(trimmed)
+	if idx := strings.LastIndex(trimmed, "```"); idx >= 0 {
+		trimmed = trimmed[:idx]
+	}
+
+	return strings.TrimSpace(trimmed)
+}
+
+// parseDecisionJSON attempts to decode response as a decision object, first
+// directly, then after stripping markdown fences, then by extracting an
+// embedded JSON object. It returns the canonical decision, its confidence,
+// and whether a valid decision was found.
+func parseDecisionJSON(response string, cfg llmDecisionConfig) (string, float64, bool) {
+	candidates := []string{
+		response,
+		stripCodeFence(response),
+	}
+	if obj := extractJSONObject(response); obj != "" {
+		candidates = append(candidates, obj)
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, dup := seen[candidate]; dup {
+			continue
+		}
+		seen[candidate] = struct{}{}
+
+		var result llmDecisionResponse
+		if err := json.Unmarshal([]byte(candidate), &result); err != nil {
+			continue
+		}
+		if canonical, ok := cfg.ValidDecisions[strings.ToLower(result.Decision)]; ok {
+			return canonical, result.Confidence, true
 		}
 	}
 
-	// Fall back to text matching
+	return "", 0, false
+}
+
+// parseLLMDecision parses an LLM response string into a decision and
+// confidence score using the provided configuration. It first attempts
+// JSON parsing (tolerating markdown code fences and surrounding prose),
+// then falls back to deterministic keyword matching in the response text.
+func parseLLMDecision(response string, cfg llmDecisionConfig) (string, float64) {
+	// Try JSON parsing first, including fenced and embedded variants.
+	if decision, confidence, ok := parseDecisionJSON(response, cfg); ok {
+		return decision, confidence
+	}
+
+	// Fall back to text matching. Keyword groups are evaluated in order so
+	// the result is deterministic and biased toward the fail-safe decision.
 	lowerResponse := strings.ToLower(response)
 
-	for decision, keywords := range cfg.TextKeywords {
-		for _, keyword := range keywords {
+	for _, group := range cfg.TextKeywords {
+		for _, keyword := range group.Keywords {
 			if strings.Contains(lowerResponse, keyword) {
-				return decision, cfg.FallbackConfidence
+				return group.Decision, cfg.FallbackConfidence
 			}
 		}
 	}
@@ -76,20 +159,29 @@ var reevaluationDecisionConfig = llmDecisionConfig{
 		"clear": "clear",
 		"keep":  "keep",
 	},
-	TextKeywords: map[string][]string{
-		"clear": {
-			"\"clear\"",
-			"'clear'",
-			"should be cleared",
-			"safe to clear",
-			"recommend clearing",
+	// Keyword groups are evaluated in order. "keep" is checked before
+	// "clear" so that ambiguous responses err toward keeping the alert
+	// active, matching the fail-safe DefaultDecision below.
+	TextKeywords: []decisionKeywords{
+		{
+			Decision: "keep",
+			Keywords: []string{
+				"\"keep\"",
+				"'keep'",
+				"should be kept",
+				"keep active",
+				"remain active",
+			},
 		},
-		"keep": {
-			"\"keep\"",
-			"'keep'",
-			"should be kept",
-			"keep active",
-			"remain active",
+		{
+			Decision: "clear",
+			Keywords: []string{
+				"\"clear\"",
+				"'clear'",
+				"should be cleared",
+				"safe to clear",
+				"recommend clearing",
+			},
 		},
 	},
 	DefaultDecision:    "keep",
@@ -107,18 +199,30 @@ var anomalyDecisionConfig = llmDecisionConfig{
 		"suppressed":     "suppress",
 		"false_positive": "suppress",
 	},
-	TextKeywords: map[string][]string{
-		"suppress": {
-			"should be suppressed",
-			"false positive",
-			"not a real issue",
-			"normal behavior",
+	// Keyword groups are evaluated in order. "alert" is checked before
+	// "suppress" so that ambiguous responses err toward alerting, matching
+	// the fail-safe DefaultDecision below. The suppress phrases are kept
+	// specific (for example "is normal behavior") so that prose such as
+	// "deviation from normal behavior" does not wrongly suppress an alert.
+	TextKeywords: []decisionKeywords{
+		{
+			Decision: "alert",
+			Keywords: []string{
+				"is a real issue",
+				"should alert",
+				"requires attention",
+				"genuine anomaly",
+			},
 		},
-		"alert": {
-			"real issue",
-			"should alert",
-			"requires attention",
-			"genuine anomaly",
+		{
+			Decision: "suppress",
+			Keywords: []string{
+				"should be suppressed",
+				"false positive",
+				"not a real issue",
+				"is normal behavior",
+				"within normal behavior",
+			},
 		},
 	},
 	DefaultDecision:    "alert",

--- a/alerter/src/internal/engine/llm_parser_test.go
+++ b/alerter/src/internal/engine/llm_parser_test.go
@@ -172,24 +172,57 @@ func TestParseLLMDecisionTextFallback(t *testing.T) {
 			expectedConfidence: 0.5,
 		},
 		{
+			// Genuine "normal" language now uses a specific phrasing so it
+			// reliably suppresses.
 			name:               "this is normal behavior",
-			response:           "This looks like normal behavior for the system",
+			response:           "This is normal behavior for the system",
 			config:             anomalyDecisionConfig,
 			expectedDecision:   "suppress",
 			expectedConfidence: 0.5,
 		},
 		{
-			name:               "normal behavior",
-			response:           "This looks like normal behavior for the workload",
+			// The "within normal behavior" phrasing also suppresses.
+			name:               "within normal behavior",
+			response:           "This stays within normal behavior for the workload",
 			config:             anomalyDecisionConfig,
 			expectedDecision:   "suppress",
 			expectedConfidence: 0.5,
+		},
+		{
+			// A bare "normal behavior" mention no longer matches the specific
+			// suppress keyword, so it falls through to the fail-safe default
+			// of "alert" rather than wrongly suppressing.
+			name:               "bare normal behavior falls through to alert",
+			response:           "This looks like normal behavior for the workload",
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "alert",
+			expectedConfidence: 0.3,
+		},
+		{
+			// "deviation from normal behavior" means NOT normal; it must not
+			// match the suppress keyword and so defaults to alert.
+			name:               "deviation from normal behavior is not suppressed",
+			response:           "This is a deviation from normal behavior",
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "alert",
+			expectedConfidence: 0.3,
 		},
 		{
 			name:               "real issue text",
 			response:           "This is a real issue that needs attention",
 			config:             anomalyDecisionConfig,
 			expectedDecision:   "alert",
+			expectedConfidence: 0.5,
+		},
+		{
+			// "not a real issue" must reach the suppress group rather than
+			// matching the alert keyword "is a real issue". The substring
+			// "is not a real issue" does not contain "is a real issue", so
+			// the response correctly falls through and suppresses.
+			name:               "not a real issue falls through to suppress",
+			response:           "After review, this is not a real issue worth alerting on",
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "suppress",
 			expectedConfidence: 0.5,
 		},
 		{
@@ -228,6 +261,142 @@ func TestParseLLMDecisionTextFallback(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseLLMDecisionFencedJSON tests that JSON wrapped in markdown code
+// fences, or embedded in surrounding prose, is parsed correctly.
+func TestParseLLMDecisionFencedJSON(t *testing.T) {
+	tests := []struct {
+		name               string
+		response           string
+		config             llmDecisionConfig
+		expectedDecision   string
+		expectedConfidence float64
+	}{
+		{
+			name:               "json fence alert",
+			response:           "```json\n{\"decision\":\"alert\",\"confidence\":0.9}\n```",
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "alert",
+			expectedConfidence: 0.9,
+		},
+		{
+			name:               "json fence suppress",
+			response:           "```json\n{\"decision\":\"suppress\",\"confidence\":0.8}\n```",
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "suppress",
+			expectedConfidence: 0.8,
+		},
+		{
+			name:               "bare fence alert",
+			response:           "```\n{\"decision\":\"alert\",\"confidence\":0.7}\n```",
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "alert",
+			expectedConfidence: 0.7,
+		},
+		{
+			name:               "bare fence reevaluation clear",
+			response:           "```\n{\"decision\":\"clear\",\"confidence\":0.6}\n```",
+			config:             reevaluationDecisionConfig,
+			expectedDecision:   "clear",
+			expectedConfidence: 0.6,
+		},
+		{
+			name:               "json embedded in prose",
+			response:           `Here is my assessment: {"decision":"alert","confidence":0.95} as requested.`,
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "alert",
+			expectedConfidence: 0.95,
+		},
+		{
+			name:               "fenced json with leading prose",
+			response:           "After analysis I conclude:\n```json\n{\"decision\":\"suppress\",\"confidence\":0.55}\n```\nThanks.",
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "suppress",
+			expectedConfidence: 0.55,
+		},
+		{
+			name:               "plain unfenced json still works",
+			response:           `{"decision":"alert","confidence":0.42}`,
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "alert",
+			expectedConfidence: 0.42,
+		},
+		{
+			name:               "fence with surrounding whitespace",
+			response:           "   ```json\n{\"decision\":\"keep\",\"confidence\":0.33}\n```   ",
+			config:             reevaluationDecisionConfig,
+			expectedDecision:   "keep",
+			expectedConfidence: 0.33,
+		},
+		{
+			// A fence marker with no newline yields no JSON; embedded object
+			// extraction recovers the decision instead.
+			name:               "single-line fence no newline",
+			response:           "```{\"decision\":\"alert\",\"confidence\":0.51}```",
+			config:             anomalyDecisionConfig,
+			expectedDecision:   "alert",
+			expectedConfidence: 0.51,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, confidence := parseLLMDecision(tt.response, tt.config)
+
+			if decision != tt.expectedDecision {
+				t.Errorf("decision = %q, expected %q", decision, tt.expectedDecision)
+			}
+
+			if math.Abs(confidence-tt.expectedConfidence) > 0.001 {
+				t.Errorf("confidence = %v, expected %v", confidence, tt.expectedConfidence)
+			}
+		})
+	}
+}
+
+// TestParseLLMDecisionDeterministic guards against regression of the map
+// iteration ordering bug. A response containing keywords for BOTH decisions
+// must always resolve to the same fail-safe decision.
+func TestParseLLMDecisionDeterministic(t *testing.T) {
+	t.Run("anomaly conflicting keywords always alert", func(t *testing.T) {
+		// "requires attention" (alert) and "false positive" (suppress) both
+		// appear; the fail-safe bias must always choose alert.
+		response := "This deviation from normal behavior requires attention, " +
+			"though some might call it a false positive."
+		for i := 0; i < 1000; i++ {
+			decision, _ := parseLLMDecision(response, anomalyDecisionConfig)
+			if decision != "alert" {
+				t.Fatalf("iteration %d: decision = %q, expected stable \"alert\"", i, decision)
+			}
+		}
+	})
+
+	t.Run("bug scenario deviation requires attention", func(t *testing.T) {
+		// The exact scenario from the bug report: must deterministically alert.
+		response := "This is a deviation from normal behavior and requires attention."
+		for i := 0; i < 1000; i++ {
+			decision, confidence := parseLLMDecision(response, anomalyDecisionConfig)
+			if decision != "alert" {
+				t.Fatalf("iteration %d: decision = %q, expected stable \"alert\"", i, decision)
+			}
+			if math.Abs(confidence-0.5) > 0.001 {
+				t.Fatalf("iteration %d: confidence = %v, expected 0.5", i, confidence)
+			}
+		}
+	})
+
+	t.Run("reevaluation conflicting keywords always keep", func(t *testing.T) {
+		// "remain active" (keep) and "safe to clear" (clear) both appear; the
+		// fail-safe bias must always choose keep.
+		response := "The alert should remain active even though it may be safe to clear."
+		for i := 0; i < 1000; i++ {
+			decision, _ := parseLLMDecision(response, reevaluationDecisionConfig)
+			if decision != "keep" {
+				t.Fatalf("iteration %d: decision = %q, expected stable \"keep\"", i, decision)
+			}
+		}
+	})
 }
 
 // TestParseLLMDecisionDefaults tests default behavior for unparseable input


### PR DESCRIPTION
## Summary

Fixes the Tier 3 anomaly parser defect where the **same** LLM response
could randomly resolve to `alert` or `suppress` (issue #263). Three
combined causes:

- JSON parsing failed whenever the LLM wrapped its object in markdown
  code fences or prose, forcing a fallback to keyword matching.
- The keyword fallback iterated a Go `map`, whose iteration order is
  randomized — so a response containing keywords for both decisions
  picked a winner by chance.
- The suppress keyword `"normal behavior"` matched prose like
  `"deviation from normal behavior"`, which means the opposite.

### Changes

- Strip markdown fences and extract an embedded JSON object before
  unmarshalling, so fenced/prose-wrapped responses parse correctly.
- Replace the keyword `map[string][]string` with an ordered slice
  evaluated in precedence order; `alert` is checked before `suppress`
  (and `keep` before `clear`) so ambiguous responses err toward the
  fail-safe default.
- Tighten suppress keywords to `"is normal behavior"` /
  `"within normal behavior"`, and the alert keyword to
  `"is a real issue"` so it no longer collides with the suppress phrase
  `"not a real issue"`.

## Test plan

- [x] `go build ./...`, `go vet ./internal/engine/` clean
- [x] Full `alerter` engine test suite passes
- [x] New tests: fenced/embedded JSON, the exact bug scenario, and a
      1000-iteration determinism guard against the map-ordering regression
- [x] Parser functions at 100% line coverage; `gofmt` clean

Closes #263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM response parsing to handle responses wrapped in markdown formatting or embedded within prose text.

* **Improvements**
  * Enhanced decision logic with deterministic keyword matching and fail-safe defaults for ambiguous responses.

* **Tests**
  * Added comprehensive test coverage for formatted JSON parsing and deterministic decision outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->