### PR TITLE
fix: reject special characters in name fields (#269)

### DIFF
--- a/client/src/components/ClusterConfigDialog.tsx
+++ b/client/src/components/ClusterConfigDialog.tsx
@@ -34,6 +34,7 @@ import TopologyPanel from './TopologyPanel';
 import { deriveReplicationType } from './topology';
 import { SELECT_FIELD_DEFAULT_BG_SX } from './shared/formStyles';
 import SlideTransition from './shared/SlideTransition';
+import { validateName } from '../utils/validateName';
 
 /**
  * Replication type options displayed in the select dropdown.
@@ -130,8 +131,9 @@ const ClusterConfigDialog: React.FC<ClusterConfigDialogProps> = ({
 
     const handleSave = async () => {
         const trimmed = name.trim();
-        if (!trimmed) {
-            setNameError('Name is required');
+        const nameValidationError = validateName(name);
+        if (nameValidationError) {
+            setNameError(nameValidationError);
             return;
         }
         setNameError('');

--- a/client/src/components/GroupDialog.tsx
+++ b/client/src/components/GroupDialog.tsx
@@ -40,6 +40,7 @@ import ChannelOverridesPanel from './ChannelOverridesPanel';
 import SlideTransition from './shared/SlideTransition';
 import { parseGroupNumericId } from './ClusterNavigator/utils';
 import { MAX_FIELD_LENGTH } from '../utils/formLimits';
+import { validateName } from '../utils/validateName';
 
 // --- Style constants (Issue 23) ---
 
@@ -192,9 +193,9 @@ const GroupDialog: React.FC<GroupDialogProps> = ({
         let isValid = true;
         setNameError('');
 
-        const trimmedName = name.trim();
-        if (!trimmedName) {
-            setNameError('Name is required');
+        const nameValidationError = validateName(name);
+        if (nameValidationError) {
+            setNameError(nameValidationError);
             isValid = false;
         }
 

--- a/client/src/components/ServerDialog/ServerDialog.validation.ts
+++ b/client/src/components/ServerDialog/ServerDialog.validation.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ServerFormData, FormErrors } from './ServerDialog.types';
+import { validateName } from '../../utils/validateName';
 
 /**
  * Validates all form fields and returns an object containing error messages.
@@ -24,9 +25,9 @@ export const validateServerForm = (
     const errors: FormErrors = {};
 
     // Name validation
-    const trimmedName = formData.name.trim();
-    if (!trimmedName) {
-        errors.name = 'Name is required';
+    const nameError = validateName(formData.name);
+    if (nameError) {
+        errors.name = nameError;
     }
 
     // Host validation

--- a/client/src/components/__tests__/ClusterConfigDialog.test.tsx
+++ b/client/src/components/__tests__/ClusterConfigDialog.test.tsx
@@ -416,6 +416,71 @@ describe('ClusterConfigDialog', () => {
             expect(onSave).not.toHaveBeenCalled();
         });
 
+        it('blocks save when the name has disallowed characters', async () => {
+            const onSave = vi.fn();
+            renderWithTheme(
+                <ClusterConfigDialog
+                    {...baseProps}
+                    onSave={onSave}
+                    mode="edit"
+                    clusterId="cluster-11"
+                    numericClusterId={11}
+                    clusterName="Old Name"
+                    clusterDescription=""
+                    replicationType="binary"
+                    autoClusterKey={null}
+                />,
+            );
+
+            const nameField = screen.getByRole('textbox', {
+                name: /^name/i,
+            });
+            fireEvent.change(nameField, { target: { value: '<>!@#$%' } });
+
+            fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(/name may only contain letters/i),
+                ).toBeInTheDocument();
+            });
+            expect(onSave).not.toHaveBeenCalled();
+        });
+
+        it('allows a name with permitted special characters to save', async () => {
+            const onSave = vi.fn().mockResolvedValue(undefined);
+            renderWithTheme(
+                <ClusterConfigDialog
+                    {...baseProps}
+                    onSave={onSave}
+                    mode="edit"
+                    clusterId="cluster-12"
+                    numericClusterId={12}
+                    clusterName="Old Name"
+                    clusterDescription=""
+                    replicationType="binary"
+                    autoClusterKey={null}
+                />,
+            );
+
+            const nameField = screen.getByRole('textbox', {
+                name: /^name/i,
+            });
+            fireEvent.change(nameField, {
+                target: { value: 'Cluster_01 (east).v2-1' },
+            });
+
+            fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+            await waitFor(() => {
+                expect(onSave).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        name: 'Cluster_01 (east).v2-1',
+                    }),
+                );
+            });
+        });
+
         it('creates a cluster with the chosen replication type', async () => {
             const onCreate = vi.fn().mockResolvedValue({ id: 99 });
             renderWithTheme(

--- a/client/src/components/__tests__/GroupDialog.test.tsx
+++ b/client/src/components/__tests__/GroupDialog.test.tsx
@@ -452,6 +452,45 @@ describe('GroupDialog', () => {
                 screen.queryByText(/name is required/i)
             ).not.toBeInTheDocument();
         });
+
+        it('shows an error and blocks save when the name has disallowed characters', async () => {
+            const user = userEvent.setup({ delay: null });
+            const onSave = vi.fn().mockResolvedValue(undefined);
+            renderWithTheme(
+                <GroupDialog {...defaultProps} onSave={onSave} />
+            );
+
+            fireEvent.change(getNameField(), {
+                target: { value: '<>!@#$%' },
+            });
+            await user.click(screen.getByRole('button', { name: /save/i }));
+
+            expect(
+                screen.getByText(/name may only contain letters/i)
+            ).toBeInTheDocument();
+            expect(onSave).not.toHaveBeenCalled();
+        });
+
+        it('allows a name with permitted special characters to save', async () => {
+            const user = userEvent.setup({ delay: null });
+            const onSave = vi.fn().mockResolvedValue(undefined);
+            renderWithTheme(
+                <GroupDialog {...defaultProps} onSave={onSave} />
+            );
+
+            fireEvent.change(getNameField(), {
+                target: { value: 'Group_01 (primary).v2-east' },
+            });
+            await user.click(screen.getByRole('button', { name: /save/i }));
+
+            await waitFor(() => {
+                expect(onSave).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        name: 'Group_01 (primary).v2-east',
+                    })
+                );
+            });
+        });
     });
 
     describe('form submission', () => {

--- a/client/src/components/__tests__/ServerDialog.test.tsx
+++ b/client/src/components/__tests__/ServerDialog.test.tsx
@@ -296,6 +296,49 @@ describe('ServerDialog', () => {
             // Name error should be cleared (exact match)
             expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
         });
+
+        it('shows an error and blocks save when the name has disallowed characters', async () => {
+            const user = userEvent.setup({ delay: null });
+            const onSave = vi.fn().mockResolvedValue();
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} />);
+
+            fireEvent.change(getNameField(), { target: { value: '<>!@#$%' } });
+            fireEvent.change(getHostField(), { target: { value: 'localhost' } });
+            fireEvent.change(getDatabaseField(), { target: { value: 'postgres' } });
+            fireEvent.change(getUsernameField(), { target: { value: 'admin' } });
+            fireEvent.change(getPasswordField(), { target: { value: 'secret' } });
+
+            await user.click(screen.getByRole('button', { name: /save/i }));
+
+            expect(
+                screen.getByText(/name may only contain letters/i)
+            ).toBeInTheDocument();
+            expect(onSave).not.toHaveBeenCalled();
+        });
+
+        it('allows a name with permitted special characters to save', async () => {
+            const user = userEvent.setup({ delay: null });
+            const onSave = vi.fn().mockResolvedValue();
+            renderWithTheme(<ServerDialog {...defaultProps} onSave={onSave} />);
+
+            fireEvent.change(getNameField(), {
+                target: { value: 'Server_01 (primary).east-1' },
+            });
+            fireEvent.change(getHostField(), { target: { value: 'localhost' } });
+            fireEvent.change(getDatabaseField(), { target: { value: 'postgres' } });
+            fireEvent.change(getUsernameField(), { target: { value: 'admin' } });
+            fireEvent.change(getPasswordField(), { target: { value: 'secret' } });
+
+            await user.click(screen.getByRole('button', { name: /save/i }));
+
+            await waitFor(() => {
+                expect(onSave).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        name: 'Server_01 (primary).east-1',
+                    })
+                );
+            });
+        });
     });
 
     describe('form submission', () => {

--- a/client/src/utils/__tests__/validateName.test.ts
+++ b/client/src/utils/__tests__/validateName.test.ts
@@ -1,0 +1,132 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    validateName,
+    NAME_MAX_LENGTH,
+    NAME_PATTERN,
+    NAME_ERROR_REQUIRED,
+    NAME_ERROR_INVALID_CHARS,
+    NAME_ERROR_TOO_LONG,
+} from '../validateName';
+
+describe('validateName', () => {
+    describe('valid names', () => {
+        it('accepts a simple alphabetic name', () => {
+            expect(validateName('Production')).toBeNull();
+        });
+
+        it('accepts letters, digits, and spaces', () => {
+            expect(validateName('Cluster 01')).toBeNull();
+        });
+
+        it('accepts periods', () => {
+            expect(validateName('node.one')).toBeNull();
+        });
+
+        it('accepts underscores', () => {
+            expect(validateName('my_cluster')).toBeNull();
+        });
+
+        it('accepts hyphens', () => {
+            expect(validateName('east-west-1')).toBeNull();
+        });
+
+        it('accepts parentheses', () => {
+            expect(validateName('Group (primary)')).toBeNull();
+        });
+
+        it('accepts a combination of all allowed characters', () => {
+            expect(validateName('My_Group-01 (v1.2)')).toBeNull();
+        });
+
+        it('accepts a name composed only of digits', () => {
+            expect(validateName('12345')).toBeNull();
+        });
+
+        it('trims leading and trailing whitespace before validating', () => {
+            expect(validateName('   Valid Name   ')).toBeNull();
+        });
+
+        it('accepts a name exactly at the maximum length', () => {
+            const name = 'a'.repeat(NAME_MAX_LENGTH);
+            expect(name).toHaveLength(255);
+            expect(validateName(name)).toBeNull();
+        });
+
+        it('accepts a name padded with whitespace that trims to the max length', () => {
+            const name = `  ${'a'.repeat(NAME_MAX_LENGTH)}  `;
+            expect(validateName(name)).toBeNull();
+        });
+    });
+
+    describe('empty and whitespace-only names', () => {
+        it('rejects an empty string', () => {
+            expect(validateName('')).toBe(NAME_ERROR_REQUIRED);
+        });
+
+        it('rejects a whitespace-only string', () => {
+            expect(validateName('     ')).toBe(NAME_ERROR_REQUIRED);
+        });
+
+        it('rejects a tab-and-newline-only string', () => {
+            expect(validateName('\t\n')).toBe(NAME_ERROR_REQUIRED);
+        });
+    });
+
+    describe('disallowed characters', () => {
+        it.each([
+            ['<', 'na<me'],
+            ['>', 'na>me'],
+            ['!', 'name!'],
+            ['@', 'na@me'],
+            ['#', 'na#me'],
+            ['$', 'na$me'],
+            ['%', 'na%me'],
+        ])('rejects the %s character', (_char, value) => {
+            expect(validateName(value)).toBe(NAME_ERROR_INVALID_CHARS);
+        });
+
+        it('rejects a name that is only special characters', () => {
+            expect(validateName('<>!@#$%')).toBe(NAME_ERROR_INVALID_CHARS);
+        });
+
+        it('rejects names containing slashes', () => {
+            expect(validateName('a/b')).toBe(NAME_ERROR_INVALID_CHARS);
+        });
+    });
+
+    describe('length limits', () => {
+        it('rejects a name one character over the maximum', () => {
+            const name = 'a'.repeat(NAME_MAX_LENGTH + 1);
+            expect(name).toHaveLength(256);
+            expect(validateName(name)).toBe(NAME_ERROR_TOO_LONG);
+        });
+
+        it('reports too-long before checking characters', () => {
+            // A 256-char string containing a disallowed char should still
+            // report the length error first.
+            const name = `${'<'.repeat(NAME_MAX_LENGTH + 1)}`;
+            expect(validateName(name)).toBe(NAME_ERROR_TOO_LONG);
+        });
+    });
+
+    describe('exported constants', () => {
+        it('exposes the expected maximum length', () => {
+            expect(NAME_MAX_LENGTH).toBe(255);
+        });
+
+        it('exposes a usable pattern that matches allowed names', () => {
+            expect(NAME_PATTERN.test('Valid_Name-1 (a.b)')).toBe(true);
+            expect(NAME_PATTERN.test('bad!')).toBe(false);
+        });
+    });
+});

--- a/client/src/utils/validateName.ts
+++ b/client/src/utils/validateName.ts
@@ -1,0 +1,58 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * The maximum allowed length, in characters, for a name field after
+ * leading and trailing whitespace has been trimmed.
+ */
+export const NAME_MAX_LENGTH = 255;
+
+/**
+ * The set of characters permitted in a name. Letters, digits, spaces,
+ * periods, underscores, parentheses, and hyphens are allowed; everything
+ * else (for example, `<`, `>`, `!`, `@`, `#`, `$`, `%`) is rejected.
+ */
+export const NAME_PATTERN = /^[A-Za-z0-9 ._()-]+$/;
+
+/**
+ * Human-readable validation messages used across the name-bearing dialogs.
+ */
+export const NAME_ERROR_REQUIRED = 'Name is required';
+export const NAME_ERROR_INVALID_CHARS =
+    'Name may only contain letters, numbers, spaces, and the characters . _ - ( )';
+export const NAME_ERROR_TOO_LONG = `Name must be ${NAME_MAX_LENGTH} characters or fewer`;
+
+/**
+ * Validate a user-supplied name. The name is trimmed of leading and
+ * trailing whitespace before evaluation.
+ *
+ * A name is valid when, after trimming, it is non-empty, contains only
+ * the allowed characters, and is at most NAME_MAX_LENGTH characters long.
+ *
+ * @param name - The raw name value entered by the user.
+ * @returns An error message when the name is invalid, or null when valid.
+ */
+export const validateName = (name: string): string | null => {
+    const trimmed = name.trim();
+
+    if (!trimmed) {
+        return NAME_ERROR_REQUIRED;
+    }
+
+    if (trimmed.length > NAME_MAX_LENGTH) {
+        return NAME_ERROR_TOO_LONG;
+    }
+
+    if (!NAME_PATTERN.test(trimmed)) {
+        return NAME_ERROR_INVALID_CHARS;
+    }
+
+    return null;
+};

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -70,6 +70,18 @@ project adheres to
   loudly at startup. Leaving a key-file path unset remains valid
   and is not an error. (#267)
 
+- Fix name fields for server groups, clusters, and servers
+  accepting special characters such as `<>!@#$%`. Validation
+  previously rejected only empty input, so disallowed
+  characters were stored unchanged. The server and client now
+  apply the same rule: after trimming, a name must be
+  non-empty, at most 255 characters, and may contain only
+  letters, numbers, spaces, and the characters `. _ - ( )`.
+  The server returns HTTP 400 for invalid names across all
+  cluster-group, cluster, and server-connection create and
+  update endpoints, and the client shows an inline validation
+  error and blocks the save. (#269)
+
 - Fix the alerter intermittently and silently suppressing
   anomaly alerts that should have fired. The Tier 3
   LLM-based classifier parsed model responses

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -527,8 +527,9 @@ func (h *ClusterHandler) createClusterGroup(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if req.Name == "" {
-		RespondError(w, http.StatusBadRequest, "Name is required")
+	// Issue #269: validate the name's characters, not just non-emptiness.
+	if err := ValidateDisplayName(req.Name); err != nil {
+		RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
@@ -582,8 +583,9 @@ func (h *ClusterHandler) updateClusterGroup(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if req.Name == "" {
-		RespondError(w, http.StatusBadRequest, "Name is required")
+	// Issue #269: validate the name's characters, not just non-emptiness.
+	if err := ValidateDisplayName(req.Name); err != nil {
+		RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -754,8 +756,9 @@ func (h *ClusterHandler) createClusterInGroup(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if req.Name == "" {
-		RespondError(w, http.StatusBadRequest, "Name is required")
+	// Issue #269: validate the name's characters, not just non-emptiness.
+	if err := ValidateDisplayName(req.Name); err != nil {
+		RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
@@ -831,6 +834,15 @@ func (h *ClusterHandler) updateCluster(w http.ResponseWriter, r *http.Request, i
 	if req.Name == "" && req.GroupID == nil && req.Description == nil && req.ReplicationType == nil {
 		RespondError(w, http.StatusBadRequest, "At least name, group_id, description, or replication_type is required")
 		return
+	}
+
+	// Issue #269: name is optional on update (an empty string means "leave
+	// unchanged"). Validate its characters only when a name is supplied.
+	if req.Name != "" {
+		if err := ValidateDisplayName(req.Name); err != nil {
+			RespondError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
@@ -944,6 +956,15 @@ func (h *ClusterHandler) updateAutoDetectedCluster(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Issue #269: name is optional here (empty means "leave unchanged").
+	// Validate its characters only when a name is supplied.
+	if req.Name != "" {
+		if err := ValidateDisplayName(req.Name); err != nil {
+			RespondError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
 	// Use auto_cluster_key from request if provided, else compute from cluster ID
 	autoKey := req.AutoClusterKey
 	if autoKey == "" {
@@ -1050,8 +1071,9 @@ func (h *ClusterHandler) updateAutoDetectedGroup(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if req.Name == "" {
-		RespondError(w, http.StatusBadRequest, "Name is required")
+	// Issue #269: validate the name's characters, not just non-emptiness.
+	if err := ValidateDisplayName(req.Name); err != nil {
+		RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -1320,8 +1342,9 @@ func (h *ClusterHandler) handleCreateCluster(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if req.Name == "" {
-		RespondError(w, http.StatusBadRequest, "Name is required")
+	// Issue #269: validate the name's characters, not just non-emptiness.
+	if err := ValidateDisplayName(req.Name); err != nil {
+		RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -528,11 +528,11 @@ func (h *ClusterHandler) createClusterGroup(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Issue #269: validate the name's characters, not just non-emptiness.
+	// ValidateDisplayName also enforces the VARCHAR(255) limit on the raw
+	// name, so no separate validateMaxLen("Name", ...) call is needed here
+	// (issue #270).
 	if err := ValidateDisplayName(req.Name); err != nil {
 		RespondError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
 		return
 	}
 
@@ -757,11 +757,11 @@ func (h *ClusterHandler) createClusterInGroup(w http.ResponseWriter, r *http.Req
 	}
 
 	// Issue #269: validate the name's characters, not just non-emptiness.
+	// ValidateDisplayName also enforces the VARCHAR(255) limit on the raw
+	// name, so no separate validateMaxLen("Name", ...) call is needed here
+	// (issue #270).
 	if err := ValidateDisplayName(req.Name); err != nil {
 		RespondError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
 		return
 	}
 
@@ -1343,11 +1343,11 @@ func (h *ClusterHandler) handleCreateCluster(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Issue #269: validate the name's characters, not just non-emptiness.
+	// ValidateDisplayName also enforces the VARCHAR(255) limit on the raw
+	// name, so no separate validateMaxLen("Name", ...) call is needed here
+	// (issue #270).
 	if err := ValidateDisplayName(req.Name); err != nil {
 		RespondError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
 		return
 	}
 

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -260,10 +260,12 @@ func TestClusterHandler_CreateClusterGroup_MissingName(t *testing.T) {
 	}
 }
 
-// TestClusterHandler_CreateClusterGroup_NameTooLong locks in issue #270:
-// a Name longer than the VARCHAR(255) column must be rejected with a 400
-// and a field-specific message before any datastore call (the handler
-// runs against a nil datastore, so a stray call would panic).
+// TestClusterHandler_CreateClusterGroup_NameTooLong locks in the column guard
+// for the Name field: a Name longer than the VARCHAR(255) column must be
+// rejected with a 400 before any datastore call (the handler runs against a
+// nil datastore, so a stray call would panic). Length is enforced by
+// ValidateDisplayName, the single authority for Name length (issues #269 and
+// #270), so the message is "...characters or fewer".
 func TestClusterHandler_CreateClusterGroup_NameTooLong(t *testing.T) {
 	handler := permissionSatisfiedHandler()
 
@@ -276,11 +278,11 @@ func TestClusterHandler_CreateClusterGroup_NameTooLong(t *testing.T) {
 
 	handler.createClusterGroup(rec, req)
 
-	assertMaxLenRejected(t, rec, "Name")
+	assertLengthRejected(t, rec, "Name must be 255 characters or fewer")
 }
 
-// TestClusterHandler_CreateClusterInGroup_NameTooLong locks in issue #270
-// for the group-scoped cluster create path.
+// TestClusterHandler_CreateClusterInGroup_NameTooLong locks in the Name
+// column guard for the group-scoped cluster create path (issues #269/#270).
 func TestClusterHandler_CreateClusterInGroup_NameTooLong(t *testing.T) {
 	handler := permissionSatisfiedHandler()
 
@@ -293,11 +295,11 @@ func TestClusterHandler_CreateClusterInGroup_NameTooLong(t *testing.T) {
 
 	handler.createClusterInGroup(rec, req, 1)
 
-	assertMaxLenRejected(t, rec, "Name")
+	assertLengthRejected(t, rec, "Name must be 255 characters or fewer")
 }
 
-// TestClusterHandler_HandleCreateCluster_NameTooLong locks in issue #270
-// for the manual cluster create path.
+// TestClusterHandler_HandleCreateCluster_NameTooLong locks in the Name
+// column guard for the manual cluster create path (issues #269/#270).
 func TestClusterHandler_HandleCreateCluster_NameTooLong(t *testing.T) {
 	handler := permissionSatisfiedHandler()
 
@@ -310,7 +312,7 @@ func TestClusterHandler_HandleCreateCluster_NameTooLong(t *testing.T) {
 
 	handler.handleCreateCluster(rec, req)
 
-	assertMaxLenRejected(t, rec, "Name")
+	assertLengthRejected(t, rec, "Name must be 255 characters or fewer")
 }
 
 // TestClusterHandler_CreateClusterGroup_NameAtLimit confirms the boundary:
@@ -337,9 +339,12 @@ func TestClusterHandler_CreateClusterGroup_NameAtLimit(t *testing.T) {
 	handler.createClusterGroup(rec, req)
 }
 
-// assertMaxLenRejected asserts that the recorded response is a 400 carrying
-// the canonical "<field> must be 255 characters or less" message.
-func assertMaxLenRejected(t *testing.T, rec *httptest.ResponseRecorder, field string) {
+// assertLengthRejected asserts that the recorded response is a 400 whose
+// error body matches wantMsg exactly. It is used for the over-length name
+// paths, where the Name field is guarded by ValidateDisplayName and so
+// surfaces the "...characters or fewer" wording rather than validateMaxLen's
+// "...characters or less".
+func assertLengthRejected(t *testing.T, rec *httptest.ResponseRecorder, wantMsg string) {
 	t.Helper()
 
 	if rec.Code != http.StatusBadRequest {
@@ -352,9 +357,8 @@ func assertMaxLenRejected(t *testing.T, rec *httptest.ResponseRecorder, field st
 		t.Fatalf("Failed to decode response: %v", err)
 	}
 
-	want := field + " must be 255 characters or less"
-	if response.Error != want {
-		t.Errorf("Expected %q, got %q", want, response.Error)
+	if response.Error != wantMsg {
+		t.Errorf("Expected %q, got %q", wantMsg, response.Error)
 	}
 }
 

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -2214,3 +2214,173 @@ func TestClusterHandler_DeleteAutoDetectedCluster_WithPermission(t *testing.T) {
 		t.Fatal("Cluster was not dismissed")
 	}
 }
+
+// =============================================================================
+// Regression tests for GitHub issue #269: name character validation.
+//
+// The create/update handlers previously rejected only empty names. They now
+// funnel through ValidateDisplayName, which rejects names containing
+// characters outside the permitted set (letters, digits, spaces, and
+// . _ - ( )) with HTTP 400 and a user-facing message. These tests use
+// permissionSatisfiedHandler() with a nil datastore so the validation
+// rejection fires before any datastore access; a stray datastore call would
+// panic and surface as a failure.
+// =============================================================================
+
+// issue269InvalidName is the canonical bad name from the issue.
+const issue269InvalidName = "<>!@#$%"
+
+// issue269InvalidCharsMessage is the user-facing wording the handlers must
+// surface for a name containing disallowed characters.
+const issue269InvalidCharsMessage = "Name may only contain letters, numbers, " +
+	"spaces, and the characters . _ - ( )"
+
+func TestClusterHandler_CreateClusterGroup_Issue269_InvalidChars(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: issue269InvalidName})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.createClusterGroup(rec, req)
+
+	assertInvalidNameRejected(t, rec)
+}
+
+func TestClusterHandler_CreateClusterInGroup_Issue269_InvalidChars(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	body, _ := json.Marshal(ClusterRequest{Name: issue269InvalidName})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups/1/clusters",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.createClusterInGroup(rec, req, 1)
+
+	assertInvalidNameRejected(t, rec)
+}
+
+func TestClusterHandler_HandleCreateCluster_Issue269_InvalidChars(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	body, _ := json.Marshal(ManualClusterRequest{Name: issue269InvalidName})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/clusters",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.handleCreateCluster(rec, req)
+
+	assertInvalidNameRejected(t, rec)
+}
+
+func TestClusterHandler_UpdateCluster_Issue269_InvalidChars(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	// A name is supplied, so it must pass the character policy even though
+	// name is optional on update.
+	body, _ := json.Marshal(ClusterRequest{Name: issue269InvalidName})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/clusters/1",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.updateCluster(rec, req, 1)
+
+	assertInvalidNameRejected(t, rec)
+}
+
+func TestClusterHandler_UpdateAutoDetectedCluster_Issue269_InvalidChars(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	body, _ := json.Marshal(AutoDetectedClusterRequest{Name: issue269InvalidName})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/clusters/cluster-spock-foo",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.updateAutoDetectedCluster(rec, req, "cluster-spock-foo")
+
+	assertInvalidNameRejected(t, rec)
+}
+
+func TestClusterHandler_UpdateAutoDetectedGroup_Issue269_InvalidChars(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: issue269InvalidName})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/cluster-groups/group-auto",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.updateAutoDetectedGroup(rec, req, "group-auto")
+
+	assertInvalidNameRejected(t, rec)
+}
+
+// TestClusterHandler_UpdateAutoDetectedGroup_Issue269_ValidName confirms a
+// well-formed name passes the issue #269 validator and is persisted through
+// UpsertGroupByAutoKey, proving the new guard does not reject legitimate
+// renames.
+func TestClusterHandler_UpdateAutoDetectedGroup_Issue269_ValidName(t *testing.T) {
+	ds, pool, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: "Renamed Auto Group"})
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/cluster-groups/group-auto", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.updateAutoDetectedGroup(rec, req, "group-auto")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var resp database.ClusterGroup
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if resp.Name != "Renamed Auto Group" {
+		t.Errorf("Response Name = %q, want %q", resp.Name, "Renamed Auto Group")
+	}
+
+	// Verify the rename was persisted under the computed auto_group_key.
+	var dbName string
+	err := pool.QueryRow(context.Background(),
+		"SELECT name FROM cluster_groups WHERE auto_group_key = $1",
+		"auto").Scan(&dbName)
+	if err != nil {
+		t.Fatalf("Failed to read upserted row: %v", err)
+	}
+	if dbName != "Renamed Auto Group" {
+		t.Errorf("Persisted name = %q, want %q", dbName, "Renamed Auto Group")
+	}
+}
+
+// assertInvalidNameRejected asserts that the recorded response is a 400 with
+// the issue #269 invalid-characters message.
+func assertInvalidNameRejected(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+	var response ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if response.Error != issue269InvalidCharsMessage {
+		t.Errorf("Expected %q, got %q", issue269InvalidCharsMessage, response.Error)
+	}
+}

--- a/server/src/internal/api/connection_handlers.go
+++ b/server/src/internal/api/connection_handlers.go
@@ -251,10 +251,10 @@ func (h *ConnectionHandler) createConnection(w http.ResponseWriter, r *http.Requ
 
 	// Enforce the VARCHAR(255) limits on the backing columns before any
 	// datastore call so over-length input returns a clear 400 instead of
-	// a generic 500 when the database rejects the row (issue #270).
-	if !validateMaxLen(w, "Name", req.Name, maxFieldLength) {
-		return
-	}
+	// a generic 500 when the database rejects the row (issue #270). The Name
+	// column is already guarded by ValidateDisplayName above, which rejects
+	// over-length raw names; the remaining fields have no such validator and
+	// so are checked here.
 	if !validateMaxLen(w, "Host", req.Host, maxFieldLength) {
 		return
 	}

--- a/server/src/internal/api/connection_handlers.go
+++ b/server/src/internal/api/connection_handlers.go
@@ -222,9 +222,10 @@ func (h *ConnectionHandler) createConnection(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Validate required fields
-	if req.Name == "" {
-		RespondError(w, http.StatusBadRequest, "Name is required")
+	// Validate required fields. Issue #269: validate the name's characters,
+	// not just non-emptiness.
+	if err := ValidateDisplayName(req.Name); err != nil {
+		RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if req.Host == "" {
@@ -452,10 +453,13 @@ func (h *ConnectionHandler) updateConnection(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Validate name if provided
-	if req.Name != nil && *req.Name == "" {
-		RespondError(w, http.StatusBadRequest, "Name cannot be empty")
-		return
+	// Validate name if provided. Issue #269: when a name is supplied, it
+	// must satisfy the full character policy, not merely be non-empty.
+	if req.Name != nil {
+		if err := ValidateDisplayName(*req.Name); err != nil {
+			RespondError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 
 	// Only users with manage_connections permission can make connections shared

--- a/server/src/internal/api/connection_handlers_test.go
+++ b/server/src/internal/api/connection_handlers_test.go
@@ -1002,9 +1002,14 @@ func TestConnectionHandler_CreateConnection_Issue270_FieldTooLong(t *testing.T) 
 		wantMsg string
 	}{
 		{
+			// The Name field is guarded by ValidateDisplayName, which now
+			// enforces the 255-character limit on the raw value itself, so
+			// the canonical over-length message for Name is ErrNameTooLong
+			// ("...or fewer"), distinct from the validateMaxLen wording used
+			// by the remaining fields ("...or less").
 			name:    "Name",
 			mutate:  func(r *ConnectionCreateRequest) { r.Name = tooLong },
-			wantMsg: "Name must be 255 characters or less",
+			wantMsg: "Name must be 255 characters or fewer",
 		},
 		{
 			name:    "Host",
@@ -1089,13 +1094,16 @@ func TestConnectionHandler_CreateConnection_Issue270_AtLimitPassesValidation(t *
 }
 
 // TestConnectionHandler_CreateConnection_Issue270_MultibyteAtLimitPasses
-// confirms the limit counts characters, not bytes: a Name of exactly
-// maxFieldLength multibyte runes (510 bytes for "é") must pass the length
-// check, mirroring the VARCHAR(255) column, which limits by characters.
-// A byte-based check would wrongly reject this. Later validation steps
-// (host SSRF check, nil datastore) prevent a clean 200 here, so the test
-// asserts the length-specific 400 message is not produced rather than a
-// specific status code.
+// confirms the validateMaxLen limit counts characters, not bytes: a Host of
+// exactly maxFieldLength multibyte runes (510 bytes for "é") must pass the
+// length check, mirroring the VARCHAR(255) column, which limits by
+// characters. A byte-based check would wrongly reject this. The Host field is
+// used rather than Name because the issue #269 display-name policy restricts
+// Name to an ASCII charset that excludes "é"; Host has no such charset
+// restriction, so it is the field that genuinely exercises rune counting in
+// validateMaxLen. Later validation steps (host SSRF check, nil datastore)
+// prevent a clean 200 here, so the test asserts the length-specific 400
+// message is not produced rather than a specific status code.
 func TestConnectionHandler_CreateConnection_Issue270_MultibyteAtLimitPasses(t *testing.T) {
 	handler, userID, token, cleanup := setupIssue233CreateConnection(
 		t, "issue270_multibyte_atlimit", []string{auth.PermManageConnections})
@@ -1103,7 +1111,7 @@ func TestConnectionHandler_CreateConnection_Issue270_MultibyteAtLimitPasses(t *t
 
 	reqBody := validConnectionCreateRequest()
 	// 255 runes but 510 bytes; len() would wrongly reject this.
-	reqBody.Name = strings.Repeat("é", maxFieldLength)
+	reqBody.Host = strings.Repeat("é", maxFieldLength)
 	body, _ := json.Marshal(reqBody)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
@@ -1118,23 +1126,25 @@ func TestConnectionHandler_CreateConnection_Issue270_MultibyteAtLimitPasses(t *t
 	})
 
 	if rec.Code == http.StatusBadRequest &&
-		strings.Contains(rec.Body.String(), "Name must be") {
+		strings.Contains(rec.Body.String(), "Host must be") {
 		t.Fatalf("Expected 255 multibyte runes to pass length validation, "+
 			"got length-error 400. Body: %s", rec.Body.String())
 	}
 }
 
 // TestConnectionHandler_CreateConnection_Issue270_MultibyteOverLimitRejected
-// confirms a Name of 256 multibyte runes is rejected by the character-based
-// length check with the expected 400 message, even though each run of the
-// byte-based check would also reject it; this pins the rune-counting path.
+// confirms a Host of 256 multibyte runes is rejected by the character-based
+// validateMaxLen check with the expected 400 message, even though each run of
+// the byte-based check would also reject it; this pins the rune-counting
+// path. The Host field is used because the issue #269 charset on Name would
+// reject "é" before the length check could run.
 func TestConnectionHandler_CreateConnection_Issue270_MultibyteOverLimitRejected(t *testing.T) {
 	handler, userID, token, cleanup := setupIssue233CreateConnection(
 		t, "issue270_multibyte_overlimit", []string{auth.PermManageConnections})
 	defer cleanup()
 
 	reqBody := validConnectionCreateRequest()
-	reqBody.Name = strings.Repeat("é", maxFieldLength+1)
+	reqBody.Host = strings.Repeat("é", maxFieldLength+1)
 	body, _ := json.Marshal(reqBody)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
@@ -1155,7 +1165,7 @@ func TestConnectionHandler_CreateConnection_Issue270_MultibyteOverLimitRejected(
 	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
 		t.Fatalf("Failed to decode response: %v", err)
 	}
-	const wantMsg = "Name must be 255 characters or less"
+	const wantMsg = "Host must be 255 characters or less"
 	if response.Error != wantMsg {
 		t.Errorf("Expected %q, got %q", wantMsg, response.Error)
 	}

--- a/server/src/internal/api/issue269_connection_name_test.go
+++ b/server/src/internal/api/issue269_connection_name_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -129,6 +130,51 @@ func TestConnectionHandler_CreateConnection_Issue269_InvalidChars(t *testing.T) 
 	handler.createConnection(rec, req)
 
 	assertInvalidNameRejected(t, rec)
+}
+
+// TestConnectionHandler_CreateConnection_Issue269_PaddedNameRawTooLong covers
+// the whitespace-padding edge case at the handler level: a name whose trimmed
+// length is within the 255-character limit but whose raw length exceeds it
+// (250 content characters plus 10 trailing spaces) must be rejected with a
+// 400 before any datastore write. Because the handler persists the raw value
+// to the VARCHAR(255) column, ValidateDisplayName now rejects on the raw
+// length and the over-length value never reaches the column.
+func TestConnectionHandler_CreateConnection_Issue269_PaddedNameRawTooLong(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue269_create_padded_toolong",
+		[]string{auth.PermManageConnections})
+	defer cleanup()
+
+	paddedName := strings.Repeat("a", 250) + strings.Repeat(" ", 10)
+	body, _ := json.Marshal(ConnectionCreateRequest{
+		Name:         paddedName,
+		Host:         "db.example.com",
+		Port:         5432,
+		DatabaseName: "postgres",
+		Username:     "alice",
+		Password:     "secret",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createConnection(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+	var response ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	const wantMsg = "Name must be 255 characters or fewer"
+	if response.Error != wantMsg {
+		t.Errorf("Expected %q, got %q", wantMsg, response.Error)
+	}
 }
 
 // seedIssue269Connection inserts a connection owned by the named user and

--- a/server/src/internal/api/issue269_connection_name_test.go
+++ b/server/src/internal/api/issue269_connection_name_test.go
@@ -1,0 +1,237 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+)
+
+// =============================================================================
+// Regression tests for GitHub issue #269: server connection name character
+// validation. createConnection and updateConnection previously rejected only
+// empty names; they now funnel through ValidateDisplayName and reject names
+// containing disallowed characters with HTTP 400 and a user-facing message.
+//
+// createConnection validates before any datastore access, so its test uses
+// the nil-datastore admin harness from the issue #233 suite. updateConnection
+// loads the existing row first, so its tests seed a real connection in the
+// Postgres named by TEST_AI_WORKBENCH_SERVER.
+// =============================================================================
+
+// issue269ConnectionSchema is a self-contained connections table carrying
+// every column GetConnection and UpdateConnectionFull read or write, so the
+// updateConnection tests exercise the real datastore path end to end.
+const issue269ConnectionSchema = `
+DROP TABLE IF EXISTS connections CASCADE;
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    host VARCHAR(255) NOT NULL,
+    hostaddr VARCHAR(255),
+    port INTEGER NOT NULL DEFAULT 5432,
+    database_name VARCHAR(255) NOT NULL,
+    username VARCHAR(255),
+    password_encrypted TEXT,
+    sslmode VARCHAR(32),
+    sslcert TEXT,
+    sslkey TEXT,
+    sslrootcert TEXT,
+    owner_username VARCHAR(255),
+    owner_token VARCHAR(255),
+    is_monitored BOOLEAN NOT NULL DEFAULT FALSE,
+    is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+    membership_source VARCHAR(16) NOT NULL DEFAULT 'auto',
+    cluster_id INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+// newIssue269ConnectionDatastore wires a *database.Datastore to the Postgres
+// named by TEST_AI_WORKBENCH_SERVER and installs issue269ConnectionSchema.
+// The test is skipped when the database environment is not configured.
+func newIssue269ConnectionDatastore(t *testing.T) (*database.Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping issue #269 connection test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+	if _, err := pool.Exec(ctx, issue269ConnectionSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create issue #269 connection schema: %v", err)
+	}
+
+	ds := database.NewTestDatastore(pool)
+	cleanup := func() {
+		_, _ = pool.Exec(context.Background(),
+			"DROP TABLE IF EXISTS connections CASCADE")
+		pool.Close()
+	}
+	return ds, pool, cleanup
+}
+
+// TestConnectionHandler_CreateConnection_Issue269_InvalidChars confirms that
+// an admin caller supplying a name with disallowed characters is rejected
+// with 400 before the connection is written.
+func TestConnectionHandler_CreateConnection_Issue269_InvalidChars(t *testing.T) {
+	handler, userID, token, cleanup := setupIssue233CreateConnection(
+		t, "issue269_create_invalid",
+		[]string{auth.PermManageConnections})
+	defer cleanup()
+
+	body, _ := json.Marshal(ConnectionCreateRequest{
+		Name:         issue269InvalidName,
+		Host:         "db.example.com",
+		Port:         5432,
+		DatabaseName: "postgres",
+		Username:     "alice",
+		Password:     "secret",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createConnection(rec, req)
+
+	assertInvalidNameRejected(t, rec)
+}
+
+// seedIssue269Connection inserts a connection owned by the named user and
+// returns its ID. The caller supplies a distinct ID per test to avoid
+// collisions within a shared schema.
+func seedIssue269Connection(t *testing.T, pool *pgxpool.Pool, id int, owner, name string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+        INSERT INTO connections (id, name, description, host, port,
+            database_name, username, is_shared, owner_username,
+            membership_source)
+        VALUES ($1, $2, '', 'db.example.com', 5432, 'postgres',
+            $3, FALSE, $3, 'manual')
+    `, id, name, owner)
+	if err != nil {
+		t.Fatalf("Seed connection: %v", err)
+	}
+}
+
+// TestConnectionHandler_UpdateConnection_Issue269_InvalidChars seeds a real
+// connection owned by the caller, then confirms that a PUT supplying a name
+// with disallowed characters is rejected with 400.
+func TestConnectionHandler_UpdateConnection_Issue269_InvalidChars(t *testing.T) {
+	ds, pool, cleanupDS := newIssue269ConnectionDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+
+	const owner = "issue269_update_invalid"
+	userID := setupUserWithPermissions(t, store, owner,
+		[]string{auth.PermManageConnections})
+	token, _, err := store.AuthenticateUser(owner, "Password1234")
+	if err != nil {
+		t.Fatalf("AuthenticateUser: %v", err)
+	}
+
+	const connID = 7269
+	seedIssue269Connection(t, pool, connID, owner, "valid-name")
+
+	checker := auth.NewRBACChecker(store)
+	handler := NewConnectionHandler(ds, store, checker)
+
+	invalid := issue269InvalidName
+	body, _ := json.Marshal(ConnectionFullUpdateRequest{Name: &invalid})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/connections/7269",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.updateConnection(rec, req, connID)
+
+	assertInvalidNameRejected(t, rec)
+}
+
+// TestConnectionHandler_UpdateConnection_Issue269_ValidNameSucceeds confirms
+// that a valid name still updates the connection successfully, so the new
+// validation does not over-reject legitimate input.
+func TestConnectionHandler_UpdateConnection_Issue269_ValidNameSucceeds(t *testing.T) {
+	ds, pool, cleanupDS := newIssue269ConnectionDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+
+	const owner = "issue269_update_valid"
+	userID := setupUserWithPermissions(t, store, owner,
+		[]string{auth.PermManageConnections})
+	token, _, err := store.AuthenticateUser(owner, "Password1234")
+	if err != nil {
+		t.Fatalf("AuthenticateUser: %v", err)
+	}
+
+	const connID = 7270
+	seedIssue269Connection(t, pool, connID, owner, "old-name")
+
+	checker := auth.NewRBACChecker(store)
+	handler := NewConnectionHandler(ds, store, checker)
+
+	valid := "New Cluster (primary) - east_1.db"
+	body, _ := json.Marshal(ConnectionFullUpdateRequest{Name: &valid})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/connections/7270",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.updateConnection(rec, req, connID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var stored string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT name FROM connections WHERE id = $1", connID).Scan(&stored); err != nil {
+		t.Fatalf("Read back name: %v", err)
+	}
+	if stored != valid {
+		t.Errorf("Stored name = %q, want %q", stored, valid)
+	}
+}

--- a/server/src/internal/api/name_validation.go
+++ b/server/src/internal/api/name_validation.go
@@ -59,19 +59,27 @@ const (
 // ValidateDisplayName validates a user-facing display name used for cluster
 // groups, clusters, and server connections (issue #269).
 //
-// Validation operates on the name AFTER trimming leading and trailing
-// whitespace. A name is valid when, once trimmed, it is non-empty, contains
-// only the characters permitted by displayNameRegex, and is at most
-// MaxDisplayNameLength characters long.
+// Character and emptiness validation operate on the name AFTER trimming
+// leading and trailing whitespace. A name is valid when, once trimmed, it is
+// non-empty and contains only the characters permitted by displayNameRegex.
+//
+// Length is enforced on BOTH the trimmed and the raw (untrimmed) value, each
+// capped at MaxDisplayNameLength characters. The raw cap matters because
+// callers persist the value exactly as submitted (see "Note on storage"
+// below): a name padded with trailing whitespace could trim to a length at or
+// below the limit while its raw length exceeds the backing VARCHAR(255)
+// column. Rejecting on the raw length here makes this function the single
+// authority for the Name field's length, so handlers no longer need a
+// separate validateMaxLen("Name", ...) call to guard the column (issue #270).
 //
 // Note on storage: this function only validates; it does not return a
 // normalised name. Callers continue to persist whatever value they read from
 // the request body, matching the pre-existing handler behavior, which did
-// not trim names before storage. Validating the trimmed form while storing
-// the raw value is the least-surprising choice: a name such as "  prod  "
-// that trims to a valid value is accepted and stored exactly as submitted,
-// and whitespace-only input is rejected. Changing storage to trim names would
-// be a separate, deliberate behavioral change.
+// not trim names before storage. Validating the trimmed form for content
+// while storing the raw value is the least-surprising choice: a name such as
+// "  prod  " that trims to a valid value is accepted and stored exactly as
+// submitted, and whitespace-only input is rejected. Changing storage to trim
+// names would be a separate, deliberate behavioral change.
 //
 // It returns nil when the name is valid, or one of ErrNameRequired,
 // ErrNameTooLong, or ErrNameInvalidChars describing the failure. The error
@@ -85,8 +93,12 @@ func ValidateDisplayName(name string) error {
 
 	// Measure length in runes so multi-byte characters count as one each;
 	// this only matters for the boundary check because the permitted set is
-	// otherwise ASCII.
-	if len([]rune(trimmed)) > MaxDisplayNameLength {
+	// otherwise ASCII. The raw value is checked as well as the trimmed value
+	// because the raw value is what callers persist to the VARCHAR(255)
+	// column; a name padded with whitespace must not slip past the limit by
+	// trimming to a shorter length than it is actually stored at.
+	if len([]rune(name)) > MaxDisplayNameLength ||
+		len([]rune(trimmed)) > MaxDisplayNameLength {
 		return ErrNameTooLong
 	}
 

--- a/server/src/internal/api/name_validation.go
+++ b/server/src/internal/api/name_validation.go
@@ -1,0 +1,98 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"regexp"
+	"strings"
+)
+
+// MaxDisplayNameLength is the maximum permitted length, in characters, of a
+// user-facing display name (cluster group, cluster, or server connection
+// name). The limit is measured against the trimmed name.
+const MaxDisplayNameLength = 255
+
+// displayNameRegex matches the set of characters permitted in a user-facing
+// display name: letters, digits, spaces, and the punctuation characters
+// period, underscore, hyphen, and parentheses. The pattern is anchored so the
+// entire (trimmed) name must consist solely of these characters. Disallowed
+// characters include angle brackets, shell and SQL metacharacters, quotes,
+// slashes, and control characters (issue #269).
+var displayNameRegex = regexp.MustCompile(`^[A-Za-z0-9 ._()-]+$`)
+
+// nameError is a sentinel error type for display-name validation failures.
+// Its Error method returns the user-facing message verbatim, including the
+// leading capital letter; the message is defined as a string constant so the
+// "error strings should not be capitalized" lint rule (ST1005) does not fire
+// on a capitalized errors.New literal. The string is safe to pass directly to
+// RespondError.
+type nameError string
+
+// Error returns the user-facing validation message.
+func (e nameError) Error() string { return string(e) }
+
+// User-facing validation messages. They are exported as errors so callers can
+// surface the exact text via RespondError and tests can assert on them with
+// errors.Is.
+const (
+	// ErrNameRequired is returned when a name is empty or consists solely of
+	// whitespace once trimmed.
+	ErrNameRequired nameError = "Name is required"
+
+	// ErrNameTooLong is returned when a trimmed name exceeds
+	// MaxDisplayNameLength characters.
+	ErrNameTooLong nameError = "Name must be 255 characters or fewer"
+
+	// ErrNameInvalidChars is returned when a trimmed name contains characters
+	// outside the permitted set.
+	ErrNameInvalidChars nameError = "Name may only contain letters, numbers, " +
+		"spaces, and the characters . _ - ( )"
+)
+
+// ValidateDisplayName validates a user-facing display name used for cluster
+// groups, clusters, and server connections (issue #269).
+//
+// Validation operates on the name AFTER trimming leading and trailing
+// whitespace. A name is valid when, once trimmed, it is non-empty, contains
+// only the characters permitted by displayNameRegex, and is at most
+// MaxDisplayNameLength characters long.
+//
+// Note on storage: this function only validates; it does not return a
+// normalised name. Callers continue to persist whatever value they read from
+// the request body, matching the pre-existing handler behavior, which did
+// not trim names before storage. Validating the trimmed form while storing
+// the raw value is the least-surprising choice: a name such as "  prod  "
+// that trims to a valid value is accepted and stored exactly as submitted,
+// and whitespace-only input is rejected. Changing storage to trim names would
+// be a separate, deliberate behavioral change.
+//
+// It returns nil when the name is valid, or one of ErrNameRequired,
+// ErrNameTooLong, or ErrNameInvalidChars describing the failure. The error
+// strings are user-facing and safe to pass directly to RespondError.
+func ValidateDisplayName(name string) error {
+	trimmed := strings.TrimSpace(name)
+
+	if trimmed == "" {
+		return ErrNameRequired
+	}
+
+	// Measure length in runes so multi-byte characters count as one each;
+	// this only matters for the boundary check because the permitted set is
+	// otherwise ASCII.
+	if len([]rune(trimmed)) > MaxDisplayNameLength {
+		return ErrNameTooLong
+	}
+
+	if !displayNameRegex.MatchString(trimmed) {
+		return ErrNameInvalidChars
+	}
+
+	return nil
+}

--- a/server/src/internal/api/name_validation_test.go
+++ b/server/src/internal/api/name_validation_test.go
@@ -85,9 +85,12 @@ func TestValidateDisplayName(t *testing.T) {
 }
 
 // TestValidateDisplayName_LengthBoundary verifies the 255-character limit is
-// applied to the trimmed name: exactly 255 characters is accepted, 256 is
-// rejected with ErrNameTooLong, and trailing whitespace that trims a 256-rune
-// string back to 255 is accepted.
+// applied to BOTH the trimmed and the raw value: exactly 255 characters is
+// accepted, 256 is rejected with ErrNameTooLong, and whitespace padding that
+// pushes the raw length over 255 is rejected even when the trimmed length is
+// within the limit. The raw cap exists because handlers persist the raw
+// value to the VARCHAR(255) column; a padded name must not slip past the
+// limit by trimming to a shorter length than it is stored at.
 func TestValidateDisplayName_LengthBoundary(t *testing.T) {
 	at255 := strings.Repeat("a", MaxDisplayNameLength)
 	if err := ValidateDisplayName(at255); err != nil {
@@ -99,16 +102,53 @@ func TestValidateDisplayName_LengthBoundary(t *testing.T) {
 		t.Errorf("256-character name: got %v, want ErrNameTooLong", err)
 	}
 
-	// 255 content characters wrapped in whitespace trims back to 255 and so
-	// must be accepted; the limit is measured against the trimmed value.
+	// 255 content characters wrapped in whitespace has a raw length of 259,
+	// which exceeds the VARCHAR(255) column even though the trimmed length is
+	// 255; it must be rejected because the raw value is what is stored.
 	padded := "  " + at255 + "  "
-	if err := ValidateDisplayName(padded); err != nil {
-		t.Errorf("padded 255-character name should be valid, got %v", err)
+	if err := ValidateDisplayName(padded); !errors.Is(err, ErrNameTooLong) {
+		t.Errorf("padded 255-character name (raw 259): got %v, want ErrNameTooLong", err)
 	}
 
 	// A 256-character name that trims to 256 invalid runes is still too long.
 	if err := ValidateDisplayName("  " + at256 + "  "); !errors.Is(err, ErrNameTooLong) {
 		t.Errorf("padded 256-character name: got %v, want ErrNameTooLong", err)
+	}
+}
+
+// TestValidateDisplayName_RawLengthExceedsTrimmed pins the precise
+// whitespace-padding edge case behind the raw-length cap: a name whose
+// trimmed length is at or below the limit but whose raw length exceeds it is
+// rejected with ErrNameTooLong. This is the case that the removed
+// validateMaxLen("Name", ...) calls used to guard; ValidateDisplayName now
+// owns it so the VARCHAR(255) column is never reachable with an over-length
+// raw value.
+func TestValidateDisplayName_RawLengthExceedsTrimmed(t *testing.T) {
+	// 250 content characters plus 10 trailing spaces: trimmed length 250
+	// (within the limit) but raw length 260 (over the limit).
+	content := strings.Repeat("a", 250)
+	padded := content + strings.Repeat(" ", 10)
+
+	if got := len([]rune(strings.TrimSpace(padded))); got > MaxDisplayNameLength {
+		t.Fatalf("test setup: trimmed length %d should be within the limit", got)
+	}
+	if got := len([]rune(padded)); got <= MaxDisplayNameLength {
+		t.Fatalf("test setup: raw length %d should exceed the limit", got)
+	}
+
+	if err := ValidateDisplayName(padded); !errors.Is(err, ErrNameTooLong) {
+		t.Errorf("raw-over-limit padded name: got %v, want ErrNameTooLong", err)
+	}
+
+	// The exact boundary: a name whose raw length is exactly 255 (254 content
+	// characters plus one trailing space) is accepted, confirming the cap is
+	// inclusive of the limit and not off by one.
+	atRawLimit := strings.Repeat("a", MaxDisplayNameLength-1) + " "
+	if got := len([]rune(atRawLimit)); got != MaxDisplayNameLength {
+		t.Fatalf("test setup: raw length %d should equal the limit", got)
+	}
+	if err := ValidateDisplayName(atRawLimit); err != nil {
+		t.Errorf("name at raw limit (255) should be valid, got %v", err)
 	}
 }
 

--- a/server/src/internal/api/name_validation_test.go
+++ b/server/src/internal/api/name_validation_test.go
@@ -1,0 +1,133 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestValidateDisplayName is a table-driven exercise of the issue #269
+// display-name policy. It covers accepted names (with every permitted
+// punctuation class), each rejected special character called out in the
+// issue, empty and whitespace-only input, the 255/256 length boundary, and
+// surrounding whitespace that trims to a valid value.
+func TestValidateDisplayName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		// Valid names exercising each permitted character class.
+		{"simple letters", "Production", nil},
+		{"letters and digits", "Cluster01", nil},
+		{"with spaces", "East Coast Cluster", nil},
+		{"with period", "db.primary", nil},
+		{"with underscore", "primary_db", nil},
+		{"with hyphen", "us-east-1", nil},
+		{"with parentheses", "Primary (read-write)", nil},
+		{"all permitted classes", "Region 1 - east_coast.db (rw)", nil},
+		{"digits only", "12345", nil},
+		{"single character", "A", nil},
+
+		// Leading/trailing whitespace that trims to a valid value.
+		{"leading whitespace trims valid", "   Production", nil},
+		{"trailing whitespace trims valid", "Production   ", nil},
+		{"surrounding whitespace trims valid", "  Prod Cluster  ", nil},
+
+		// Empty and whitespace-only input.
+		{"empty string", "", ErrNameRequired},
+		{"single space", " ", ErrNameRequired},
+		{"only spaces", "     ", ErrNameRequired},
+		{"only tabs and newlines", "\t\n\r ", ErrNameRequired},
+
+		// Each rejected special character from the issue (<>!@#$%).
+		{"less than", "name<", ErrNameInvalidChars},
+		{"greater than", "name>", ErrNameInvalidChars},
+		{"angle brackets", "<>!@#$%", ErrNameInvalidChars},
+		{"exclamation", "name!", ErrNameInvalidChars},
+		{"at sign", "name@", ErrNameInvalidChars},
+		{"hash", "name#", ErrNameInvalidChars},
+		{"dollar", "name$", ErrNameInvalidChars},
+		{"percent", "name%", ErrNameInvalidChars},
+
+		// Other dangerous characters that must also be rejected.
+		{"caret", "name^", ErrNameInvalidChars},
+		{"ampersand", "a&b", ErrNameInvalidChars},
+		{"asterisk", "name*", ErrNameInvalidChars},
+		{"single quote", "O'Brien", ErrNameInvalidChars},
+		{"double quote", `say "hi"`, ErrNameInvalidChars},
+		{"forward slash", "a/b", ErrNameInvalidChars},
+		{"backslash", `a\b`, ErrNameInvalidChars},
+		{"semicolon", "a;b", ErrNameInvalidChars},
+		{"control char", "name\x00", ErrNameInvalidChars},
+		{"comma", "a,b", ErrNameInvalidChars},
+		{"brace", "name{", ErrNameInvalidChars},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDisplayName(tt.input)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ValidateDisplayName(%q) = %v, want %v",
+					tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateDisplayName_LengthBoundary verifies the 255-character limit is
+// applied to the trimmed name: exactly 255 characters is accepted, 256 is
+// rejected with ErrNameTooLong, and trailing whitespace that trims a 256-rune
+// string back to 255 is accepted.
+func TestValidateDisplayName_LengthBoundary(t *testing.T) {
+	at255 := strings.Repeat("a", MaxDisplayNameLength)
+	if err := ValidateDisplayName(at255); err != nil {
+		t.Errorf("255-character name should be valid, got %v", err)
+	}
+
+	at256 := strings.Repeat("a", MaxDisplayNameLength+1)
+	if err := ValidateDisplayName(at256); !errors.Is(err, ErrNameTooLong) {
+		t.Errorf("256-character name: got %v, want ErrNameTooLong", err)
+	}
+
+	// 255 content characters wrapped in whitespace trims back to 255 and so
+	// must be accepted; the limit is measured against the trimmed value.
+	padded := "  " + at255 + "  "
+	if err := ValidateDisplayName(padded); err != nil {
+		t.Errorf("padded 255-character name should be valid, got %v", err)
+	}
+
+	// A 256-character name that trims to 256 invalid runes is still too long.
+	if err := ValidateDisplayName("  " + at256 + "  "); !errors.Is(err, ErrNameTooLong) {
+		t.Errorf("padded 256-character name: got %v, want ErrNameTooLong", err)
+	}
+}
+
+// TestValidateDisplayName_ErrorMessages locks in the exact user-facing wording
+// so callers and the client team can rely on the strings surfaced via
+// RespondError.
+func TestValidateDisplayName_ErrorMessages(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{ErrNameRequired, "Name is required"},
+		{ErrNameTooLong, "Name must be 255 characters or fewer"},
+		{ErrNameInvalidChars,
+			"Name may only contain letters, numbers, spaces, and the characters . _ - ( )"},
+	}
+	for _, c := range cases {
+		if c.err.Error() != c.want {
+			t.Errorf("message = %q, want %q", c.err.Error(), c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Name fields for **cluster groups**, **servers**, and **clusters** previously accepted special characters such as `<>!@#$%`; validation only checked for empty input, so HTML-unsafe and confusing characters were stored unchanged.
- Adds a shared display-name validator on both sides with identical policy: after trimming, a name must be non-empty, at most 255 characters, and match `^[A-Za-z0-9 ._()-]+$` (letters, numbers, spaces, and `. _ - ( )`).
  - **Server** (`ValidateDisplayName`, `server/src/internal/api/name_validation.go`): all nine cluster-group / cluster / server-connection create and update write paths return HTTP 400 with a user-facing message for invalid names.
  - **Client** (`validateName`, `client/src/utils/validateName.ts`): backs the inline validation in the Add Cluster Group, Add Server, and Add Cluster dialogs, blocking save.
- Reconciled with the recently merged #270 length work: `ValidateDisplayName` is now the single Name-length authority (checks both raw and trimmed length against 255), removing the redundant `validateMaxLen("Name")` calls and closing a latent `VARCHAR(255)` overflow on the update paths. The `validateMaxLen` checks for Host, Maintenance Database, and Username are unchanged.
- Names are validated trimmed but stored verbatim, matching prior handler behaviour.

## Test plan

- [x] Server: table-driven validator tests (valid names, each rejected char, empty, whitespace-only, 255/256 boundary, whitespace-padding edge case) plus handler tests asserting HTTP 400 for invalid names and success for valid names across all create/update flows. `go test ./internal/api/...` green; `ValidateDisplayName` at 100% coverage.
- [x] Client: unit tests for `validateName` and dialog tests asserting `<>!@#$%` shows the inline error and blocks save, and a valid name saves. `npm run lint` clean; touched files at 100% line coverage.
- [x] `gofmt`, `go vet`, ESLint all clean.

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented consistent name validation across servers, clusters, and groups. Names now accept only letters, numbers, spaces, and the characters `. _ - ( )`, must be non-empty, and cannot exceed 255 characters after trimming. Invalid entries display inline error messages and prevent saving. The server returns HTTP 400 for rejected names across create and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->