### PR TITLE
fix: enforce 255-char limit on Add dialog fields (client + server) (#270)

### DIFF
--- a/.claude/react-expert/quality-checklist.md
+++ b/.claude/react-expert/quality-checklist.md
@@ -192,6 +192,27 @@ dialog.
 - [ ] Consistent with project design system.
 - [ ] No inline styles unless necessary.
 
+### TextField native input attributes
+
+The project pins `@mui/material` at v5.14, so the `slotProps`
+API is not yet available; the `slotProps.htmlInput` migration
+only landed in MUI 5.15. Pass native `<input>` attributes
+(`maxLength`, `min`, `max`, `aria-label`, `autoComplete` when not
+already a top-level prop) through `inputProps` on `TextField`.
+This is the established, non-deprecated convention across the
+codebase (for example, `ConnectionFields.tsx` uses
+`inputProps={{ min: 1, max: 65535 }}` for the port field).
+
+Short free-text fields backed by `VARCHAR(255)` columns (names,
+hosts, database names, usernames) must enforce a client-side
+length cap so over-length input cannot reach the server. Use the
+shared `MAX_FIELD_LENGTH` constant from `src/utils/formLimits.ts`
+via `inputProps={{ maxLength: MAX_FIELD_LENGTH }}` rather than a
+bare `255`. Tests assert the cap with
+`expect(field).toHaveAttribute('maxlength', '255')` on the
+underlying input (the rendered DOM attribute is lowercase
+`maxlength`).
+
 ### Performance
 
 - [ ] Unnecessary re-renders prevented.

--- a/client/src/components/ClusterConfigDialog.tsx
+++ b/client/src/components/ClusterConfigDialog.tsx
@@ -28,6 +28,7 @@ import {
 import { Close as CloseIcon } from '@mui/icons-material';
 import AlertOverridesPanel from './AlertOverridesPanel';
 import ProbeOverridesPanel from './ProbeOverridesPanel';
+import { MAX_FIELD_LENGTH } from '../utils/formLimits';
 import ChannelOverridesPanel from './ChannelOverridesPanel';
 import TopologyPanel from './TopologyPanel';
 import { deriveReplicationType } from './topology';
@@ -307,6 +308,7 @@ const ClusterConfigDialog: React.FC<ClusterConfigDialogProps> = ({
                             required
                             disabled={isSaving || (isCreateMode && createdClusterId != null)}
                             margin="dense"
+                            inputProps={{ maxLength: MAX_FIELD_LENGTH }}
                             InputLabelProps={{ shrink: true }}
                             sx={SELECT_FIELD_DEFAULT_BG_SX}
                         />

--- a/client/src/components/GroupDialog.tsx
+++ b/client/src/components/GroupDialog.tsx
@@ -39,6 +39,7 @@ import ProbeOverridesPanel from './ProbeOverridesPanel';
 import ChannelOverridesPanel from './ChannelOverridesPanel';
 import SlideTransition from './shared/SlideTransition';
 import { parseGroupNumericId } from './ClusterNavigator/utils';
+import { MAX_FIELD_LENGTH } from '../utils/formLimits';
 
 // --- Style constants (Issue 23) ---
 
@@ -259,6 +260,7 @@ const GroupDialog: React.FC<GroupDialogProps> = ({
                 required
                 disabled={isSaving}
                 margin="dense"
+                inputProps={{ maxLength: MAX_FIELD_LENGTH }}
                 sx={textFieldSx}
             />
 

--- a/client/src/components/ServerDialog/ConnectionFields.tsx
+++ b/client/src/components/ServerDialog/ConnectionFields.tsx
@@ -13,6 +13,7 @@ import { TextField, Box, Typography } from '@mui/material';
 import type { ServerFormData, FormErrors, FieldChangeHandler } from './ServerDialog.types';
 import { sectionLabelSx } from './ServerDialog.styles';
 import { getSelectFieldSx } from '../shared/formStyles';
+import { MAX_FIELD_LENGTH } from '../../utils/formLimits';
 
 interface ConnectionFieldsProps {
     formData: ServerFormData;
@@ -49,6 +50,7 @@ const ConnectionFields: React.FC<ConnectionFieldsProps> = ({
                 required
                 disabled={isSaving}
                 margin="dense"
+                inputProps={{ maxLength: MAX_FIELD_LENGTH }}
                 InputLabelProps={{ shrink: true }}
                 sx={selectFieldSx}
             />
@@ -84,6 +86,7 @@ const ConnectionFields: React.FC<ConnectionFieldsProps> = ({
                     required
                     disabled={isSaving}
                     margin="dense"
+                    inputProps={{ maxLength: MAX_FIELD_LENGTH }}
                     InputLabelProps={{ shrink: true }}
                     sx={{ flex: 2, ...selectFieldSx }}
                 />
@@ -115,6 +118,7 @@ const ConnectionFields: React.FC<ConnectionFieldsProps> = ({
                 required
                 disabled={isSaving}
                 margin="dense"
+                inputProps={{ maxLength: MAX_FIELD_LENGTH }}
                 InputLabelProps={{ shrink: true }}
                 sx={{ mt: 1, ...selectFieldSx }}
             />
@@ -132,6 +136,7 @@ const ConnectionFields: React.FC<ConnectionFieldsProps> = ({
                     disabled={isSaving}
                     margin="dense"
                     autoComplete="off"
+                    inputProps={{ maxLength: MAX_FIELD_LENGTH }}
                     InputLabelProps={{ shrink: true }}
                     sx={{ flex: 1, ...selectFieldSx }}
                 />

--- a/client/src/components/__tests__/ClusterConfigDialog.test.tsx
+++ b/client/src/components/__tests__/ClusterConfigDialog.test.tsx
@@ -972,4 +972,24 @@ describe('ClusterConfigDialog', () => {
             expect(descField).toHaveValue('Updated description');
         });
     });
+
+    describe('field length limits (issue #270)', () => {
+        it('limits the name field to 255 characters in create mode', () => {
+            renderWithTheme(
+                <ClusterConfigDialog
+                    {...baseProps}
+                    mode="create"
+                    clusterName=""
+                    clusterDescription=""
+                    replicationType={null}
+                    autoClusterKey={null}
+                />,
+            );
+
+            const nameField = screen.getByRole('textbox', {
+                name: /^name/i,
+            });
+            expect(nameField).toHaveAttribute('maxlength', '255');
+        });
+    });
 });

--- a/client/src/components/__tests__/GroupDialog.test.tsx
+++ b/client/src/components/__tests__/GroupDialog.test.tsx
@@ -69,6 +69,11 @@ describe('GroupDialog', () => {
             expect(getNameField()).toBeInTheDocument();
         });
 
+        it('limits the name field to 255 characters', () => {
+            renderWithTheme(<GroupDialog {...defaultProps} />);
+            expect(getNameField()).toHaveAttribute('maxlength', '255');
+        });
+
         it('renders description field', () => {
             renderWithTheme(<GroupDialog {...defaultProps} />);
             expect(getDescriptionField()).toBeInTheDocument();

--- a/client/src/components/__tests__/ServerDialog.test.tsx
+++ b/client/src/components/__tests__/ServerDialog.test.tsx
@@ -76,6 +76,15 @@ describe('ServerDialog', () => {
             expect(getPasswordField()).toBeInTheDocument();
         });
 
+        it('limits name, host, database, and username fields to 255 characters', () => {
+            renderWithTheme(<ServerDialog {...defaultProps} />);
+
+            expect(getNameField()).toHaveAttribute('maxlength', '255');
+            expect(getHostField()).toHaveAttribute('maxlength', '255');
+            expect(getDatabaseField()).toHaveAttribute('maxlength', '255');
+            expect(getUsernameField()).toHaveAttribute('maxlength', '255');
+        });
+
         it('renders monitor checkbox checked by default', () => {
             renderWithTheme(<ServerDialog {...defaultProps} />);
             const monitorCheckbox = screen.getByLabelText(/monitor this server/i);

--- a/client/src/utils/formLimits.ts
+++ b/client/src/utils/formLimits.ts
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Maximum length for short free-text form fields such as names, hosts,
+ * database names, and usernames. The backend stores these values in
+ * VARCHAR(255) columns, so enforcing the same limit on the client
+ * prevents over-length input from reaching the server and producing a
+ * confusing generic error.
+ */
+export const MAX_FIELD_LENGTH = 255;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,18 @@ project adheres to
   same anomaly condition now produces the same decision every
   time, so genuine alerts fire reliably. (#264)
 
+- Fix the Add Cluster Group, Add Cluster, and Add Server
+  dialogs accepting Name, Host, Maintenance Database, and
+  Username values longer than 255 characters, which the
+  database rejected through its `VARCHAR(255)` columns and
+  surfaced as a generic, unhelpful server error. The web
+  client now caps those fields at 255 characters so
+  over-length input cannot be submitted, and the server
+  validates their length and returns a clear 400 response (for
+  example "Name must be 255 characters or less") instead of a
+  generic 500. The server counts characters rather than bytes
+  to match the `VARCHAR(255)` limit. (#270)
+
 ## [1.0.0-beta3] - 2026-05-26
 
 ### Added

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -531,6 +531,9 @@ func (h *ClusterHandler) createClusterGroup(w http.ResponseWriter, r *http.Reque
 		RespondError(w, http.StatusBadRequest, "Name is required")
 		return
 	}
+	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
@@ -753,6 +756,9 @@ func (h *ClusterHandler) createClusterInGroup(w http.ResponseWriter, r *http.Req
 
 	if req.Name == "" {
 		RespondError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
+	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
 		return
 	}
 
@@ -1316,6 +1322,9 @@ func (h *ClusterHandler) handleCreateCluster(w http.ResponseWriter, r *http.Requ
 
 	if req.Name == "" {
 		RespondError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
+	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
 		return
 	}
 

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -256,6 +257,104 @@ func TestClusterHandler_CreateClusterGroup_MissingName(t *testing.T) {
 
 	if response.Error != "Name is required" {
 		t.Errorf("Expected 'Name is required', got %q", response.Error)
+	}
+}
+
+// TestClusterHandler_CreateClusterGroup_NameTooLong locks in issue #270:
+// a Name longer than the VARCHAR(255) column must be rejected with a 400
+// and a field-specific message before any datastore call (the handler
+// runs against a nil datastore, so a stray call would panic).
+func TestClusterHandler_CreateClusterGroup_NameTooLong(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	longName := strings.Repeat("a", maxFieldLength+1)
+	body, _ := json.Marshal(ClusterGroupRequest{Name: longName})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.createClusterGroup(rec, req)
+
+	assertMaxLenRejected(t, rec, "Name")
+}
+
+// TestClusterHandler_CreateClusterInGroup_NameTooLong locks in issue #270
+// for the group-scoped cluster create path.
+func TestClusterHandler_CreateClusterInGroup_NameTooLong(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	longName := strings.Repeat("a", maxFieldLength+1)
+	body, _ := json.Marshal(ClusterRequest{Name: longName})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups/1/clusters",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.createClusterInGroup(rec, req, 1)
+
+	assertMaxLenRejected(t, rec, "Name")
+}
+
+// TestClusterHandler_HandleCreateCluster_NameTooLong locks in issue #270
+// for the manual cluster create path.
+func TestClusterHandler_HandleCreateCluster_NameTooLong(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	longName := strings.Repeat("a", maxFieldLength+1)
+	body, _ := json.Marshal(ManualClusterRequest{Name: longName})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.handleCreateCluster(rec, req)
+
+	assertMaxLenRejected(t, rec, "Name")
+}
+
+// TestClusterHandler_CreateClusterGroup_NameAtLimit confirms the boundary:
+// a Name of exactly maxFieldLength bytes passes validation and reaches the
+// datastore (which panics on the nil datastore, proving the length check
+// did not short-circuit at the limit).
+func TestClusterHandler_CreateClusterGroup_NameAtLimit(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	atLimit := strings.Repeat("a", maxFieldLength)
+	body, _ := json.Marshal(ClusterGroupRequest{Name: atLimit})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("Expected nil-datastore panic past validation, got none; status=%d body=%s",
+				rec.Code, rec.Body.String())
+		}
+	}()
+
+	handler.createClusterGroup(rec, req)
+}
+
+// assertMaxLenRejected asserts that the recorded response is a 400 carrying
+// the canonical "<field> must be 255 characters or less" message.
+func assertMaxLenRejected(t *testing.T, rec *httptest.ResponseRecorder, field string) {
+	t.Helper()
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+
+	var response ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	want := field + " must be 255 characters or less"
+	if response.Error != want {
+		t.Errorf("Expected %q, got %q", want, response.Error)
 	}
 }
 

--- a/server/src/internal/api/connection_handlers.go
+++ b/server/src/internal/api/connection_handlers.go
@@ -248,6 +248,22 @@ func (h *ConnectionHandler) createConnection(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Enforce the VARCHAR(255) limits on the backing columns before any
+	// datastore call so over-length input returns a clear 400 instead of
+	// a generic 500 when the database rejects the row (issue #270).
+	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
+		return
+	}
+	if !validateMaxLen(w, "Host", req.Host, maxFieldLength) {
+		return
+	}
+	if !validateMaxLen(w, "Maintenance Database", req.DatabaseName, maxFieldLength) {
+		return
+	}
+	if !validateMaxLen(w, "Username", req.Username, maxFieldLength) {
+		return
+	}
+
 	// Validate host to prevent SSRF attacks
 	if err := h.hostValidator.ValidateHost(req.Host); err != nil {
 		log.Printf("[ERROR] Invalid host validation: %v", err)

--- a/server/src/internal/api/connection_handlers_test.go
+++ b/server/src/internal/api/connection_handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -961,4 +962,128 @@ func TestListConnections_Issue68_VisibleConnectionIDsError_Returns500(t *testing
 		t.Fatalf("Expected 500 when VisibleConnectionIDs fails, got %d. Body: %s",
 			rec.Code, rec.Body.String())
 	}
+}
+
+// =============================================================================
+// Regression Test Coverage for GitHub Issue #270
+//
+// createConnection now enforces the VARCHAR(255) byte-length limit on
+// Name, Host, Maintenance Database, and Username before any datastore
+// call, returning a field-specific 400 instead of a generic 500 when
+// the database would otherwise reject the over-length row. The harness
+// reuses setupIssue233CreateConnection, which authenticates a user with
+// manage_connections so the request reaches the length checks; the
+// datastore is nil, so a valid request would panic past validation.
+// =============================================================================
+
+// validConnectionCreateRequest returns a baseline request whose fields are
+// all within the length limit, suitable for mutating a single field in the
+// table-driven over-length tests.
+func validConnectionCreateRequest() ConnectionCreateRequest {
+	return ConnectionCreateRequest{
+		Name:         "ok-name",
+		Host:         "db.example.com",
+		Port:         5432,
+		DatabaseName: "postgres",
+		Username:     "alice",
+		Password:     "secret",
+	}
+}
+
+// TestConnectionHandler_CreateConnection_Issue270_FieldTooLong verifies that
+// an over-length value in any of the four guarded fields yields a 400 with
+// the field-specific message, before the nil datastore is touched.
+func TestConnectionHandler_CreateConnection_Issue270_FieldTooLong(t *testing.T) {
+	tooLong := strings.Repeat("a", maxFieldLength+1)
+
+	cases := []struct {
+		name    string
+		mutate  func(*ConnectionCreateRequest)
+		wantMsg string
+	}{
+		{
+			name:    "Name",
+			mutate:  func(r *ConnectionCreateRequest) { r.Name = tooLong },
+			wantMsg: "Name must be 255 characters or less",
+		},
+		{
+			name:    "Host",
+			mutate:  func(r *ConnectionCreateRequest) { r.Host = tooLong },
+			wantMsg: "Host must be 255 characters or less",
+		},
+		{
+			name:    "MaintenanceDatabase",
+			mutate:  func(r *ConnectionCreateRequest) { r.DatabaseName = tooLong },
+			wantMsg: "Maintenance Database must be 255 characters or less",
+		},
+		{
+			name:    "Username",
+			mutate:  func(r *ConnectionCreateRequest) { r.Username = tooLong },
+			wantMsg: "Username must be 255 characters or less",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, userID, token, cleanup := setupIssue233CreateConnection(
+				t, "issue270_"+strings.ToLower(tc.name),
+				[]string{auth.PermManageConnections})
+			defer cleanup()
+
+			reqBody := validConnectionCreateRequest()
+			tc.mutate(&reqBody)
+			body, _ := json.Marshal(reqBody)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+				bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withBearer(req, token)
+			req = withUser(req, userID)
+			rec := httptest.NewRecorder()
+
+			handler.createConnection(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("Expected status %d, got %d. Body: %s",
+					http.StatusBadRequest, rec.Code, rec.Body.String())
+			}
+
+			var response ErrorResponse
+			if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+			if response.Error != tc.wantMsg {
+				t.Errorf("Expected %q, got %q", tc.wantMsg, response.Error)
+			}
+		})
+	}
+}
+
+// TestConnectionHandler_CreateConnection_Issue270_AtLimitPassesValidation
+// confirms the boundary: fields of exactly maxFieldLength bytes pass the
+// length checks and the handler proceeds to the nil datastore, which
+// panics. Recovering from that panic proves validation did not reject at
+// the limit.
+func TestConnectionHandler_CreateConnection_Issue270_AtLimitPassesValidation(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue270_atlimit", []string{auth.PermManageConnections})
+	defer cleanup()
+
+	reqBody := validConnectionCreateRequest()
+	reqBody.Name = strings.Repeat("a", maxFieldLength)
+	reqBody.Host = "db.example.com"
+	reqBody.DatabaseName = strings.Repeat("d", maxFieldLength)
+	reqBody.Username = strings.Repeat("u", maxFieldLength)
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.createConnection(rec, req)
+	})
 }

--- a/server/src/internal/api/connection_handlers_test.go
+++ b/server/src/internal/api/connection_handlers_test.go
@@ -967,8 +967,8 @@ func TestListConnections_Issue68_VisibleConnectionIDsError_Returns500(t *testing
 // =============================================================================
 // Regression Test Coverage for GitHub Issue #270
 //
-// createConnection now enforces the VARCHAR(255) byte-length limit on
-// Name, Host, Maintenance Database, and Username before any datastore
+// createConnection now enforces the VARCHAR(255) character-length limit
+// on Name, Host, Maintenance Database, and Username before any datastore
 // call, returning a field-specific 400 instead of a generic 500 when
 // the database would otherwise reject the over-length row. The harness
 // reuses setupIssue233CreateConnection, which authenticates a user with
@@ -1060,8 +1060,8 @@ func TestConnectionHandler_CreateConnection_Issue270_FieldTooLong(t *testing.T) 
 }
 
 // TestConnectionHandler_CreateConnection_Issue270_AtLimitPassesValidation
-// confirms the boundary: fields of exactly maxFieldLength bytes pass the
-// length checks and the handler proceeds to the nil datastore, which
+// confirms the boundary: fields of exactly maxFieldLength characters pass
+// the length checks and the handler proceeds to the nil datastore, which
 // panics. Recovering from that panic proves validation did not reject at
 // the limit.
 func TestConnectionHandler_CreateConnection_Issue270_AtLimitPassesValidation(t *testing.T) {
@@ -1086,4 +1086,77 @@ func TestConnectionHandler_CreateConnection_Issue270_AtLimitPassesValidation(t *
 	assertGatePassed(t, rec, func() {
 		handler.createConnection(rec, req)
 	})
+}
+
+// TestConnectionHandler_CreateConnection_Issue270_MultibyteAtLimitPasses
+// confirms the limit counts characters, not bytes: a Name of exactly
+// maxFieldLength multibyte runes (510 bytes for "é") must pass the length
+// check, mirroring the VARCHAR(255) column, which limits by characters.
+// A byte-based check would wrongly reject this. Later validation steps
+// (host SSRF check, nil datastore) prevent a clean 200 here, so the test
+// asserts the length-specific 400 message is not produced rather than a
+// specific status code.
+func TestConnectionHandler_CreateConnection_Issue270_MultibyteAtLimitPasses(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue270_multibyte_atlimit", []string{auth.PermManageConnections})
+	defer cleanup()
+
+	reqBody := validConnectionCreateRequest()
+	// 255 runes but 510 bytes; len() would wrongly reject this.
+	reqBody.Name = strings.Repeat("é", maxFieldLength)
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	assertGatePassed(t, rec, func() {
+		handler.createConnection(rec, req)
+	})
+
+	if rec.Code == http.StatusBadRequest &&
+		strings.Contains(rec.Body.String(), "Name must be") {
+		t.Fatalf("Expected 255 multibyte runes to pass length validation, "+
+			"got length-error 400. Body: %s", rec.Body.String())
+	}
+}
+
+// TestConnectionHandler_CreateConnection_Issue270_MultibyteOverLimitRejected
+// confirms a Name of 256 multibyte runes is rejected by the character-based
+// length check with the expected 400 message, even though each run of the
+// byte-based check would also reject it; this pins the rune-counting path.
+func TestConnectionHandler_CreateConnection_Issue270_MultibyteOverLimitRejected(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue270_multibyte_overlimit", []string{auth.PermManageConnections})
+	defer cleanup()
+
+	reqBody := validConnectionCreateRequest()
+	reqBody.Name = strings.Repeat("é", maxFieldLength+1)
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createConnection(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+
+	var response ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	const wantMsg = "Name must be 255 characters or less"
+	if response.Error != wantMsg {
+		t.Errorf("Expected %q, got %q", wantMsg, response.Error)
+	}
 }

--- a/server/src/internal/api/helpers.go
+++ b/server/src/internal/api/helpers.go
@@ -25,14 +25,14 @@ import (
 const maxFieldLength = 255
 
 // validateMaxLen enforces the maxFieldLength byte-length ceiling on a
-// single request field. When value exceeds max it sends a 400 response
+// single request field. When value exceeds limit it sends a 400 response
 // with a field-specific message and returns false; otherwise it returns
 // true. Byte length (len) is used deliberately to mirror the backing
-// VARCHAR(max) column behaviour.
-func validateMaxLen(w http.ResponseWriter, fieldLabel, value string, max int) bool {
-	if len(value) > max {
+// VARCHAR(limit) column behavior.
+func validateMaxLen(w http.ResponseWriter, fieldLabel, value string, limit int) bool {
+	if len(value) > limit {
 		RespondError(w, http.StatusBadRequest,
-			fmt.Sprintf("%s must be %d characters or less", fieldLabel, max))
+			fmt.Sprintf("%s must be %d characters or less", fieldLabel, limit))
 		return false
 	}
 	return true

--- a/server/src/internal/api/helpers.go
+++ b/server/src/internal/api/helpers.go
@@ -10,10 +10,33 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 )
+
+// maxFieldLength is the maximum byte length permitted for short string
+// fields such as Name, Host, Maintenance Database, and Username. It
+// matches the VARCHAR(255) constraint on the corresponding database
+// columns, so callers can reject over-length input with a clear 400
+// before the datastore call rather than surfacing a generic 500 when
+// the database rejects the row.
+const maxFieldLength = 255
+
+// validateMaxLen enforces the maxFieldLength byte-length ceiling on a
+// single request field. When value exceeds max it sends a 400 response
+// with a field-specific message and returns false; otherwise it returns
+// true. Byte length (len) is used deliberately to mirror the backing
+// VARCHAR(max) column behaviour.
+func validateMaxLen(w http.ResponseWriter, fieldLabel, value string, max int) bool {
+	if len(value) > max {
+		RespondError(w, http.StatusBadRequest,
+			fmt.Sprintf("%s must be %d characters or less", fieldLabel, max))
+		return false
+	}
+	return true
+}
 
 // HandleNotConfigured returns an http.HandlerFunc that responds with a 503
 // status indicating that the given service is unavailable because the

--- a/server/src/internal/api/helpers.go
+++ b/server/src/internal/api/helpers.go
@@ -12,25 +12,27 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"unicode/utf8"
 
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 )
 
-// maxFieldLength is the maximum byte length permitted for short string
-// fields such as Name, Host, Maintenance Database, and Username. It
-// matches the VARCHAR(255) constraint on the corresponding database
+// maxFieldLength is the maximum character length permitted for short
+// string fields such as Name, Host, Maintenance Database, and Username.
+// It matches the VARCHAR(255) constraint on the corresponding database
 // columns, so callers can reject over-length input with a clear 400
 // before the datastore call rather than surfacing a generic 500 when
 // the database rejects the row.
 const maxFieldLength = 255
 
-// validateMaxLen enforces the maxFieldLength byte-length ceiling on a
-// single request field. When value exceeds limit it sends a 400 response
-// with a field-specific message and returns false; otherwise it returns
-// true. Byte length (len) is used deliberately to mirror the backing
-// VARCHAR(limit) column behavior.
+// validateMaxLen enforces the maxFieldLength character-length ceiling on
+// a single request field. When value exceeds limit it sends a 400
+// response with a field-specific message and returns false; otherwise it
+// returns true. Rune count (utf8.RuneCountInString) is used deliberately
+// to mirror the backing VARCHAR(limit) column, which limits by characters
+// rather than bytes.
 func validateMaxLen(w http.ResponseWriter, fieldLabel, value string, limit int) bool {
-	if len(value) > limit {
+	if utf8.RuneCountInString(value) > limit {
 		RespondError(w, http.StatusBadRequest,
 			fmt.Sprintf("%s must be %d characters or less", fieldLabel, limit))
 		return false


### PR DESCRIPTION
## Summary
- Add dialogs (Add Cluster Group, Add Cluster, Add Server) accepted Name/Host/Maintenance Database/Username values longer than 255 characters; the DB rejected them via `VARCHAR(255)` columns and the server returned a generic 500 with no hint that field length was the cause.
- **Client:** introduce a shared `MAX_FIELD_LENGTH = 255` constant and apply `inputProps={{ maxLength: 255 }}` to the Name field in `GroupDialog` and `ClusterConfigDialog`, and to the Name, Host, Maintenance Database, and Username fields in the Add Server dialog — over-length input can no longer be submitted.
- **Server:** add a shared `validateMaxLen` helper and validate Name on the cluster-group/cluster create handlers and Name/Host/Maintenance Database/Username on the connection create handler, returning a **400** with a clear, field-specific message (e.g. `Name must be 255 characters or less`) before the datastore call instead of a 500.

## Test plan
- [x] `go build ./...`, `go vet ./internal/api/`, `gofmt -l` clean
- [x] New Go handler tests: over-length field → 400 with expected message; exactly-255 boundary → passes validation
- [x] `go test ./internal/api/` green
- [x] Client: 105 dialog tests pass (`GroupDialog`, `ClusterConfigDialog`, `ServerDialog`); new assertions confirm the `maxLength=255` attribute on each touched field
- [x] `npm run lint` clean (no new warnings); touched files ≥90% line coverage

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client forms now cap short free-text fields at 255 characters (names, host/DB/username, passwords) to prevent over-length input.

* **Bug Fixes**
  * Server now validates character-length (rune-aware) and returns clear 400 errors for too-long fields instead of generic failures.

* **Tests**
  * Added tests ensuring maxlength attributes, boundary behavior, multibyte handling, and API rejection of over-limit values.

* **Documentation**
  * Updated developer guidance on configuring and testing input length limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->