### PR TITLE
docs(changelog): record deterministic LLM parsing fix (#264)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,25 @@ The format is based on
 project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix the alerter intermittently and silently suppressing
+  anomaly alerts that should have fired. The Tier 3
+  LLM-based classifier parsed model responses
+  non-deterministically, so the same response could resolve
+  to either "alert" or "suppress" from one run to the next.
+  The parser now strips markdown code fences and extracts an
+  embedded JSON object before falling back to keyword
+  matching, and the keyword fallback applies a deterministic,
+  fail-safe precedence (alert before suppress, keep before
+  clear) instead of iterating a randomly ordered map. An
+  over-broad suppress keyword that matched phrases such as
+  "deviation from normal behavior" was also tightened. The
+  same anomaly condition now produces the same decision every
+  time, so genuine alerts fire reliably. (#264)
+
 ## [1.0.0-beta3] - 2026-05-26
 
 ### Added


### PR DESCRIPTION
## Summary

Adds the changelog entry that was missed when #264 merged. Records the
alerter Tier 3 deterministic-parsing fix under a new `## [Unreleased]`
section, since `1.0.0-beta3` is now released and frozen.

The entry describes the operator-visible behaviour: anomaly alerts that
were intermittently and silently suppressed now fire reliably for the
same condition.

## Test plan

- [x] Docs-only change; entry placed under `## [Unreleased]` > `### Fixed`
- [x] beta3 section left untouched
- [x] Lines wrapped at 79 characters

Follow-up to #264 / #263.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the alerter's anomaly classifier to ensure consistent, deterministic decisions for identical conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->