### PR TITLE
feat(server): add password_file YAML config support

### DIFF
--- a/alerter/src/cmd/ai-dba-alerter/main.go
+++ b/alerter/src/cmd/ai-dba-alerter/main.go
@@ -319,7 +319,7 @@ func applyFlagOverrides(cfg *config.Config, dbHost string, dbPort int, dbName, d
 		cfg.Datastore.Username = dbUser
 	}
 	if dbPasswordFile != "" {
-		password, err := fileutil.ReadTrimmedFileWithTilde(dbPasswordFile)
+		password, err := fileutil.ReadSecretFile(dbPasswordFile)
 		if err != nil {
 			return fmt.Errorf("failed to read password file: %w", err)
 		}

--- a/alerter/src/cmd/ai-dba-alerter/main_test.go
+++ b/alerter/src/cmd/ai-dba-alerter/main_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pgedge/ai-workbench/alerter/internal/config"
 	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
@@ -343,4 +344,64 @@ func TestReloadConfigOnSignal_PasswordFileMissing(t *testing.T) {
 	if !strings.Contains(err.Error(), "password") {
 		t.Errorf("err = %v, want it to mention 'password'", err)
 	}
+}
+
+// TestApplyFlagOverrides exercises every override branch, with
+// particular focus on the db-password-file read, which now flows
+// through fileutil.ReadSecretFile.
+func TestApplyFlagOverrides(t *testing.T) {
+	t.Run("all scalar overrides applied", func(t *testing.T) {
+		cfg := config.NewConfig()
+		if err := applyFlagOverrides(cfg, "h", 5433, "db", "user", "", "require"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Datastore.Host != "h" || cfg.Datastore.Port != 5433 ||
+			cfg.Datastore.Database != "db" || cfg.Datastore.Username != "user" ||
+			cfg.Datastore.SSLMode != "require" {
+			t.Errorf("scalar overrides not applied: %+v", cfg.Datastore)
+		}
+	})
+
+	t.Run("no overrides leaves config untouched", func(t *testing.T) {
+		cfg := config.NewConfig()
+		host := cfg.Datastore.Host
+		if err := applyFlagOverrides(cfg, "", 0, "", "", "", ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Datastore.Host != host {
+			t.Errorf("host changed unexpectedly to %q", cfg.Datastore.Host)
+		}
+	})
+
+	t.Run("password file loaded", func(t *testing.T) {
+		pwFile := filepath.Join(t.TempDir(), "pw.txt")
+		if err := os.WriteFile(pwFile, []byte("flag-password\n"), 0600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		cfg := config.NewConfig()
+		if err := applyFlagOverrides(cfg, "", 0, "", "", pwFile, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Datastore.Password != "flag-password" {
+			t.Errorf("Password = %q, want %q", cfg.Datastore.Password, "flag-password")
+		}
+	})
+
+	t.Run("missing password file is an error", func(t *testing.T) {
+		cfg := config.NewConfig()
+		if err := applyFlagOverrides(cfg, "", 0, "", "", "/nonexistent/pw", ""); err == nil {
+			t.Error("expected error for missing password file")
+		}
+	})
+
+	t.Run("empty password file is an error", func(t *testing.T) {
+		pwFile := filepath.Join(t.TempDir(), "empty.txt")
+		if err := os.WriteFile(pwFile, []byte("\n"), 0600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		cfg := config.NewConfig()
+		if err := applyFlagOverrides(cfg, "", 0, "", "", pwFile, ""); err == nil {
+			t.Error("expected error for empty password file")
+		}
+	})
 }

--- a/alerter/src/internal/config/config.go
+++ b/alerter/src/internal/config/config.go
@@ -345,7 +345,7 @@ func (c *Config) LoadPassword() error {
 	}
 
 	if c.Datastore.PasswordFile != "" {
-		password, err := fileutil.ReadTrimmedFileWithTilde(c.Datastore.PasswordFile)
+		password, err := fileutil.ReadSecretFile(c.Datastore.PasswordFile)
 		if err != nil {
 			return fmt.Errorf("failed to read password file: %w", err)
 		}
@@ -358,7 +358,7 @@ func (c *Config) LoadPassword() error {
 // LoadAPIKeys loads API keys from their respective files
 func (c *Config) LoadAPIKeys() error {
 	if c.LLM.OpenAI.APIKeyFile != "" {
-		key, err := fileutil.ReadTrimmedFileWithTilde(c.LLM.OpenAI.APIKeyFile)
+		key, err := fileutil.ReadSecretFile(c.LLM.OpenAI.APIKeyFile)
 		if err != nil {
 			return fmt.Errorf("failed to read OpenAI API key: %w", err)
 		}
@@ -366,7 +366,7 @@ func (c *Config) LoadAPIKeys() error {
 	}
 
 	if c.LLM.Anthropic.APIKeyFile != "" {
-		key, err := fileutil.ReadTrimmedFileWithTilde(c.LLM.Anthropic.APIKeyFile)
+		key, err := fileutil.ReadSecretFile(c.LLM.Anthropic.APIKeyFile)
 		if err != nil {
 			return fmt.Errorf("failed to read Anthropic API key: %w", err)
 		}
@@ -374,7 +374,7 @@ func (c *Config) LoadAPIKeys() error {
 	}
 
 	if c.LLM.Voyage.APIKeyFile != "" {
-		key, err := fileutil.ReadTrimmedFileWithTilde(c.LLM.Voyage.APIKeyFile)
+		key, err := fileutil.ReadSecretFile(c.LLM.Voyage.APIKeyFile)
 		if err != nil {
 			return fmt.Errorf("failed to read Voyage API key: %w", err)
 		}
@@ -382,7 +382,7 @@ func (c *Config) LoadAPIKeys() error {
 	}
 
 	if c.LLM.Gemini.APIKeyFile != "" {
-		key, err := fileutil.ReadTrimmedFileWithTilde(c.LLM.Gemini.APIKeyFile)
+		key, err := fileutil.ReadSecretFile(c.LLM.Gemini.APIKeyFile)
 		if err != nil {
 			return fmt.Errorf("failed to read Gemini API key: %w", err)
 		}

--- a/alerter/src/internal/config/config_test.go
+++ b/alerter/src/internal/config/config_test.go
@@ -356,6 +356,37 @@ func TestLoadPassword(t *testing.T) {
 		}
 	})
 
+	t.Run("empty file is an error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		pwFile := filepath.Join(tmpDir, "empty.txt")
+		if err := os.WriteFile(pwFile, []byte("\n"), 0600); err != nil {
+			t.Fatalf("failed to create password file: %v", err)
+		}
+
+		cfg := NewConfig()
+		cfg.Datastore.PasswordFile = pwFile
+		if err := cfg.LoadPassword(); err == nil {
+			t.Error("expected error for empty password file, got nil")
+		}
+	})
+
+	t.Run("preserves interior whitespace", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		pwFile := filepath.Join(tmpDir, "pw.txt")
+		if err := os.WriteFile(pwFile, []byte("file password \n"), 0600); err != nil {
+			t.Fatalf("failed to create password file: %v", err)
+		}
+
+		cfg := NewConfig()
+		cfg.Datastore.PasswordFile = pwFile
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Datastore.Password != "file password " {
+			t.Errorf("password = %q, expected %q", cfg.Datastore.Password, "file password ")
+		}
+	})
+
 	t.Run("no password file specified", func(t *testing.T) {
 		cfg := NewConfig()
 
@@ -473,6 +504,44 @@ func TestLoadAPIKeys(t *testing.T) {
 		err := cfg.LoadAPIKeys()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty key file is an error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		emptyFile := filepath.Join(tmpDir, "empty.key")
+		if err := os.WriteFile(emptyFile, []byte("\n"), 0600); err != nil {
+			t.Fatalf("failed to create key file: %v", err)
+		}
+
+		// Exercise each provider's error branch.
+		setters := []func(*Config){
+			func(c *Config) { c.LLM.OpenAI.APIKeyFile = emptyFile },
+			func(c *Config) { c.LLM.Anthropic.APIKeyFile = emptyFile },
+			func(c *Config) { c.LLM.Voyage.APIKeyFile = emptyFile },
+			func(c *Config) { c.LLM.Gemini.APIKeyFile = emptyFile },
+		}
+		for i, set := range setters {
+			cfg := NewConfig()
+			set(cfg)
+			if err := cfg.LoadAPIKeys(); err == nil {
+				t.Errorf("provider %d: expected error for empty key file, got nil", i)
+			}
+		}
+	})
+
+	t.Run("missing anthropic voyage gemini key files", func(t *testing.T) {
+		setters := []func(*Config){
+			func(c *Config) { c.LLM.Anthropic.APIKeyFile = "/nonexistent/anthropic.key" },
+			func(c *Config) { c.LLM.Voyage.APIKeyFile = "/nonexistent/voyage.key" },
+			func(c *Config) { c.LLM.Gemini.APIKeyFile = "/nonexistent/gemini.key" },
+		}
+		for i, set := range setters {
+			cfg := NewConfig()
+			set(cfg)
+			if err := cfg.LoadAPIKeys(); err == nil {
+				t.Errorf("provider %d: expected error for missing key file, got nil", i)
+			}
 		}
 	})
 }

--- a/alerter/src/internal/notifications/manager.go
+++ b/alerter/src/internal/notifications/manager.go
@@ -13,13 +13,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/pgedge/ai-workbench/alerter/internal/config"
 	"github.com/pgedge/ai-workbench/alerter/internal/database"
 	"github.com/pgedge/ai-workbench/pkg/crypto"
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
 // Manager implements NotificationManager
@@ -44,13 +43,9 @@ func NewManager(ds *database.Datastore, cfg *config.NotificationsConfig, debug b
 	}
 
 	// Load server secret from file (plain text, same format as server secret)
-	secretData, err := os.ReadFile(cfg.SecretFile)
+	serverSecret, err := fileutil.ReadSecretFile(cfg.SecretFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read secret file: %w", err)
-	}
-	serverSecret := strings.TrimSpace(string(secretData))
-	if serverSecret == "" {
-		return nil, fmt.Errorf("secret file is empty")
 	}
 
 	renderer := NewTemplateRenderer()

--- a/alerter/src/internal/notifications/manager_test.go
+++ b/alerter/src/internal/notifications/manager_test.go
@@ -68,6 +68,26 @@ func TestNewManager(t *testing.T) {
 		}
 	})
 
+	t.Run("whitespace-only secret file is an error", func(t *testing.T) {
+		// A file holding only whitespace has no real secret content;
+		// before the shared-helper refactor it was rejected, and the
+		// regression that allowed a useless whitespace-only secret to
+		// reach channel-decryption key material must stay fixed here.
+		for _, content := range []string{"   \n", "\t \n", "   "} {
+			secretPath := filepath.Join(t.TempDir(), "whitespace.secret")
+			if err := os.WriteFile(secretPath, []byte(content), 0600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			cfg := &config.NotificationsConfig{
+				Enabled:    true,
+				SecretFile: secretPath,
+			}
+			if _, err := NewManager(nil, cfg, false, nil); err == nil {
+				t.Errorf("expected error for whitespace-only secret file %q, got nil", content)
+			}
+		}
+	})
+
 	t.Run("valid secret file builds a manager", func(t *testing.T) {
 		secretPath := filepath.Join(t.TempDir(), "valid.secret")
 		if err := os.WriteFile(secretPath, []byte("server-secret-value\n"), 0600); err != nil {

--- a/alerter/src/internal/notifications/manager_test.go
+++ b/alerter/src/internal/notifications/manager_test.go
@@ -11,6 +11,8 @@ package notifications
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,6 +20,76 @@ import (
 	"github.com/pgedge/ai-workbench/alerter/internal/database"
 	"github.com/pgedge/ai-workbench/pkg/crypto"
 )
+
+// TestNewManager exercises the construction paths that depend on the
+// secret-file read, which now flows through fileutil.ReadSecretFile.
+func TestNewManager(t *testing.T) {
+	t.Run("nil config returns nil manager", func(t *testing.T) {
+		m, err := NewManager(nil, nil, false, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m != nil {
+			t.Error("expected nil manager when config is nil")
+		}
+	})
+
+	t.Run("disabled config returns nil manager", func(t *testing.T) {
+		m, err := NewManager(nil, &config.NotificationsConfig{Enabled: false}, false, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m != nil {
+			t.Error("expected nil manager when notifications are disabled")
+		}
+	})
+
+	t.Run("missing secret file is an error", func(t *testing.T) {
+		cfg := &config.NotificationsConfig{
+			Enabled:    true,
+			SecretFile: "/nonexistent/secret",
+		}
+		if _, err := NewManager(nil, cfg, false, nil); err == nil {
+			t.Error("expected error when secret file is missing")
+		}
+	})
+
+	t.Run("empty secret file is an error", func(t *testing.T) {
+		secretPath := filepath.Join(t.TempDir(), "empty.secret")
+		if err := os.WriteFile(secretPath, []byte("\n"), 0600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		cfg := &config.NotificationsConfig{
+			Enabled:    true,
+			SecretFile: secretPath,
+		}
+		if _, err := NewManager(nil, cfg, false, nil); err == nil {
+			t.Error("expected error when secret file is empty")
+		}
+	})
+
+	t.Run("valid secret file builds a manager", func(t *testing.T) {
+		secretPath := filepath.Join(t.TempDir(), "valid.secret")
+		if err := os.WriteFile(secretPath, []byte("server-secret-value\n"), 0600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		cfg := &config.NotificationsConfig{
+			Enabled:            true,
+			SecretFile:         secretPath,
+			HTTPTimeoutSeconds: 0, // exercises the default-timeout branch
+		}
+		m, err := NewManager(nil, cfg, false, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m == nil {
+			t.Fatal("expected a manager instance")
+		}
+		if m.serverSecret != "server-secret-value" {
+			t.Errorf("serverSecret = %q, want %q", m.serverSecret, "server-secret-value")
+		}
+	})
+}
 
 func TestManager_GetBackoffMinutes(t *testing.T) {
 	tests := []struct {

--- a/alerter/src/internal/notifications/secrets.go
+++ b/alerter/src/internal/notifications/secrets.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	pkgcrypto "github.com/pgedge/ai-workbench/pkg/crypto"
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
 // secretManager implements SecretManager using AES-256-GCM
@@ -34,21 +35,15 @@ func NewSecretManager(key []byte) (SecretManager, error) {
 
 // LoadSecretKey loads a secret key from a file.
 // The file should contain a hex-encoded 32-byte key (64 hex characters).
-// The file must have 0600 permissions (owner read/write only).
+// The file must not grant group or world access; owner-only modes such
+// as 0400 and 0600 are accepted, while 0640, 0644, and friends fail.
 func LoadSecretKey(path string) ([]byte, error) {
-	// Check file permissions before loading
-	fileInfo, err := os.Stat(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to stat secret key file: %w", err)
+	// Reject any file that grants group or world access.
+	if err := fileutil.RequireOwnerOnly(path); err != nil {
+		return nil, err
 	}
 
-	mode := fileInfo.Mode().Perm()
-	if mode != 0600 {
-		return nil, fmt.Errorf(
-			"insecure permissions on secret key file %s: %04o (expected 0600). "+
-				"Please run: chmod 600 %s", path, mode, path)
-	}
-
+	// #nosec G304 - File path is provided by administrator configuration
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read secret key file: %w", err)

--- a/alerter/src/internal/notifications/secrets.go
+++ b/alerter/src/internal/notifications/secrets.go
@@ -34,12 +34,15 @@ func NewSecretManager(key []byte) (SecretManager, error) {
 
 // LoadSecretKey loads a secret key from a file.
 // The file should contain a hex-encoded 32-byte key (64 hex characters).
-// The file must not grant group or world access; owner-only modes such
-// as 0400 and 0600 are accepted, while 0640, 0644, and friends fail.
+// On non-Windows platforms the file must not grant group or world
+// access; owner-only modes such as 0400 and 0600 are accepted, while
+// 0640, 0644, and friends fail. Windows mode bits do not map cleanly,
+// so that permission check is skipped there.
 func LoadSecretKey(path string) ([]byte, error) {
-	// Reject any file that grants group or world access. The permission
-	// check and read happen on the same open descriptor to close the
-	// TOCTOU window a separate stat + read would leave.
+	// On non-Windows platforms, reject any file that grants group or
+	// world access. The regular-file, size, and permission checks all
+	// happen on the same open descriptor that is read, closing the TOCTOU
+	// window a separate stat + read would leave.
 	data, err := fileutil.ReadOwnerOnlyFile(path)
 	if err != nil {
 		return nil, err

--- a/alerter/src/internal/notifications/secrets.go
+++ b/alerter/src/internal/notifications/secrets.go
@@ -13,7 +13,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"strings"
 
 	pkgcrypto "github.com/pgedge/ai-workbench/pkg/crypto"
@@ -38,15 +37,12 @@ func NewSecretManager(key []byte) (SecretManager, error) {
 // The file must not grant group or world access; owner-only modes such
 // as 0400 and 0600 are accepted, while 0640, 0644, and friends fail.
 func LoadSecretKey(path string) ([]byte, error) {
-	// Reject any file that grants group or world access.
-	if err := fileutil.RequireOwnerOnly(path); err != nil {
-		return nil, err
-	}
-
-	// #nosec G304 - File path is provided by administrator configuration
-	data, err := os.ReadFile(path)
+	// Reject any file that grants group or world access. The permission
+	// check and read happen on the same open descriptor to close the
+	// TOCTOU window a separate stat + read would leave.
+	data, err := fileutil.ReadOwnerOnlyFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read secret key file: %w", err)
+		return nil, err
 	}
 
 	// Trim whitespace (newlines, spaces, etc.)

--- a/alerter/src/internal/notifications/secrets_test.go
+++ b/alerter/src/internal/notifications/secrets_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -362,6 +363,10 @@ func TestLoadSecretKey_FileNotFound(t *testing.T) {
 // permission check accepts owner-only modes beyond 0600. A 0400
 // (read-only owner) key file must load successfully.
 func TestLoadSecretKey_ReadOnlyOwnerPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-bit enforcement is not applied on Windows")
+	}
+
 	tmpDir := t.TempDir()
 	keyFile := filepath.Join(tmpDir, "readonly.key")
 
@@ -379,6 +384,10 @@ func TestLoadSecretKey_ReadOnlyOwnerPermissions(t *testing.T) {
 }
 
 func TestLoadSecretKey_InsecurePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-bit enforcement is not applied on Windows")
+	}
+
 	tmpDir := t.TempDir()
 	keyFile := filepath.Join(tmpDir, "secret.key")
 

--- a/alerter/src/internal/notifications/secrets_test.go
+++ b/alerter/src/internal/notifications/secrets_test.go
@@ -353,8 +353,28 @@ func TestLoadSecretKey_FileNotFound(t *testing.T) {
 		t.Error("LoadSecretKey() expected error for nonexistent file")
 	}
 
-	if !strings.Contains(err.Error(), "secret key file") {
-		t.Errorf("Error should mention secret key file: %v", err)
+	if !strings.Contains(err.Error(), "key file") {
+		t.Errorf("Error should mention the key file: %v", err)
+	}
+}
+
+// TestLoadSecretKey_ReadOnlyOwnerPermissions verifies the relaxed
+// permission check accepts owner-only modes beyond 0600. A 0400
+// (read-only owner) key file must load successfully.
+func TestLoadSecretKey_ReadOnlyOwnerPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyFile := filepath.Join(tmpDir, "readonly.key")
+
+	validKey := strings.Repeat("ab", 32) // 64 hex chars = 32 bytes
+	if err := os.WriteFile(keyFile, []byte(validKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key file: %v", err)
+	}
+	if err := os.Chmod(keyFile, 0400); err != nil {
+		t.Fatalf("Failed to chmod test key file: %v", err)
+	}
+
+	if _, err := LoadSecretKey(keyFile); err != nil {
+		t.Errorf("LoadSecretKey() expected 0400 file to load, got error: %v", err)
 	}
 }
 

--- a/collector/src/config.go
+++ b/collector/src/config.go
@@ -131,7 +131,7 @@ func (c *Config) LoadPassword() error {
 	}
 
 	if c.Datastore.PasswordFile != "" {
-		password, err := fileutil.ReadTrimmedFileWithTilde(c.Datastore.PasswordFile)
+		password, err := fileutil.ReadSecretFile(c.Datastore.PasswordFile)
 		if err != nil {
 			return fmt.Errorf("failed to read password file: %w", err)
 		}
@@ -159,7 +159,7 @@ func (c *Config) LoadSecret(binaryPath string) error {
 
 	// If secret file is explicitly specified, use it.
 	if c.SecretFile != "" {
-		secret, err := fileutil.ReadTrimmedFileWithTilde(c.SecretFile)
+		secret, err := fileutil.ReadSecretFile(c.SecretFile)
 		if err != nil {
 			return fmt.Errorf("failed to read secret file: %w", err)
 		}
@@ -170,7 +170,7 @@ func (c *Config) LoadSecret(binaryPath string) error {
 	// Resolve via the shared helper so all three services apply
 	// identical precedence to default paths.
 	if path := fileutil.GetDefaultConfigPath("", "ai-dba-collector.secret"); path != "" {
-		secret, err := fileutil.ReadTrimmedFileWithTilde(path)
+		secret, err := fileutil.ReadSecretFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to read secret file %s: %w", path, err)
 		}

--- a/collector/src/config_test.go
+++ b/collector/src/config_test.go
@@ -437,7 +437,8 @@ func TestReadSecretFile(t *testing.T) {
 }
 
 func TestReadSecretFile_NotFound(t *testing.T) {
-	_, err := fileutil.ReadSecretFile("/nonexistent/path/to/secret.txt")
+	missingPath := filepath.Join(t.TempDir(), "missing.secret")
+	_, err := fileutil.ReadSecretFile(missingPath)
 	if err == nil {
 		t.Error("Expected error when reading non-existent secret file")
 	}

--- a/collector/src/config_test.go
+++ b/collector/src/config_test.go
@@ -268,9 +268,9 @@ func TestReadPasswordFromSecretFile(t *testing.T) {
 		t.Fatalf("Failed to write test password file: %v", err)
 	}
 
-	password, err := fileutil.ReadTrimmedFileWithTilde(passwordFile)
+	password, err := fileutil.ReadSecretFile(passwordFile)
 	if err != nil {
-		t.Fatalf("fileutil.ReadTrimmedFileWithTilde() error = %v", err)
+		t.Fatalf("fileutil.ReadSecretFile() error = %v", err)
 	}
 
 	if password != testPassword {
@@ -426,9 +426,9 @@ func TestReadSecretFile(t *testing.T) {
 		t.Fatalf("Failed to write test secret file: %v", err)
 	}
 
-	secret, err := fileutil.ReadTrimmedFileWithTilde(secretFile)
+	secret, err := fileutil.ReadSecretFile(secretFile)
 	if err != nil {
-		t.Fatalf("fileutil.ReadTrimmedFileWithTilde() error = %v", err)
+		t.Fatalf("fileutil.ReadSecretFile() error = %v", err)
 	}
 
 	if secret != testSecret {
@@ -437,7 +437,7 @@ func TestReadSecretFile(t *testing.T) {
 }
 
 func TestReadSecretFile_NotFound(t *testing.T) {
-	_, err := fileutil.ReadTrimmedFileWithTilde("/nonexistent/path/to/secret.txt")
+	_, err := fileutil.ReadSecretFile("/nonexistent/path/to/secret.txt")
 	if err == nil {
 		t.Error("Expected error when reading non-existent secret file")
 	}
@@ -658,6 +658,39 @@ func TestConfigLoadPassword_FileMissing(t *testing.T) {
 	}
 }
 
+func TestConfigLoadPassword_FileEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	pwFile := filepath.Join(tmpDir, "empty.txt")
+	if err := os.WriteFile(pwFile, []byte("\n"), 0600); err != nil {
+		t.Fatalf("failed to write password file: %v", err)
+	}
+
+	config := NewConfig()
+	config.Datastore.PasswordFile = pwFile
+
+	if err := config.LoadPassword(); err == nil {
+		t.Error("expected error when password file is empty")
+	}
+}
+
+func TestConfigLoadPassword_PreservesInteriorWhitespace(t *testing.T) {
+	tmpDir := t.TempDir()
+	pwFile := filepath.Join(tmpDir, "pw.txt")
+	// A trailing space is part of the secret; only the newline is trimmed.
+	if err := os.WriteFile(pwFile, []byte("file password \n"), 0600); err != nil {
+		t.Fatalf("failed to write password file: %v", err)
+	}
+
+	config := NewConfig()
+	config.Datastore.PasswordFile = pwFile
+	if err := config.LoadPassword(); err != nil {
+		t.Fatalf("LoadPassword() error = %v", err)
+	}
+	if config.Datastore.Password != "file password " {
+		t.Errorf("Password: got %q, want %q", config.Datastore.Password, "file password ")
+	}
+}
+
 func TestConfigLoadPassword_NoFileNoDirect(t *testing.T) {
 	config := NewConfig()
 	// Neither Password nor PasswordFile set: LoadPassword returns nil
@@ -736,6 +769,21 @@ func TestLoadSecret_ExplicitPath(t *testing.T) {
 
 	if config.GetServerSecret() != testSecret {
 		t.Errorf("Expected secret to be '%s', got '%s'", testSecret, config.GetServerSecret())
+	}
+}
+
+func TestLoadSecret_ExplicitPathEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	secretFile := filepath.Join(tmpDir, "empty.secret")
+	if err := os.WriteFile(secretFile, []byte("\n"), 0600); err != nil {
+		t.Fatalf("Failed to write test secret file: %v", err)
+	}
+
+	config := NewConfig()
+	config.SecretFile = secretFile
+
+	if err := config.LoadSecret(""); err == nil {
+		t.Error("expected error when explicit secret file is empty")
 	}
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,7 +34,7 @@ project adheres to
   tokens, API keys, server and notification secrets, and proxy
   header values. Secrets that legitimately contain leading,
   trailing, or interior spaces are now preserved verbatim.
-  **Operational:** operators who relied on the old
+  Operational: operators who relied on the old
   whitespace-stripping behaviour may need to re-create affected
   secret files so the stored value matches the intended secret.
   (#267)
@@ -43,7 +43,7 @@ project adheres to
   startup error, instead of silently treating the file as "no
   value". Previously an empty file fell through to `.pgpass` or a
   passwordless connection, which could mask a misconfigured
-  deployment. **Operational:** operators must ensure every
+  deployment. Operators must ensure every
   configured secret file contains a value before starting the new
   binaries. (#267)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,57 @@ project adheres to
   `password` value and no CLI password flag are set, bringing the
   server in line with the collector and alerter. (#267)
 
+### Changed
+
+- Unify how the server, collector, and alerter read secrets from
+  files onto a single hardened helper. The change covers database
+  and user passwords, service tokens, LLM and embedding API keys,
+  server and notification secrets, proxy header values, and binary
+  encryption keys. Several behaviours below are
+  backward-incompatible, so operators upgrading the collector or
+  alerter should review them before rolling out the new binaries.
+  (#267)
+
+- Trim only the trailing newline from a secret file, rather than
+  stripping all surrounding whitespace. This applies to passwords,
+  tokens, API keys, server and notification secrets, and proxy
+  header values. Secrets that legitimately contain leading,
+  trailing, or interior spaces are now preserved verbatim.
+  **Operational:** operators who relied on the old
+  whitespace-stripping behaviour may need to re-create affected
+  secret files so the stored value matches the intended secret.
+  (#267)
+
+- Treat a configured-but-empty secret or password file as a hard
+  startup error, instead of silently treating the file as "no
+  value". Previously an empty file fell through to `.pgpass` or a
+  passwordless connection, which could mask a misconfigured
+  deployment. **Operational:** operators must ensure every
+  configured secret file contains a value before starting the new
+  binaries. (#267)
+
+- Accept any owner-only permission mode, such as `0400` or `0600`,
+  for the binary key loaders that read the server encryption key
+  and the alerter notification secret key, instead of requiring
+  exactly `0600`. Group- or world-accessible modes such as `0640`
+  and `0644` are still rejected. (#267)
+
+- Expand a leading `~` in a secret or server-secret file path to
+  the user's home directory consistently across all components.
+  (#267)
+
+- Allow the server's `-db-password-file` flag to accept paths
+  containing `..`, so legitimate relative paths now work. The flag
+  previously rejected any path containing `..`. (#267)
+
 ### Fixed
+
+- Fix the server silently swallowing read errors for configured
+  LLM, embedding, and knowledgebase API-key files. The server
+  previously proceeded with no key when such a file was unreadable
+  or empty; an unreadable or empty configured key file now fails
+  loudly at startup. Leaving a key-file path unset remains valid
+  and is not an error. (#267)
 
 - Fix the alerter intermittently and silently suppressing
   anomaly alerts that should have fired. The Tier 3
@@ -49,6 +99,13 @@ project adheres to
   the failing tool, shows the underlying error, and suggests a
   likely permissions or connection-access problem to raise with
   an administrator. (#268)
+
+### Security
+
+- Log a warning recommending `chmod 600` when reading any secret
+  file from a group- or world-readable path. The read still
+  succeeds, so existing deployments continue to work while
+  operators tighten the affected file permissions. (#267)
 
 ## [1.0.0-beta3] - 2026-05-26
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,14 @@ project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add a `password_file` option to the server's `database:` YAML
+  block, allowing the server to read the datastore password from
+  a file. The server uses this file only when no inline
+  `password` value and no CLI password flag are set, bringing the
+  server in line with the collector and alerter. (#267)
+
 ### Fixed
 
 - Fix the alerter intermittently and silently suppressing

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -99,6 +99,7 @@ database:
   database: "ai_workbench"
   user: "postgres"
   # password: ""
+  # password_file: "/etc/pgedge/password.txt"
   sslmode: "prefer"
   pool_max_conns: 4
   pool_min_conns: 0
@@ -215,6 +216,7 @@ builtins:
 | `-db-name string` | Database name |
 | `-db-user string` | Database user |
 | `-db-password string` | Database password |
+| `-db-password-file string` | Path to file containing the database password |
 | `-db-sslmode string` | SSL mode |
 
 ### Token Management Options
@@ -359,6 +361,7 @@ protection for user-created database connections.
 | `database` | string | `postgres` | Database name |
 | `user` | string | | Database user (required) |
 | `password` | string | | Database password |
+| `password_file` | string | | Path to a file containing the database password (used only if `password` is empty) |
 | `sslmode` | string | `prefer` | SSL mode |
 | `pool_max_conns` | int | `4` | Max pool connections |
 | `pool_min_conns` | int | `0` | Min pool connections |

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -361,7 +361,7 @@ protection for user-created database connections.
 | `database` | string | `postgres` | Database name |
 | `user` | string | | Database user (required) |
 | `password` | string | | Database password |
-| `password_file` | string | | DB password file; used if `password` empty |
+| `password_file` | string | | DB password file (if `password` empty) |
 | `sslmode` | string | `prefer` | SSL mode |
 | `pool_max_conns` | int | `4` | Max pool connections |
 | `pool_min_conns` | int | `0` | Min pool connections |

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -216,7 +216,7 @@ builtins:
 | `-db-name string` | Database name |
 | `-db-user string` | Database user |
 | `-db-password string` | Database password |
-| `-db-password-file string` | Path to file containing the database password |
+| `-db-password-file string` | Path to file with the database password |
 | `-db-sslmode string` | SSL mode |
 
 ### Token Management Options
@@ -361,7 +361,7 @@ protection for user-created database connections.
 | `database` | string | `postgres` | Database name |
 | `user` | string | | Database user (required) |
 | `password` | string | | Database password |
-| `password_file` | string | | Path to a file containing the database password (used only if `password` is empty) |
+| `password_file` | string | | DB password file; used if `password` empty |
 | `sslmode` | string | `prefer` | SSL mode |
 | `pool_max_conns` | int | `4` | Max pool connections |
 | `pool_min_conns` | int | `0` | Min pool connections |

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -216,7 +216,7 @@ builtins:
 | `-db-name string` | Database name |
 | `-db-user string` | Database user |
 | `-db-password string` | Database password |
-| `-db-password-file string` | Path to file with the database password |
+| `-db-password-file string` | Path to DB password file |
 | `-db-sslmode string` | SSL mode |
 
 ### Token Management Options

--- a/examples/ai-dba-alerter.yaml
+++ b/examples/ai-dba-alerter.yaml
@@ -59,10 +59,10 @@ datastore:
   # Command-line: -pg-password-file
   #
   # Example: Create a password file with restricted permissions:
-  #   echo "your-password" > /etc/ai-workbench/password.txt
-  #   chmod 600 /etc/ai-workbench/password.txt
+  #   echo "your-password" > /etc/pgedge/password.txt
+  #   chmod 600 /etc/pgedge/password.txt
   #
-  # password_file: /etc/ai-workbench/password.txt
+  # password_file: /etc/pgedge/password.txt
 
   # Port on which the AI DBA Workbench datastore is listening
   # Default: 5432
@@ -554,7 +554,7 @@ notifications:
 #   host: datastore.internal.example.com
 #   database: ai_workbench_prod
 #   username: ai_workbench
-#   password_file: /var/secrets/ai-workbench/db-password.txt
+#   password_file: /etc/pgedge/password.txt
 #   port: 5432
 #   sslmode: verify-full
 #   sslcert: /etc/ai-workbench/certs/client-cert.pem

--- a/examples/ai-dba-collector.yaml
+++ b/examples/ai-dba-collector.yaml
@@ -63,10 +63,10 @@ datastore:
   # Command-line: -pg-password-file
   #
   # Example: Create a password file with restricted permissions:
-  #   echo "your-password" > /etc/ai-workbench/password.txt
-  #   chmod 600 /etc/ai-workbench/password.txt
+  #   echo "your-password" > /etc/pgedge/password.txt
+  #   chmod 600 /etc/pgedge/password.txt
   #
-  # password_file: /etc/ai-workbench/password.txt
+  # password_file: /etc/pgedge/password.txt
 
   # Port on which the AI DBA Workbench datastore is listening
   # Default: 5432
@@ -227,7 +227,7 @@ pool:
 #   host: datastore.internal.example.com
 #   database: ai_workbench_prod
 #   username: ai_workbench
-#   password_file: /var/secrets/ai-workbench/db-password.txt
+#   password_file: /etc/pgedge/password.txt
 #   port: 5432
 #   sslmode: verify-full
 #   sslcert: /etc/ai-workbench/certs/client-cert.pem
@@ -249,7 +249,7 @@ pool:
 #   host: metrics-db.internal.example.com
 #   database: ai_workbench
 #   username: ai_workbench
-#   password_file: /etc/ai-workbench/password.txt
+#   password_file: /etc/pgedge/password.txt
 #   sslmode: require
 # pool:
 #   datastore_max_connections: 200

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -168,8 +168,8 @@ database:
 
   # Path to a file containing the database password
   # Used only when password is empty; the file contents are read and
-  # trimmed of surrounding whitespace. CLI flags, the PGEDGE_DB_PASSWORD
-  # environment variable, and an inline password all take precedence.
+  # trimmed of surrounding whitespace. CLI flags and an inline password
+  # all take precedence.
   # password_file: /etc/pgedge/password.txt
 
   # SSL mode: disable, require, verify-ca, verify-full

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -167,9 +167,9 @@ database:
   # password: ""
 
   # Path to a file containing the database password
-  # Used only when password is empty; the file contents are read and
-  # trimmed of surrounding whitespace. CLI flags and an inline password
-  # all take precedence.
+  # Used only when password is empty; the file contents are read and only
+  # the trailing newline is trimmed (leading/interior spaces are preserved).
+  # CLI flags and an inline password all take precedence.
   # password_file: /etc/pgedge/password.txt
 
   # SSL mode: disable, require, verify-ca, verify-full

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -166,6 +166,12 @@ database:
   # If not set, will use .pgpass file automatically
   # password: ""
 
+  # Path to a file containing the database password
+  # Used only when password is empty; the file contents are read and
+  # trimmed of surrounding whitespace. CLI flags, the PGEDGE_DB_PASSWORD
+  # environment variable, and an inline password all take precedence.
+  # password_file: /etc/pgedge/password.txt
+
   # SSL mode: disable, require, verify-ca, verify-full
   # Default: prefer
   sslmode: "prefer"

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -37,54 +38,83 @@ func ExpandTildePath(path string) (string, error) {
 	return filepath.Join(homeDir, path[1:]), nil
 }
 
-// ReadTrimmedFile reads a file and returns its contents with leading and
-// trailing whitespace removed.
-func ReadTrimmedFile(path string) (string, error) {
-	// #nosec G304 - File path is provided by administrator configuration
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-
-	return strings.TrimSpace(string(content)), nil
-}
-
-// ReadTrimmedFileWithTilde reads a file after expanding any leading tilde
-// in the path, then returns the contents with whitespace trimmed.
-func ReadTrimmedFileWithTilde(path string) (string, error) {
+// ReadSecretFile reads a secret (password, token, API key, or server
+// secret) from an operator-supplied file path. It expands a leading
+// tilde, warns (to stderr) if the file is group/world-readable, trims
+// only a trailing newline sequence (preserving any in-secret
+// whitespace), and returns an error if the resulting secret is empty.
+//
+// The trailing-newline trim uses strings.TrimRight(data, "\r\n") rather
+// than TrimSpace so that secrets containing intentional leading,
+// trailing, or interior spaces survive intact; only the line-ending a
+// text editor appends is stripped.
+func ReadSecretFile(path string) (string, error) {
 	expandedPath, err := ExpandTildePath(path)
 	if err != nil {
 		return "", err
 	}
 
-	return ReadTrimmedFile(expandedPath)
-}
+	WarnIfPermissive(expandedPath)
 
-// ReadOptionalTrimmedFile reads a file and returns its contents with
-// whitespace trimmed. If the file does not exist, it returns an empty
-// string without an error. The path is expanded if it starts with tilde.
-func ReadOptionalTrimmedFile(path string) (string, error) {
-	if path == "" {
-		return "", nil
-	}
-
-	expandedPath, err := ExpandTildePath(path)
+	// #nosec G304 - File path is provided by administrator configuration
+	data, err := os.ReadFile(expandedPath)
 	if err != nil {
 		return "", err
 	}
 
-	// Check if file exists
-	if _, err := os.Stat(expandedPath); os.IsNotExist(err) {
-		return "", nil
+	secret := strings.TrimRight(string(data), "\r\n")
+	if secret == "" {
+		return "", fmt.Errorf("secret file %s is empty", expandedPath)
 	}
 
-	// #nosec G304 - File path is provided by administrator configuration
-	content, err := os.ReadFile(expandedPath)
+	return secret, nil
+}
+
+// WarnIfPermissive prints a stderr warning if the file is group- or
+// world-readable (mode & 0o077 != 0). It never returns an error and is
+// a no-op on Windows, where Unix mode bits do not map cleanly.
+func WarnIfPermissive(path string) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	info, err := os.Stat(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file %s: %w", expandedPath, err)
+		// Stat failures are surfaced by the subsequent read; the
+		// warning is best-effort only.
+		return
 	}
 
-	return strings.TrimSpace(string(content)), nil
+	if info.Mode().Perm()&0o077 != 0 {
+		fmt.Fprintf(os.Stderr,
+			"WARNING: secret file %s is group/world-accessible (%04o); "+
+				"restrict it with: chmod 600 %s\n",
+			path, info.Mode().Perm(), path)
+	}
+}
+
+// RequireOwnerOnly returns an error if the file grants any group or
+// world access (mode & 0o077 != 0). Modes 0400 and 0600 pass; 0640,
+// 0644, and friends fail. It is a no-op (returns nil) on Windows, where
+// Unix mode bits do not map cleanly.
+func RequireOwnerOnly(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat key file %s: %w", path, err)
+	}
+
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		return fmt.Errorf(
+			"insecure permissions on key file %s: %04o (group/world access "+
+				"not permitted). Please run: chmod 600 %s", path, mode, path)
+	}
+
+	return nil
 }
 
 // FileExists checks if a file exists at the given path.

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -119,22 +119,32 @@ func readRegularFileBounded(path string, check func(info os.FileInfo) error) ([]
 // home directory. Returns the path unchanged if it does not start with a
 // tilde.
 //
-// Only the current-user forms "~", "~/..." (and "~\\..." on Windows) are
-// supported. The "~user/..." syntax (the home directory of a named user) is
-// NOT supported: rather than silently remapping it onto the current user's
-// home directory (which would read the wrong file), ExpandTildePath returns
-// an error for any tilde path whose second character is neither a path
-// separator nor the end of the string.
+// Only the current-user forms "~" and "~/..." are supported on every
+// platform; the backslash form "~\\..." is accepted only on Windows,
+// where the backslash is a real path separator. On non-Windows
+// platforms the backslash is an ordinary filename character, not a
+// separator, so "~\\..." is treated as an unsupported tilde form and
+// rejected rather than expanded under the current user's home (which
+// could resolve the wrong secret path). The "~user/..." syntax (the
+// home directory of a named user) is NOT supported on any platform:
+// rather than silently remapping it onto the current user's home
+// directory (which would read the wrong file), ExpandTildePath returns
+// an error for any tilde path whose second character is neither a
+// supported separator nor the end of the string.
 func ExpandTildePath(path string) (string, error) {
 	if path == "" || path[0] != '~' {
 		return path, nil
 	}
 
-	// Reject "~user/..." style paths. A bare "~" (len 1) and the
-	// "~/..." / "~\\..." current-user forms are accepted; anything else
-	// after the leading tilde would be a named-user home, which we do not
-	// support and must not silently remap onto the current user's home.
-	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+	// Reject "~user/..." style paths and the cross-platform-ambiguous
+	// "~\\..." form. A bare "~" (len 1) and the "~/..." current-user
+	// form are accepted everywhere; the "~\\..." form is accepted only
+	// on Windows, where the backslash is a genuine path separator. On
+	// other platforms the backslash is a normal filename character, so
+	// "~\\..." is an unsupported named-user-style form and must not be
+	// silently remapped onto the current user's home.
+	if len(path) > 1 && path[1] != '/' &&
+		!(runtime.GOOS == "windows" && path[1] == '\\') {
 		return "", fmt.Errorf(
 			"unsupported tilde path %q: use ~ or ~/..., not ~user/...", path)
 	}

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -151,9 +151,18 @@ func ReadSecretFile(path string) (string, error) {
 		return "", err
 	}
 
-	WarnIfPermissive(expandedPath)
-
-	data, err := readRegularFileBounded(expandedPath, nil)
+	// The permissive-mode warning runs as the check closure rather than
+	// before the read, so it fires only after readRegularFileBounded has
+	// confirmed the target is a regular file. A path pointing at a
+	// directory or FIFO is rejected without emitting a misleading
+	// "chmod 600" warning, and the warning reuses the descriptor's stat
+	// info rather than performing a second os.Stat. The closure is
+	// advisory only and never returns an error.
+	data, err := readRegularFileBounded(expandedPath,
+		func(info os.FileInfo) error {
+			warnIfPermissiveInfo(expandedPath, info)
+			return nil
+		})
 	if err != nil {
 		return "", err
 	}
@@ -168,7 +177,10 @@ func ReadSecretFile(path string) (string, error) {
 
 // WarnIfPermissive prints a stderr warning if the file is group- or
 // world-readable (mode & 0o077 != 0). It never returns an error and is
-// a no-op on Windows, where Unix mode bits do not map cleanly.
+// a no-op on Windows, where Unix mode bits do not map cleanly. It stats
+// the path and delegates to warnIfPermissiveInfo; callers that already
+// hold a FileInfo (for example from an open descriptor) should call
+// warnIfPermissiveInfo directly to avoid a redundant stat.
 func WarnIfPermissive(path string) {
 	if runtime.GOOS == "windows" {
 		return
@@ -178,6 +190,22 @@ func WarnIfPermissive(path string) {
 	if err != nil {
 		// Stat failures are surfaced by the subsequent read; the
 		// warning is best-effort only.
+		return
+	}
+
+	warnIfPermissiveInfo(path, info)
+}
+
+// warnIfPermissiveInfo prints a stderr warning if the supplied FileInfo
+// describes a group- or world-readable file (mode & 0o077 != 0). It is a
+// no-op on Windows, where Unix mode bits do not map cleanly, and never
+// returns an error: the warning is advisory only. Accepting an existing
+// FileInfo lets callers that already hold one (such as the descriptor
+// stat inside readRegularFileBounded) warn without a second os.Stat,
+// which both avoids a redundant syscall and ensures the warning reflects
+// the same TOCTOU-safe stat used for the read.
+func warnIfPermissiveInfo(path string, info os.FileInfo) {
+	if runtime.GOOS == "windows" {
 		return
 	}
 

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -227,6 +227,15 @@ func warnIfPermissiveInfo(path string, info os.FileInfo) {
 		return
 	}
 
+	// Only regular files produce the chmod-600 warning. When this is
+	// reached via ReadSecretFile's check closure the regular-file check
+	// has already passed, so this is harmless; when reached via the
+	// exported WarnIfPermissive on a directory or FIFO it correctly stays
+	// silent, matching the regular-file-only contract of ReadSecretFile.
+	if !info.Mode().IsRegular() {
+		return
+	}
+
 	if info.Mode().Perm()&0o077 != 0 {
 		fmt.Fprintf(os.Stderr,
 			"WARNING: secret file %s is group/world-accessible (%04o); "+

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -24,6 +24,97 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// MaxSecretFileSize is the maximum size, in bytes, that the secret and
+// key readers in this package will read from a single file. Secrets,
+// tokens, API keys, and encryption keys are all comfortably under a few
+// kilobytes, so a 1 MiB ceiling is generous while still bounding the
+// memory a single file read can allocate. Files larger than this limit
+// are rejected outright rather than truncated, so an oversized or
+// runaway file is treated as a configuration error.
+const MaxSecretFileSize = 1 << 20 // 1 MiB
+
+// maxSecretFileSize is the effective ceiling enforced by
+// readRegularFileBounded. It defaults to MaxSecretFileSize and is a
+// variable only so tests can lower it to exercise the size-rejection
+// and post-read overflow guards deterministically without allocating
+// multi-megabyte fixtures. Production code never reassigns it.
+var maxSecretFileSize int64 = MaxSecretFileSize
+
+// openFileForRead is the open primitive used by readRegularFileBounded.
+// It is a variable wrapping openNonBlocking so tests can substitute an
+// open that yields a descriptor whose Stat fails, exercising the
+// otherwise-unreachable stat-error guard. Production code never
+// reassigns it.
+var openFileForRead = openNonBlocking
+
+// readRegularFileBounded opens path, verifies on the open descriptor
+// that the target is a regular file (rejecting FIFOs, devices,
+// directories, and symlinks resolving to non-regular files), enforces
+// the MaxSecretFileSize ceiling on the bytes actually read, and returns
+// the contents read from that same descriptor. Performing the stat, the
+// regular-file check, the optional fd-based check, and the read on a
+// single descriptor closes the TOCTOU window that a separate os.Stat +
+// os.ReadFile would leave open.
+//
+// The size ceiling is enforced with an io.LimitReader capped at the
+// limit plus one byte, so a file that grows after the stat (or a
+// pseudo-file that under-reports its size) is rejected rather than read
+// without bound or silently truncated.
+//
+// The check closure, when non-nil, runs against the open descriptor
+// after the regular-file check passes but before the read, so
+// additional fd-based validation (such as a permission check) shares
+// the same TOCTOU-safe descriptor. The file is closed before the bytes
+// are returned to the caller.
+func readRegularFileBounded(path string, check func(info os.FileInfo) error) ([]byte, error) {
+	// Open non-blocking where the platform supports it. A plain
+	// os.Open of a FIFO blocks until a writer appears, which would
+	// hang startup on a misconfigured path; opening O_NONBLOCK lets
+	// the regular-file check below reject the FIFO immediately.
+	f, err := openFileForRead(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file %s: %w", path, err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf(
+			"file %s is not a regular file (mode %s); refusing to read",
+			path, info.Mode())
+	}
+
+	if check != nil {
+		if err := check(info); err != nil {
+			return nil, err
+		}
+	}
+
+	// Read with a hard cap of maxSecretFileSize+1 so the limit is
+	// enforced authoritatively on the bytes actually read. Relying on
+	// the bounded read rather than the advisory info.Size() means a
+	// file that grows after the stat, or a pseudo-file that under-
+	// reports its size, is still rejected rather than read unbounded or
+	// silently truncated.
+	limit := maxSecretFileSize
+	data, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf(
+			"file %s is too large: exceeds the %d-byte limit",
+			path, limit)
+	}
+
+	return data, nil
+}
+
 // ExpandTildePath expands a leading tilde (~) in a file path to the user's
 // home directory. Returns the path unchanged if it does not start with tilde.
 func ExpandTildePath(path string) (string, error) {
@@ -45,6 +136,11 @@ func ExpandTildePath(path string) (string, error) {
 // only a trailing newline sequence (preserving any in-secret
 // whitespace), and returns an error if the resulting secret is empty.
 //
+// The read goes through readRegularFileBounded, so a path that points
+// at a FIFO, device, directory, or other non-regular file is rejected
+// (rather than hanging startup), and a file larger than
+// MaxSecretFileSize is refused rather than read into unbounded memory.
+//
 // The trailing-newline trim uses strings.TrimRight(data, "\r\n") rather
 // than TrimSpace so that secrets containing intentional leading,
 // trailing, or interior spaces survive intact; only the line-ending a
@@ -57,8 +153,7 @@ func ReadSecretFile(path string) (string, error) {
 
 	WarnIfPermissive(expandedPath)
 
-	// #nosec G304 - File path is provided by administrator configuration
-	data, err := os.ReadFile(expandedPath)
+	data, err := readRegularFileBounded(expandedPath, nil)
 	if err != nil {
 		return "", err
 	}
@@ -94,37 +189,36 @@ func WarnIfPermissive(path string) {
 	}
 }
 
-// ReadOwnerOnlyFile opens path, verifies on the open file descriptor
-// that the file grants no group or world access (mode & 0o077 == 0),
-// and returns its raw bytes. Checking permissions on the already-open
-// descriptor and reading from that same descriptor closes the TOCTOU
-// window that a separate os.Stat + os.ReadFile would leave. The
-// permission check is skipped on Windows, where Unix mode bits do not
-// map cleanly. Modes such as 0400 and 0600 pass; 0640, 0644, and
-// friends are rejected.
+// ReadOwnerOnlyFile reads path and returns its raw bytes after
+// verifying, on the open file descriptor, that the target is a regular
+// file no larger than MaxSecretFileSize. On non-Windows platforms it
+// additionally requires that the file grant no group or world access
+// (mode & 0o077 == 0). The regular-file check, size check, permission
+// check, and read all happen on the same open descriptor, closing the
+// TOCTOU window that a separate os.Stat + os.ReadFile would leave.
+//
+// On non-Windows platforms, owner-only modes such as 0400 and 0600
+// pass while 0640, 0644, and friends are rejected. On Windows the
+// Unix mode bits do not map cleanly, so the permission check is
+// skipped; only the regular-file and size checks apply there.
+//
+// The raw bytes are returned without trimming.
 func ReadOwnerOnlyFile(path string) ([]byte, error) {
-	// #nosec G304 - path is administrator-supplied configuration
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open key file %s: %w", path, err)
-	}
-	defer f.Close()
-
-	if runtime.GOOS != "windows" {
-		info, err := f.Stat()
-		if err != nil {
-			return nil, fmt.Errorf("failed to stat key file %s: %w", path, err)
+	check := func(info os.FileInfo) error {
+		if runtime.GOOS == "windows" {
+			return nil
 		}
 
 		mode := info.Mode().Perm()
 		if mode&0o077 != 0 {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"insecure permissions on key file %s: %04o (group/world access "+
 					"not permitted). Please run: chmod 600 %s", path, mode, path)
 		}
+		return nil
 	}
 
-	data, err := io.ReadAll(f)
+	data, err := readRegularFileBounded(path, check)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read key file %s: %w", path, err)
 	}

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -134,7 +134,8 @@ func ExpandTildePath(path string) (string, error) {
 // secret) from an operator-supplied file path. It expands a leading
 // tilde, warns (to stderr) if the file is group/world-readable, trims
 // only a trailing newline sequence (preserving any in-secret
-// whitespace), and returns an error if the resulting secret is empty.
+// whitespace), and returns an error if the resulting secret is empty or
+// contains only whitespace.
 //
 // The read goes through readRegularFileBounded, so a path that points
 // at a FIFO, device, directory, or other non-regular file is rejected
@@ -144,7 +145,12 @@ func ExpandTildePath(path string) (string, error) {
 // The trailing-newline trim uses strings.TrimRight(data, "\r\n") rather
 // than TrimSpace so that secrets containing intentional leading,
 // trailing, or interior spaces survive intact; only the line-ending a
-// text editor appends is stripped.
+// text editor appends is stripped. The emptiness check uses
+// strings.TrimSpace so a file holding only whitespace (spaces, tabs, or
+// newlines) is rejected rather than yielding a useless whitespace-only
+// secret; the value RETURNED, however, is the TrimRight("\r\n") result,
+// so meaningful leading, trailing, or interior whitespace in a real
+// secret is preserved unchanged. Only the validation trims whitespace.
 func ReadSecretFile(path string) (string, error) {
 	expandedPath, err := ExpandTildePath(path)
 	if err != nil {
@@ -168,8 +174,10 @@ func ReadSecretFile(path string) (string, error) {
 	}
 
 	secret := strings.TrimRight(string(data), "\r\n")
-	if secret == "" {
-		return "", fmt.Errorf("secret file %s is empty", expandedPath)
+	if strings.TrimSpace(secret) == "" {
+		return "", fmt.Errorf(
+			"secret file %s is empty or contains only whitespace",
+			expandedPath)
 	}
 
 	return secret, nil

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -177,23 +177,33 @@ func ReadSecretFile(path string) (string, error) {
 
 // WarnIfPermissive prints a stderr warning if the file is group- or
 // world-readable (mode & 0o077 != 0). It never returns an error and is
-// a no-op on Windows, where Unix mode bits do not map cleanly. It stats
-// the path and delegates to warnIfPermissiveInfo; callers that already
-// hold a FileInfo (for example from an open descriptor) should call
-// warnIfPermissiveInfo directly to avoid a redundant stat.
+// a no-op on Windows, where Unix mode bits do not map cleanly. It
+// expands a leading tilde (reusing ExpandTildePath) before the stat so a
+// "~"-relative path warns consistently with ReadSecretFile and
+// ReadOwnerOnlyFile, then stats the expanded path and delegates to
+// warnIfPermissiveInfo; callers that already hold a FileInfo (for
+// example from an open descriptor) should call warnIfPermissiveInfo
+// directly to avoid a redundant stat.
 func WarnIfPermissive(path string) {
 	if runtime.GOOS == "windows" {
 		return
 	}
 
-	info, err := os.Stat(path)
+	expandedPath, err := ExpandTildePath(path)
+	if err != nil {
+		// Tilde expansion failures (HOME unset) are surfaced by the
+		// subsequent read; the warning is advisory only.
+		return
+	}
+
+	info, err := os.Stat(expandedPath)
 	if err != nil {
 		// Stat failures are surfaced by the subsequent read; the
 		// warning is best-effort only.
 		return
 	}
 
-	warnIfPermissiveInfo(path, info)
+	warnIfPermissiveInfo(expandedPath, info)
 }
 
 // warnIfPermissiveInfo prints a stderr warning if the supplied FileInfo
@@ -230,8 +240,18 @@ func warnIfPermissiveInfo(path string, info os.FileInfo) {
 // Unix mode bits do not map cleanly, so the permission check is
 // skipped; only the regular-file and size checks apply there.
 //
+// A leading tilde is expanded (reusing ExpandTildePath) before the
+// file is opened, so a "~"-relative key path resolves consistently
+// with ReadSecretFile. The expanded path is used in the permission-
+// error and read-error messages so they show the resolved location.
+//
 // The raw bytes are returned without trimming.
 func ReadOwnerOnlyFile(path string) ([]byte, error) {
+	expandedPath, err := ExpandTildePath(path)
+	if err != nil {
+		return nil, err
+	}
+
 	check := func(info os.FileInfo) error {
 		if runtime.GOOS == "windows" {
 			return nil
@@ -241,14 +261,16 @@ func ReadOwnerOnlyFile(path string) ([]byte, error) {
 		if mode&0o077 != 0 {
 			return fmt.Errorf(
 				"insecure permissions on key file %s: %04o (group/world access "+
-					"not permitted). Please run: chmod 600 %s", path, mode, path)
+					"not permitted). Please run: chmod 600 %s",
+				expandedPath, mode, expandedPath)
 		}
 		return nil
 	}
 
-	data, err := readRegularFileBounded(path, check)
+	data, err := readRegularFileBounded(expandedPath, check)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read key file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to read key file %s: %w",
+			expandedPath, err)
 	}
 
 	return data, nil

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -15,6 +15,7 @@ package fileutil
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -93,28 +94,42 @@ func WarnIfPermissive(path string) {
 	}
 }
 
-// RequireOwnerOnly returns an error if the file grants any group or
-// world access (mode & 0o077 != 0). Modes 0400 and 0600 pass; 0640,
-// 0644, and friends fail. It is a no-op (returns nil) on Windows, where
-// Unix mode bits do not map cleanly.
-func RequireOwnerOnly(path string) error {
-	if runtime.GOOS == "windows" {
-		return nil
-	}
-
-	info, err := os.Stat(path)
+// ReadOwnerOnlyFile opens path, verifies on the open file descriptor
+// that the file grants no group or world access (mode & 0o077 == 0),
+// and returns its raw bytes. Checking permissions on the already-open
+// descriptor and reading from that same descriptor closes the TOCTOU
+// window that a separate os.Stat + os.ReadFile would leave. The
+// permission check is skipped on Windows, where Unix mode bits do not
+// map cleanly. Modes such as 0400 and 0600 pass; 0640, 0644, and
+// friends are rejected.
+func ReadOwnerOnlyFile(path string) ([]byte, error) {
+	// #nosec G304 - path is administrator-supplied configuration
+	f, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("failed to stat key file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to open key file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	if runtime.GOOS != "windows" {
+		info, err := f.Stat()
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat key file %s: %w", path, err)
+		}
+
+		mode := info.Mode().Perm()
+		if mode&0o077 != 0 {
+			return nil, fmt.Errorf(
+				"insecure permissions on key file %s: %04o (group/world access "+
+					"not permitted). Please run: chmod 600 %s", path, mode, path)
+		}
 	}
 
-	mode := info.Mode().Perm()
-	if mode&0o077 != 0 {
-		return fmt.Errorf(
-			"insecure permissions on key file %s: %04o (group/world access "+
-				"not permitted). Please run: chmod 600 %s", path, mode, path)
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file %s: %w", path, err)
 	}
 
-	return nil
+	return data, nil
 }
 
 // FileExists checks if a file exists at the given path.

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -116,10 +116,27 @@ func readRegularFileBounded(path string, check func(info os.FileInfo) error) ([]
 }
 
 // ExpandTildePath expands a leading tilde (~) in a file path to the user's
-// home directory. Returns the path unchanged if it does not start with tilde.
+// home directory. Returns the path unchanged if it does not start with a
+// tilde.
+//
+// Only the current-user forms "~", "~/..." (and "~\\..." on Windows) are
+// supported. The "~user/..." syntax (the home directory of a named user) is
+// NOT supported: rather than silently remapping it onto the current user's
+// home directory (which would read the wrong file), ExpandTildePath returns
+// an error for any tilde path whose second character is neither a path
+// separator nor the end of the string.
 func ExpandTildePath(path string) (string, error) {
 	if path == "" || path[0] != '~' {
 		return path, nil
+	}
+
+	// Reject "~user/..." style paths. A bare "~" (len 1) and the
+	// "~/..." / "~\\..." current-user forms are accepted; anything else
+	// after the leading tilde would be a named-user home, which we do not
+	// support and must not silently remap onto the current user's home.
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", fmt.Errorf(
+			"unsupported tilde path %q: use ~ or ~/..., not ~user/...", path)
 	}
 
 	homeDir, err := os.UserHomeDir()

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -61,6 +61,18 @@ func TestExpandTildePath(t *testing.T) {
 			expected: "./config.yaml",
 			wantErr:  false,
 		},
+		{
+			name:     "named-user home is rejected",
+			path:     "~postgres/password.txt",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "bare named-user is rejected",
+			path:     "~user",
+			expected: "",
+			wantErr:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,6 +86,29 @@ func TestExpandTildePath(t *testing.T) {
 				t.Errorf("ExpandTildePath() = %v, want %v", result, tt.expected)
 			}
 		})
+	}
+
+	// Guard explicitly against the silent-remap footgun: a "~user/..."
+	// path must NOT be rewritten to "$HOME/user/...". Confirm the error
+	// path returns an empty string rather than the remapped path under
+	// the current user's home directory.
+	remapped := filepath.Join(homeDir, "postgres/password.txt")
+	if got, err := ExpandTildePath("~postgres/password.txt"); err == nil {
+		t.Errorf("ExpandTildePath(~postgres/...) = %q, want error (no silent remap)", got)
+	} else if got == remapped {
+		t.Errorf("ExpandTildePath silently remapped ~postgres/... to %q", remapped)
+	} else if got != "" {
+		t.Errorf("ExpandTildePath(~postgres/...) returned %q on error, want empty string", got)
+	}
+
+	// On Windows the backslash form of the current-user home is accepted.
+	// On other platforms backslash is an ordinary path character, so a
+	// "~\\..." path is treated as a named-user home and rejected; assert
+	// the platform-appropriate behaviour without requiring a Windows host.
+	if runtime.GOOS == "windows" {
+		if _, err := ExpandTildePath("~\\foo"); err != nil {
+			t.Errorf("ExpandTildePath(~\\foo) on Windows error = %v, want nil", err)
+		}
 	}
 }
 

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -184,6 +184,12 @@ func TestReadSecretFilePermissiveWarning(t *testing.T) {
 	if err := os.WriteFile(filePath, []byte("secret\n"), 0644); err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}
+	// os.WriteFile applies the mode before the process umask, so force
+	// the group/world-readable bits explicitly; otherwise a strict umask
+	// (e.g. 0077) would create the file 0600 and the warning would not fire.
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
 
 	// The warning goes to stderr; this exercises the warn branch and
 	// confirms the read still succeeds despite the permissive mode.
@@ -236,6 +242,12 @@ func TestReadSecretFilePermissiveWarningEmitted(t *testing.T) {
 	filePath := filepath.Join(tmpDir, "secret.txt")
 	if err := os.WriteFile(filePath, []byte("secret\n"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
+	}
+	// os.WriteFile applies the mode before the process umask, so force
+	// the group/world-readable bits explicitly; otherwise a strict umask
+	// (e.g. 0077) would create the file 0600 and the warning would not fire.
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatalf("chmod: %v", err)
 	}
 
 	var got string
@@ -304,6 +316,12 @@ func TestWarnIfPermissive(t *testing.T) {
 	if err := os.WriteFile(permissive, []byte("x"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
+	// os.WriteFile applies the mode before the process umask, so force
+	// the group/world-readable bits explicitly; otherwise a strict umask
+	// (e.g. 0077) would create the file 0600 and the warning would not fire.
+	if err := os.Chmod(permissive, 0644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
 	WarnIfPermissive(permissive)
 
 	// Missing file: best-effort, returns without panic.
@@ -328,6 +346,12 @@ func TestWarnIfPermissiveTildeExpansion(t *testing.T) {
 	filePath := filepath.Join(home, "secret.txt")
 	if err := os.WriteFile(filePath, []byte("x"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
+	}
+	// os.WriteFile applies the mode before the process umask, so force
+	// the group/world-readable bits explicitly; otherwise a strict umask
+	// (e.g. 0077) would create the file 0600 and the warning would not fire.
+	if err := os.Chmod(filePath, 0644); err != nil {
+		t.Fatalf("chmod: %v", err)
 	}
 
 	stderr := captureStderr(t, func() {

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -11,9 +11,11 @@
 package fileutil
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -191,6 +193,95 @@ func TestReadSecretFilePermissiveWarning(t *testing.T) {
 	}
 	if got != "secret" {
 		t.Errorf("ReadSecretFile() = %q, want %q", got, "secret")
+	}
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns
+// everything written to it. It lets the warning-path tests assert on the
+// presence or absence of the permissive-mode warning without depending on
+// the global logger.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read captured stderr: %v", err)
+	}
+	return string(data)
+}
+
+// TestReadSecretFilePermissiveWarningEmitted confirms that a permissive
+// (group/world-accessible) regular secret file still triggers the
+// "chmod 600" stderr warning now that the warning runs as the
+// readRegularFileBounded check closure rather than ahead of the read.
+func TestReadSecretFilePermissiveWarningEmitted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(filePath, []byte("secret\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var got string
+	stderr := captureStderr(t, func() {
+		var err error
+		got, err = ReadSecretFile(filePath)
+		if err != nil {
+			t.Fatalf("ReadSecretFile() unexpected error: %v", err)
+		}
+	})
+
+	if got != "secret" {
+		t.Errorf("ReadSecretFile() = %q, want %q", got, "secret")
+	}
+	if !strings.Contains(stderr, "group/world-accessible") {
+		t.Errorf("expected permissive warning on stderr, got %q", stderr)
+	}
+}
+
+// TestReadSecretFileNoWarningForDirectory confirms that a path pointing at
+// a non-regular target (a directory) is rejected without emitting the
+// misleading permissive-mode warning. The warning must fire only after the
+// regular-file check passes, so a directory rejected by
+// readRegularFileBounded never reaches the warn closure.
+func TestReadSecretFileNoWarningForDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
+	}
+
+	// A directory created with default mode is group/world-accessible,
+	// so the old ordering would have warned about it before refusing it.
+	dirPath := filepath.Join(t.TempDir(), "secretdir")
+	if err := os.Mkdir(dirPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var readErr error
+	stderr := captureStderr(t, func() {
+		_, readErr = ReadSecretFile(dirPath)
+	})
+
+	if readErr == nil {
+		t.Fatal("ReadSecretFile() on a directory: expected error, got nil")
+	}
+	if strings.Contains(stderr, "group/world-accessible") {
+		t.Errorf("unexpected permissive warning for directory: %q", stderr)
 	}
 }
 

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -116,8 +116,13 @@ func TestReadSecretFile(t *testing.T) {
 func TestReadSecretFileEmpty(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// A file that is empty or contains only a trailing newline is an error.
-	for _, content := range []string{"", "\n", "\r\n", "\n\n"} {
+	// A file that is empty, contains only a trailing newline, or holds
+	// only whitespace (spaces, tabs, newlines) is an error: a
+	// whitespace-only file has no real secret content, so accepting it
+	// would silently yield useless key material downstream.
+	for _, content := range []string{
+		"", "\n", "\r\n", "\n\n", "   ", "\t \n", "   \n", " \t\r\n",
+	} {
 		filePath := filepath.Join(tmpDir, "empty.txt")
 		if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
 			t.Fatalf("failed to write test file: %v", err)
@@ -125,8 +130,35 @@ func TestReadSecretFileEmpty(t *testing.T) {
 
 		_, err := ReadSecretFile(filePath)
 		if err == nil {
-			t.Errorf("ReadSecretFile(%q) expected empty-file error, got nil", content)
+			t.Errorf("ReadSecretFile(%q) expected empty/whitespace error, got nil", content)
+			continue
 		}
+		if !strings.Contains(err.Error(), "empty or contains only whitespace") {
+			t.Errorf("ReadSecretFile(%q) error = %q, want it to mention "+
+				"'empty or contains only whitespace'", content, err.Error())
+		}
+	}
+}
+
+// TestReadSecretFileWhitespacePreserved confirms that the emptiness
+// check uses strings.TrimSpace while the RETURNED value does not: a real
+// secret carrying meaningful leading and trailing whitespace passes
+// validation and is returned with that whitespace intact, trimmed only
+// of the trailing newline a text editor appends.
+func TestReadSecretFileWhitespacePreserved(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(filePath, []byte("  s3cret \n"), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	got, err := ReadSecretFile(filePath)
+	if err != nil {
+		t.Fatalf("ReadSecretFile() unexpected error: %v", err)
+	}
+	if got != "  s3cret " {
+		t.Errorf("ReadSecretFile() = %q, want %q (surrounding whitespace "+
+			"must be preserved)", got, "  s3cret ")
 	}
 }
 

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -140,6 +140,9 @@ func TestReadSecretFileMissing(t *testing.T) {
 func TestReadSecretFileTildeExpansion(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	// os.UserHomeDir reads %USERPROFILE% on Windows, so set it too to
+	// keep the tilde resolving inside the temp dir on every platform.
+	t.Setenv("USERPROFILE", home)
 
 	filePath := filepath.Join(home, "secret.txt")
 	if err := os.WriteFile(filePath, []byte("tilde-secret\n"), 0600); err != nil {
@@ -216,7 +219,7 @@ func TestWarnIfPermissive(t *testing.T) {
 	WarnIfPermissive(filepath.Join(tmpDir, "missing.txt"))
 }
 
-func TestRequireOwnerOnly(t *testing.T) {
+func TestReadOwnerOnlyFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission bits do not map on Windows")
 	}
@@ -245,26 +248,74 @@ func TestRequireOwnerOnly(t *testing.T) {
 				t.Fatalf("chmod: %v", err)
 			}
 
-			err := RequireOwnerOnly(filePath)
-			if tt.wantErr && err == nil {
-				t.Errorf("RequireOwnerOnly(%04o) = nil, want error", tt.mode)
+			data, err := ReadOwnerOnlyFile(filePath)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ReadOwnerOnlyFile(%04o) = nil error, want error",
+						tt.mode)
+				}
+				return
 			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("RequireOwnerOnly(%04o) = %v, want nil", tt.mode, err)
+			if err != nil {
+				t.Errorf("ReadOwnerOnlyFile(%04o) = %v, want nil", tt.mode, err)
+				return
+			}
+			if string(data) != "key" {
+				t.Errorf("ReadOwnerOnlyFile() = %q, want %q", data, "key")
 			}
 		})
 	}
 }
 
-func TestRequireOwnerOnlyMissing(t *testing.T) {
+// TestReadOwnerOnlyFileReturnsRawBytes confirms the helper returns the
+// file contents verbatim, performing no trimming of surrounding or
+// interior whitespace.
+func TestReadOwnerOnlyFileReturnsRawBytes(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission bits do not map on Windows")
 	}
 
 	tmpDir := t.TempDir()
-	err := RequireOwnerOnly(filepath.Join(tmpDir, "nonexistent.txt"))
+	filePath := filepath.Join(tmpDir, "raw.txt")
+	content := "  raw\tcontent\n\n"
+	if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	data, err := ReadOwnerOnlyFile(filePath)
+	if err != nil {
+		t.Fatalf("ReadOwnerOnlyFile() unexpected error: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf("ReadOwnerOnlyFile() = %q, want verbatim %q", data, content)
+	}
+}
+
+func TestReadOwnerOnlyFileMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	_, err := ReadOwnerOnlyFile(filepath.Join(tmpDir, "nonexistent.txt"))
 	if err == nil {
-		t.Error("RequireOwnerOnly() expected error for missing file")
+		t.Error("ReadOwnerOnlyFile() expected error for missing file")
+	}
+}
+
+// TestReadOwnerOnlyFileReadError exercises the io.ReadAll failure
+// branch. Opening a directory succeeds and its 0700 mode passes the
+// owner-only check, but reading its bytes fails, so the helper must
+// surface a read error rather than returning content.
+func TestReadOwnerOnlyFileReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory read semantics differ on Windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "ownerdir")
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	_, err := ReadOwnerOnlyFile(dir)
+	if err == nil {
+		t.Error("ReadOwnerOnlyFile() expected error reading a directory")
 	}
 }
 

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -360,6 +360,37 @@ func TestWarnIfPermissive(t *testing.T) {
 	WarnIfPermissive(filepath.Join(tmpDir, "missing.txt"))
 }
 
+// TestWarnIfPermissiveNoWarningForDirectory confirms that the exported
+// WarnIfPermissive, which stats the raw path and calls
+// warnIfPermissiveInfo directly rather than going through
+// readRegularFileBounded, stays silent for a non-regular file. A
+// directory created with the default mode is group/world-accessible, so
+// without the regular-file guard it would wrongly emit the "chmod 600"
+// warning; this asserts no such warning reaches stderr.
+func TestWarnIfPermissiveNoWarningForDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
+	}
+
+	dirPath := filepath.Join(t.TempDir(), "permdir")
+	if err := os.Mkdir(dirPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Force the group/world-readable bits explicitly so a strict umask
+	// cannot make the directory owner-only and mask the regular-file guard.
+	if err := os.Chmod(dirPath, 0755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	stderr := captureStderr(t, func() {
+		WarnIfPermissive(dirPath)
+	})
+
+	if strings.Contains(stderr, "group/world-accessible") {
+		t.Errorf("unexpected permissive warning for directory: %q", stderr)
+	}
+}
+
 // TestWarnIfPermissiveTildeExpansion confirms WarnIfPermissive expands a
 // leading tilde before the stat, so a permissive "~"-relative file emits
 // the warning rather than silently skipping it when the stat of the

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -13,6 +13,7 @@ package fileutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -74,94 +75,196 @@ func TestExpandTildePath(t *testing.T) {
 	}
 }
 
-func TestReadTrimmedFile(t *testing.T) {
+func TestReadSecretFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Test reading valid file with whitespace
-	filePath := filepath.Join(tmpDir, "test.txt")
-	if err := os.WriteFile(filePath, []byte("  hello world  \n\n"), 0600); err != nil {
-		t.Fatalf("failed to write test file: %v", err)
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"trailing newline trimmed", "secret-value\n", "secret-value"},
+		{"trailing CRLF trimmed", "secret-value\r\n", "secret-value"},
+		{"multiple trailing newlines trimmed", "secret-value\n\n\n", "secret-value"},
+		{"no trailing newline", "secret-value", "secret-value"},
+		{"interior spaces preserved", "a secret with spaces\n", "a secret with spaces"},
+		{"leading spaces preserved", "   leading\n", "   leading"},
+		{"trailing spaces preserved", "trailing   \n", "trailing   "},
+		{"tabs preserved", "a\tb\tc\n", "a\tb\tc"},
 	}
 
-	content, err := ReadTrimmedFile(filePath)
-	if err != nil {
-		t.Errorf("ReadTrimmedFile() unexpected error: %v", err)
-	}
-	if content != "hello world" {
-		t.Errorf("ReadTrimmedFile() = %q, want %q", content, "hello world")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tmpDir, tt.name+".txt")
+			if err := os.WriteFile(filePath, []byte(tt.content), 0600); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
 
-	// Test reading non-existent file
-	_, err = ReadTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
+			got, err := ReadSecretFile(filePath)
+			if err != nil {
+				t.Fatalf("ReadSecretFile() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ReadSecretFile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadSecretFileEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// A file that is empty or contains only a trailing newline is an error.
+	for _, content := range []string{"", "\n", "\r\n", "\n\n"} {
+		filePath := filepath.Join(tmpDir, "empty.txt")
+		if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		_, err := ReadSecretFile(filePath)
+		if err == nil {
+			t.Errorf("ReadSecretFile(%q) expected empty-file error, got nil", content)
+		}
+	}
+}
+
+func TestReadSecretFileMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, err := ReadSecretFile(filepath.Join(tmpDir, "nonexistent.txt"))
 	if err == nil {
-		t.Error("ReadTrimmedFile() expected error for non-existent file")
-	}
-
-	// Test reading empty file
-	emptyFile := filepath.Join(tmpDir, "empty.txt")
-	if err := os.WriteFile(emptyFile, []byte(""), 0600); err != nil {
-		t.Fatalf("failed to write empty file: %v", err)
-	}
-	content, err = ReadTrimmedFile(emptyFile)
-	if err != nil {
-		t.Errorf("ReadTrimmedFile() unexpected error for empty file: %v", err)
-	}
-	if content != "" {
-		t.Errorf("ReadTrimmedFile() = %q, want empty string", content)
+		t.Error("ReadSecretFile() expected error for non-existent file")
 	}
 }
 
-func TestReadTrimmedFileWithTilde(t *testing.T) {
-	tmpDir := t.TempDir()
+func TestReadSecretFileTildeExpansion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
-	// Test reading valid file
+	filePath := filepath.Join(home, "secret.txt")
+	if err := os.WriteFile(filePath, []byte("tilde-secret\n"), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	got, err := ReadSecretFile("~/secret.txt")
+	if err != nil {
+		t.Fatalf("ReadSecretFile() unexpected error: %v", err)
+	}
+	if got != "tilde-secret" {
+		t.Errorf("ReadSecretFile() = %q, want %q", got, "tilde-secret")
+	}
+}
+
+func TestReadSecretFileTildeExpansionError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME-unset behaviour differs on Windows")
+	}
+
+	// With HOME unset, os.UserHomeDir() fails, so ExpandTildePath
+	// returns an error and ReadSecretFile must propagate it.
+	t.Setenv("HOME", "")
+	_, err := ReadSecretFile("~/secret.txt")
+	if err == nil {
+		t.Error("ReadSecretFile() expected error when HOME is unset")
+	}
+}
+
+func TestReadSecretFilePermissiveWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
+	}
+
+	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "secret.txt")
-	if err := os.WriteFile(filePath, []byte("  secret-value  "), 0600); err != nil {
+	if err := os.WriteFile(filePath, []byte("secret\n"), 0644); err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}
 
-	content, err := ReadTrimmedFileWithTilde(filePath)
+	// The warning goes to stderr; this exercises the warn branch and
+	// confirms the read still succeeds despite the permissive mode.
+	got, err := ReadSecretFile(filePath)
 	if err != nil {
-		t.Errorf("ReadTrimmedFileWithTilde() unexpected error: %v", err)
+		t.Fatalf("ReadSecretFile() unexpected error: %v", err)
 	}
-	if content != "secret-value" {
-		t.Errorf("ReadTrimmedFileWithTilde() = %q, want %q", content, "secret-value")
+	if got != "secret" {
+		t.Errorf("ReadSecretFile() = %q, want %q", got, "secret")
 	}
 }
 
-func TestReadOptionalTrimmedFile(t *testing.T) {
+func TestWarnIfPermissive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
+	}
+
 	tmpDir := t.TempDir()
 
-	// Test reading valid file
-	filePath := filepath.Join(tmpDir, "api_key.txt")
-	if err := os.WriteFile(filePath, []byte("  test-api-key  \n"), 0600); err != nil {
-		t.Fatalf("failed to write test file: %v", err)
+	// Owner-only file: no warning path, must not panic.
+	ownerOnly := filepath.Join(tmpDir, "owner.txt")
+	if err := os.WriteFile(ownerOnly, []byte("x"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	WarnIfPermissive(ownerOnly)
+
+	// Group/world readable: exercises the warning branch.
+	permissive := filepath.Join(tmpDir, "perm.txt")
+	if err := os.WriteFile(permissive, []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	WarnIfPermissive(permissive)
+
+	// Missing file: best-effort, returns without panic.
+	WarnIfPermissive(filepath.Join(tmpDir, "missing.txt"))
+}
+
+func TestRequireOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
 	}
 
-	content, err := ReadOptionalTrimmedFile(filePath)
-	if err != nil {
-		t.Errorf("ReadOptionalTrimmedFile() unexpected error: %v", err)
-	}
-	if content != "test-api-key" {
-		t.Errorf("ReadOptionalTrimmedFile() = %q, want %q", content, "test-api-key")
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+	}{
+		{"0400 accepted", 0400, false},
+		{"0600 accepted", 0600, false},
+		{"0640 rejected", 0640, true},
+		{"0644 rejected", 0644, true},
+		{"0604 rejected", 0604, true},
 	}
 
-	// Test empty path
-	content, err = ReadOptionalTrimmedFile("")
-	if err != nil {
-		t.Errorf("ReadOptionalTrimmedFile() unexpected error for empty path: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tmpDir, tt.name)
+			if err := os.WriteFile(filePath, []byte("key"), 0600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := os.Chmod(filePath, tt.mode); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+
+			err := RequireOwnerOnly(filePath)
+			if tt.wantErr && err == nil {
+				t.Errorf("RequireOwnerOnly(%04o) = nil, want error", tt.mode)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("RequireOwnerOnly(%04o) = %v, want nil", tt.mode, err)
+			}
+		})
 	}
-	if content != "" {
-		t.Errorf("ReadOptionalTrimmedFile() = %q, want empty string", content)
+}
+
+func TestRequireOwnerOnlyMissing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
 	}
 
-	// Test non-existent file (should return empty, not error)
-	content, err = ReadOptionalTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
-	if err != nil {
-		t.Errorf("ReadOptionalTrimmedFile() unexpected error for non-existent file: %v", err)
-	}
-	if content != "" {
-		t.Errorf("ReadOptionalTrimmedFile() = %q, want empty string", content)
+	tmpDir := t.TempDir()
+	err := RequireOwnerOnly(filepath.Join(tmpDir, "nonexistent.txt"))
+	if err == nil {
+		t.Error("RequireOwnerOnly() expected error for missing file")
 	}
 }
 
@@ -429,57 +532,18 @@ func TestGetDefaultConfigPath_EmptyUserConfigDir(t *testing.T) {
 	}
 }
 
-func TestReadOptionalTrimmedFileError(t *testing.T) {
-	// Test with a directory (should fail when trying to read)
+func TestReadSecretFileDirectory(t *testing.T) {
+	// Reading a directory should fail.
 	tmpDir := t.TempDir()
 
-	// Create a subdirectory
 	subDir := filepath.Join(tmpDir, "subdir")
 	if err := os.Mkdir(subDir, 0755); err != nil {
 		t.Fatalf("failed to create subdirectory: %v", err)
 	}
 
-	// Attempting to read a directory should fail
-	_, err := ReadOptionalTrimmedFile(subDir)
+	_, err := ReadSecretFile(subDir)
 	if err == nil {
-		t.Error("ReadOptionalTrimmedFile() should fail when reading directory")
-	}
-}
-
-func TestReadTrimmedFileWithWhitespaceVariants(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	tests := []struct {
-		name     string
-		content  string
-		expected string
-	}{
-		{"leading spaces", "   hello", "hello"},
-		{"trailing spaces", "hello   ", "hello"},
-		{"leading tabs", "\t\thello", "hello"},
-		{"trailing tabs", "hello\t\t", "hello"},
-		{"leading newlines", "\n\nhello", "hello"},
-		{"trailing newlines", "hello\n\n", "hello"},
-		{"mixed whitespace", " \t\n hello world \n\t ", "hello world"},
-		{"only whitespace", "   \t\n  ", ""},
-		{"carriage returns", "\r\nhello\r\n", "hello"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			filePath := filepath.Join(tmpDir, tt.name+".txt")
-			if err := os.WriteFile(filePath, []byte(tt.content), 0600); err != nil {
-				t.Fatalf("failed to write test file: %v", err)
-			}
-
-			result, err := ReadTrimmedFile(filePath)
-			if err != nil {
-				t.Fatalf("ReadTrimmedFile() error: %v", err)
-			}
-			if result != tt.expected {
-				t.Errorf("ReadTrimmedFile() = %q, want %q", result, tt.expected)
-			}
-		})
+		t.Error("ReadSecretFile() should fail when reading a directory")
 	}
 }
 
@@ -528,14 +592,6 @@ database:
 	if cfg.Database.Username != "admin" {
 		t.Errorf("Database.Username = %q, want %q",
 			cfg.Database.Username, "admin")
-	}
-}
-
-func TestReadTrimmedFileWithTildeError(t *testing.T) {
-	// Test when file doesn't exist after tilde expansion
-	_, err := ReadTrimmedFileWithTilde("~/nonexistent_file_12345.txt")
-	if err == nil {
-		t.Error("ReadTrimmedFileWithTilde() expected error for non-existent file")
 	}
 }
 

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -310,6 +310,97 @@ func TestWarnIfPermissive(t *testing.T) {
 	WarnIfPermissive(filepath.Join(tmpDir, "missing.txt"))
 }
 
+// TestWarnIfPermissiveTildeExpansion confirms WarnIfPermissive expands a
+// leading tilde before the stat, so a permissive "~"-relative file emits
+// the warning rather than silently skipping it when the stat of the
+// literal "~/..." path fails.
+func TestWarnIfPermissiveTildeExpansion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// os.UserHomeDir reads %USERPROFILE% on Windows, so set it too to
+	// keep the tilde resolving inside the temp dir on every platform.
+	t.Setenv("USERPROFILE", home)
+
+	filePath := filepath.Join(home, "secret.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	stderr := captureStderr(t, func() {
+		WarnIfPermissive("~/secret.txt")
+	})
+
+	if !strings.Contains(stderr, "group/world-accessible") {
+		t.Errorf("expected permissive warning for tilde path, got %q", stderr)
+	}
+}
+
+// TestWarnIfPermissiveTildeExpansionError confirms WarnIfPermissive
+// silently returns (advisory only, never errors) when tilde expansion
+// fails because HOME is unset.
+func TestWarnIfPermissiveTildeExpansionError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME-unset behaviour differs on Windows")
+	}
+
+	t.Setenv("HOME", "")
+	stderr := captureStderr(t, func() {
+		WarnIfPermissive("~/secret.txt")
+	})
+
+	if strings.Contains(stderr, "group/world-accessible") {
+		t.Errorf("unexpected warning when HOME is unset: %q", stderr)
+	}
+}
+
+// TestReadOwnerOnlyFileTildeExpansion confirms ReadOwnerOnlyFile expands
+// a leading tilde before opening the file, so a "~"-relative key path
+// resolves under the user's home directory and is read successfully.
+func TestReadOwnerOnlyFileTildeExpansion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not map on Windows")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// os.UserHomeDir reads %USERPROFILE% on Windows, so set it too to
+	// keep the tilde resolving inside the temp dir on every platform.
+	t.Setenv("USERPROFILE", home)
+
+	filePath := filepath.Join(home, "key")
+	if err := os.WriteFile(filePath, []byte("tilde-key"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	data, err := ReadOwnerOnlyFile("~/key")
+	if err != nil {
+		t.Fatalf("ReadOwnerOnlyFile() unexpected error: %v", err)
+	}
+	if string(data) != "tilde-key" {
+		t.Errorf("ReadOwnerOnlyFile() = %q, want %q", data, "tilde-key")
+	}
+}
+
+// TestReadOwnerOnlyFileTildeExpansionError confirms that a tilde
+// expansion failure (HOME unset) is propagated rather than swallowed.
+func TestReadOwnerOnlyFileTildeExpansionError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME-unset behaviour differs on Windows")
+	}
+
+	// With HOME unset, os.UserHomeDir() fails, so ExpandTildePath
+	// returns an error and ReadOwnerOnlyFile must propagate it.
+	t.Setenv("HOME", "")
+	_, err := ReadOwnerOnlyFile("~/key")
+	if err == nil {
+		t.Error("ReadOwnerOnlyFile() expected error when HOME is unset")
+	}
+}
+
 func TestReadOwnerOnlyFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission bits do not map on Windows")

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -71,8 +71,26 @@ func TestExpandTildePath(t *testing.T) {
 			name:     "bare named-user is rejected",
 			path:     "~user",
 			expected: "",
-			wantErr:  true,
+			// On a non-Windows host backslash is not a separator, so
+			// "~\\secret.txt" is an unsupported named-user-style form
+			// and must be rejected; the Windows-accepts-backslash case
+			// is asserted separately below since tests run on Linux.
+			wantErr: true,
 		},
+	}
+
+	if runtime.GOOS != "windows" {
+		tests = append(tests, struct {
+			name     string
+			path     string
+			expected string
+			wantErr  bool
+		}{
+			name:     "backslash form rejected off Windows",
+			path:     "~\\secret.txt",
+			expected: "",
+			wantErr:  true,
+		})
 	}
 
 	for _, tt := range tests {
@@ -108,6 +126,20 @@ func TestExpandTildePath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		if _, err := ExpandTildePath("~\\foo"); err != nil {
 			t.Errorf("ExpandTildePath(~\\foo) on Windows error = %v, want nil", err)
+		}
+	} else {
+		// On Unix the backslash is an ordinary filename character, not a
+		// separator. Guard explicitly against the silent-remap footgun:
+		// "~\\secret.txt" must NOT be expanded to "$HOME\\secret.txt"
+		// (which could resolve the wrong secret); it must error and
+		// return an empty string.
+		remapped := filepath.Join(homeDir, "\\secret.txt")
+		if got, err := ExpandTildePath("~\\secret.txt"); err == nil {
+			t.Errorf("ExpandTildePath(~\\secret.txt) = %q, want error on non-Windows", got)
+		} else if got == remapped {
+			t.Errorf("ExpandTildePath silently remapped ~\\secret.txt to %q", remapped)
+		} else if got != "" {
+			t.Errorf("ExpandTildePath(~\\secret.txt) returned %q on error, want empty string", got)
 		}
 	}
 }

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -299,10 +299,9 @@ func TestReadOwnerOnlyFileMissing(t *testing.T) {
 	}
 }
 
-// TestReadOwnerOnlyFileReadError exercises the io.ReadAll failure
-// branch. Opening a directory succeeds and its 0700 mode passes the
-// owner-only check, but reading its bytes fails, so the helper must
-// surface a read error rather than returning content.
+// TestReadOwnerOnlyFileReadError opens a directory: the regular-file
+// guard in readRegularFileBounded must reject it before any read is
+// attempted, so the helper surfaces an error rather than content.
 func TestReadOwnerOnlyFileReadError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("directory read semantics differ on Windows")
@@ -316,6 +315,134 @@ func TestReadOwnerOnlyFileReadError(t *testing.T) {
 	_, err := ReadOwnerOnlyFile(dir)
 	if err == nil {
 		t.Error("ReadOwnerOnlyFile() expected error reading a directory")
+	}
+}
+
+// TestReadSecretFileFIFORejected confirms that pointing ReadSecretFile
+// at a named pipe (FIFO) is rejected by the regular-file guard rather
+// than blocking on an open/read of the pipe.
+func TestReadSecretFileFIFORejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are not supported on Windows")
+	}
+
+	fifoPath := filepath.Join(t.TempDir(), "secret.fifo")
+	if err := mkfifoForTest(fifoPath); err != nil {
+		t.Skipf("mkfifo unsupported on this platform: %v", err)
+	}
+
+	_, err := ReadSecretFile(fifoPath)
+	if err == nil {
+		t.Fatal("ReadSecretFile() expected error for a FIFO, got nil")
+	}
+}
+
+// TestReadOwnerOnlyFileFIFORejected confirms ReadOwnerOnlyFile rejects a
+// FIFO via the shared regular-file guard.
+func TestReadOwnerOnlyFileFIFORejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are not supported on Windows")
+	}
+
+	fifoPath := filepath.Join(t.TempDir(), "key.fifo")
+	if err := mkfifoForTest(fifoPath); err != nil {
+		t.Skipf("mkfifo unsupported on this platform: %v", err)
+	}
+
+	_, err := ReadOwnerOnlyFile(fifoPath)
+	if err == nil {
+		t.Fatal("ReadOwnerOnlyFile() expected error for a FIFO, got nil")
+	}
+}
+
+// withMaxSecretFileSize lowers the effective size ceiling for the
+// duration of a test so the oversize-rejection and boundary branches
+// can be exercised with tiny fixtures, then restores it.
+func withMaxSecretFileSize(t *testing.T, limit int64) {
+	t.Helper()
+	prev := maxSecretFileSize
+	maxSecretFileSize = limit
+	t.Cleanup(func() { maxSecretFileSize = prev })
+}
+
+// TestReadSecretFileOversizedRejected confirms ReadSecretFile refuses a
+// file larger than the effective ceiling rather than allocating
+// unbounded memory.
+func TestReadSecretFileOversizedRejected(t *testing.T) {
+	withMaxSecretFileSize(t, 8)
+
+	filePath := filepath.Join(t.TempDir(), "big.secret")
+	if err := os.WriteFile(filePath, []byte("0123456789"), 0600); err != nil {
+		t.Fatalf("write oversized file: %v", err)
+	}
+
+	_, err := ReadSecretFile(filePath)
+	if err == nil {
+		t.Fatal("ReadSecretFile() expected error for an oversized file, got nil")
+	}
+}
+
+// TestReadOwnerOnlyFileOversizedRejected confirms ReadOwnerOnlyFile
+// refuses a file larger than the effective ceiling.
+func TestReadOwnerOnlyFileOversizedRejected(t *testing.T) {
+	withMaxSecretFileSize(t, 8)
+
+	filePath := filepath.Join(t.TempDir(), "big.key")
+	if err := os.WriteFile(filePath, []byte("0123456789"), 0600); err != nil {
+		t.Fatalf("write oversized file: %v", err)
+	}
+
+	_, err := ReadOwnerOnlyFile(filePath)
+	if err == nil {
+		t.Fatal("ReadOwnerOnlyFile() expected error for an oversized file, got nil")
+	}
+}
+
+// TestReadRegularFileBoundedStatError substitutes the open primitive
+// with one that returns an already-closed descriptor, so f.Stat() fails
+// and the helper surfaces the stat-error path.
+func TestReadRegularFileBoundedStatError(t *testing.T) {
+	realPath := filepath.Join(t.TempDir(), "real.secret")
+	if err := os.WriteFile(realPath, []byte("value"), 0600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	prev := openFileForRead
+	openFileForRead = func(p string) (*os.File, error) {
+		f, err := os.Open(p)
+		if err != nil {
+			return nil, err
+		}
+		// Close it immediately so the subsequent Stat on the returned
+		// descriptor fails.
+		_ = f.Close()
+		return f, nil
+	}
+	t.Cleanup(func() { openFileForRead = prev })
+
+	_, err := readRegularFileBounded(realPath, nil)
+	if err == nil {
+		t.Fatal("readRegularFileBounded() expected stat error, got nil")
+	}
+}
+
+// TestReadSecretFileAtSizeLimit confirms a file exactly at the size
+// limit is still read successfully (boundary check, just below the
+// rejection threshold).
+func TestReadSecretFileAtSizeLimit(t *testing.T) {
+	withMaxSecretFileSize(t, 8)
+
+	filePath := filepath.Join(t.TempDir(), "atlimit.secret")
+	if err := os.WriteFile(filePath, []byte("01234567"), 0600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	got, err := ReadSecretFile(filePath)
+	if err != nil {
+		t.Fatalf("ReadSecretFile() unexpected error at size limit: %v", err)
+	}
+	if got != "01234567" {
+		t.Errorf("ReadSecretFile() = %q, want %q", got, "01234567")
 	}
 }
 

--- a/pkg/fileutil/mkfifo_unix_test.go
+++ b/pkg/fileutil/mkfifo_unix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package fileutil
+
+import "syscall"
+
+// mkfifoForTest creates a named pipe (FIFO) at path. It is only built on
+// non-Windows platforms, where syscall.Mkfifo is available.
+func mkfifoForTest(path string) error {
+	return syscall.Mkfifo(path, 0600)
+}

--- a/pkg/fileutil/mkfifo_windows_test.go
+++ b/pkg/fileutil/mkfifo_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package fileutil
+
+import "errors"
+
+// mkfifoForTest is unsupported on Windows; callers skip the FIFO tests
+// when this stub returns an error.
+func mkfifoForTest(_ string) error {
+	return errors.New("mkfifo not supported on windows")
+}

--- a/pkg/fileutil/open_unix.go
+++ b/pkg/fileutil/open_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package fileutil
+
+import (
+	"os"
+	"syscall"
+)
+
+// openNonBlocking opens path read-only with O_NONBLOCK so that a path
+// resolving to a FIFO does not block waiting for a writer. The caller is
+// expected to verify on the returned descriptor that the target is a
+// regular file before reading. Clearing the file's status flags after
+// the open is unnecessary for regular files, which ignore O_NONBLOCK.
+func openNonBlocking(path string) (*os.File, error) {
+	// #nosec G304 - File path is provided by administrator configuration
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}

--- a/pkg/fileutil/open_windows.go
+++ b/pkg/fileutil/open_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package fileutil
+
+import "os"
+
+// openNonBlocking opens path read-only. Windows has no O_NONBLOCK and
+// the named-pipe semantics that motivate it on Unix do not apply to the
+// regular config and secret files this package reads, so a plain open is
+// sufficient here.
+func openNonBlocking(path string) (*os.File, error) {
+	// #nosec G304 - File path is provided by administrator configuration
+	return os.Open(path)
+}

--- a/server/src/cmd/mcp-server/main.go
+++ b/server/src/cmd/mcp-server/main.go
@@ -116,9 +116,9 @@ func main() {
 	}
 
 	// Resolve the datastore password from a password_file when no
-	// password was supplied via CLI flag, environment variable, or
-	// inline YAML. LoadConfig has already applied those higher-priority
-	// sources, so a non-empty Password here means one of them won and
+	// password was supplied via CLI flag or inline YAML. LoadConfig has
+	// already applied those higher-priority sources, so a non-empty
+	// Password here means one of them won and
 	// LoadPassword is a no-op. This keeps the YAML password_file option
 	// consistent with the collector and alerter components.
 	if cfg.Database != nil {

--- a/server/src/cmd/mcp-server/main.go
+++ b/server/src/cmd/mcp-server/main.go
@@ -115,6 +115,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Resolve the datastore password from a password_file when no
+	// password was supplied via CLI flag, environment variable, or
+	// inline YAML. LoadConfig has already applied those higher-priority
+	// sources, so a non-empty Password here means one of them won and
+	// LoadPassword is a no-op. This keeps the YAML password_file option
+	// consistent with the collector and alerter components.
+	if cfg.Database != nil {
+		if err := cfg.Database.LoadPassword(); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	// Create and initialize the server
 	server, err := NewServer(&ServerConfig{
 		Config:   cfg,

--- a/server/src/cmd/mcp-server/passwords.go
+++ b/server/src/cmd/mcp-server/passwords.go
@@ -12,7 +12,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
+
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
 // PasswordSource indicates how a password was resolved.
@@ -38,6 +39,13 @@ type PasswordResult struct {
 // When the CLI flag is used, a deprecation warning is printed to
 // stderr because command-line arguments are visible in process
 // listings.
+//
+// When a file path is supplied, the read is delegated to
+// fileutil.ReadSecretFile, which expands a leading tilde, warns on
+// group/world-readable permissions, trims only the trailing newline,
+// and reports an empty file as an error. There is no directory-traversal
+// guard: the path is operator-supplied configuration, and legitimate
+// relative paths (including those containing "..") must be honored.
 func ResolvePassword(flagValue string, flagSet bool, filePath string) (PasswordResult, error) {
 	// 1. CLI flag (highest precedence, but deprecated)
 	if flagSet && flagValue != "" {
@@ -49,16 +57,9 @@ func ResolvePassword(flagValue string, flagSet bool, filePath string) (PasswordR
 
 	// 2. Password file
 	if filePath != "" {
-		if strings.Contains(filePath, "..") {
-			return PasswordResult{}, fmt.Errorf("password file path must not contain directory traversal sequences")
-		}
-		data, err := os.ReadFile(filePath)
+		password, err := fileutil.ReadSecretFile(filePath)
 		if err != nil {
 			return PasswordResult{}, fmt.Errorf("reading password file %s: %w", filePath, err)
-		}
-		password := strings.TrimRight(string(data), "\r\n")
-		if password == "" {
-			return PasswordResult{}, fmt.Errorf("password file %s is empty", filePath)
 		}
 		return PasswordResult{Value: password, Source: PasswordSourceFile}, nil
 	}

--- a/server/src/cmd/mcp-server/server.go
+++ b/server/src/cmd/mcp-server/server.go
@@ -14,10 +14,10 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/chat"
 	"github.com/pgedge/ai-workbench/server/internal/config"
@@ -253,15 +253,10 @@ func (s *Server) loadServerSecret(execPath string) (string, error) {
 			"the config or place the file in one of those locations")
 	}
 
-	secretData, err := os.ReadFile(secretPath)
+	serverSecret, err := fileutil.ReadSecretFile(secretPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read secret file '%s': %w\n"+
 			"       The secret file must match the collector's secret for password decryption", secretPath, err)
-	}
-
-	serverSecret := strings.TrimSpace(string(secretData))
-	if serverSecret == "" {
-		return "", fmt.Errorf("secret file '%s' is empty", secretPath)
 	}
 
 	fmt.Fprintf(os.Stderr, "Server secret: loaded from %s\n", secretPath)

--- a/server/src/cmd/mcp-server/server_test.go
+++ b/server/src/cmd/mcp-server/server_test.go
@@ -32,11 +32,12 @@ func newServerWithSecretFile(secretFile string) *Server {
 }
 
 // TestLoadServerSecret_ExplicitFile verifies that an explicit
-// SecretFile in the config is read verbatim and trimmed.
+// SecretFile in the config is read with only its trailing newline
+// trimmed.
 func TestLoadServerSecret_ExplicitFile(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "server.secret")
-	if err := os.WriteFile(path, []byte("  explicit-secret\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte("explicit-secret\n"), 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	s := newServerWithSecretFile(path)
@@ -111,11 +112,13 @@ func TestLoadServerSecret_NoneFound(t *testing.T) {
 }
 
 // TestLoadServerSecret_EmptyFile verifies that a secret file
-// containing only whitespace is rejected.
+// containing only newlines is rejected as empty. Only the trailing
+// newline sequence is trimmed, so a file of in-secret whitespace is
+// no longer treated as empty.
 func TestLoadServerSecret_EmptyFile(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "blank.secret")
-	if err := os.WriteFile(path, []byte("   \n\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte("\n\n"), 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	s := newServerWithSecretFile(path)

--- a/server/src/cmd/mcp-server/server_test.go
+++ b/server/src/cmd/mcp-server/server_test.go
@@ -112,9 +112,10 @@ func TestLoadServerSecret_NoneFound(t *testing.T) {
 }
 
 // TestLoadServerSecret_EmptyFile verifies that a secret file
-// containing only newlines is rejected as empty. Only the trailing
-// newline sequence is trimmed, so a file of in-secret whitespace is
-// no longer treated as empty.
+// containing only newlines is rejected as empty. ReadSecretFile strips
+// only the trailing CR/LF sequence before validation, but content that
+// is empty or consists solely of whitespace is still treated as empty
+// and rejected.
 func TestLoadServerSecret_EmptyFile(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "blank.secret")

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -203,7 +203,7 @@ type DatabaseConfig struct {
 	Port         int    `yaml:"port"`          // Database port (default: 5432)
 	Database     string `yaml:"database"`      // Database name (default: postgres)
 	User         string `yaml:"user"`          // Database user (required)
-	Password     string `yaml:"password"`      // Database password (optional, will use PGEDGE_DB_PASSWORD env var or .pgpass if not set)
+	Password     string `yaml:"password"`      // Database password (optional; falls back to password_file then pgx .pgpass when unset)
 	PasswordFile string `yaml:"password_file"` // Path to a file containing the database password (used only if Password is empty)
 	SSLMode      string `yaml:"sslmode"`       // SSL mode: disable, require, verify-ca, verify-full (default: prefer)
 
@@ -254,8 +254,8 @@ func (cfg *DatabaseConfig) BuildConnectionString() string {
 
 // LoadPassword resolves the database password from PasswordFile when
 // Password is not already set. A non-empty Password always wins, so a
-// password supplied via CLI flag, environment variable, or inline YAML
-// takes precedence over the file. When PasswordFile is set and Password
+// password supplied via CLI flag or inline YAML takes precedence over
+// the file. When PasswordFile is set and Password
 // is empty, the file contents (with surrounding whitespace trimmed) are
 // read into Password. An error is returned only when the file cannot be
 // read.

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -265,7 +265,7 @@ func (cfg *DatabaseConfig) LoadPassword() error {
 	}
 
 	if cfg.PasswordFile != "" {
-		password, err := fileutil.ReadTrimmedFileWithTilde(cfg.PasswordFile)
+		password, err := fileutil.ReadSecretFile(cfg.PasswordFile)
 		if err != nil {
 			return fmt.Errorf("failed to read password file: %w", err)
 		}
@@ -467,7 +467,9 @@ func LoadConfig(configPath string, cliFlags CLIFlags) (*Config, error) {
 	}
 
 	// Load API keys from files if specified
-	loadAPIKeysFromFiles(cfg)
+	if err := loadAPIKeysFromFiles(cfg); err != nil {
+		return nil, err
+	}
 
 	// Apply environment variable overrides
 	applyEnvOverrides(cfg)
@@ -874,58 +876,83 @@ func mergeConfig(dest, src *Config) {
 	// Prompts - no built-in prompts currently, merge logic can be added here for future prompts
 }
 
-// loadAPIKeysFromFiles loads API keys from files if specified in config
-func loadAPIKeysFromFiles(cfg *Config) {
+// loadAPIKeysFromFiles loads API keys from files when a *_file path is
+// configured. A key file is optional: when no path is set the field is
+// left untouched and that is not an error. When a path IS configured,
+// the file must exist, be readable, and be non-empty; any failure
+// (including a configured-but-empty file) is propagated to the caller
+// instead of being silently swallowed.
+func loadAPIKeysFromFiles(cfg *Config) error {
 	// Embedding API keys
 	if cfg.Embedding.VoyageAPIKey == "" && cfg.Embedding.VoyageAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Embedding.VoyageAPIKeyFile); err == nil && key != "" {
-			cfg.Embedding.VoyageAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.Embedding.VoyageAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read embedding Voyage API key: %w", err)
 		}
+		cfg.Embedding.VoyageAPIKey = key
 	}
 	if cfg.Embedding.OpenAIAPIKey == "" && cfg.Embedding.OpenAIAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Embedding.OpenAIAPIKeyFile); err == nil && key != "" {
-			cfg.Embedding.OpenAIAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.Embedding.OpenAIAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read embedding OpenAI API key: %w", err)
 		}
+		cfg.Embedding.OpenAIAPIKey = key
 	}
 	if cfg.Embedding.GeminiAPIKey == "" && cfg.Embedding.GeminiAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Embedding.GeminiAPIKeyFile); err == nil && key != "" {
-			cfg.Embedding.GeminiAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.Embedding.GeminiAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read embedding Gemini API key: %w", err)
 		}
+		cfg.Embedding.GeminiAPIKey = key
 	}
 
 	// LLM API keys
 	if cfg.LLM.AnthropicAPIKey == "" && cfg.LLM.AnthropicAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.LLM.AnthropicAPIKeyFile); err == nil && key != "" {
-			cfg.LLM.AnthropicAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.LLM.AnthropicAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read LLM Anthropic API key: %w", err)
 		}
+		cfg.LLM.AnthropicAPIKey = key
 	}
 	if cfg.LLM.OpenAIAPIKey == "" && cfg.LLM.OpenAIAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.LLM.OpenAIAPIKeyFile); err == nil && key != "" {
-			cfg.LLM.OpenAIAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.LLM.OpenAIAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read LLM OpenAI API key: %w", err)
 		}
+		cfg.LLM.OpenAIAPIKey = key
 	}
 	if cfg.LLM.GeminiAPIKey == "" && cfg.LLM.GeminiAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.LLM.GeminiAPIKeyFile); err == nil && key != "" {
-			cfg.LLM.GeminiAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.LLM.GeminiAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read LLM Gemini API key: %w", err)
 		}
+		cfg.LLM.GeminiAPIKey = key
 	}
 
 	// Knowledgebase API keys
 	if cfg.Knowledgebase.EmbeddingVoyageAPIKey == "" && cfg.Knowledgebase.EmbeddingVoyageAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Knowledgebase.EmbeddingVoyageAPIKeyFile); err == nil && key != "" {
-			cfg.Knowledgebase.EmbeddingVoyageAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.Knowledgebase.EmbeddingVoyageAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read knowledgebase Voyage API key: %w", err)
 		}
+		cfg.Knowledgebase.EmbeddingVoyageAPIKey = key
 	}
 	if cfg.Knowledgebase.EmbeddingOpenAIAPIKey == "" && cfg.Knowledgebase.EmbeddingOpenAIAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Knowledgebase.EmbeddingOpenAIAPIKeyFile); err == nil && key != "" {
-			cfg.Knowledgebase.EmbeddingOpenAIAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.Knowledgebase.EmbeddingOpenAIAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read knowledgebase OpenAI API key: %w", err)
 		}
+		cfg.Knowledgebase.EmbeddingOpenAIAPIKey = key
 	}
 	if cfg.Knowledgebase.EmbeddingGeminiAPIKey == "" && cfg.Knowledgebase.EmbeddingGeminiAPIKeyFile != "" {
-		if key, err := fileutil.ReadOptionalTrimmedFile(cfg.Knowledgebase.EmbeddingGeminiAPIKeyFile); err == nil && key != "" {
-			cfg.Knowledgebase.EmbeddingGeminiAPIKey = key
+		key, err := fileutil.ReadSecretFile(cfg.Knowledgebase.EmbeddingGeminiAPIKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read knowledgebase Gemini API key: %w", err)
 		}
+		cfg.Knowledgebase.EmbeddingGeminiAPIKey = key
 	}
+
+	return nil
 }
 
 // applyEnvOverrides applies environment variable overrides to the configuration.

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -272,7 +272,23 @@ func (cfg *DatabaseConfig) BuildConnectionString() string {
 // disk if the config is ever marshaled (see SaveConfig). Callers must
 // read the resolved value via EffectivePassword rather than Password.
 // An inline Password is left untouched and may legitimately round-trip.
+//
+// LoadPassword clears any previously resolved file-sourced secret
+// before doing anything else, so it is safe to call repeatedly on the
+// same DatabaseConfig (for example across a SIGHUP reload). A stale
+// secret never survives a subsequent load: if PasswordFile is later
+// cleared, points at an unreadable file, or an inline Password is set,
+// the old resolved value is discarded.
 func (cfg *DatabaseConfig) LoadPassword() error {
+	if cfg == nil {
+		return nil
+	}
+
+	// Clear any previously resolved file-sourced secret first so that a
+	// stale value can never survive a subsequent load, regardless of the
+	// early returns below.
+	cfg.resolvedPassword = ""
+
 	if cfg.Password != "" {
 		return nil
 	}
@@ -280,6 +296,8 @@ func (cfg *DatabaseConfig) LoadPassword() error {
 	if cfg.PasswordFile != "" {
 		password, err := fileutil.ReadSecretFile(cfg.PasswordFile)
 		if err != nil {
+			// Leave resolvedPassword cleared on error; do not restore
+			// any prior value.
 			return fmt.Errorf("failed to read password file: %w", err)
 		}
 		cfg.resolvedPassword = password

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -199,12 +199,13 @@ type TLSConfig struct {
 
 // DatabaseConfig holds database connection settings
 type DatabaseConfig struct {
-	Host     string `yaml:"host"`     // Database host (default: localhost)
-	Port     int    `yaml:"port"`     // Database port (default: 5432)
-	Database string `yaml:"database"` // Database name (default: postgres)
-	User     string `yaml:"user"`     // Database user (required)
-	Password string `yaml:"password"` // Database password (optional, will use PGEDGE_DB_PASSWORD env var or .pgpass if not set)
-	SSLMode  string `yaml:"sslmode"`  // SSL mode: disable, require, verify-ca, verify-full (default: prefer)
+	Host         string `yaml:"host"`          // Database host (default: localhost)
+	Port         int    `yaml:"port"`          // Database port (default: 5432)
+	Database     string `yaml:"database"`      // Database name (default: postgres)
+	User         string `yaml:"user"`          // Database user (required)
+	Password     string `yaml:"password"`      // Database password (optional, will use PGEDGE_DB_PASSWORD env var or .pgpass if not set)
+	PasswordFile string `yaml:"password_file"` // Path to a file containing the database password (used only if Password is empty)
+	SSLMode      string `yaml:"sslmode"`       // SSL mode: disable, require, verify-ca, verify-full (default: prefer)
 
 	// Connection pool settings
 	PoolMaxConns        int    `yaml:"pool_max_conns"`          // Maximum number of connections (default: 4)
@@ -249,6 +250,29 @@ func (cfg *DatabaseConfig) BuildConnectionString() string {
 	}
 
 	return connStr
+}
+
+// LoadPassword resolves the database password from PasswordFile when
+// Password is not already set. A non-empty Password always wins, so a
+// password supplied via CLI flag, environment variable, or inline YAML
+// takes precedence over the file. When PasswordFile is set and Password
+// is empty, the file contents (with surrounding whitespace trimmed) are
+// read into Password. An error is returned only when the file cannot be
+// read.
+func (cfg *DatabaseConfig) LoadPassword() error {
+	if cfg.Password != "" {
+		return nil
+	}
+
+	if cfg.PasswordFile != "" {
+		password, err := fileutil.ReadTrimmedFileWithTilde(cfg.PasswordFile)
+		if err != nil {
+			return fmt.Errorf("failed to read password file: %w", err)
+		}
+		cfg.Password = password
+	}
+
+	return nil
 }
 
 // EmbeddingConfig holds embedding generation settings

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -255,10 +255,10 @@ func (cfg *DatabaseConfig) BuildConnectionString() string {
 // LoadPassword resolves the database password from PasswordFile when
 // Password is not already set. A non-empty Password always wins, so a
 // password supplied via CLI flag or inline YAML takes precedence over
-// the file. When PasswordFile is set and Password
-// is empty, the file contents (with surrounding whitespace trimmed) are
-// read into Password. An error is returned only when the file cannot be
-// read.
+// the file. When PasswordFile is set and Password is empty, the file
+// is read via fileutil.ReadSecretFile, which trims only the trailing
+// newline (not all surrounding whitespace) and returns an error if the
+// file cannot be read or resolves to an empty secret.
 func (cfg *DatabaseConfig) LoadPassword() error {
 	if cfg.Password != "" {
 		return nil

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -207,6 +207,13 @@ type DatabaseConfig struct {
 	PasswordFile string `yaml:"password_file"` // Path to a file containing the database password (used only if Password is empty)
 	SSLMode      string `yaml:"sslmode"`       // SSL mode: disable, require, verify-ca, verify-full (default: prefer)
 
+	// resolvedPassword holds a password read from PasswordFile. It is
+	// deliberately unexported and tagged yaml:"-" / json:"-" so that a
+	// file-sourced secret never round-trips into a serialized config
+	// (e.g. via SaveConfig); writing it inline would defeat the purpose
+	// of password_file. Read the effective password via EffectivePassword.
+	resolvedPassword string `yaml:"-" json:"-"`
+
 	// Connection pool settings
 	PoolMaxConns        int    `yaml:"pool_max_conns"`          // Maximum number of connections (default: 4)
 	PoolMinConns        int    `yaml:"pool_min_conns"`          // Minimum number of connections (default: 0)
@@ -236,10 +243,10 @@ func (cfg *DatabaseConfig) BuildConnectionString() string {
 	// Build connection string components with URL-encoded user/password
 	connStr := fmt.Sprintf("postgres://%s", url.PathEscape(cfg.User))
 
-	// Add password only if explicitly set
+	// Add password only if one was resolved (inline or from password_file)
 	// If not set, pgx will use .pgpass file automatically
-	if cfg.Password != "" {
-		connStr += ":" + url.PathEscape(cfg.Password)
+	if password := cfg.EffectivePassword(); password != "" {
+		connStr += ":" + url.PathEscape(password)
 	}
 
 	connStr += fmt.Sprintf("@%s:%d/%s", cfg.Host, cfg.Port, cfg.Database)
@@ -259,6 +266,12 @@ func (cfg *DatabaseConfig) BuildConnectionString() string {
 // is read via fileutil.ReadSecretFile, which trims only the trailing
 // newline (not all surrounding whitespace) and returns an error if the
 // file cannot be read or resolves to an empty secret.
+//
+// A file-sourced secret is stored in the unexported resolvedPassword
+// field, NOT in the exported Password field, so it cannot leak back to
+// disk if the config is ever marshaled (see SaveConfig). Callers must
+// read the resolved value via EffectivePassword rather than Password.
+// An inline Password is left untouched and may legitimately round-trip.
 func (cfg *DatabaseConfig) LoadPassword() error {
 	if cfg.Password != "" {
 		return nil
@@ -269,10 +282,22 @@ func (cfg *DatabaseConfig) LoadPassword() error {
 		if err != nil {
 			return fmt.Errorf("failed to read password file: %w", err)
 		}
-		cfg.Password = password
+		cfg.resolvedPassword = password
 	}
 
 	return nil
+}
+
+// EffectivePassword returns the database password to use for connecting.
+// An inline Password (from CLI flag or YAML) takes precedence; otherwise
+// the value resolved from PasswordFile by LoadPassword is returned. The
+// result is empty when no password was configured, in which case pgx
+// falls back to the .pgpass file.
+func (cfg *DatabaseConfig) EffectivePassword() string {
+	if cfg.Password != "" {
+		return cfg.Password
+	}
+	return cfg.resolvedPassword
 }
 
 // EmbeddingConfig holds embedding generation settings

--- a/server/src/internal/config/config.go
+++ b/server/src/internal/config/config.go
@@ -240,14 +240,24 @@ type ConnectionSecurityConfig struct {
 // BuildConnectionString creates a PostgreSQL connection string from DatabaseConfig
 // If password is not set, pgx will automatically look it up from .pgpass file
 func (cfg *DatabaseConfig) BuildConnectionString() string {
-	// Build connection string components with URL-encoded user/password
-	connStr := fmt.Sprintf("postgres://%s", url.PathEscape(cfg.User))
-
-	// Add password only if one was resolved (inline or from password_file)
-	// If not set, pgx will use .pgpass file automatically
+	// Build the userinfo component using net/url's userinfo encoders so
+	// that characters with special meaning in the userinfo (notably ':'
+	// and '@') are correctly percent-encoded. url.PathEscape must NOT be
+	// used here: it leaves ':' and '@' unescaped because they are valid
+	// path-segment characters, which would corrupt a DSN whose user or
+	// password contains them (increasingly likely with password_file).
+	//
+	// When no password is resolved, emit the username only (no ':' and
+	// no empty password component) so pgx can still fall back to .pgpass,
+	// preserving the previous behavior.
+	var userinfo string
 	if password := cfg.EffectivePassword(); password != "" {
-		connStr += ":" + url.PathEscape(password)
+		userinfo = url.UserPassword(cfg.User, password).String()
+	} else {
+		userinfo = url.User(cfg.User).String()
 	}
+
+	connStr := fmt.Sprintf("postgres://%s", userinfo)
 
 	connStr += fmt.Sprintf("@%s:%d/%s", cfg.Host, cfg.Port, cfg.Database)
 

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -1158,6 +1158,113 @@ func TestDatabaseConfigLoadPassword(t *testing.T) {
 	})
 }
 
+// TestDatabaseConfigLoadPasswordClearsStaleSecret verifies that calling
+// LoadPassword more than once on the SAME DatabaseConfig never leaves a
+// previously resolved file-sourced secret behind. A second load that no
+// longer has a readable password_file must clear the resolved value so
+// EffectivePassword stops returning the stale secret. A nil receiver is
+// also a safe no-op.
+func TestDatabaseConfigLoadPasswordClearsStaleSecret(t *testing.T) {
+	t.Run("ClearedWhenPasswordFileRemoved", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "db.password")
+		const secret = "first-secret"
+		if err := os.WriteFile(passFile, []byte(secret+"\n"), 0600); err != nil {
+			t.Fatalf("failed to write password file: %v", err)
+		}
+
+		cfg := &DatabaseConfig{PasswordFile: passFile}
+
+		// First load resolves the secret from the file.
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("first LoadPassword: %v", err)
+		}
+		if got := cfg.EffectivePassword(); got != secret {
+			t.Fatalf("after first load EffectivePassword() = %q, want %q", got, secret)
+		}
+
+		// Operator removes password_file before a reload. The second
+		// load must clear the previously resolved secret.
+		cfg.PasswordFile = ""
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("second LoadPassword: %v", err)
+		}
+		if cfg.resolvedPassword != "" {
+			t.Errorf("resolvedPassword = %q, want empty after password_file removed", cfg.resolvedPassword)
+		}
+		if got := cfg.EffectivePassword(); got != "" {
+			t.Errorf("EffectivePassword() = %q, want empty after password_file removed", got)
+		}
+	})
+
+	t.Run("ClearedWhenSecondFileMissing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "db.password")
+		const secret = "first-secret"
+		if err := os.WriteFile(passFile, []byte(secret+"\n"), 0600); err != nil {
+			t.Fatalf("failed to write password file: %v", err)
+		}
+
+		cfg := &DatabaseConfig{PasswordFile: passFile}
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("first LoadPassword: %v", err)
+		}
+		if got := cfg.EffectivePassword(); got != secret {
+			t.Fatalf("after first load EffectivePassword() = %q, want %q", got, secret)
+		}
+
+		// Point at a now-missing file. The second load must return an
+		// error AND leave no stale secret behind.
+		cfg.PasswordFile = filepath.Join(tmpDir, "does-not-exist.password")
+		if err := cfg.LoadPassword(); err == nil {
+			t.Fatal("second LoadPassword expected error for missing file, got nil")
+		}
+		if cfg.resolvedPassword != "" {
+			t.Errorf("resolvedPassword = %q, want empty after failed read", cfg.resolvedPassword)
+		}
+		if got := cfg.EffectivePassword(); got != "" {
+			t.Errorf("EffectivePassword() = %q, want empty after failed read", got)
+		}
+	})
+
+	t.Run("ClearedWhenInlinePasswordSet", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "db.password")
+		const secret = "first-secret"
+		if err := os.WriteFile(passFile, []byte(secret+"\n"), 0600); err != nil {
+			t.Fatalf("failed to write password file: %v", err)
+		}
+
+		cfg := &DatabaseConfig{PasswordFile: passFile}
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("first LoadPassword: %v", err)
+		}
+		if cfg.resolvedPassword != secret {
+			t.Fatalf("after first load resolvedPassword = %q, want %q", cfg.resolvedPassword, secret)
+		}
+
+		// An inline Password now takes precedence. The reset must run
+		// before the early return so the stale resolved value is gone.
+		cfg.Password = "inline-now"
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("second LoadPassword: %v", err)
+		}
+		if cfg.resolvedPassword != "" {
+			t.Errorf("resolvedPassword = %q, want empty once inline Password is set", cfg.resolvedPassword)
+		}
+		if got := cfg.EffectivePassword(); got != "inline-now" {
+			t.Errorf("EffectivePassword() = %q, want 'inline-now'", got)
+		}
+	})
+
+	t.Run("NilReceiverIsNoOp", func(t *testing.T) {
+		var cfg *DatabaseConfig
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("nil-receiver LoadPassword: %v", err)
+		}
+	})
+}
+
 // TestDatabaseConfigEffectivePassword verifies the precedence rules of
 // EffectivePassword independently of the file-resolution path: an inline
 // Password always wins, otherwise the resolved (file-sourced) value is

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -285,40 +285,115 @@ func containsHelper(s, substr string) bool {
 	return false
 }
 
-func TestReadOptionalTrimmedFile(t *testing.T) {
-	// Create temp directory
+// TestLoadAPIKeysFromFilesNotConfigured verifies that leaving every
+// *_file path empty is not an error and leaves the keys untouched.
+func TestLoadAPIKeysFromFilesNotConfigured(t *testing.T) {
+	cfg := &Config{}
+	if err := loadAPIKeysFromFiles(cfg); err != nil {
+		t.Fatalf("loadAPIKeysFromFiles with no files: %v", err)
+	}
+	if cfg.Embedding.VoyageAPIKey != "" || cfg.LLM.AnthropicAPIKey != "" {
+		t.Error("expected keys to remain empty when no files configured")
+	}
+}
+
+// TestLoadAPIKeysFromFilesMissingErrors verifies that a configured
+// key file that cannot be read now produces a propagated error rather
+// than being silently swallowed. Each provider field is exercised so
+// every error branch is covered.
+func TestLoadAPIKeysFromFilesMissingErrors(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.key")
+
+	cases := []struct {
+		name  string
+		apply func(*Config)
+	}{
+		{"embedding voyage", func(c *Config) { c.Embedding.VoyageAPIKeyFile = missing }},
+		{"embedding openai", func(c *Config) { c.Embedding.OpenAIAPIKeyFile = missing }},
+		{"embedding gemini", func(c *Config) { c.Embedding.GeminiAPIKeyFile = missing }},
+		{"llm anthropic", func(c *Config) { c.LLM.AnthropicAPIKeyFile = missing }},
+		{"llm openai", func(c *Config) { c.LLM.OpenAIAPIKeyFile = missing }},
+		{"llm gemini", func(c *Config) { c.LLM.GeminiAPIKeyFile = missing }},
+		{"kb voyage", func(c *Config) { c.Knowledgebase.EmbeddingVoyageAPIKeyFile = missing }},
+		{"kb openai", func(c *Config) { c.Knowledgebase.EmbeddingOpenAIAPIKeyFile = missing }},
+		{"kb gemini", func(c *Config) { c.Knowledgebase.EmbeddingGeminiAPIKeyFile = missing }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{}
+			tc.apply(cfg)
+			if err := loadAPIKeysFromFiles(cfg); err == nil {
+				t.Errorf("expected error for missing %s key file", tc.name)
+			}
+		})
+	}
+}
+
+// TestLoadAPIKeysFromFilesAllProviders verifies every provider's
+// success-assignment branch loads the key from disk when a path is
+// configured and the field is otherwise empty.
+func TestLoadAPIKeysFromFilesAllProviders(t *testing.T) {
 	tmpDir := t.TempDir()
-
-	// Test reading valid file
-	keyFile := filepath.Join(tmpDir, "api_key.txt")
-	if err := os.WriteFile(keyFile, []byte("  test-api-key-123  \n"), 0600); err != nil {
-		t.Fatalf("failed to write test file: %v", err)
+	write := func(name, value string) string {
+		p := filepath.Join(tmpDir, name)
+		if err := os.WriteFile(p, []byte(value+"\n"), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
 	}
 
-	key, err := fileutil.ReadOptionalTrimmedFile(keyFile)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if key != "test-api-key-123" {
-		t.Errorf("expected 'test-api-key-123', got %q", key)
+	cfg := &Config{
+		Embedding: EmbeddingConfig{
+			VoyageAPIKeyFile: write("e-voyage", "e-voyage-key"),
+			OpenAIAPIKeyFile: write("e-openai", "e-openai-key"),
+			GeminiAPIKeyFile: write("e-gemini", "e-gemini-key"),
+		},
+		LLM: LLMConfig{
+			AnthropicAPIKeyFile: write("l-anthropic", "l-anthropic-key"),
+			OpenAIAPIKeyFile:    write("l-openai", "l-openai-key"),
+			GeminiAPIKeyFile:    write("l-gemini", "l-gemini-key"),
+		},
+		Knowledgebase: KnowledgebaseConfig{
+			EmbeddingVoyageAPIKeyFile: write("kb-voyage", "kb-voyage-key"),
+			EmbeddingOpenAIAPIKeyFile: write("kb-openai", "kb-openai-key"),
+			EmbeddingGeminiAPIKeyFile: write("kb-gemini", "kb-gemini-key"),
+		},
 	}
 
-	// Test empty path
-	key, err = fileutil.ReadOptionalTrimmedFile("")
-	if err != nil {
-		t.Errorf("unexpected error for empty path: %v", err)
-	}
-	if key != "" {
-		t.Errorf("expected empty string for empty path, got %q", key)
+	if err := loadAPIKeysFromFiles(cfg); err != nil {
+		t.Fatalf("loadAPIKeysFromFiles: %v", err)
 	}
 
-	// Test non-existent file (should return empty, not error)
-	key, err = fileutil.ReadOptionalTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
-	if err != nil {
-		t.Errorf("unexpected error for non-existent file: %v", err)
+	checks := map[string]string{
+		cfg.Embedding.VoyageAPIKey:              "e-voyage-key",
+		cfg.Embedding.OpenAIAPIKey:              "e-openai-key",
+		cfg.Embedding.GeminiAPIKey:              "e-gemini-key",
+		cfg.LLM.AnthropicAPIKey:                 "l-anthropic-key",
+		cfg.LLM.OpenAIAPIKey:                    "l-openai-key",
+		cfg.LLM.GeminiAPIKey:                    "l-gemini-key",
+		cfg.Knowledgebase.EmbeddingVoyageAPIKey: "kb-voyage-key",
+		cfg.Knowledgebase.EmbeddingOpenAIAPIKey: "kb-openai-key",
+		cfg.Knowledgebase.EmbeddingGeminiAPIKey: "kb-gemini-key",
 	}
-	if key != "" {
-		t.Errorf("expected empty string for non-existent file, got %q", key)
+	for got, want := range checks {
+		if got != want {
+			t.Errorf("loaded key = %q, want %q", got, want)
+		}
+	}
+}
+
+// TestLoadAPIKeysFromFilesEmptyErrors verifies that a configured but
+// empty key file is now reported as an error.
+func TestLoadAPIKeysFromFilesEmptyErrors(t *testing.T) {
+	emptyPath := filepath.Join(t.TempDir(), "empty.key")
+	if err := os.WriteFile(emptyPath, []byte("\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg := &Config{Embedding: EmbeddingConfig{VoyageAPIKeyFile: emptyPath}}
+	if err := loadAPIKeysFromFiles(cfg); err == nil {
+		t.Error("expected error for empty key file")
 	}
 }
 
@@ -822,7 +897,7 @@ func TestMergeConfigGeminiKnowledgebase(t *testing.T) {
 func TestLoadAPIKeysFromFilesGeminiEmbedding(t *testing.T) {
 	tmpDir := t.TempDir()
 	keyPath := filepath.Join(tmpDir, "gemini.key")
-	if err := os.WriteFile(keyPath, []byte("  file-loaded-gemini-key  \n"), 0600); err != nil {
+	if err := os.WriteFile(keyPath, []byte("file-loaded-gemini-key\n"), 0600); err != nil {
 		t.Fatalf("failed to write key file: %v", err)
 	}
 
@@ -832,7 +907,9 @@ func TestLoadAPIKeysFromFilesGeminiEmbedding(t *testing.T) {
 		},
 	}
 
-	loadAPIKeysFromFiles(cfg)
+	if err := loadAPIKeysFromFiles(cfg); err != nil {
+		t.Fatalf("loadAPIKeysFromFiles: %v", err)
+	}
 
 	if cfg.Embedding.GeminiAPIKey != "file-loaded-gemini-key" {
 		t.Errorf("expected GeminiAPIKey 'file-loaded-gemini-key', got %q",
@@ -855,7 +932,9 @@ func TestLoadAPIKeysFromFilesGeminiKnowledgebase(t *testing.T) {
 		},
 	}
 
-	loadAPIKeysFromFiles(cfg)
+	if err := loadAPIKeysFromFiles(cfg); err != nil {
+		t.Fatalf("loadAPIKeysFromFiles: %v", err)
+	}
 
 	if cfg.Knowledgebase.EmbeddingGeminiAPIKey != "kb-file-gemini-key" {
 		t.Errorf("expected EmbeddingGeminiAPIKey 'kb-file-gemini-key', got %q",
@@ -883,7 +962,9 @@ func TestLoadAPIKeysFromFilesGeminiPreservesExisting(t *testing.T) {
 		},
 	}
 
-	loadAPIKeysFromFiles(cfg)
+	if err := loadAPIKeysFromFiles(cfg); err != nil {
+		t.Fatalf("loadAPIKeysFromFiles: %v", err)
+	}
 
 	if cfg.Embedding.GeminiAPIKey != "preset-key" {
 		t.Errorf("expected existing Embedding key to be preserved, got %q",
@@ -986,10 +1067,12 @@ func TestDatabaseConfigLoadPassword(t *testing.T) {
 		}
 	})
 
-	t.Run("ReadsAndTrimsFromValidFile", func(t *testing.T) {
+	t.Run("ReadsAndTrimsTrailingNewlineFromValidFile", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		passFile := filepath.Join(tmpDir, "password.txt")
-		if err := os.WriteFile(passFile, []byte("  secret-pass\n"), 0600); err != nil {
+		// Only the trailing newline is stripped; in-secret whitespace
+		// (here a deliberate trailing space) is preserved.
+		if err := os.WriteFile(passFile, []byte("secret pass \n"), 0600); err != nil {
 			t.Fatalf("failed to write password file: %v", err)
 		}
 
@@ -998,8 +1081,21 @@ func TestDatabaseConfigLoadPassword(t *testing.T) {
 		if err := cfg.LoadPassword(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if cfg.Password != "secret-pass" {
-			t.Errorf("expected password 'secret-pass', got %q", cfg.Password)
+		if cfg.Password != "secret pass " {
+			t.Errorf("expected password 'secret pass ', got %q", cfg.Password)
+		}
+	})
+
+	t.Run("EmptyFileReturnsError", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "empty.txt")
+		if err := os.WriteFile(passFile, []byte("\n"), 0600); err != nil {
+			t.Fatalf("failed to write password file: %v", err)
+		}
+
+		cfg := &DatabaseConfig{PasswordFile: passFile}
+		if err := cfg.LoadPassword(); err == nil {
+			t.Fatal("expected an error for an empty password file, got nil")
 		}
 	})
 

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -365,20 +365,27 @@ func TestLoadAPIKeysFromFilesAllProviders(t *testing.T) {
 		t.Fatalf("loadAPIKeysFromFiles: %v", err)
 	}
 
-	checks := map[string]string{
-		cfg.Embedding.VoyageAPIKey:              "e-voyage-key",
-		cfg.Embedding.OpenAIAPIKey:              "e-openai-key",
-		cfg.Embedding.GeminiAPIKey:              "e-gemini-key",
-		cfg.LLM.AnthropicAPIKey:                 "l-anthropic-key",
-		cfg.LLM.OpenAIAPIKey:                    "l-openai-key",
-		cfg.LLM.GeminiAPIKey:                    "l-gemini-key",
-		cfg.Knowledgebase.EmbeddingVoyageAPIKey: "kb-voyage-key",
-		cfg.Knowledgebase.EmbeddingOpenAIAPIKey: "kb-openai-key",
-		cfg.Knowledgebase.EmbeddingGeminiAPIKey: "kb-gemini-key",
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Embedding.VoyageAPIKey", cfg.Embedding.VoyageAPIKey, "e-voyage-key"},
+		{"Embedding.OpenAIAPIKey", cfg.Embedding.OpenAIAPIKey, "e-openai-key"},
+		{"Embedding.GeminiAPIKey", cfg.Embedding.GeminiAPIKey, "e-gemini-key"},
+		{"LLM.AnthropicAPIKey", cfg.LLM.AnthropicAPIKey, "l-anthropic-key"},
+		{"LLM.OpenAIAPIKey", cfg.LLM.OpenAIAPIKey, "l-openai-key"},
+		{"LLM.GeminiAPIKey", cfg.LLM.GeminiAPIKey, "l-gemini-key"},
+		{"Knowledgebase.EmbeddingVoyageAPIKey",
+			cfg.Knowledgebase.EmbeddingVoyageAPIKey, "kb-voyage-key"},
+		{"Knowledgebase.EmbeddingOpenAIAPIKey",
+			cfg.Knowledgebase.EmbeddingOpenAIAPIKey, "kb-openai-key"},
+		{"Knowledgebase.EmbeddingGeminiAPIKey",
+			cfg.Knowledgebase.EmbeddingGeminiAPIKey, "kb-gemini-key"},
 	}
-	for got, want := range checks {
-		if got != want {
-			t.Errorf("loaded key = %q, want %q", got, want)
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
 		}
 	}
 }

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -12,9 +12,11 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pgedge/ai-workbench/pkg/fileutil"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -1049,10 +1051,12 @@ knowledgebase:
 }
 
 // TestDatabaseConfigLoadPassword exercises the password_file resolution
-// path on DatabaseConfig.LoadPassword across its four behaviors: an
+// path on DatabaseConfig.LoadPassword across its behaviors: an
 // already-set password short-circuits the file read; a valid file is
-// read and trimmed into Password; a missing file surfaces an error; and
-// an empty Password with an empty PasswordFile is a no-op.
+// read and trimmed into the unexported resolved field (NOT Password); a
+// missing or empty file surfaces an error; and an empty Password with an
+// empty PasswordFile is a no-op. A file-sourced secret must never land
+// in the marshalable Password field.
 func TestDatabaseConfigLoadPassword(t *testing.T) {
 	t.Run("PasswordAlreadySetIsNoOp", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -1072,6 +1076,13 @@ func TestDatabaseConfigLoadPassword(t *testing.T) {
 		if cfg.Password != "explicit-password" {
 			t.Errorf("expected password to remain 'explicit-password', got %q", cfg.Password)
 		}
+		// The file read must be skipped entirely; nothing resolved.
+		if cfg.resolvedPassword != "" {
+			t.Errorf("expected resolvedPassword to stay empty, got %q", cfg.resolvedPassword)
+		}
+		if got := cfg.EffectivePassword(); got != "explicit-password" {
+			t.Errorf("EffectivePassword() = %q, want 'explicit-password'", got)
+		}
 	})
 
 	t.Run("ReadsAndTrimsTrailingNewlineFromValidFile", func(t *testing.T) {
@@ -1088,8 +1099,16 @@ func TestDatabaseConfigLoadPassword(t *testing.T) {
 		if err := cfg.LoadPassword(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if cfg.Password != "secret pass " {
-			t.Errorf("expected password 'secret pass ', got %q", cfg.Password)
+		// The marshalable Password field must remain empty so the
+		// file-sourced secret cannot round-trip to disk.
+		if cfg.Password != "" {
+			t.Errorf("expected Password to remain empty, got %q", cfg.Password)
+		}
+		if cfg.resolvedPassword != "secret pass " {
+			t.Errorf("expected resolvedPassword 'secret pass ', got %q", cfg.resolvedPassword)
+		}
+		if got := cfg.EffectivePassword(); got != "secret pass " {
+			t.Errorf("EffectivePassword() = %q, want 'secret pass '", got)
 		}
 	})
 
@@ -1119,6 +1138,9 @@ func TestDatabaseConfigLoadPassword(t *testing.T) {
 		if cfg.Password != "" {
 			t.Errorf("expected password to remain empty on error, got %q", cfg.Password)
 		}
+		if cfg.resolvedPassword != "" {
+			t.Errorf("expected resolvedPassword to remain empty on error, got %q", cfg.resolvedPassword)
+		}
 	})
 
 	t.Run("BothEmptyIsNoOp", func(t *testing.T) {
@@ -1130,5 +1152,157 @@ func TestDatabaseConfigLoadPassword(t *testing.T) {
 		if cfg.Password != "" {
 			t.Errorf("expected password to remain empty, got %q", cfg.Password)
 		}
+		if got := cfg.EffectivePassword(); got != "" {
+			t.Errorf("EffectivePassword() = %q, want empty", got)
+		}
 	})
+}
+
+// TestDatabaseConfigEffectivePassword verifies the precedence rules of
+// EffectivePassword independently of the file-resolution path: an inline
+// Password always wins, otherwise the resolved (file-sourced) value is
+// returned, and an unconfigured password yields the empty string.
+func TestDatabaseConfigEffectivePassword(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		resolved string
+		want     string
+	}{
+		{"inline wins over resolved", "inline-pw", "file-pw", "inline-pw"},
+		{"inline only", "inline-pw", "", "inline-pw"},
+		{"resolved only", "", "file-pw", "file-pw"},
+		{"neither configured", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &DatabaseConfig{
+				Password:         tt.password,
+				resolvedPassword: tt.resolved,
+			}
+			if got := cfg.EffectivePassword(); got != tt.want {
+				t.Errorf("EffectivePassword() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildConnectionStringUsesResolvedPassword confirms the connection
+// string includes a file-sourced password resolved via LoadPassword,
+// even though that secret lives only in the unexported resolved field.
+func TestBuildConnectionStringUsesResolvedPassword(t *testing.T) {
+	tmpDir := t.TempDir()
+	passFile := filepath.Join(tmpDir, "db.password")
+	const secret = "resolved-secret"
+	if err := os.WriteFile(passFile, []byte(secret+"\n"), 0600); err != nil {
+		t.Fatalf("failed to write password file: %v", err)
+	}
+
+	cfg := &DatabaseConfig{
+		User:         "postgres",
+		Host:         "localhost",
+		Port:         5432,
+		Database:     "testdb",
+		PasswordFile: passFile,
+	}
+
+	if err := cfg.LoadPassword(); err != nil {
+		t.Fatalf("LoadPassword: %v", err)
+	}
+	if cfg.Password != "" {
+		t.Fatalf("expected Password to remain empty, got %q", cfg.Password)
+	}
+
+	got := cfg.BuildConnectionString()
+	want := "postgres://postgres:" + secret + "@localhost:5432/testdb"
+	if got != want {
+		t.Errorf("BuildConnectionString() = %q, want %q", got, want)
+	}
+}
+
+// TestMarshalDoesNotLeakResolvedPassword is the regression test for the
+// CodeRabbit finding on config.go: a password sourced from password_file
+// must not appear when the config is marshaled (the path SaveConfig
+// uses). Because LoadPassword stores file-sourced secrets in the
+// unexported, yaml:"-" resolvedPassword field, marshaling must emit an
+// empty password and never the secret itself.
+func TestMarshalDoesNotLeakResolvedPassword(t *testing.T) {
+	tmpDir := t.TempDir()
+	passFile := filepath.Join(tmpDir, "db.password")
+	const secret = "must-not-leak-to-disk"
+	if err := os.WriteFile(passFile, []byte(secret+"\n"), 0600); err != nil {
+		t.Fatalf("failed to write password file: %v", err)
+	}
+
+	cfg := &Config{
+		Database: &DatabaseConfig{
+			User:         "postgres",
+			Host:         "localhost",
+			Port:         5432,
+			Database:     "testdb",
+			PasswordFile: passFile,
+		},
+	}
+
+	if err := cfg.Database.LoadPassword(); err != nil {
+		t.Fatalf("LoadPassword: %v", err)
+	}
+	// Sanity: the secret was resolved and is usable at runtime.
+	if cfg.Database.EffectivePassword() != secret {
+		t.Fatalf("EffectivePassword() = %q, want %q", cfg.Database.EffectivePassword(), secret)
+	}
+
+	// Marshal the live config exactly as SaveConfig does.
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	out := string(data)
+
+	if strings.Contains(out, secret) {
+		t.Fatalf("marshaled config leaked the file-sourced secret:\n%s", out)
+	}
+	// The password key must be present but empty for the file-sourced case.
+	if !strings.Contains(out, "password: \"\"") {
+		t.Errorf("expected an empty password field in marshaled output, got:\n%s", out)
+	}
+}
+
+// TestSaveConfigDoesNotLeakResolvedPassword drives the same regression
+// through the actual SaveConfig path, reading the written file back to
+// confirm the file-sourced secret never reaches disk.
+func TestSaveConfigDoesNotLeakResolvedPassword(t *testing.T) {
+	tmpDir := t.TempDir()
+	passFile := filepath.Join(tmpDir, "db.password")
+	const secret = "save-config-secret"
+	if err := os.WriteFile(passFile, []byte(secret+"\n"), 0600); err != nil {
+		t.Fatalf("failed to write password file: %v", err)
+	}
+
+	cfg := &Config{
+		Database: &DatabaseConfig{
+			User:         "postgres",
+			Host:         "localhost",
+			Port:         5432,
+			Database:     "testdb",
+			PasswordFile: passFile,
+		},
+	}
+	if err := cfg.Database.LoadPassword(); err != nil {
+		t.Fatalf("LoadPassword: %v", err)
+	}
+
+	outPath := filepath.Join(tmpDir, "saved.yaml")
+	if err := SaveConfig(outPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	written, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	if strings.Contains(string(written), secret) {
+		t.Fatalf("SaveConfig leaked the file-sourced secret to disk:\n%s", written)
+	}
 }

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -10,11 +10,13 @@
 package config
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pgedge/ai-workbench/pkg/fileutil"
 	"gopkg.in/yaml.v3"
 )
@@ -112,7 +114,7 @@ func TestBuildConnectionString(t *testing.T) {
 				Database: "production",
 				SSLMode:  "verify-full",
 			},
-			expected: "postgres://admin:p@ssw0rd@db.example.com:5433/production?sslmode=verify-full",
+			expected: "postgres://admin:p%40ssw0rd@db.example.com:5433/production?sslmode=verify-full",
 		},
 	}
 
@@ -123,6 +125,99 @@ func TestBuildConnectionString(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, result)
 			}
 		})
+	}
+}
+
+// TestBuildConnectionStringRoundTrip is the authoritative correctness
+// check for userinfo encoding. For each password containing characters
+// with special meaning in a URL userinfo component, it builds the DSN,
+// parses it back with url.Parse, and asserts the recovered user and
+// password match the originals byte-for-byte. This proves the encoding
+// is correct regardless of the exact percent-encoded representation.
+func TestBuildConnectionStringRoundTrip(t *testing.T) {
+	const user = "admin@corp"
+
+	passwords := []string{
+		"p@ssw0rd",
+		"p:ss/w?rd",
+		"pa ss",
+		"p%40 word",
+		"p#ss&w=rd",
+	}
+
+	for _, pw := range passwords {
+		pw := pw
+		t.Run(pw, func(t *testing.T) {
+			cfg := DatabaseConfig{
+				User:     user,
+				Password: pw,
+				Host:     "db.example.com",
+				Port:     5432,
+				Database: "production",
+				SSLMode:  "require",
+			}
+
+			dsn := cfg.BuildConnectionString()
+
+			parsed, err := url.Parse(dsn)
+			if err != nil {
+				t.Fatalf("url.Parse(%q) returned error: %v", dsn, err)
+			}
+
+			if got := parsed.User.Username(); got != user {
+				t.Errorf("username = %q, want %q (dsn=%q)", got, user, dsn)
+			}
+
+			gotPW, hasPW := parsed.User.Password()
+			if !hasPW {
+				t.Fatalf("parsed DSN has no password component (dsn=%q)", dsn)
+			}
+			if gotPW != pw {
+				t.Errorf("password = %q, want %q (dsn=%q)", gotPW, pw, dsn)
+			}
+
+			// pgconn.ParseConfig validates the DSN the way pgx itself
+			// does; it parses only and never opens a connection, so it
+			// is safe to run without a database.
+			if _, err := pgconn.ParseConfig(dsn); err != nil {
+				t.Errorf("pgconn.ParseConfig(%q) returned error: %v", dsn, err)
+			}
+		})
+	}
+}
+
+// TestBuildConnectionStringNoPassword confirms that an empty effective
+// password yields a DSN carrying the username but no password component,
+// preserving pgx's .pgpass fallback, and that the DSN remains parseable.
+func TestBuildConnectionStringNoPassword(t *testing.T) {
+	cfg := DatabaseConfig{
+		User:     "admin@corp",
+		Host:     "db.example.com",
+		Port:     5432,
+		Database: "production",
+	}
+
+	dsn := cfg.BuildConnectionString()
+
+	if strings.Contains(dsn, ":@") {
+		t.Errorf("DSN must not contain an empty password component: %q", dsn)
+	}
+
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) returned error: %v", dsn, err)
+	}
+
+	if got := parsed.User.Username(); got != cfg.User {
+		t.Errorf("username = %q, want %q (dsn=%q)", got, cfg.User, dsn)
+	}
+
+	if _, hasPW := parsed.User.Password(); hasPW {
+		t.Errorf("expected no password component, but one was present: %q", dsn)
+	}
+
+	if _, err := pgconn.ParseConfig(dsn); err != nil {
+		t.Errorf("pgconn.ParseConfig(%q) returned error: %v", dsn, err)
 	}
 }
 

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -959,3 +959,73 @@ knowledgebase:
 			cfg.Knowledgebase.EmbeddingGeminiBaseURL)
 	}
 }
+
+// TestDatabaseConfigLoadPassword exercises the password_file resolution
+// path on DatabaseConfig.LoadPassword across its four behaviors: an
+// already-set password short-circuits the file read; a valid file is
+// read and trimmed into Password; a missing file surfaces an error; and
+// an empty Password with an empty PasswordFile is a no-op.
+func TestDatabaseConfigLoadPassword(t *testing.T) {
+	t.Run("PasswordAlreadySetIsNoOp", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		if err := os.WriteFile(passFile, []byte("from-file"), 0600); err != nil {
+			t.Fatalf("failed to write password file: %v", err)
+		}
+
+		cfg := &DatabaseConfig{
+			Password:     "explicit-password",
+			PasswordFile: passFile,
+		}
+
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Password != "explicit-password" {
+			t.Errorf("expected password to remain 'explicit-password', got %q", cfg.Password)
+		}
+	})
+
+	t.Run("ReadsAndTrimsFromValidFile", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		if err := os.WriteFile(passFile, []byte("  secret-pass\n"), 0600); err != nil {
+			t.Fatalf("failed to write password file: %v", err)
+		}
+
+		cfg := &DatabaseConfig{PasswordFile: passFile}
+
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Password != "secret-pass" {
+			t.Errorf("expected password 'secret-pass', got %q", cfg.Password)
+		}
+	})
+
+	t.Run("MissingFileReturnsError", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &DatabaseConfig{
+			PasswordFile: filepath.Join(tmpDir, "does-not-exist.txt"),
+		}
+
+		err := cfg.LoadPassword()
+		if err == nil {
+			t.Fatal("expected an error for a missing password file, got nil")
+		}
+		if cfg.Password != "" {
+			t.Errorf("expected password to remain empty on error, got %q", cfg.Password)
+		}
+	})
+
+	t.Run("BothEmptyIsNoOp", func(t *testing.T) {
+		cfg := &DatabaseConfig{}
+
+		if err := cfg.LoadPassword(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Password != "" {
+			t.Errorf("expected password to remain empty, got %q", cfg.Password)
+		}
+	})
+}

--- a/server/src/internal/config/headers.go
+++ b/server/src/internal/config/headers.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 	"github.com/pgedge/ai-workbench/server/internal/logging"
 )
 
@@ -49,16 +50,19 @@ func parseHeadersEnvVar(envVal string) (map[string]string, error) {
 }
 
 // loadHeadersFromFiles reads header values from the specified file paths.
-// Each file should contain the header value. Leading/trailing whitespace
-// and newlines are trimmed.
+// Each file should contain the header value, which may be a bearer token
+// or other secret. Values are read through fileutil.ReadSecretFile, so a
+// leading tilde is expanded, only the trailing newline is trimmed
+// (preserving any in-value whitespace), a permissive-permission warning
+// is emitted, and a configured-but-empty file is reported as an error.
 func loadHeadersFromFiles(files map[string]string) (map[string]string, error) {
 	result := make(map[string]string)
 	for headerName, filePath := range files {
-		content, err := os.ReadFile(filePath)
+		content, err := fileutil.ReadSecretFile(filePath)
 		if err != nil {
 			return nil, fmt.Errorf("reading header %q from file %q: %w", headerName, filePath, err)
 		}
-		result[headerName] = strings.TrimSpace(string(content))
+		result[headerName] = content
 	}
 	return result, nil
 }

--- a/server/src/internal/config/reload.go
+++ b/server/src/internal/config/reload.go
@@ -62,6 +62,20 @@ func (rc *ReloadableConfig) Reload() error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	// Resolve the datastore password from a password_file before the new
+	// config is swapped in or handed to any onReload callback. LoadConfig
+	// applies CLI-flag and inline-YAML passwords, but a YAML password_file
+	// is only materialized here; without this step a reload would leave
+	// DatabaseConfig.Password empty and silently fall back to .pgpass.
+	// Doing it at this single chokepoint guarantees every reload consumer
+	// (including the SIGHUP client-manager update) sees the resolved
+	// password. On failure we abort the reload and keep the old config.
+	if newConfig.Database != nil {
+		if err := newConfig.Database.LoadPassword(); err != nil {
+			return fmt.Errorf("failed to resolve database password: %w", err)
+		}
+	}
+
 	// Log what settings require restart (won't be applied)
 	rc.logRestartRequiredSettings(newConfig)
 

--- a/server/src/internal/config/reload_test.go
+++ b/server/src/internal/config/reload_test.go
@@ -1,0 +1,134 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeReloadConfig writes a minimal valid server config to a temp file
+// and returns its path. The database user is always set so the config
+// passes validateConfig. The passwordFile argument, when non-empty, is
+// written into the database block as password_file.
+func writeReloadConfig(t *testing.T, dir, passwordFile string) string {
+	t.Helper()
+
+	pwLine := ""
+	if passwordFile != "" {
+		pwLine = fmt.Sprintf("  password_file: %q\n", passwordFile)
+	}
+
+	body := fmt.Sprintf(`database:
+  host: 127.0.0.1
+  port: 5432
+  database: ai_workbench
+  user: postgres
+%s`, pwLine)
+
+	path := filepath.Join(dir, "ai-dba-server.yaml")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// TestReloadResolvesPasswordFile confirms that a SIGHUP-style reload
+// re-resolves a YAML password_file, so the reloaded DatabaseConfig has
+// its Password populated from the file contents (matching startup).
+func TestReloadResolvesPasswordFile(t *testing.T) {
+	dir := t.TempDir()
+
+	const secret = "s3cr3t-reload-pw"
+	pwFile := filepath.Join(dir, "db.password")
+	if err := os.WriteFile(pwFile, []byte(secret+"\n"), 0600); err != nil {
+		t.Fatalf("write password file: %v", err)
+	}
+
+	cfgPath := writeReloadConfig(t, dir, pwFile)
+
+	// Build an initial config from the same file; it should already have
+	// the password resolved if we run LoadPassword, but the reloadable
+	// wrapper starts from whatever we hand it.
+	initial, err := LoadConfig(cfgPath, CLIFlags{ConfigFileSet: true, ConfigFile: cfgPath})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	rc := NewReloadableConfig(initial, cfgPath, CLIFlags{ConfigFileSet: true, ConfigFile: cfgPath})
+
+	var seenByCallback string
+	rc.OnReload(func(newCfg *Config) {
+		if newCfg.Database != nil {
+			seenByCallback = newCfg.Database.Password
+		}
+	})
+
+	if err := rc.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	got := rc.Get()
+	if got.Database == nil {
+		t.Fatal("reloaded config has nil Database")
+	}
+	if got.Database.Password != secret {
+		t.Errorf("reloaded Password = %q, want %q", got.Database.Password, secret)
+	}
+	if seenByCallback != secret {
+		t.Errorf("onReload callback saw Password %q, want %q", seenByCallback, secret)
+	}
+}
+
+// TestReloadMissingPasswordFileAbortsReload confirms that a reload whose
+// password_file cannot be read returns an error and does NOT swap the
+// active config.
+func TestReloadMissingPasswordFileAbortsReload(t *testing.T) {
+	dir := t.TempDir()
+
+	// Start from a valid config with no password_file.
+	startPath := writeReloadConfig(t, dir, "")
+	initial, err := LoadConfig(startPath, CLIFlags{ConfigFileSet: true, ConfigFile: startPath})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	rc := NewReloadableConfig(initial, startPath, CLIFlags{ConfigFileSet: true, ConfigFile: startPath})
+
+	callbackRan := false
+	rc.OnReload(func(_ *Config) { callbackRan = true })
+
+	// Rewrite the same config path to point at a missing password file.
+	missing := filepath.Join(dir, "does-not-exist.password")
+	if err := os.WriteFile(startPath, []byte(fmt.Sprintf(`database:
+  host: 127.0.0.1
+  port: 5432
+  database: ai_workbench
+  user: postgres
+  password_file: %q
+`, missing)), 0600); err != nil {
+		t.Fatalf("rewrite config: %v", err)
+	}
+
+	err = rc.Reload()
+	if err == nil {
+		t.Fatal("Reload() expected error for missing password file, got nil")
+	}
+
+	// Config must not have been swapped: it is still the initial pointer.
+	if rc.Get() != initial {
+		t.Error("Reload() swapped config despite password resolution failure")
+	}
+	if callbackRan {
+		t.Error("onReload callback ran despite failed reload")
+	}
+}

--- a/server/src/internal/config/reload_test.go
+++ b/server/src/internal/config/reload_test.go
@@ -43,8 +43,10 @@ func writeReloadConfig(t *testing.T, dir, passwordFile string) string {
 }
 
 // TestReloadResolvesPasswordFile confirms that a SIGHUP-style reload
-// re-resolves a YAML password_file, so the reloaded DatabaseConfig has
-// its Password populated from the file contents (matching startup).
+// re-resolves a YAML password_file. The reload does NOT populate the
+// marshalable DatabaseConfig.Password field; the file-sourced secret is
+// kept out of Password and surfaced only through EffectivePassword
+// (matching startup behavior).
 func TestReloadResolvesPasswordFile(t *testing.T) {
 	dir := t.TempDir()
 

--- a/server/src/internal/config/reload_test.go
+++ b/server/src/internal/config/reload_test.go
@@ -69,7 +69,7 @@ func TestReloadResolvesPasswordFile(t *testing.T) {
 	var seenByCallback string
 	rc.OnReload(func(newCfg *Config) {
 		if newCfg.Database != nil {
-			seenByCallback = newCfg.Database.Password
+			seenByCallback = newCfg.Database.EffectivePassword()
 		}
 	})
 
@@ -81,11 +81,17 @@ func TestReloadResolvesPasswordFile(t *testing.T) {
 	if got.Database == nil {
 		t.Fatal("reloaded config has nil Database")
 	}
-	if got.Database.Password != secret {
-		t.Errorf("reloaded Password = %q, want %q", got.Database.Password, secret)
+	// A file-sourced secret must not populate the marshalable Password
+	// field; it is resolved into the unexported field and surfaced only
+	// through EffectivePassword.
+	if got.Database.Password != "" {
+		t.Errorf("reloaded Password = %q, want empty (file-sourced secret must not leak)", got.Database.Password)
+	}
+	if got.Database.EffectivePassword() != secret {
+		t.Errorf("reloaded EffectivePassword() = %q, want %q", got.Database.EffectivePassword(), secret)
 	}
 	if seenByCallback != secret {
-		t.Errorf("onReload callback saw Password %q, want %q", seenByCallback, secret)
+		t.Errorf("onReload callback saw EffectivePassword %q, want %q", seenByCallback, secret)
 	}
 }
 

--- a/server/src/internal/crypto/encryption.go
+++ b/server/src/internal/crypto/encryption.go
@@ -17,6 +17,7 @@ import (
 	"os"
 
 	pkgcrypto "github.com/pgedge/ai-workbench/pkg/crypto"
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
 const (
@@ -48,18 +49,13 @@ func GenerateKey() (*EncryptionKey, error) {
 
 // LoadKeyFromFile loads an encryption key from a file
 func LoadKeyFromFile(path string) (*EncryptionKey, error) {
-	// Check file permissions before loading
-	fileInfo, err := os.Stat(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to stat key file: %w", err)
+	// Reject any file that grants group or world access. Owner-only
+	// modes such as 0400 and 0600 pass; 0640, 0644, and friends fail.
+	if err := fileutil.RequireOwnerOnly(path); err != nil {
+		return nil, err
 	}
 
-	// Verify file has 0600 permissions (owner read/write only)
-	mode := fileInfo.Mode().Perm()
-	if mode != 0600 {
-		return nil, fmt.Errorf("insecure permissions on key file %s: %04o (expected 0600). Please run: chmod 600 %s", path, mode, path)
-	}
-
+	// #nosec G304 - File path is provided by administrator configuration
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read key file: %w", err)

--- a/server/src/internal/crypto/encryption.go
+++ b/server/src/internal/crypto/encryption.go
@@ -51,14 +51,11 @@ func GenerateKey() (*EncryptionKey, error) {
 func LoadKeyFromFile(path string) (*EncryptionKey, error) {
 	// Reject any file that grants group or world access. Owner-only
 	// modes such as 0400 and 0600 pass; 0640, 0644, and friends fail.
-	if err := fileutil.RequireOwnerOnly(path); err != nil {
-		return nil, err
-	}
-
-	// #nosec G304 - File path is provided by administrator configuration
-	data, err := os.ReadFile(path)
+	// The permission check and read happen on the same open descriptor
+	// to close the TOCTOU window a separate stat + read would leave.
+	data, err := fileutil.ReadOwnerOnlyFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read key file: %w", err)
+		return nil, err
 	}
 
 	// Decode base64

--- a/server/src/internal/crypto/encryption.go
+++ b/server/src/internal/crypto/encryption.go
@@ -49,10 +49,12 @@ func GenerateKey() (*EncryptionKey, error) {
 
 // LoadKeyFromFile loads an encryption key from a file
 func LoadKeyFromFile(path string) (*EncryptionKey, error) {
-	// Reject any file that grants group or world access. Owner-only
-	// modes such as 0400 and 0600 pass; 0640, 0644, and friends fail.
-	// The permission check and read happen on the same open descriptor
-	// to close the TOCTOU window a separate stat + read would leave.
+	// On non-Windows platforms, reject any file that grants group or
+	// world access: owner-only modes such as 0400 and 0600 pass, while
+	// 0640, 0644, and friends fail. Windows mode bits do not map cleanly,
+	// so that permission check is skipped there. The regular-file, size,
+	// and permission checks all happen on the same open descriptor that
+	// is read, closing the TOCTOU window a separate stat + read leaves.
 	data, err := fileutil.ReadOwnerOnlyFile(path)
 	if err != nil {
 		return nil, err

--- a/server/src/internal/crypto/encryption_test.go
+++ b/server/src/internal/crypto/encryption_test.go
@@ -258,6 +258,29 @@ func TestLoadKeyFromInvalidFile(t *testing.T) {
 	}
 }
 
+// TestLoadKeyWithReadOnlyOwnerPermissions verifies the relaxed
+// permission check accepts owner-only modes beyond 0600. A 0400
+// (read-only owner) key file must load successfully.
+func TestLoadKeyWithReadOnlyOwnerPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "readonly.key")
+
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+	if err := key.SaveToFile(keyPath); err != nil {
+		t.Fatalf("SaveToFile failed: %v", err)
+	}
+	if err := os.Chmod(keyPath, 0400); err != nil {
+		t.Fatalf("Chmod failed: %v", err)
+	}
+
+	if _, err := LoadKeyFromFile(keyPath); err != nil {
+		t.Errorf("expected 0400 key file to load, got error: %v", err)
+	}
+}
+
 func TestLoadKeyWithInsecurePermissions(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pgedge-crypto-test-*")
 	if err != nil {

--- a/server/src/internal/crypto/encryption_test.go
+++ b/server/src/internal/crypto/encryption_test.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -262,6 +263,10 @@ func TestLoadKeyFromInvalidFile(t *testing.T) {
 // permission check accepts owner-only modes beyond 0600. A 0400
 // (read-only owner) key file must load successfully.
 func TestLoadKeyWithReadOnlyOwnerPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-bit enforcement is not applied on Windows")
+	}
+
 	tmpDir := t.TempDir()
 	keyPath := filepath.Join(tmpDir, "readonly.key")
 
@@ -282,6 +287,10 @@ func TestLoadKeyWithReadOnlyOwnerPermissions(t *testing.T) {
 }
 
 func TestLoadKeyWithInsecurePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-bit enforcement is not applied on Windows")
+	}
+
 	tmpDir, err := os.MkdirTemp("", "pgedge-crypto-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)

--- a/server/src/internal/database/connection_queries.go
+++ b/server/src/internal/database/connection_queries.go
@@ -606,13 +606,26 @@ func (d *Datastore) BuildConnectionString(conn *MonitoredConnection, password st
 		database = databaseOverride
 	}
 
-	// Start with user (URL-encode in case of special characters)
-	connStr := fmt.Sprintf("postgres://%s", url.QueryEscape(conn.Username))
-
-	// Add password if present (URL-encode to handle special characters)
+	// Build the userinfo component using net/url's userinfo encoders so
+	// that characters with special meaning in the userinfo (notably ':'
+	// and '@') are correctly percent-encoded. url.QueryEscape must NOT be
+	// used here: it follows application/x-www-form-urlencoded rules and
+	// encodes a space ' ' as '+', but '+' is a literal plus in a URL
+	// userinfo component, so a password containing a space would round-trip
+	// incorrectly. url.User/url.UserPassword apply the correct userinfo
+	// encoding instead.
+	//
+	// When no password is present, emit the username only (no ':' and no
+	// empty password component) so pgx can still fall back to the .pgpass
+	// file, preserving the previous behavior.
+	var userinfo string
 	if password != "" {
-		connStr += ":" + url.QueryEscape(password)
+		userinfo = url.UserPassword(conn.Username, password).String()
+	} else {
+		userinfo = url.User(conn.Username).String()
 	}
+
+	connStr := fmt.Sprintf("postgres://%s", userinfo)
 
 	// Use hostaddr if available, otherwise host
 	host := conn.Host

--- a/server/src/internal/database/queries_test.go
+++ b/server/src/internal/database/queries_test.go
@@ -13,9 +13,12 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // ---------------------------------------------------------------------------
@@ -2754,6 +2757,112 @@ func TestBuildConnectionString(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestBuildConnectionStringUserinfoRoundTrip proves that the userinfo
+// component (username and password) survives a build/parse cycle exactly,
+// even for characters with special meaning in a URL. This is the regression
+// guard for the url.QueryEscape -> url.UserPassword fix: QueryEscape encodes
+// a space as '+', which a URL parser reads back as a literal '+', corrupting
+// any password that contains a space. url.UserPassword applies the correct
+// userinfo encoding (a space becomes %20) so the value round-trips intact.
+func TestBuildConnectionStringUserinfoRoundTrip(t *testing.T) {
+	ds := &Datastore{}
+
+	// Each of these characters is special in some part of a URL; the space
+	// case is the one that specifically distinguishes the correct userinfo
+	// encoding (%20) from QueryEscape's form encoding (+).
+	specialPasswords := []string{
+		"@",          // userinfo delimiter
+		":",          // user/password separator
+		"/",          // path separator
+		" ",          // space: QueryEscape would emit '+'
+		"%",          // percent: must be escaped to round-trip
+		"#",          // fragment delimiter
+		"&",          // query separator
+		"=",          // query key/value separator
+		"p@ss:w/ord", // realistic mixed password
+		"a b+c",      // space adjacent to a literal '+'
+	}
+
+	for _, pw := range specialPasswords {
+		pw := pw
+		t.Run(fmt.Sprintf("password=%q", pw), func(t *testing.T) {
+			conn := &MonitoredConnection{
+				Host:         "localhost",
+				Port:         5432,
+				DatabaseName: "mydb",
+				Username:     "weird@user:name",
+			}
+
+			dsn := ds.BuildConnectionString(conn, pw, "")
+
+			parsed, err := url.Parse(dsn)
+			if err != nil {
+				t.Fatalf("url.Parse(%q) failed: %v", dsn, err)
+			}
+
+			if got := parsed.User.Username(); got != conn.Username {
+				t.Errorf("username round-trip mismatch: built %q, recovered %q", conn.Username, got)
+			}
+
+			gotPw, hasPw := parsed.User.Password()
+			if !hasPw {
+				t.Fatalf("expected a password component in %q", dsn)
+			}
+			if gotPw != pw {
+				t.Errorf("password round-trip mismatch: built %q, recovered %q (dsn=%q)", pw, gotPw, dsn)
+			}
+		})
+	}
+
+	t.Run("space encodes as %20 not +", func(t *testing.T) {
+		conn := &MonitoredConnection{
+			Host:         "localhost",
+			Port:         5432,
+			DatabaseName: "mydb",
+			Username:     "user",
+		}
+		dsn := ds.BuildConnectionString(conn, "pass word", "")
+		if !strings.Contains(dsn, "pass%20word") {
+			t.Errorf("expected space-containing password to encode as %%20, got %q", dsn)
+		}
+		if strings.Contains(dsn, "pass+word") {
+			t.Errorf("password must not use form-encoding '+' for a space, got %q", dsn)
+		}
+	})
+}
+
+// TestBuildConnectionStringPgconnParse confirms that pgconn, the parser pgx
+// actually uses for monitored-connection DSNs, accepts a DSN built from a
+// password full of special characters and recovers the password verbatim.
+// This is a parse-only assertion; it never opens a database connection.
+func TestBuildConnectionStringPgconnParse(t *testing.T) {
+	ds := &Datastore{}
+
+	const specialPassword = "p@ss w:o/rd#%&="
+	conn := &MonitoredConnection{
+		Host:         "localhost",
+		Port:         5432,
+		DatabaseName: "mydb",
+		Username:     "user",
+	}
+
+	dsn := ds.BuildConnectionString(conn, specialPassword, "")
+
+	cfg, err := pgconn.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("pgconn.ParseConfig(%q) failed: %v", dsn, err)
+	}
+	if cfg.Password != specialPassword {
+		t.Errorf("pgconn recovered password %q, want %q", cfg.Password, specialPassword)
+	}
+	if cfg.User != conn.Username {
+		t.Errorf("pgconn recovered user %q, want %q", cfg.User, conn.Username)
+	}
+	if cfg.Database != conn.DatabaseName {
+		t.Errorf("pgconn recovered database %q, want %q", cfg.Database, conn.DatabaseName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `PasswordFile string` field to `DatabaseConfig` in the server component so `password_file:` is now a valid YAML option alongside the existing `password:` field.
- Adds a `LoadPassword()` method that reads and trims the file when `Password` is empty; higher-priority sources (CLI flags, `PGEDGE_DB_PASSWORD` env var, inline YAML `password`) always take precedence.
- Calls `LoadPassword()` in `main.go` after all CLI flags are applied, keeping the behaviour consistent with the collector and alerter components.
- Standardises all `password_file` example paths across `ai-dba-server.yaml`, `ai-dba-collector.yaml`, and `ai-dba-alerter.yaml` to `/etc/pgedge/password.txt`.

## Test plan

- [ ] `TestDatabaseConfigLoadPassword` — four subtests covering: password already set (no-op), valid file read with whitespace trimming, missing file returns error, both fields empty (no-op).
- [ ] `cd server && make test` passes with no failures.
- [ ] Existing inline `password:` and CLI `--db-password-file` behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for loading DB password from a password_file (CLI flag); resolution occurs at startup and on config reload and will abort if the configured file is unreadable or empty.

* **Security**
  * Unified secret-file handling with size limits, stricter empty-file failure, owner-only key acceptance, and warnings for permissive group/world file permissions.

* **Behavior Changes**
  * Only trailing newline is trimmed (other whitespace preserved); inline/CLI password takes precedence.

* **Documentation**
  * Updated docs, changelog, and example configs.

* **Tests**
  * Expanded tests for secret loading, permissions, DSNs, and reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->