### PR TITLE
fix(alerter): resolve default server secret like collector and server

### DIFF
--- a/alerter/src/internal/config/config.go
+++ b/alerter/src/internal/config/config.go
@@ -190,6 +190,46 @@ type NotificationsConfig struct {
 	HTTPMaxIdleConns int `yaml:"http_max_idle_conns"`
 }
 
+// ResolveServerSecret loads the server secret used to decrypt
+// notification channel credentials.
+//
+// Search order (highest priority first):
+//
+//  1. The explicit SecretFile path from the YAML config (if set).
+//  2. The per-user config directory reported by os.UserConfigDir(),
+//     under pgedge/ai-dba-alerter.secret.
+//  3. The system-wide path /etc/pgedge/ai-dba-alerter.secret.
+//
+// This mirrors the precedence the collector and server apply via
+// fileutil.GetDefaultConfigPath, so all three services resolve their
+// default secret paths identically. The existing ReadSecretFile
+// semantics (empty-file rejection, permissive-mode warning) are
+// preserved for every candidate.
+func (n *NotificationsConfig) ResolveServerSecret() (string, error) {
+	// If a secret file is explicitly specified, use it directly.
+	if n.SecretFile != "" {
+		secret, err := fileutil.ReadSecretFile(n.SecretFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read secret file: %w", err)
+		}
+		return secret, nil
+	}
+
+	// Resolve via the shared helper so all three services apply
+	// identical precedence to default paths.
+	if path := fileutil.GetDefaultConfigPath("", "ai-dba-alerter.secret"); path != "" {
+		secret, err := fileutil.ReadSecretFile(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to read secret file %s: %w", path, err)
+		}
+		return secret, nil
+	}
+
+	return "", fmt.Errorf("server secret file not found. Searched: " +
+		"per-user config dir (~/.config/pgedge or platform " +
+		"equivalent) and /etc/pgedge/ai-dba-alerter.secret")
+}
+
 // OllamaConfig holds Ollama provider settings
 type OllamaConfig struct {
 	BaseURL        string `yaml:"base_url"`

--- a/alerter/src/internal/config/config_test.go
+++ b/alerter/src/internal/config/config_test.go
@@ -844,3 +844,125 @@ func TestAPIKeyGetters(t *testing.T) {
 		t.Errorf("GetVoyageAPIKey = %q, expected empty string", cfg.GetVoyageAPIKey())
 	}
 }
+
+// isolateSecretDirs redirects both default secret-search locations to
+// fresh temporary directories so ResolveServerSecret never touches the
+// host's real per-user config dir or /etc/pgedge. It returns the
+// resolved per-user pgedge directory and the system-wide directory so
+// callers can place candidate secret files.
+func isolateSecretDirs(t *testing.T) (userPgedgeDir, systemDir string) {
+	t.Helper()
+
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("HOME", base)
+	t.Setenv("AppData", base)
+
+	systemDir = filepath.Join(base, "absent-etc-pgedge")
+	fileutil.SetSystemConfigDirForTest(t, systemDir)
+
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir: %v", err)
+	}
+	userPgedgeDir = filepath.Join(userDir, "pgedge")
+
+	return userPgedgeDir, systemDir
+}
+
+// TestResolveServerSecret covers the alerter's server-secret search
+// order: an explicit SecretFile, fallback to the per-user config dir,
+// fallback to /etc/pgedge, and the not-found error path.
+func TestResolveServerSecret(t *testing.T) {
+	t.Run("explicit secret file honored", func(t *testing.T) {
+		// Isolate defaults so a stray host file cannot satisfy the
+		// lookup; the explicit path must take precedence regardless.
+		isolateSecretDirs(t)
+
+		secretPath := filepath.Join(t.TempDir(), "explicit.secret")
+		if err := os.WriteFile(secretPath, []byte("explicit-secret\n"), 0600); err != nil {
+			t.Fatalf("failed to write secret file: %v", err)
+		}
+
+		cfg := &NotificationsConfig{SecretFile: secretPath}
+		secret, err := cfg.ResolveServerSecret()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret != "explicit-secret" {
+			t.Errorf("secret = %q, expected %q", secret, "explicit-secret")
+		}
+	})
+
+	t.Run("explicit secret file read error", func(t *testing.T) {
+		isolateSecretDirs(t)
+
+		cfg := &NotificationsConfig{SecretFile: "/nonexistent/path/alerter.secret"}
+		_, err := cfg.ResolveServerSecret()
+		if err == nil {
+			t.Fatal("expected error for nonexistent explicit secret file")
+		}
+		if !strings.Contains(err.Error(), "failed to read secret file") {
+			t.Errorf("error = %q, expected it to mention reading the secret file", err)
+		}
+	})
+
+	t.Run("fallback to per-user config dir", func(t *testing.T) {
+		userPgedgeDir, _ := isolateSecretDirs(t)
+
+		if err := os.MkdirAll(userPgedgeDir, 0700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		candidate := filepath.Join(userPgedgeDir, "ai-dba-alerter.secret")
+		if err := os.WriteFile(candidate, []byte("user-dir-secret\n"), 0600); err != nil {
+			t.Fatalf("failed to write secret file: %v", err)
+		}
+
+		cfg := &NotificationsConfig{}
+		secret, err := cfg.ResolveServerSecret()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret != "user-dir-secret" {
+			t.Errorf("secret = %q, expected %q", secret, "user-dir-secret")
+		}
+	})
+
+	t.Run("fallback to /etc/pgedge", func(t *testing.T) {
+		_, systemDir := isolateSecretDirs(t)
+
+		if err := os.MkdirAll(systemDir, 0700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		candidate := filepath.Join(systemDir, "ai-dba-alerter.secret")
+		if err := os.WriteFile(candidate, []byte("system-dir-secret\n"), 0600); err != nil {
+			t.Fatalf("failed to write secret file: %v", err)
+		}
+
+		cfg := &NotificationsConfig{}
+		secret, err := cfg.ResolveServerSecret()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret != "system-dir-secret" {
+			t.Errorf("secret = %q, expected %q", secret, "system-dir-secret")
+		}
+	})
+
+	t.Run("error names both locations when none found", func(t *testing.T) {
+		isolateSecretDirs(t)
+
+		cfg := &NotificationsConfig{}
+		_, err := cfg.ResolveServerSecret()
+		if err == nil {
+			t.Fatal("expected error when no secret file exists on default paths")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "per-user config dir") {
+			t.Errorf("error = %q, expected it to mention the per-user config dir", msg)
+		}
+		if !strings.Contains(msg, "/etc/pgedge/ai-dba-alerter.secret") {
+			t.Errorf("error = %q, expected it to mention /etc/pgedge/ai-dba-alerter.secret", msg)
+		}
+	})
+}

--- a/alerter/src/internal/notifications/manager.go
+++ b/alerter/src/internal/notifications/manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pgedge/ai-workbench/alerter/internal/config"
 	"github.com/pgedge/ai-workbench/alerter/internal/database"
 	"github.com/pgedge/ai-workbench/pkg/crypto"
-	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
 // Manager implements NotificationManager
@@ -42,10 +41,14 @@ func NewManager(ds *database.Datastore, cfg *config.NotificationsConfig, debug b
 		return nil, nil
 	}
 
-	// Load server secret from file (plain text, same format as server secret)
-	serverSecret, err := fileutil.ReadSecretFile(cfg.SecretFile)
+	// Load server secret from file (plain text, same format as server
+	// secret). When SecretFile is empty, ResolveServerSecret falls back
+	// to the shared default locations (per-user config dir, then
+	// /etc/pgedge/ai-dba-alerter.secret), matching the collector and
+	// server precedence.
+	serverSecret, err := cfg.ResolveServerSecret()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read secret file: %w", err)
+		return nil, err
 	}
 
 	renderer := NewTemplateRenderer()

--- a/alerter/src/internal/notifications/manager_test.go
+++ b/alerter/src/internal/notifications/manager_test.go
@@ -19,10 +19,13 @@ import (
 	"github.com/pgedge/ai-workbench/alerter/internal/config"
 	"github.com/pgedge/ai-workbench/alerter/internal/database"
 	"github.com/pgedge/ai-workbench/pkg/crypto"
+	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
 // TestNewManager exercises the construction paths that depend on the
-// secret-file read, which now flows through fileutil.ReadSecretFile.
+// secret-file read, which now flows through
+// config.NotificationsConfig.ResolveServerSecret (and in turn
+// fileutil.ReadSecretFile / fileutil.GetDefaultConfigPath).
 func TestNewManager(t *testing.T) {
 	t.Run("nil config returns nil manager", func(t *testing.T) {
 		m, err := NewManager(nil, nil, false, nil)
@@ -85,6 +88,52 @@ func TestNewManager(t *testing.T) {
 			if _, err := NewManager(nil, cfg, false, nil); err == nil {
 				t.Errorf("expected error for whitespace-only secret file %q, got nil", content)
 			}
+		}
+	})
+
+	t.Run("empty SecretFile falls back to default location", func(t *testing.T) {
+		// With no explicit SecretFile, NewManager must resolve the
+		// secret from the shared /etc/pgedge fallback. Both default
+		// locations are redirected so the test cannot read or depend
+		// on the host's real per-user config dir or /etc/pgedge.
+		base := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "xdg"))
+		t.Setenv("HOME", filepath.Join(base, "home"))
+		t.Setenv("AppData", filepath.Join(base, "appdata"))
+
+		systemDir := filepath.Join(base, "etc-pgedge")
+		fileutil.SetSystemConfigDirForTest(t, systemDir)
+		if err := os.MkdirAll(systemDir, 0700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		candidate := filepath.Join(systemDir, "ai-dba-alerter.secret")
+		if err := os.WriteFile(candidate, []byte("fallback-secret\n"), 0600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		cfg := &config.NotificationsConfig{Enabled: true}
+		m, err := NewManager(nil, cfg, false, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m == nil {
+			t.Fatal("expected a manager instance")
+		}
+		if m.serverSecret != "fallback-secret" {
+			t.Errorf("serverSecret = %q, want %q", m.serverSecret, "fallback-secret")
+		}
+	})
+
+	t.Run("empty SecretFile with no default is an error", func(t *testing.T) {
+		base := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "xdg"))
+		t.Setenv("HOME", filepath.Join(base, "home"))
+		t.Setenv("AppData", filepath.Join(base, "appdata"))
+		fileutil.SetSystemConfigDirForTest(t, filepath.Join(base, "absent-etc-pgedge"))
+
+		cfg := &config.NotificationsConfig{Enabled: true}
+		if _, err := NewManager(nil, cfg, false, nil); err == nil {
+			t.Error("expected error when no secret file exists on default paths")
 		}
 	})
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,6 +83,14 @@ project adheres to
   `pg_stat_bgwriter` view on PostgreSQL 16 and earlier, choosing the
   view based on the target server's version. (#286)
 
+- Fix the alerter failing to load its server secret when
+  `secret_file` was unset, with no fallback search. The alerter now
+  resolves a default secret file the way the collector and server
+  already do; when `secret_file` is not set, it searches the
+  per-user config directory first and then `/etc/pgedge`. This
+  brings the three services to parity and makes the search order
+  documented in `examples/ai-dba-alerter.yaml` accurate. (#291)
+
 - Fix the alerter's Gemini provider lacking a configurable embedding
   model. The `llm.gemini` section now exposes an `embedding_model`
   option that defaults to `gemini-embedding-001`; the alerter


### PR DESCRIPTION
## Summary

Brings the alerter's server-secret loading into parity with the
collector and server. The alerter previously read its encryption
secret only from an explicitly configured `secret_file`; when that
field was unset, secret loading failed with **no fallback search**.
The collector and server both already fall back to a default secret
location, so the alerter was the odd one out — and the search order
documented in `examples/ai-dba-alerter.yaml` (updated in #283)
described behavior the alerter binary did not implement.

This surfaced during review of #283 (which corrected the *comments*
in the example YAML files). This PR makes the alerter *code* match
those corrected comments.

## What changed

- New `NotificationsConfig.ResolveServerSecret()` in
  `alerter/src/internal/config/config.go`:
  - reads an explicit `secret_file` directly when set;
  - otherwise falls back to the shared
    `fileutil.GetDefaultConfigPath` search —
    `~/.config/pgedge/ai-dba-alerter.secret` (per-user config dir,
    platform-dependent) first, then `/etc/pgedge/ai-dba-alerter.secret`;
  - returns an error naming both searched locations when neither
    exists, mirroring the collector's wording.
- `NewManager` now calls `ResolveServerSecret()` instead of reading
  `cfg.SecretFile` directly. The early return when notifications are
  disabled is unchanged, so the secret is only resolved when needed.
- Changelog entry under `## [Unreleased]` → `### Fixed`.

This deliberately mirrors the collector's existing `LoadSecret`
(`collector/src/config.go`) and the server's `GetDefaultSecretPath`.

## Testing

- New/extended unit tests cover all four paths: explicit `secret_file`,
  per-user-dir fallback, `/etc/pgedge` fallback, and the not-found
  error (asserting both locations appear). Tests isolate from the
  host's real `/etc/pgedge` and per-user dir via
  `fileutil.SetSystemConfigDirForTest` and `XDG`/`HOME` overrides.
- Coverage of touched units: `ResolveServerSecret` 90.9%,
  `NewManager` 100% — both clear the 90% floor.
- Full Go suite green; `golangci-lint` reports 0 issues.
- Security-auditor review: clean, no findings — confirmed a faithful
  copy of the already-reviewed collector pattern, no new path-resolution
  surface, secret never logged, permissive-mode warning still applied
  on the fallback paths.

## Follow-up (non-blocking)

`ResolveServerSecret` is now a third near-verbatim copy of the same
logic across the three services. A future refactor could hoist a
shared `fileutil.ResolveSecret(explicitPath, basename)` helper so the
empty-file / permissive-warning / error-message semantics can't drift.

Related: #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alerter failing to load server secret when not explicitly configured; now resolves and falls back to default locations consistently with other components.

* **Tests**
  * Added tests validating secret lookup order, fallback behavior, and error cases for missing secrets.

* **Documentation**
  * Updated changelog documenting the server secret resolution fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->