### PR TITLE
fix(embedding): make Gemini embedding model configurable and current

### DIFF
--- a/alerter/src/internal/config/config.go
+++ b/alerter/src/internal/config/config.go
@@ -226,6 +226,7 @@ type VoyageConfig struct {
 type GeminiConfig struct {
 	APIKeyFile     string `yaml:"api_key_file"`
 	BaseURL        string `yaml:"base_url"`
+	EmbeddingModel string `yaml:"embedding_model"`
 	ReasoningModel string `yaml:"reasoning_model"`
 	apiKey         string
 }
@@ -315,6 +316,7 @@ func NewConfig() *Config {
 				EmbeddingModel: "voyage-3-lite",
 			},
 			Gemini: GeminiConfig{
+				EmbeddingModel: "gemini-embedding-001",
 				ReasoningModel: "gemini-2.5-flash",
 			},
 		},

--- a/alerter/src/internal/config/config_test.go
+++ b/alerter/src/internal/config/config_test.go
@@ -51,6 +51,8 @@ func TestNewConfig(t *testing.T) {
 		{"correlation window", cfg.Correlation.WindowSeconds, 120},
 		{"llm embedding provider", cfg.LLM.EmbeddingProvider, "ollama"},
 		{"llm reasoning provider", cfg.LLM.ReasoningProvider, "ollama"},
+		{"gemini embedding model", cfg.LLM.Gemini.EmbeddingModel, "gemini-embedding-001"},
+		{"gemini reasoning model", cfg.LLM.Gemini.ReasoningModel, "gemini-2.5-flash"},
 	}
 
 	for _, tt := range tests {
@@ -586,6 +588,35 @@ threshold:
 		if cfg.Threshold.EvaluationIntervalSeconds != 120 {
 			t.Errorf("evaluation_interval = %d, expected %d",
 				cfg.Threshold.EvaluationIntervalSeconds, 120)
+		}
+	})
+
+	t.Run("gemini embedding model round-trip", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "gemini.yaml")
+		yamlContent := `
+llm:
+  embedding_provider: gemini
+  gemini:
+    embedding_model: gemini-embedding-2
+    reasoning_model: gemini-2.5-pro
+`
+		if err := os.WriteFile(configFile, []byte(yamlContent), 0644); err != nil {
+			t.Fatalf("failed to create config file: %v", err)
+		}
+
+		cfg := NewConfig()
+		if err := cfg.LoadFromFile(configFile); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.LLM.Gemini.EmbeddingModel != "gemini-embedding-2" {
+			t.Errorf("gemini embedding_model = %q, expected %q",
+				cfg.LLM.Gemini.EmbeddingModel, "gemini-embedding-2")
+		}
+		if cfg.LLM.Gemini.ReasoningModel != "gemini-2.5-pro" {
+			t.Errorf("gemini reasoning_model = %q, expected %q",
+				cfg.LLM.Gemini.ReasoningModel, "gemini-2.5-pro")
 		}
 	})
 

--- a/alerter/src/internal/llm/llm.go
+++ b/alerter/src/internal/llm/llm.go
@@ -123,6 +123,17 @@ func NewEmbeddingProvider(cfg *config.Config) (EmbeddingProvider, error) {
 		}
 		return &embeddingAdapter{provider: provider}, nil
 
+	case "gemini":
+		apiKey := cfg.GetGeminiAPIKey()
+		if apiKey == "" {
+			return nil, fmt.Errorf("gemini: %w", ErrAPIKeyMissing)
+		}
+		provider, err := embedding.NewGeminiProvider(apiKey, cfg.LLM.Gemini.EmbeddingModel, cfg.LLM.Gemini.BaseURL)
+		if err != nil {
+			return nil, fmt.Errorf("gemini: %w", err)
+		}
+		return &embeddingAdapter{provider: provider}, nil
+
 	case "ollama":
 		baseURL := cfg.LLM.Ollama.BaseURL
 		if baseURL == "" {

--- a/alerter/src/internal/llm/llm_test.go
+++ b/alerter/src/internal/llm/llm_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"os"
 	"strings"
 	"testing"
 
@@ -246,6 +247,65 @@ func TestNewEmbeddingProvider_VoyageMissingKey(t *testing.T) {
 	_, err := NewEmbeddingProvider(cfg)
 	if !errors.Is(err, ErrAPIKeyMissing) {
 		t.Errorf("err = %v, want ErrAPIKeyMissing", err)
+	}
+}
+
+func TestNewEmbeddingProvider_GeminiMissingKey(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.EmbeddingProvider = "gemini"
+	_, err := NewEmbeddingProvider(cfg)
+	if !errors.Is(err, ErrAPIKeyMissing) {
+		t.Errorf("err = %v, want ErrAPIKeyMissing", err)
+	}
+}
+
+func TestNewEmbeddingProvider_GeminiSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyFile := tmpDir + "/gemini.key"
+	if err := os.WriteFile(keyFile, []byte("AIza-test-key-12345678\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	cfg := config.NewConfig()
+	cfg.LLM.EmbeddingProvider = "gemini"
+	cfg.LLM.Gemini.APIKeyFile = keyFile
+	if err := cfg.LoadAPIKeys(); err != nil {
+		t.Fatalf("LoadAPIKeys: %v", err)
+	}
+
+	p, err := NewEmbeddingProvider(cfg)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if p == nil {
+		t.Fatal("provider nil")
+	}
+	if p.ModelName() != "gemini-embedding-001" {
+		t.Errorf("model = %q, want gemini-embedding-001", p.ModelName())
+	}
+}
+
+func TestNewEmbeddingProvider_GeminiInvalidModel(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyFile := tmpDir + "/gemini.key"
+	if err := os.WriteFile(keyFile, []byte("AIza-test-key-12345678\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	cfg := config.NewConfig()
+	cfg.LLM.EmbeddingProvider = "gemini"
+	cfg.LLM.Gemini.APIKeyFile = keyFile
+	cfg.LLM.Gemini.EmbeddingModel = "text-embedding-004"
+	if err := cfg.LoadAPIKeys(); err != nil {
+		t.Fatalf("LoadAPIKeys: %v", err)
+	}
+
+	_, err := NewEmbeddingProvider(cfg)
+	if err == nil {
+		t.Fatal("expected error for unsupported gemini embedding model")
+	}
+	if !strings.Contains(err.Error(), "gemini:") {
+		t.Errorf("err = %v, want gemini-prefixed error", err)
 	}
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -73,6 +73,22 @@ project adheres to
 
 ### Fixed
 
+- Fix the alerter's Gemini provider lacking a configurable embedding
+  model. The `llm.gemini` section now exposes an `embedding_model`
+  option that defaults to `gemini-embedding-001`; the alerter
+  previously offered no embedding model field for Gemini. When Gemini
+  is the embedding provider, the configured model must match the model
+  that the KB Builder used to produce the knowledgebase. (#284)
+
+- Fix the documented Gemini embedding model list, which referenced the
+  deprecated `text-embedding-004` and `embedding-001` models that
+  Google has retired. The supported models are now
+  `gemini-embedding-001` (the default), `gemini-embedding-2`, and
+  `gemini-embedding-2-preview`, all of which output 3072 dimensions
+  rather than the previously documented 768. The server's
+  knowledgebase status log now reports the Gemini API key as loaded.
+  (#285)
+
 - Fix the Admin Panel's Create Group, Edit Group, and Create
   Token dialogs accepting unsupported special characters and
   over-long Name values. RBAC group and token names now reuse the

--- a/docs/getting-started/configuration/alerter.md
+++ b/docs/getting-started/configuration/alerter.md
@@ -383,6 +383,12 @@ key can access.
 | `api_key_file` | string | None | Path to API key file |
 | `base_url` | string | `https://generativelanguage.googleapis.com` | Gemini base URL |
 | `reasoning_model` | string | `gemini-2.5-flash` | Reasoning model |
+| `embedding_model` | string | `gemini-embedding-001` | Embedding model |
+
+When Gemini is the embedding provider, the
+`embedding_model` must match the model that the KB
+Builder used to produce the knowledgebase; the KB
+Builder uses `gemini-embedding-001`.
 
 #### Voyage Configuration
 

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -370,8 +370,9 @@ protection for user-created database connections.
 ### Embedding (`embedding`)
 
 The `provider` option accepts `voyage`, `openai`, `gemini`, or
-`ollama`. The Gemini provider supports `text-embedding-004` (default,
-768 dimensions) and `embedding-001` (768 dimensions). Model
+`ollama`. The Gemini provider supports `gemini-embedding-001` (the
+default, 3072 dimensions), `gemini-embedding-2`, and
+`gemini-embedding-2-preview` (also 3072 dimensions). Model
 availability varies by Gemini API key tier; run ListModels to verify
 which embedding models a given key can access.
 
@@ -513,10 +514,17 @@ llm:
 ### Knowledgebase (`knowledgebase`)
 
 The `embedding_provider` option accepts `voyage`, `openai`, `gemini`,
-or `ollama`. The Gemini provider supports `text-embedding-004`
-(default, 768 dimensions) and `embedding-001` (768 dimensions). Model
+or `ollama`. The Gemini provider supports `gemini-embedding-001` (the
+default, 3072 dimensions), `gemini-embedding-2`, and
+`gemini-embedding-2-preview` (also 3072 dimensions). Model
 availability varies by Gemini API key tier; run ListModels to verify
 which embedding models a given key can access.
+
+When Gemini provides the knowledgebase embeddings, the configured
+`embedding_model` must match the model that the KB Builder used to
+produce the knowledgebase. The KB Builder uses `gemini-embedding-001`;
+selecting a different model produces incompatible embeddings and breaks
+similarity search.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/examples/ai-dba-alerter.yaml
+++ b/examples/ai-dba-alerter.yaml
@@ -399,6 +399,13 @@ llm:
     # Base URL for the Gemini API
     # base_url: https://generativelanguage.googleapis.com
 
+    # Model to use for embeddings
+    # Default: gemini-embedding-001
+    # This MUST match the embedding model used by the KB Builder
+    # that produced the knowledgebase; otherwise the generated
+    # embeddings are incompatible with the stored vectors.
+    embedding_model: gemini-embedding-001
+
     # Model to use for reasoning/classification
     # Model availability varies by Gemini API key tier; run
     # ListModels to verify which models a given key can access.

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -212,7 +212,7 @@ embedding:
   # Default depends on provider:
   #   - voyage: voyage-3
   #   - openai: text-embedding-3-small
-  #   - gemini: text-embedding-004
+  #   - gemini: gemini-embedding-001
   #   - ollama: nomic-embed-text
   model: "nomic-embed-text"
 
@@ -415,7 +415,10 @@ knowledgebase:
   # embedding_gemini_api_key_file (raw keys cannot be set inline
   # for security). Model availability varies by Gemini API key
   # tier; run ListModels to verify which embedding models a given
-  # key can access.
+  # key can access. The embedding model (set via "model" above;
+  # default gemini-embedding-001) MUST match the model used by the
+  # KB Builder that produced the knowledgebase; otherwise the
+  # generated embeddings are incompatible with the stored vectors.
   # embedding_gemini_api_key_file: "~/.gemini-api-key"
 
   # Base URL for the Gemini API used for knowledgebase embeddings

--- a/pkg/embedding/README.md
+++ b/pkg/embedding/README.md
@@ -56,12 +56,16 @@ The following models are supported:
 
 | Model | Dimensions |
 |-------|------------|
-| `text-embedding-004` | 768 |
-| `embedding-001` | 768 |
+| `gemini-embedding-001` | 3072 |
+| `gemini-embedding-2` | 3072 |
+| `gemini-embedding-2-preview` | 3072 |
 
-The default model is `text-embedding-004`. Model availability varies
-by Gemini API key tier; run ListModels to verify which embedding
-models a given key can access.
+The default model is `gemini-embedding-001`, the model the KB Builder
+uses. When Gemini supplies knowledgebase embeddings, the configured
+model must match the model that produced the knowledgebase; otherwise
+the embeddings are incompatible. Model availability varies by Gemini
+API key tier; run ListModels to verify which embedding models a given
+key can access.
 
 In the following example, the server configuration selects the
 Gemini provider and reads the API key from a file on disk:
@@ -69,7 +73,7 @@ Gemini provider and reads the API key from a file on disk:
 ```yaml
 embedding:
   provider: "gemini"
-  model: "text-embedding-004"
+  model: "gemini-embedding-001"
   gemini_api_key_file: "~/.gemini-api-key"
   # gemini_base_url: "https://generativelanguage.googleapis.com"
 ```

--- a/pkg/embedding/gemini.go
+++ b/pkg/embedding/gemini.go
@@ -56,10 +56,14 @@ type geminiEmbeddingResponse struct {
 	} `json:"embedding"`
 }
 
-// Model dimensions for Gemini embedding models
+// Model dimensions for Gemini embedding models. The current
+// gemini-embedding-* family produces 3072-dimensional vectors;
+// the deprecated text-embedding-004 and embedding-001 models are
+// no longer supported.
 var geminiModelDimensions = map[string]int{
-	"text-embedding-004": 768,
-	"embedding-001":      768,
+	"gemini-embedding-001":       3072,
+	"gemini-embedding-2":         3072,
+	"gemini-embedding-2-preview": 3072,
 }
 
 // NewGeminiProvider creates a new Gemini embedding provider.
@@ -69,14 +73,16 @@ func NewGeminiProvider(apiKey, model, baseURL string) (*GeminiProvider, error) {
 		return nil, fmt.Errorf("Gemini API key cannot be empty")
 	}
 
-	// Default to text-embedding-004 if no model specified
+	// Default to gemini-embedding-001 if no model specified. This is
+	// the model the KB Builder uses, so the server and alerter must
+	// match it for embedding compatibility.
 	if model == "" {
-		model = "text-embedding-004"
+		model = "gemini-embedding-001"
 	}
 
 	// Validate model is supported
 	if _, ok := geminiModelDimensions[model]; !ok {
-		return nil, fmt.Errorf("unsupported Gemini model: %s (supported: text-embedding-004, embedding-001)", model)
+		return nil, fmt.Errorf("unsupported Gemini model: %s (supported: gemini-embedding-001, gemini-embedding-2, gemini-embedding-2-preview)", model)
 	}
 
 	// Default base URL if not provided

--- a/pkg/embedding/gemini_test.go
+++ b/pkg/embedding/gemini_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestNewGeminiProvider(t *testing.T) {
 	t.Run("valid config", func(t *testing.T) {
-		provider, err := NewGeminiProvider("AIza-test-key-12345678", "text-embedding-004", "")
+		provider, err := NewGeminiProvider("AIza-test-key-12345678", "gemini-embedding-001", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -30,7 +30,7 @@ func TestNewGeminiProvider(t *testing.T) {
 	})
 
 	t.Run("empty API key", func(t *testing.T) {
-		_, err := NewGeminiProvider("", "text-embedding-004", "")
+		_, err := NewGeminiProvider("", "gemini-embedding-001", "")
 		if err == nil {
 			t.Fatal("expected error for empty API key")
 		}
@@ -44,18 +44,36 @@ func TestNewGeminiProvider(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if provider.ModelName() != "text-embedding-004" {
-			t.Errorf("expected default model 'text-embedding-004', got %q", provider.ModelName())
+		if provider.ModelName() != "gemini-embedding-001" {
+			t.Errorf("expected default model 'gemini-embedding-001', got %q", provider.ModelName())
 		}
 	})
 
 	t.Run("custom model", func(t *testing.T) {
-		provider, err := NewGeminiProvider("AIza-test-key-12345678", "embedding-001", "")
+		provider, err := NewGeminiProvider("AIza-test-key-12345678", "gemini-embedding-2", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if provider.ModelName() != "embedding-001" {
-			t.Errorf("expected model 'embedding-001', got %q", provider.ModelName())
+		if provider.ModelName() != "gemini-embedding-2" {
+			t.Errorf("expected model 'gemini-embedding-2', got %q", provider.ModelName())
+		}
+	})
+
+	t.Run("preview model", func(t *testing.T) {
+		provider, err := NewGeminiProvider("AIza-test-key-12345678", "gemini-embedding-2-preview", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if provider.ModelName() != "gemini-embedding-2-preview" {
+			t.Errorf("expected model 'gemini-embedding-2-preview', got %q", provider.ModelName())
+		}
+	})
+
+	t.Run("deprecated models rejected", func(t *testing.T) {
+		for _, m := range []string{"text-embedding-004", "embedding-001"} {
+			if _, err := NewGeminiProvider("AIza-test-key-12345678", m, ""); err == nil {
+				t.Errorf("expected error for deprecated model %q", m)
+			}
 		}
 	})
 
@@ -64,10 +82,14 @@ func TestNewGeminiProvider(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for unsupported model")
 		}
+		want := "unsupported Gemini model: unsupported-model (supported: gemini-embedding-001, gemini-embedding-2, gemini-embedding-2-preview)"
+		if err.Error() != want {
+			t.Errorf("unexpected error message:\n got: %q\nwant: %q", err.Error(), want)
+		}
 	})
 
 	t.Run("custom base URL", func(t *testing.T) {
-		provider, err := NewGeminiProvider("AIza-test-key-12345678", "text-embedding-004", "https://custom.example.com")
+		provider, err := NewGeminiProvider("AIza-test-key-12345678", "gemini-embedding-001", "https://custom.example.com")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -82,8 +104,9 @@ func TestGeminiProvider_Dimensions(t *testing.T) {
 		model      string
 		dimensions int
 	}{
-		{"text-embedding-004", 768},
-		{"embedding-001", 768},
+		{"gemini-embedding-001", 3072},
+		{"gemini-embedding-2", 3072},
+		{"gemini-embedding-2-preview", 3072},
 	}
 
 	for _, tt := range tests {
@@ -100,17 +123,17 @@ func TestGeminiProvider_Dimensions(t *testing.T) {
 }
 
 func TestGeminiProvider_ModelName(t *testing.T) {
-	provider, err := NewGeminiProvider("AIza-test-key-12345678", "text-embedding-004", "")
+	provider, err := NewGeminiProvider("AIza-test-key-12345678", "gemini-embedding-001", "")
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}
-	if provider.ModelName() != "text-embedding-004" {
-		t.Errorf("expected model 'text-embedding-004', got %q", provider.ModelName())
+	if provider.ModelName() != "gemini-embedding-001" {
+		t.Errorf("expected model 'gemini-embedding-001', got %q", provider.ModelName())
 	}
 }
 
 func TestGeminiProvider_ProviderName(t *testing.T) {
-	provider, err := NewGeminiProvider("AIza-test-key-12345678", "text-embedding-004", "")
+	provider, err := NewGeminiProvider("AIza-test-key-12345678", "gemini-embedding-001", "")
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}
@@ -137,13 +160,13 @@ func TestGeminiProvider_Embed_Success(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 			t.Errorf("failed to decode request body: %v", err)
 		}
-		if reqBody.Model != "models/text-embedding-004" {
-			t.Errorf("expected model 'models/text-embedding-004', got %q", reqBody.Model)
+		if reqBody.Model != "models/gemini-embedding-001" {
+			t.Errorf("expected model 'models/gemini-embedding-001', got %q", reqBody.Model)
 		}
 
 		// Return mock embedding response
 		response := geminiEmbeddingResponse{}
-		response.Embedding.Values = make([]float64, 768)
+		response.Embedding.Values = make([]float64, 3072)
 		for i := range response.Embedding.Values {
 			response.Embedding.Values[i] = 0.01 * float64(i)
 		}
@@ -158,7 +181,7 @@ func TestGeminiProvider_Embed_Success(t *testing.T) {
 
 	provider := &GeminiProvider{
 		apiKey:  "AIza-test-key-12345678",
-		model:   "text-embedding-004",
+		model:   "gemini-embedding-001",
 		baseURL: server.URL,
 		client:  server.Client(),
 	}
@@ -167,13 +190,13 @@ func TestGeminiProvider_Embed_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(embedding) != 768 {
-		t.Errorf("expected 768 dimensions, got %d", len(embedding))
+	if len(embedding) != 3072 {
+		t.Errorf("expected 3072 dimensions, got %d", len(embedding))
 	}
 }
 
 func TestGeminiProvider_Embed_EmptyText(t *testing.T) {
-	provider, err := NewGeminiProvider("AIza-test-key-12345678", "text-embedding-004", "")
+	provider, err := NewGeminiProvider("AIza-test-key-12345678", "gemini-embedding-001", "")
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}
@@ -200,7 +223,7 @@ func TestGeminiProvider_Embed_APIError(t *testing.T) {
 
 	provider := &GeminiProvider{
 		apiKey:  "invalid-key",
-		model:   "text-embedding-004",
+		model:   "gemini-embedding-001",
 		baseURL: server.URL,
 		client:  server.Client(),
 	}
@@ -224,7 +247,7 @@ func TestGeminiProvider_Embed_RateLimit(t *testing.T) {
 
 	provider := &GeminiProvider{
 		apiKey:  "AIza-test-key-12345678",
-		model:   "text-embedding-004",
+		model:   "gemini-embedding-001",
 		baseURL: server.URL,
 		client:  server.Client(),
 	}
@@ -251,7 +274,7 @@ func TestGeminiProvider_Embed_EmptyResponse(t *testing.T) {
 
 	provider := &GeminiProvider{
 		apiKey:  "AIza-test-key-12345678",
-		model:   "text-embedding-004",
+		model:   "gemini-embedding-001",
 		baseURL: server.URL,
 		client:  server.Client(),
 	}
@@ -278,7 +301,7 @@ func TestGeminiProvider_Embed_MalformedJSON(t *testing.T) {
 
 	provider := &GeminiProvider{
 		apiKey:  "AIza-test-key-12345678",
-		model:   "text-embedding-004",
+		model:   "gemini-embedding-001",
 		baseURL: server.URL,
 		client:  server.Client(),
 	}
@@ -291,7 +314,7 @@ func TestGeminiProvider_Embed_MalformedJSON(t *testing.T) {
 
 func TestGeminiProvider_APIKeyMasking(t *testing.T) {
 	// Test with short API key (less than 8 chars)
-	provider, err := NewGeminiProvider("short", "text-embedding-004", "")
+	provider, err := NewGeminiProvider("short", "gemini-embedding-001", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -317,7 +340,7 @@ func TestGeminiProvider_Embed_EmptyEmbeddingValues(t *testing.T) {
 
 	provider := &GeminiProvider{
 		apiKey:  "AIza-test-key-12345678",
-		model:   "text-embedding-004",
+		model:   "gemini-embedding-001",
 		baseURL: server.URL,
 		client:  server.Client(),
 	}

--- a/pkg/embedding/logger_test.go
+++ b/pkg/embedding/logger_test.go
@@ -353,7 +353,7 @@ func TestLogResponseTrace(t *testing.T) {
 		logger: log.New(&buf, "[LLM] ", 0),
 	}
 
-	LogResponseTrace("gemini", "text-embedding-004", 200, 768)
+	LogResponseTrace("gemini", "gemini-embedding-001", 200, 768)
 	output := buf.String()
 
 	if !strings.Contains(output, "Response details") {

--- a/pkg/embedding/provider_test.go
+++ b/pkg/embedding/provider_test.go
@@ -179,7 +179,7 @@ func TestNewProvider_Gemini(t *testing.T) {
     t.Run("valid config", func(t *testing.T) {
         cfg := Config{
             Provider:     "gemini",
-            Model:        "text-embedding-004",
+            Model:        "gemini-embedding-001",
             GeminiAPIKey: "AIza-test-key-12345678",
         }
 
@@ -198,7 +198,7 @@ func TestNewProvider_Gemini(t *testing.T) {
     t.Run("missing API key", func(t *testing.T) {
         cfg := Config{
             Provider: "gemini",
-            Model:    "text-embedding-004",
+            Model:    "gemini-embedding-001",
         }
 
         _, err := NewProvider(cfg)
@@ -210,7 +210,7 @@ func TestNewProvider_Gemini(t *testing.T) {
     t.Run("with custom base URL", func(t *testing.T) {
         cfg := Config{
             Provider:      "gemini",
-            Model:         "text-embedding-004",
+            Model:         "gemini-embedding-001",
             GeminiAPIKey:  "AIza-test-key-12345678",
             GeminiBaseURL: "https://custom.example.com",
         }

--- a/server/src/cmd/mcp-server/server.go
+++ b/server/src/cmd/mcp-server/server.go
@@ -514,6 +514,8 @@ func (s *Server) logStartupInfo() {
 			apiKeyStatus = "loaded"
 		} else if s.cfg.Knowledgebase.EmbeddingOpenAIAPIKey != "" {
 			apiKeyStatus = "loaded"
+		} else if s.cfg.Knowledgebase.EmbeddingGeminiAPIKey != "" {
+			apiKeyStatus = "loaded"
 		}
 		fmt.Fprintf(os.Stderr, "Knowledgebase: ENABLED (provider: %s, model: %s, API key: %s)\n",
 			s.cfg.Knowledgebase.EmbeddingProvider, s.cfg.Knowledgebase.EmbeddingModel, apiKeyStatus)

--- a/server/src/cmd/mcp-server/server_test.go
+++ b/server/src/cmd/mcp-server/server_test.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -208,5 +209,103 @@ func TestLoadServerSecret_ExplicitMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to read secret file") {
 		t.Errorf("err = %v, want it to mention 'failed to read secret file'", err)
+	}
+}
+
+// captureStderr runs fn with os.Stderr redirected to a pipe and
+// returns everything fn writes to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+// TestLogStartupInfo_KnowledgebaseAPIKeyStatus exercises the
+// knowledgebase API-key status branch in logStartupInfo, including
+// the Gemini branch that previously never set "loaded".
+func TestLogStartupInfo_KnowledgebaseAPIKeyStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		kb   config.KnowledgebaseConfig
+		want string
+	}{
+		{
+			name: "voyage key loaded",
+			kb: config.KnowledgebaseConfig{
+				Enabled:               true,
+				EmbeddingProvider:     "voyage",
+				EmbeddingVoyageAPIKey: "voyage-key",
+			},
+			want: "API key: loaded",
+		},
+		{
+			name: "openai key loaded",
+			kb: config.KnowledgebaseConfig{
+				Enabled:               true,
+				EmbeddingProvider:     "openai",
+				EmbeddingOpenAIAPIKey: "openai-key",
+			},
+			want: "API key: loaded",
+		},
+		{
+			name: "gemini key loaded",
+			kb: config.KnowledgebaseConfig{
+				Enabled:               true,
+				EmbeddingProvider:     "gemini",
+				EmbeddingModel:        "gemini-embedding-001",
+				EmbeddingGeminiAPIKey: "gemini-key",
+			},
+			want: "API key: loaded",
+		},
+		{
+			name: "no key set",
+			kb: config.KnowledgebaseConfig{
+				Enabled:           true,
+				EmbeddingProvider: "gemini",
+			},
+			want: "API key: not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{cfg: &config.Config{Knowledgebase: tt.kb}}
+			out := captureStderr(t, s.logStartupInfo)
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("logStartupInfo output = %q, want it to contain %q", out, tt.want)
+			}
+			if !strings.Contains(out, "Knowledgebase: ENABLED") {
+				t.Errorf("expected knowledgebase enabled line, got %q", out)
+			}
+		})
+	}
+}
+
+// TestLogStartupInfo_KnowledgebaseDisabled covers the disabled
+// knowledgebase branch of logStartupInfo.
+func TestLogStartupInfo_KnowledgebaseDisabled(t *testing.T) {
+	s := &Server{cfg: &config.Config{}, debug: true}
+	out := captureStderr(t, s.logStartupInfo)
+	if !strings.Contains(out, "Knowledgebase: DISABLED") {
+		t.Errorf("expected disabled knowledgebase line, got %q", out)
+	}
+	if !strings.Contains(out, "Debug logging: ENABLED") {
+		t.Errorf("expected debug line, got %q", out)
 	}
 }

--- a/server/src/cmd/mcp-server/server_test.go
+++ b/server/src/cmd/mcp-server/server_test.go
@@ -221,6 +221,7 @@ func captureStderr(t *testing.T, fn func()) string {
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
+	defer func() { _ = r.Close() }()
 	os.Stderr = w
 	defer func() { os.Stderr = orig }()
 

--- a/server/src/internal/config/config_test.go
+++ b/server/src/internal/config/config_test.go
@@ -929,7 +929,7 @@ func TestMergeConfigGeminiEmbedding(t *testing.T) {
 		Embedding: EmbeddingConfig{
 			Enabled:          true,
 			Provider:         "gemini",
-			Model:            "text-embedding-004",
+			Model:            "gemini-embedding-001",
 			GeminiAPIKey:     "test-gemini-key",
 			GeminiAPIKeyFile: "/path/to/gemini-key",
 			GeminiBaseURL:    "https://gemini.example.com",
@@ -941,8 +941,8 @@ func TestMergeConfigGeminiEmbedding(t *testing.T) {
 	if dest.Embedding.Provider != "gemini" {
 		t.Errorf("expected provider 'gemini', got %q", dest.Embedding.Provider)
 	}
-	if dest.Embedding.Model != "text-embedding-004" {
-		t.Errorf("expected model 'text-embedding-004', got %q", dest.Embedding.Model)
+	if dest.Embedding.Model != "gemini-embedding-001" {
+		t.Errorf("expected model 'gemini-embedding-001', got %q", dest.Embedding.Model)
 	}
 	if dest.Embedding.GeminiAPIKey != "test-gemini-key" {
 		t.Errorf("expected GeminiAPIKey 'test-gemini-key', got %q",
@@ -968,7 +968,7 @@ func TestMergeConfigGeminiKnowledgebase(t *testing.T) {
 			Enabled:                   true,
 			DatabasePath:              "/tmp/kb.db",
 			EmbeddingProvider:         "gemini",
-			EmbeddingModel:            "text-embedding-004",
+			EmbeddingModel:            "gemini-embedding-001",
 			EmbeddingGeminiAPIKey:     "kb-gemini-key",
 			EmbeddingGeminiAPIKeyFile: "/path/to/kb-gemini-key",
 			EmbeddingGeminiBaseURL:    "https://gemini.example.com",
@@ -1099,14 +1099,14 @@ func TestLoadConfigGeminiFromYAML(t *testing.T) {
 embedding:
     enabled: true
     provider: gemini
-    model: text-embedding-004
+    model: gemini-embedding-001
     gemini_api_key_file: ` + keyPath + `
     gemini_base_url: https://gemini.example.com
 knowledgebase:
     enabled: true
     database_path: /tmp/kb.db
     embedding_provider: gemini
-    embedding_model: text-embedding-004
+    embedding_model: gemini-embedding-001
     embedding_gemini_api_key_file: ` + kbKeyPath + `
     embedding_gemini_base_url: https://gemini.example.com
 `

--- a/server/src/internal/tools/generate_embedding_test.go
+++ b/server/src/internal/tools/generate_embedding_test.go
@@ -212,7 +212,7 @@ func TestGenerateEmbeddingTool_GeminiMissingAPIKey(t *testing.T) {
 		Embedding: config.EmbeddingConfig{
 			Enabled:  true,
 			Provider: "gemini",
-			Model:    "text-embedding-004",
+			Model:    "gemini-embedding-001",
 		},
 	}
 	tool := GenerateEmbeddingTool(cfg)
@@ -240,7 +240,7 @@ func TestGenerateEmbeddingTool_GeminiMissingAPIKey(t *testing.T) {
 // echo back in its success response.
 func TestGenerateEmbeddingTool_GeminiSuccess(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.Contains(r.URL.Path, "/v1beta/models/text-embedding-004:embedContent") {
+		if !strings.Contains(r.URL.Path, "/v1beta/models/gemini-embedding-001:embedContent") {
 			t.Errorf("unexpected request path %q", r.URL.Path)
 		}
 		if r.URL.Query().Get("key") != "test-gemini-key" {
@@ -258,7 +258,7 @@ func TestGenerateEmbeddingTool_GeminiSuccess(t *testing.T) {
 		Embedding: config.EmbeddingConfig{
 			Enabled:       true,
 			Provider:      "gemini",
-			Model:         "text-embedding-004",
+			Model:         "gemini-embedding-001",
 			GeminiAPIKey:  "test-gemini-key",
 			GeminiBaseURL: srv.URL,
 		},
@@ -280,8 +280,8 @@ func TestGenerateEmbeddingTool_GeminiSuccess(t *testing.T) {
 	if !strings.Contains(body, "Provider: gemini") {
 		t.Errorf("expected 'Provider: gemini' in response, got: %s", body)
 	}
-	if !strings.Contains(body, "Model: text-embedding-004") {
-		t.Errorf("expected 'Model: text-embedding-004' in response, got: %s", body)
+	if !strings.Contains(body, "Model: gemini-embedding-001") {
+		t.Errorf("expected 'Model: gemini-embedding-001' in response, got: %s", body)
 	}
 	if !strings.Contains(body, "0.1") || !strings.Contains(body, "0.3") {
 		t.Errorf("expected embedding vector in response, got: %s", body)

--- a/server/src/internal/tools/search_knowledgebase_test.go
+++ b/server/src/internal/tools/search_knowledgebase_test.go
@@ -582,7 +582,7 @@ func TestGenerateKBQueryEmbedding_Gemini(t *testing.T) {
 	cfg := &config.Config{
 		Knowledgebase: config.KnowledgebaseConfig{
 			EmbeddingProvider:      "gemini",
-			EmbeddingModel:         "text-embedding-004",
+			EmbeddingModel:         "gemini-embedding-001",
 			EmbeddingGeminiAPIKey:  "kb-test-key",
 			EmbeddingGeminiBaseURL: srv.URL,
 		},

--- a/server/src/internal/tools/similarity_search_test.go
+++ b/server/src/internal/tools/similarity_search_test.go
@@ -632,7 +632,7 @@ func TestGenerateQueryEmbeddingWithConfig_Gemini(t *testing.T) {
 		Embedding: config.EmbeddingConfig{
 			Enabled:       true,
 			Provider:      "gemini",
-			Model:         "text-embedding-004",
+			Model:         "gemini-embedding-001",
 			GeminiAPIKey:  "test-key",
 			GeminiBaseURL: srv.URL,
 		},


### PR DESCRIPTION
## Summary
- Add a configurable `embedding_model` to the alerter's `llm.gemini`
  config (default `gemini-embedding-001`) and wire it through the
  alerter's embedding provider factory, which was previously missing a
  `gemini` case entirely — so `embedding_provider: gemini` could never
  build a provider. (#284)
- Replace the deprecated Gemini embedding models (`text-embedding-004`,
  `embedding-001`, 768 dims) — which Google has retired — with the
  current `gemini-embedding-001` (default), `gemini-embedding-2`, and
  `gemini-embedding-2-preview` models (3072 dims). Default to
  `gemini-embedding-001` to match the KB Builder. (#285)
- Add the missing `EmbeddingGeminiAPIKey` check to the server's
  knowledgebase startup status log. (#285)
- Update configuration docs, example YAML, the `pkg/embedding` README,
  and the changelog, documenting that the embedding model must match
  the model the KB Builder used to produce the knowledgebase.

## Test plan
- [x] `pkg`, `alerter/src`, and `server/src` modules build.
- [x] Unit tests pass for the touched packages, including new coverage
      for the alerter Gemini embedding case, the updated model map and
      default, and the server status-log branch.
- [x] `gofmt -l` clean on `server/src` and `alerter/src`; `make lint`
      reports 0 issues for both modules.
- [x] No new lint findings introduced in `pkg/embedding`.

Closes #284
Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gemini embedding model is now configurable, defaulting to gemini-embedding-001.
  * Gemini embedding provider is supported and reports missing API key appropriately.
  * Knowledgebase startup now shows Gemini API key status ("loaded" vs "not set").

* **Documentation**
  * Updated supported Gemini embedding models and vector dimensions.
  * Added requirement: embedding models must match between runtime and KB Builder.

* **Tests**
  * Added/updated tests covering Gemini embedding provider and startup logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->