### PR TITLE
Update fallback paths for secret files in the example.yaml files

### DIFF
--- a/examples/ai-dba-alerter.yaml
+++ b/examples/ai-dba-alerter.yaml
@@ -502,9 +502,9 @@ notifications:
 #   chmod 600 /etc/pgedge/ai-dba-alerter.secret
 #
 # Default search paths (if not specified):
-#   1. /etc/pgedge/ai-dba-alerter.secret
-#   2. <binary-directory>/ai-dba-alerter.secret
-#   3. ./ai-dba-alerter.secret
+#   1. <user-config-dir>/pgedge/ai-dba-alerter.secret
+#      (e.g. ~/.config/pgedge/ai-dba-alerter.secret)
+#   2. /etc/pgedge/ai-dba-alerter.secret
 #
 # secret_file: /etc/pgedge/ai-dba-alerter.secret
 

--- a/examples/ai-dba-collector.yaml
+++ b/examples/ai-dba-collector.yaml
@@ -193,9 +193,9 @@ pool:
 #   chmod 600 /etc/pgedge/ai-dba-collector.secret
 #
 # Default search paths (if not specified):
-#   1. /etc/pgedge/ai-dba-collector.secret
-#   2. <binary-directory>/ai-dba-collector.secret
-#   3. ./ai-dba-collector.secret
+#   1. <user-config-dir>/pgedge/ai-dba-collector.secret
+#      (e.g. ~/.config/pgedge/ai-dba-collector.secret)
+#   2. /etc/pgedge/ai-dba-collector.secret
 #
 # secret_file: /etc/pgedge/ai-dba-collector.secret
 

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -470,7 +470,8 @@ builtins:
 #=========================================================================
 
 # Path to server secret file (for encryption)
-# Default: /etc/pgedge/ai-dba-server.secret or ./ai-dba-server.secret
+# Default: <user-config-dir>/pgedge/ai-dba-server.secret,
+#          then /etc/pgedge/ai-dba-server.secret
 # secret_file: "/etc/ai-workbench/server.secret"
 
 # Path to custom definitions file (user-defined prompts and resources)


### PR DESCRIPTION
## Summary

The example YAML configs for the server, alerter, and collector each
described three fallback paths for `secret_file`, but two of them
(`<binary-directory>/ai-dba-*.secret` and `./ai-dba-*.secret`) were
never implemented in the code. This PR removes those phantom entries and
replaces them with the actual two-level search order the binaries use:

1. `<user-config-dir>/pgedge/server.secret` (e.g. `~/.config/pgedge/server.secret`)
2. `/etc/pgedge/server.secret`

## Files changed

- `examples/ai-dba-alerter.yaml`
- `examples/ai-dba-collector.yaml`
- `examples/ai-dba-server.yaml`

## Test plan

- [ ] Comment-only change; no functional code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated example configuration docs: default secret-file lookup now prefers the user's configuration directory first, then the system configuration directory, removing previous binary-directory and local-directory fallbacks across the examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->