### PR TITLE
fix(client): break Ellie's infinite tool-validation loop for regular users

### DIFF
--- a/client/src/hooks/chat/__tests__/chatAgenticLoop.test.ts
+++ b/client/src/hooks/chat/__tests__/chatAgenticLoop.test.ts
@@ -16,6 +16,8 @@ import {
     ITERATION_LIMIT_MESSAGE,
     NO_MCP_PRIVILEGES_MESSAGE,
     UNKNOWN_TOOL_MESSAGE,
+    MAX_REPEATED_TOOL_FAILURES,
+    buildRepeatedToolFailureMessage,
 } from '../chatAgenticLoop';
 import type { APIMessage, ToolDefinition } from '../chatTypes';
 import type { LLMResponse, ToolCallResponse } from '../../../types/llm';
@@ -1008,6 +1010,334 @@ describe('chatAgenticLoop', () => {
         });
 
         // ---------------------------------------------------------------
+        // Repeated-failure circuit breaker (issue #268)
+        //
+        // Some tools pass the LLM's test_query validation but fail at
+        // execution time with an "Access denied"-style error. Without a
+        // breaker, the LLM retries indefinitely until the iteration
+        // limit. The breaker trips after MAX_REPEATED_TOOL_FAILURES
+        // identical (tool + error) failures.
+        // ---------------------------------------------------------------
+
+        describe('repeated-failure circuit breaker', () => {
+            it('trips after MAX_REPEATED_TOOL_FAILURES identical failures', async () => {
+                const accessDenied = 'Access denied for connection 7';
+                // Always ask for query_database; the tool always fails
+                // with the same error.
+                const mockFetch = createMockFetch(
+                    Array(50).fill(
+                        createToolUseResponse([
+                            {
+                                id: 'q1',
+                                name: 'query_database',
+                                input: { query: 'SELECT 1' },
+                            },
+                        ]),
+                    ),
+                    new Map([
+                        [
+                            'query_database',
+                            createToolCallResponse(accessDenied, true),
+                        ],
+                    ]),
+                );
+                const params = createLoopParams({
+                    maxIterations: 50,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.isError).toBe(true);
+                expect(result.finalMessage.content).toBe(
+                    buildRepeatedToolFailureMessage(
+                        'query_database',
+                        accessDenied,
+                    ),
+                );
+                expect(result.finalMessage.content).toContain(accessDenied);
+            });
+
+            it('stops the loop early, well before maxIterations', async () => {
+                const accessDenied = 'Access denied';
+                const mockFetch = createMockFetch(
+                    Array(50).fill(
+                        createToolUseResponse([
+                            {
+                                id: 'q1',
+                                name: 'query_database',
+                                input: { query: 'SELECT 1' },
+                            },
+                        ]),
+                    ),
+                    new Map([
+                        [
+                            'query_database',
+                            createToolCallResponse(accessDenied, true),
+                        ],
+                    ]),
+                );
+                const params = createLoopParams({
+                    maxIterations: 50,
+                    fetchFn: mockFetch,
+                });
+
+                await runAgenticLoop(params);
+
+                const llmCalls = (
+                    mockFetch as ReturnType<typeof vi.fn>
+                ).mock.calls.filter(c => c[0] === '/api/v1/llm/chat');
+                // The breaker trips on the 3rd identical failure, so the
+                // LLM is called exactly MAX_REPEATED_TOOL_FAILURES times,
+                // far fewer than maxIterations would allow.
+                expect(llmCalls).toHaveLength(MAX_REPEATED_TOOL_FAILURES);
+                expect(llmCalls.length).toBeLessThan(50);
+            });
+
+            it('appends the breaker message to API history', async () => {
+                const accessDenied = 'Access denied';
+                const mockFetch = createMockFetch(
+                    Array(50).fill(
+                        createToolUseResponse([
+                            {
+                                id: 'q1',
+                                name: 'query_database',
+                                input: { query: 'SELECT 1' },
+                            },
+                        ]),
+                    ),
+                    new Map([
+                        [
+                            'query_database',
+                            createToolCallResponse(accessDenied, true),
+                        ],
+                    ]),
+                );
+                const params = createLoopParams({
+                    maxIterations: 50,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                const last =
+                    result.updatedApiMessages[
+                        result.updatedApiMessages.length - 1
+                    ];
+                expect(last.role).toBe('assistant');
+                expect(last.content).toBe(
+                    buildRepeatedToolFailureMessage(
+                        'query_database',
+                        accessDenied,
+                    ),
+                );
+            });
+
+            it('trips via the catch path on repeated network failures', async () => {
+                // The tool call endpoint always throws; the catch path
+                // records identical errors that trip the breaker.
+                const mockFetch = vi
+                    .fn()
+                    .mockImplementation(async (url: string) => {
+                        if (url === '/api/v1/llm/chat') {
+                            return {
+                                ok: true,
+                                json: () =>
+                                    Promise.resolve(
+                                        createToolUseResponse([
+                                            {
+                                                id: 'q1',
+                                                name: 'query_database',
+                                                input: { query: 'SELECT 1' },
+                                            },
+                                        ]),
+                                    ),
+                            };
+                        }
+                        if (url === '/api/v1/mcp/tools/call') {
+                            throw new Error('Connection refused');
+                        }
+                        return { ok: false, text: () => Promise.resolve('') };
+                    });
+                const params = createLoopParams({
+                    maxIterations: 50,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.isError).toBe(true);
+                expect(result.finalMessage.content).toContain(
+                    'Connection refused',
+                );
+                const llmCalls = (
+                    mockFetch as ReturnType<typeof vi.fn>
+                ).mock.calls.filter(c => c[0] === '/api/v1/llm/chat');
+                expect(llmCalls).toHaveLength(MAX_REPEATED_TOOL_FAILURES);
+            });
+
+            it('does not trip when the same tool fails with different errors then succeeds', async () => {
+                // query_database fails with two distinct errors, then
+                // succeeds. No single (tool + error) signature reaches
+                // the threshold, so the breaker must not trip.
+                let toolCall = 0;
+                let llmCall = 0;
+                const mockFetch = vi
+                    .fn()
+                    .mockImplementation(async (url: string) => {
+                        if (url === '/api/v1/llm/chat') {
+                            llmCall++;
+                            // The first three iterations request the
+                            // tool; after the tool succeeds the LLM
+                            // returns a final text response.
+                            if (llmCall >= 4) {
+                                return {
+                                    ok: true,
+                                    json: () =>
+                                        Promise.resolve(
+                                            createTextResponse('All good'),
+                                        ),
+                                };
+                            }
+                            return {
+                                ok: true,
+                                json: () =>
+                                    Promise.resolve(
+                                        createToolUseResponse([
+                                            {
+                                                id: 'q1',
+                                                name: 'query_database',
+                                                input: { query: 'SELECT 1' },
+                                            },
+                                        ]),
+                                    ),
+                            };
+                        }
+                        if (url === '/api/v1/mcp/tools/call') {
+                            toolCall++;
+                            if (toolCall === 1) {
+                                return {
+                                    ok: true,
+                                    json: () =>
+                                        Promise.resolve(
+                                            createToolCallResponse(
+                                                'Error A',
+                                                true,
+                                            ),
+                                        ),
+                                };
+                            }
+                            if (toolCall === 2) {
+                                return {
+                                    ok: true,
+                                    json: () =>
+                                        Promise.resolve(
+                                            createToolCallResponse(
+                                                'Error B',
+                                                true,
+                                            ),
+                                        ),
+                                };
+                            }
+                            return {
+                                ok: true,
+                                json: () =>
+                                    Promise.resolve(
+                                        createToolCallResponse('OK'),
+                                    ),
+                            };
+                        }
+                        return { ok: false, text: () => Promise.resolve('') };
+                    });
+                const params = createLoopParams({
+                    maxIterations: 50,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.isError).toBeUndefined();
+                expect(result.finalMessage.content).toBe('All good');
+            });
+
+            it('trips on a tool even when another tool succeeds in between', async () => {
+                // test_query-style success interleaves with repeated
+                // query_database failures. The interleaved success must
+                // not reset the failing tool's counter.
+                let llmCall = 0;
+                const mockFetch = vi
+                    .fn()
+                    .mockImplementation(async (url: string, init?: RequestInit) => {
+                        if (url === '/api/v1/llm/chat') {
+                            llmCall++;
+                            // Each iteration requests both a successful
+                            // list_connections call and a failing
+                            // query_database call.
+                            return {
+                                ok: true,
+                                json: () =>
+                                    Promise.resolve(
+                                        createToolUseResponse([
+                                            {
+                                                id: `lc-${llmCall}`,
+                                                name: 'list_connections',
+                                                input: {},
+                                            },
+                                            {
+                                                id: `qd-${llmCall}`,
+                                                name: 'query_database',
+                                                input: { query: 'SELECT 1' },
+                                            },
+                                        ]),
+                                    ),
+                            };
+                        }
+                        if (url === '/api/v1/mcp/tools/call') {
+                            const body = JSON.parse(init?.body as string);
+                            if (body.name === 'list_connections') {
+                                return {
+                                    ok: true,
+                                    json: () =>
+                                        Promise.resolve(
+                                            createToolCallResponse('Conn A'),
+                                        ),
+                                };
+                            }
+                            return {
+                                ok: true,
+                                json: () =>
+                                    Promise.resolve(
+                                        createToolCallResponse(
+                                            'Access denied',
+                                            true,
+                                        ),
+                                    ),
+                            };
+                        }
+                        return { ok: false, text: () => Promise.resolve('') };
+                    });
+                const params = createLoopParams({
+                    maxIterations: 50,
+                    fetchFn: mockFetch,
+                });
+
+                const result = await runAgenticLoop(params);
+
+                expect(result.finalMessage.isError).toBe(true);
+                expect(result.finalMessage.content).toBe(
+                    buildRepeatedToolFailureMessage(
+                        'query_database',
+                        'Access denied',
+                    ),
+                );
+                const llmCalls = (
+                    mockFetch as ReturnType<typeof vi.fn>
+                ).mock.calls.filter(c => c[0] === '/api/v1/llm/chat');
+                expect(llmCalls).toHaveLength(MAX_REPEATED_TOOL_FAILURES);
+            });
+        });
+
+        // ---------------------------------------------------------------
         // Module-level constants exposed for the orchestrator (issue #188)
         // ---------------------------------------------------------------
 
@@ -1020,6 +1350,21 @@ describe('chatAgenticLoop', () => {
             it('exports a non-empty UNKNOWN_TOOL_MESSAGE', () => {
                 expect(UNKNOWN_TOOL_MESSAGE.length).toBeGreaterThan(0);
                 expect(UNKNOWN_TOOL_MESSAGE).toContain('tools');
+            });
+
+            it('exports MAX_REPEATED_TOOL_FAILURES as a positive integer', () => {
+                expect(MAX_REPEATED_TOOL_FAILURES).toBe(3);
+                expect(Number.isInteger(MAX_REPEATED_TOOL_FAILURES)).toBe(true);
+            });
+
+            it('buildRepeatedToolFailureMessage names the tool and includes the error', () => {
+                const msg = buildRepeatedToolFailureMessage(
+                    'query_database',
+                    'Access denied',
+                );
+                expect(msg).toContain('query_database');
+                expect(msg).toContain('Access denied');
+                expect(msg).toContain('administrator');
             });
         });
     });

--- a/client/src/hooks/chat/chatAgenticLoop.ts
+++ b/client/src/hooks/chat/chatAgenticLoop.ts
@@ -97,6 +97,46 @@ export const UNKNOWN_TOOL_MESSAGE =
     'privileges. Please contact your administrator.';
 
 /**
+ * Threshold for the repeated-failure circuit breaker.
+ *
+ * When the same tool fails with the same error this many times across
+ * loop iterations, the loop stops rather than churning to the iteration
+ * limit. The 3rd identical failure trips the breaker. See issue #268.
+ */
+export const MAX_REPEATED_TOOL_FAILURES = 3;
+
+/**
+ * Build the user-facing message returned when the repeated-failure
+ * circuit breaker trips.
+ *
+ * Some tools (for example `query_database` or `get_schema_info`) pass
+ * the LLM's pre-flight validation via `test_query` but then fail at
+ * execution time with an "Access denied"-style error. The LLM responds
+ * by retrying slightly different SQL, which validates and fails again,
+ * looping until the iteration limit is exhausted. This builder produces
+ * a clear error that names the failing tool, surfaces the underlying
+ * error text, and points the user at a likely permissions or
+ * connection-access cause. See issue #268.
+ *
+ * @param toolName - The name of the tool that failed repeatedly.
+ * @param errorText - The underlying error text from the failed calls.
+ * @returns A clear, user-facing error message.
+ */
+export function buildRepeatedToolFailureMessage(
+    toolName: string,
+    errorText: string,
+): string {
+    return (
+        `The "${toolName}" tool failed repeatedly with the same error, ` +
+        'so I stopped retrying. The error was:\n\n' +
+        `${errorText}\n\n` +
+        'This is often a permissions or connection-access problem. ' +
+        'Ask your administrator to confirm you have access to this ' +
+        'connection and the relevant MCP privileges, then try again.'
+    );
+}
+
+/**
  * Run the agentic LLM tool-use loop.
  *
  * This function calls the LLM with the current message history. If the
@@ -129,6 +169,12 @@ export async function runAgenticLoop(
     let currentMessages = [...apiMessages];
     let iterations = 0;
     const collectedActivity: ToolActivity[] = [];
+
+    // Repeated-failure circuit breaker state (issue #268). Keyed by a
+    // signature combining the tool name and the error text, this counts
+    // how many times each distinct tool-error has been seen across loop
+    // iterations. Only error results (is_error truthy) are counted.
+    const failureCounts = new Map<string, number>();
 
     while (iterations < maxIterations) {
         if (abortSignal.aborted) {
@@ -232,6 +278,11 @@ export async function runAgenticLoop(
         // Execute each tool call sequentially
         const toolResults: ToolResult[] = [];
 
+        // The tool name and error text of the failure that tripped the
+        // circuit breaker, if any, recorded during this iteration.
+        let trippedToolName: string | null = null;
+        let trippedErrorText = '';
+
         for (const toolUse of toolUses) {
             const toolName = toolUse.name ?? 'unknown';
 
@@ -279,6 +330,19 @@ export async function runAgenticLoop(
                     content: resultText,
                     is_error: toolData.isError || undefined,
                 });
+
+                // Track repeated failures of this (tool, error) pair so
+                // the loop can break out rather than spinning until the
+                // iteration limit. Only error results count. See #268.
+                if (toolData.isError) {
+                    const signature = `${toolName} ${resultText}`;
+                    const count = (failureCounts.get(signature) ?? 0) + 1;
+                    failureCounts.set(signature, count);
+                    if (count >= MAX_REPEATED_TOOL_FAILURES) {
+                        trippedToolName = toolName;
+                        trippedErrorText = resultText;
+                    }
+                }
             } catch (toolErr) {
                 if ((toolErr as Error).name === 'AbortError') {
                     throw toolErr;
@@ -294,6 +358,16 @@ export async function runAgenticLoop(
                     content: errMsg,
                     is_error: true,
                 });
+
+                // The catch path always produces an error result, so
+                // count it toward the circuit breaker as well. See #268.
+                const signature = `${toolName} ${errMsg}`;
+                const count = (failureCounts.get(signature) ?? 0) + 1;
+                failureCounts.set(signature, count);
+                if (count >= MAX_REPEATED_TOOL_FAILURES) {
+                    trippedToolName = toolName;
+                    trippedErrorText = errMsg;
+                }
             }
         }
 
@@ -302,6 +376,32 @@ export async function runAgenticLoop(
             ...currentMessages,
             { role: 'user', content: toolResults },
         ];
+
+        // Repeated-failure circuit breaker (issue #268). If a tool has
+        // now failed with the same error MAX_REPEATED_TOOL_FAILURES
+        // times, stop looping and return a clear error rather than
+        // letting the LLM retry until the iteration limit is reached.
+        if (trippedToolName !== null) {
+            const breakerMessage = buildRepeatedToolFailureMessage(
+                trippedToolName,
+                trippedErrorText,
+            );
+            const finalMessage: ChatMessageData = {
+                role: 'assistant',
+                content: breakerMessage,
+                timestamp: new Date().toISOString(),
+                isError: true,
+                activity:
+                    collectedActivity.length > 0
+                        ? [...collectedActivity]
+                        : undefined,
+            };
+            currentMessages = [
+                ...currentMessages,
+                { role: 'assistant', content: breakerMessage },
+            ];
+            return { finalMessage, updatedApiMessages: currentMessages };
+        }
     }
 
     // Loop exhausted iterations without a final text response

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,7 +34,7 @@ project adheres to
   tool kept succeeding while the tools that execute the query
   failed with an access error. The assistant retried slightly
   different queries indefinitely, repeatedly showing
-  "Validating query" and never responding. The chat loop now
+  `Validating query` and never responding. The chat loop now
   applies a repeated-failure circuit breaker: when the same
   tool fails with the same error three times, the assistant
   stops retrying and returns a clear message. The message names

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,21 @@ project adheres to
   same anomaly condition now produces the same decision every
   time, so genuine alerts fire reliably. (#264)
 
+- Fix Ellie, the AI chat assistant, hanging in an effectively
+  infinite tool-validation loop for regular, non-superuser
+  users. When a regular user selected a connection shared with
+  them and asked Ellie to describe it, the query-validation
+  tool kept succeeding while the tools that execute the query
+  failed with an access error. The assistant retried slightly
+  different queries indefinitely, repeatedly showing
+  "Validating query" and never responding. The chat loop now
+  applies a repeated-failure circuit breaker: when the same
+  tool fails with the same error three times, the assistant
+  stops retrying and returns a clear message. The message names
+  the failing tool, shows the underlying error, and suggests a
+  likely permissions or connection-access problem to raise with
+  an administrator. (#268)
+
 ## [1.0.0-beta3] - 2026-05-26
 
 ### Added


### PR DESCRIPTION
## Summary

- Ellie could spin in an effectively infinite tool-validation loop for regular (non-superuser) users — e.g. when a regular user selected a shared connection and asked Ellie to describe it. The ungated `test_query` tool always validated successfully while the tools that execute the query (`query_database`, `get_schema_info`) failed at runtime with an access error, so the LLM re-validated and re-failed until `maxIterations` (50) was exhausted, showing "Validating query" 30+ times and never responding.
- Adds a repeated-failure circuit breaker to the chat agentic loop (`client/src/hooks/chat/chatAgenticLoop.ts`): failures are tracked by tool name + error text, and when the same tool fails with the same error `MAX_REPEATED_TOOL_FAILURES` (3) times, the loop stops and returns a clear assistant message naming the failing tool, surfacing the underlying error, and suggesting a likely permissions/connection-access cause.
- Successful `test_query` calls never count toward the breaker, and distinct errors from the same tool are tracked separately, so only genuinely repeated failures of the same type trip it. No server code or `test_query` gating was changed.

## Test plan

- [x] `npm run test -- chatAgenticLoop` — 45 tests pass, including new cases: trips after 3 identical failures, stops early well before `maxIterations`, does not trip on two different errors then success, trips even when another tool succeeds in between, and message-builder shape.
- [x] `chatAgenticLoop.ts` at 100% line coverage (above the 90% floor).
- [x] ESLint clean on the changed files.

Closes #268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the AI chat assistant from getting stuck retrying the same failing tool: after three identical failures it stops early and returns a clear assistant error naming the failing tool and underlying issue.

* **Documentation**
  * Updated changelog with details about the repeated-failure safeguard and the assistant’s new administrator-oriented error wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->