### PR TITLE
fix(embedding): store embeddings as halfvec(4000) for all providers

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -52,8 +52,11 @@ engines:
   # engine (gosec, golangci-lint, etc.) still scans these files.
   opengrep:
     exclude_paths:
+      - 'alerter/src/internal/database/anomaly_queries.go'
       - 'alerter/src/internal/engine/anomalies_test.go'
       - 'alerter/src/internal/engine/baselines_test.go'
+      - 'collector/src/database/migration_v6_test.go'
+      - 'collector/src/database/schema.go'
       - 'server/src/internal/tools/get_metric_baselines.go'
 
   # Codacy's ESLint8 ruleset enables eslint-plugin-xss and

--- a/alerter/src/internal/database/anomaly_queries.go
+++ b/alerter/src/internal/database/anomaly_queries.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	embeddingpkg "github.com/pgedge/ai-workbench/pkg/embedding"
 )
 
 // scanAcknowledgedAnomalyAlert scans all 15 fields from a query row into an
@@ -112,14 +114,21 @@ func (d *Datastore) UpdateAnomalyCandidate(ctx context.Context, c *AnomalyCandid
 
 // StoreAnomalyEmbedding stores an embedding for an anomaly candidate
 func (d *Datastore) StoreAnomalyEmbedding(ctx context.Context, candidateID int64, embedding []float32, modelName string) error {
-	// Convert []float32 to PostgreSQL vector format
-	vectorStr := float32SliceToVectorString(embedding)
+	// Zero-pad to the fixed halfvec width so any provider's embedding
+	// fits the column; reject vectors above the supported maximum.
+	padded, err := embeddingpkg.PadTo(embedding, embeddingpkg.MaxDimensions)
+	if err != nil {
+		return err
+	}
 
-	_, err := d.pool.Exec(ctx, `
+	// Convert []float32 to PostgreSQL vector format
+	vectorStr := float32SliceToVectorString(padded)
+
+	_, err = d.pool.Exec(ctx, `
 		INSERT INTO anomaly_embeddings (candidate_id, embedding, model_name)
-		VALUES ($1, $2::vector, $3)
+		VALUES ($1, $2::halfvec, $3)
 		ON CONFLICT (candidate_id) DO UPDATE
-		SET embedding = $2::vector, model_name = $3, created_at = CURRENT_TIMESTAMP
+		SET embedding = $2::halfvec, model_name = $3, created_at = CURRENT_TIMESTAMP
 	`, candidateID, vectorStr, modelName)
 
 	if err != nil {
@@ -143,13 +152,20 @@ func (d *Datastore) StoreAnomalyEmbedding(ctx context.Context, candidateID int64
 // FindSimilarAnomalies finds past anomalies similar to the given embedding
 // Returns candidates with similarity scores above threshold, excluding the current candidate
 func (d *Datastore) FindSimilarAnomalies(ctx context.Context, embedding []float32, excludeCandidateID int64, threshold float64, limit int) ([]*SimilarAnomaly, error) {
+	// Pad the query vector to the same fixed width as the stored
+	// vectors so cosine distance is computed over identical layouts.
+	padded, err := embeddingpkg.PadTo(embedding, embeddingpkg.MaxDimensions)
+	if err != nil {
+		return nil, err
+	}
+
 	// Convert []float32 to PostgreSQL vector format
-	vectorStr := float32SliceToVectorString(embedding)
+	vectorStr := float32SliceToVectorString(padded)
 
 	rows, err := d.pool.Query(ctx, `
 		SELECT
 			c.id,
-			1 - (e.embedding <=> $1::vector) as similarity,
+			1 - (e.embedding <=> $1::halfvec) as similarity,
 			c.final_decision,
 			c.metric_name,
 			c.context
@@ -158,7 +174,7 @@ func (d *Datastore) FindSimilarAnomalies(ctx context.Context, embedding []float3
 		WHERE c.id != $2
 		  AND c.processed_at IS NOT NULL
 		  AND c.final_decision IS NOT NULL
-		ORDER BY e.embedding <=> $1::vector
+		ORDER BY e.embedding <=> $1::halfvec
 		LIMIT $3
 	`, vectorStr, excludeCandidateID, limit)
 	if err != nil {

--- a/alerter/src/internal/database/anomaly_queries_full_integration_test.go
+++ b/alerter/src/internal/database/anomaly_queries_full_integration_test.go
@@ -189,6 +189,16 @@ func TestStoreAnomalyEmbeddingAndFindSimilar(t *testing.T) {
 		t.Errorf("update path: %v", err)
 	}
 
+	// An oversized embedding (beyond the supported maximum width) must
+	// be rejected by the PadTo guard before reaching the database.
+	oversized := make([]float32, 4001)
+	if err := ds.StoreAnomalyEmbedding(ctx, c.ID, oversized, "too-big"); err == nil {
+		t.Errorf("expected StoreAnomalyEmbedding to reject oversized vector")
+	}
+	if _, err := ds.FindSimilarAnomalies(ctx, oversized, c2.ID, 0.5, 10); err == nil {
+		t.Errorf("expected FindSimilarAnomalies to reject oversized vector")
+	}
+
 	// Force the second-Exec error path: drop the embedding_id column
 	// after the first Exec succeeds. The follow-up UPDATE on
 	// anomaly_candidates references the missing column and must error.
@@ -204,6 +214,54 @@ func TestStoreAnomalyEmbeddingAndFindSimilar(t *testing.T) {
 	}
 	if err := ds.StoreAnomalyEmbedding(ctx, c3.ID, []float32{1.0, 0.0, 0.0}, "model-bad"); err == nil {
 		t.Errorf("expected StoreAnomalyEmbedding to fail when embedding_id column is missing")
+	}
+}
+
+// TestFindSimilarAnomaliesScanError exercises the row-scan error branch
+// of FindSimilarAnomalies. A candidate row with a NULL metric_name
+// cannot be scanned into the non-pointer SimilarAnomaly.MetricName
+// field, so the query must surface a wrapped scan error.
+func TestFindSimilarAnomaliesScanError(t *testing.T) {
+	ds, pool, cleanup := newFullTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if !pgvectorAvailable(ctx, pool) {
+		t.Skip("pgvector not available; skipping embedding tests")
+	}
+	if err := createAnomalyEmbeddingsTable(ctx, pool); err != nil {
+		t.Skipf("anomaly_embeddings could not be created: %v", err)
+	}
+
+	connID := insertTestConnection(t, pool, "scan-err-conn")
+
+	// Relax the NOT NULL constraint so a NULL metric_name row can be
+	// seeded; the production schema keeps the constraint.
+	if _, err := pool.Exec(ctx,
+		`ALTER TABLE anomaly_candidates ALTER COLUMN metric_name DROP NOT NULL`); err != nil {
+		t.Fatalf("drop NOT NULL on metric_name: %v", err)
+	}
+
+	// Seed a processed candidate with a NULL metric_name and a matching
+	// embedding so it is eligible for the similarity query.
+	var candID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO anomaly_candidates
+			(connection_id, metric_name, metric_value, z_score, detected_at,
+			 context, tier1_pass, processed_at, final_decision)
+		VALUES ($1, NULL, 1.0, 4.0, NOW(), '{}', true, NOW(), 'alert')
+		RETURNING id
+	`, connID).Scan(&candID); err != nil {
+		t.Fatalf("seed NULL metric_name candidate: %v", err)
+	}
+	if err := ds.StoreAnomalyEmbedding(ctx, candID, []float32{1.0, 0.0, 0.0}, "m"); err != nil {
+		t.Fatalf("StoreAnomalyEmbedding: %v", err)
+	}
+
+	// Exclude a different (non-existent) candidate so the NULL row is
+	// returned; scanning it into a non-pointer string must error.
+	if _, err := ds.FindSimilarAnomalies(ctx, []float32{1.0, 0.0, 0.0}, candID+1000, 0.0, 10); err == nil {
+		t.Errorf("expected scan error for NULL metric_name row")
 	}
 }
 

--- a/alerter/src/internal/database/queries_full_integration_test.go
+++ b/alerter/src/internal/database/queries_full_integration_test.go
@@ -401,7 +401,9 @@ func pgvectorAvailable(ctx context.Context, pool *pgxpool.Pool) bool {
 
 // createAnomalyEmbeddingsTable creates anomaly_embeddings when pgvector
 // is available. The table is required by StoreAnomalyEmbedding and
-// FindSimilarAnomalies; the tests skip when it cannot be created.
+// FindSimilarAnomalies; the tests skip when it cannot be created. The
+// embedding column is halfvec(4000) to match the production schema;
+// StoreAnomalyEmbedding zero-pads short test vectors to that width.
 func createAnomalyEmbeddingsTable(ctx context.Context, pool *pgxpool.Pool) error {
 	_, err := pool.Exec(ctx, `
 		DROP TABLE IF EXISTS anomaly_embeddings CASCADE;
@@ -409,7 +411,7 @@ func createAnomalyEmbeddingsTable(ctx context.Context, pool *pgxpool.Pool) error
 		CREATE TABLE anomaly_embeddings (
 			id BIGSERIAL PRIMARY KEY,
 			candidate_id BIGINT REFERENCES anomaly_candidates(id) ON DELETE CASCADE,
-			embedding vector(3),
+			embedding halfvec(4000),
 			model_name TEXT NOT NULL,
 			created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			UNIQUE(candidate_id)

--- a/collector/src/database/migration_v6_test.go
+++ b/collector/src/database/migration_v6_test.go
@@ -434,6 +434,95 @@ func TestUpgradeEmbeddingColumn_AbsentAndUnexpectedType(t *testing.T) {
 	}
 }
 
+// TestUpgradeEmbeddingColumn_WrongHalfvecWidth proves that a column
+// already sitting at a halfvec width other than the 4000-dim target is
+// rejected rather than silently treated as migrated. The application
+// pads and casts every embedding to halfvec(4000), so a stray
+// halfvec(1536) would only fail at runtime; the migration must catch it.
+func TestUpgradeEmbeddingColumn_WrongHalfvecWidth(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		t.Skipf("pgvector not installable: %v", err)
+	}
+	if !pgvectorHasHalfvec(ctx, t, pool) {
+		t.Skip("pgvector build lacks halfvec; skipping")
+	}
+
+	// A column already at the wrong halfvec width simulates a partial or
+	// manual migration; the upgrade must refuse it rather than skip it.
+	if _, err := pool.Exec(ctx, `
+		DROP TABLE IF EXISTS wrong_width CASCADE;
+		CREATE TABLE wrong_width (id BIGSERIAL PRIMARY KEY, embedding halfvec(1536))
+	`); err != nil {
+		t.Fatalf("create wrong_width: %v", err)
+	}
+	defer func() {
+		if _, err := pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS wrong_width CASCADE`); err != nil {
+			t.Logf("drop wrong_width: %v", err)
+		}
+	}()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin wrong-width: %v", err)
+	}
+	err = upgradeEmbeddingColumnToHalfvec(ctx, tx,
+		"wrong_width", "embedding", "wrong_width_idx",
+		"CREATE INDEX IF NOT EXISTS wrong_width_idx ON wrong_width USING hnsw (embedding halfvec_cosine_ops)",
+	)
+	if err == nil {
+		t.Errorf("expected error for halfvec width other than 4000")
+	} else if !strings.Contains(err.Error(), "unexpected halfvec width") {
+		t.Errorf("error should name the unexpected halfvec width, got: %v", err)
+	}
+	if rbErr := tx.Rollback(ctx); rbErr != nil {
+		t.Logf("rollback wrong-width tx: %v", rbErr)
+	}
+
+	// A column already at the exact target type is a clean no-op, proving
+	// the strict guard still lets a correctly migrated column pass.
+	if _, err := pool.Exec(ctx, `
+		DROP TABLE IF EXISTS right_width CASCADE;
+		CREATE TABLE right_width (id BIGSERIAL PRIMARY KEY, embedding halfvec(4000))
+	`); err != nil {
+		t.Fatalf("create right_width: %v", err)
+	}
+	defer func() {
+		if _, err := pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS right_width CASCADE`); err != nil {
+			t.Logf("drop right_width: %v", err)
+		}
+	}()
+
+	tx2, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin right-width: %v", err)
+	}
+	if err := upgradeEmbeddingColumnToHalfvec(ctx, tx2,
+		"right_width", "embedding", "right_width_idx",
+		"CREATE INDEX IF NOT EXISTS right_width_idx ON right_width USING hnsw (embedding halfvec_cosine_ops)",
+	); err != nil {
+		if rbErr := tx2.Rollback(ctx); rbErr != nil {
+			t.Logf("rollback right-width tx: %v", rbErr)
+		}
+		t.Fatalf("halfvec(4000) column should be a no-op, got: %v", err)
+	}
+	if err := tx2.Commit(ctx); err != nil {
+		t.Fatalf("commit right-width no-op: %v", err)
+	}
+}
+
 // TestUpgradeEmbeddingColumn_StepFailures covers the conversion error
 // branches: a malformed CREATE INDEX statement after a successful column
 // conversion, and an ALTER that cannot complete because a stored vector

--- a/collector/src/database/migration_v6_test.go
+++ b/collector/src/database/migration_v6_test.go
@@ -1,0 +1,593 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// fakeRow implements pgx.Row to return a canned error, letting the test
+// drive embeddingColumnTypeName's non-ErrNoRows error branch without a
+// live database fault.
+type fakeRow struct{ err error }
+
+func (r fakeRow) Scan(dest ...any) error { return r.err }
+
+// fakeQuerier returns a fakeRow carrying a fixed error from QueryRow.
+type fakeQuerier struct{ err error }
+
+func (q fakeQuerier) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	return fakeRow(q)
+}
+
+// TestEmbeddingColumnTypeName_ErrorPaths exercises both Scan outcomes of
+// embeddingColumnTypeName via a fake querier: pgx.ErrNoRows maps to an
+// empty type name with no error, and any other error is wrapped.
+func TestEmbeddingColumnTypeName_ErrorPaths(t *testing.T) {
+	ctx := context.Background()
+
+	got, err := embeddingColumnTypeName(ctx,
+		fakeQuerier{err: pgx.ErrNoRows}, "t", "c")
+	if err != nil {
+		t.Errorf("ErrNoRows should map to (\"\", nil); got err=%v", err)
+	}
+	if got != "" {
+		t.Errorf("ErrNoRows should yield empty type, got %q", got)
+	}
+
+	sentinel := errors.New("boom")
+	if _, err := embeddingColumnTypeName(ctx,
+		fakeQuerier{err: sentinel}, "t", "c"); err == nil {
+		t.Errorf("expected wrapped error for non-ErrNoRows Scan failure")
+	} else if !errors.Is(err, sentinel) {
+		t.Errorf("error should wrap the underlying cause, got %v", err)
+	}
+}
+
+// columnTypeName returns format_type() for a public-schema column, the
+// same probe migration #6 uses to decide whether a column still needs
+// converting. Tests use it to assert the resulting column types.
+func columnTypeName(ctx context.Context, t *testing.T, pool *pgxpool.Pool, table, column string) string {
+	t.Helper()
+	var typeName string
+	err := pool.QueryRow(ctx, `
+		SELECT format_type(a.atttypid, a.atttypmod)
+		FROM pg_attribute a
+		JOIN pg_class c ON c.oid = a.attrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public'
+		  AND c.relname = $1
+		  AND a.attname = $2
+		  AND a.attnum > 0
+		  AND NOT a.attisdropped
+	`, table, column).Scan(&typeName)
+	if err != nil {
+		t.Fatalf("read type of %s.%s: %v", table, column, err)
+	}
+	return typeName
+}
+
+// indexAccessMethod returns the access method (e.g. "hnsw") and the
+// indexdef for the named index, or empty strings when it is absent.
+func indexDef(ctx context.Context, t *testing.T, pool *pgxpool.Pool, name string) string {
+	t.Helper()
+	var def string
+	err := pool.QueryRow(ctx, `
+		SELECT indexdef FROM pg_indexes
+		WHERE schemaname = 'public' AND indexname = $1
+	`, name).Scan(&def)
+	if err != nil {
+		return ""
+	}
+	return def
+}
+
+// pgvectorHasHalfvec reports whether the installed pgvector build knows
+// the halfvec type. Older pgvector releases lack it; the test degrades
+// to a skip in that case, matching the migration's graceful behavior.
+func pgvectorHasHalfvec(ctx context.Context, t *testing.T, pool *pgxpool.Pool) bool {
+	t.Helper()
+	var exists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS(SELECT 1 FROM pg_type WHERE typname = 'halfvec')
+	`).Scan(&exists); err != nil {
+		return false
+	}
+	return exists
+}
+
+// TestMigrationV6_FreshSchemaUsesHalfvec verifies that a brand-new
+// install creates both embedding columns as halfvec(4000) with HNSW
+// halfvec_cosine_ops indexes, with no manual upgrade step required.
+func TestMigrationV6_FreshSchemaUsesHalfvec(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	if !pgvectorHasHalfvec(ctx, t, pool) {
+		// halfvec presence is only knowable after the extension exists;
+		// create it first so the probe is meaningful.
+		if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+			t.Skipf("pgvector not installable: %v", err)
+		}
+		if !pgvectorHasHalfvec(ctx, t, pool) {
+			t.Skip("pgvector build lacks halfvec; skipping")
+		}
+	}
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	for _, tc := range []struct {
+		table, index string
+	}{
+		{"chat_memories", "idx_chat_memories_embedding"},
+		{"anomaly_embeddings", "idx_anomaly_embeddings_vector"},
+	} {
+		typeName := columnTypeName(ctx, t, pool, tc.table, "embedding")
+		if !strings.HasPrefix(typeName, "halfvec") {
+			t.Errorf("%s.embedding type = %q, want halfvec(...)", tc.table, typeName)
+		}
+		if !strings.Contains(typeName, "4000") {
+			t.Errorf("%s.embedding type = %q, want width 4000", tc.table, typeName)
+		}
+		def := indexDef(ctx, t, pool, tc.index)
+		if def == "" {
+			t.Errorf("index %s missing on fresh schema", tc.index)
+			continue
+		}
+		if !strings.Contains(def, "hnsw") || !strings.Contains(def, "halfvec_cosine_ops") {
+			t.Errorf("index %s not HNSW halfvec_cosine_ops: %s", tc.index, def)
+		}
+	}
+}
+
+// TestMigrationV6_UpgradesLegacyVectorColumns proves the in-place
+// upgrade path. It migrates a fresh database, rewrites both embedding
+// columns back to the legacy vector(1536) shape with the old
+// vector_cosine_ops indexes, seeds a populated row and a NULL row, then
+// runs the migration #6 conversion logic. It asserts the columns become
+// halfvec(4000), the populated row is zero-padded, the NULL row stays
+// NULL, the index is rebuilt with halfvec_cosine_ops, and a second run
+// is a no-op.
+func TestMigrationV6_UpgradesLegacyVectorColumns(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		t.Skipf("pgvector not installable: %v", err)
+	}
+	if !pgvectorHasHalfvec(ctx, t, pool) {
+		t.Skip("pgvector build lacks halfvec; skipping")
+	}
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("baseline migrate: %v", err)
+	}
+
+	// Synthesize the pre-#6 (legacy) shape: revert both columns to
+	// vector(1536) with the original vector_cosine_ops HNSW indexes,
+	// exactly what a database originally provisioned under OpenAI dims
+	// carries on disk.
+	legacy := []struct {
+		table, index string
+	}{
+		{"chat_memories", "idx_chat_memories_embedding"},
+		{"anomaly_embeddings", "idx_anomaly_embeddings_vector"},
+	}
+	for _, l := range legacy {
+		if _, err := pool.Exec(ctx,
+			"DROP INDEX IF EXISTS "+l.index); err != nil {
+			t.Fatalf("drop %s: %v", l.index, err)
+		}
+		if _, err := pool.Exec(ctx,
+			"ALTER TABLE "+l.table+
+				" ALTER COLUMN embedding TYPE vector(1536) USING NULL"); err != nil {
+			t.Fatalf("revert %s.embedding to vector(1536): %v", l.table, err)
+		}
+		if _, err := pool.Exec(ctx,
+			"CREATE INDEX "+l.index+" ON "+l.table+
+				" USING hnsw (embedding vector_cosine_ops)"); err != nil {
+			t.Fatalf("recreate legacy index %s: %v", l.index, err)
+		}
+		// Confirm the legacy shape is in place before the upgrade.
+		if got := columnTypeName(ctx, t, pool, l.table, "embedding"); !strings.HasPrefix(got, "vector") {
+			t.Fatalf("setup failure: %s.embedding type = %q, want vector(...)", l.table, got)
+		}
+	}
+
+	// Seed chat_memories: one populated 1536-dim row and one NULL row.
+	vec := "[" + strings.Repeat("0.5,", 1535) + "0.5]"
+	var populatedID, nullID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO chat_memories (username, scope, category, content, embedding, model_name)
+		VALUES ('alice', 'user', 'c', 'populated', $1::vector, 'm')
+		RETURNING id
+	`, vec).Scan(&populatedID); err != nil {
+		t.Fatalf("seed populated chat_memories row: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO chat_memories (username, scope, category, content, embedding, model_name)
+		VALUES ('alice', 'user', 'c', 'null-embed', NULL, 'm')
+		RETURNING id
+	`).Scan(&nullID); err != nil {
+		t.Fatalf("seed null chat_memories row: %v", err)
+	}
+
+	// Run migration #6's conversion logic exactly as the migration does.
+	runV6 := func() {
+		tx, err := conn.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		if err := upgradeEmbeddingColumnToHalfvec(ctx, tx,
+			"chat_memories", "embedding", "idx_chat_memories_embedding",
+			"CREATE INDEX IF NOT EXISTS idx_chat_memories_embedding "+
+				"ON chat_memories USING hnsw (embedding halfvec_cosine_ops)",
+		); err != nil {
+			if rbErr := tx.Rollback(ctx); rbErr != nil {
+				t.Logf("rollback chat_memories upgrade: %v", rbErr)
+			}
+			t.Fatalf("upgrade chat_memories: %v", err)
+		}
+		if err := upgradeEmbeddingColumnToHalfvec(ctx, tx,
+			"anomaly_embeddings", "embedding", "idx_anomaly_embeddings_vector",
+			"CREATE INDEX IF NOT EXISTS idx_anomaly_embeddings_vector "+
+				"ON anomaly_embeddings USING hnsw (embedding halfvec_cosine_ops)",
+		); err != nil {
+			if rbErr := tx.Rollback(ctx); rbErr != nil {
+				t.Logf("rollback anomaly_embeddings upgrade: %v", rbErr)
+			}
+			t.Fatalf("upgrade anomaly_embeddings: %v", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("commit upgrade: %v", err)
+		}
+	}
+
+	runV6()
+
+	// Columns must now be halfvec(4000) with rebuilt halfvec indexes.
+	for _, l := range legacy {
+		typeName := columnTypeName(ctx, t, pool, l.table, "embedding")
+		if !strings.HasPrefix(typeName, "halfvec") || !strings.Contains(typeName, "4000") {
+			t.Errorf("%s.embedding type = %q, want halfvec(4000)", l.table, typeName)
+		}
+		def := indexDef(ctx, t, pool, l.index)
+		if !strings.Contains(def, "halfvec_cosine_ops") {
+			t.Errorf("index %s not rebuilt with halfvec_cosine_ops: %s", l.index, def)
+		}
+	}
+
+	// The populated row must be widened to 4000 dims and its leading
+	// values preserved; the NULL row must stay NULL.
+	var dims int
+	if err := pool.QueryRow(ctx,
+		`SELECT vector_dims(embedding) FROM chat_memories WHERE id = $1`,
+		populatedID).Scan(&dims); err != nil {
+		t.Fatalf("read padded dims: %v", err)
+	}
+	if dims != 4000 {
+		t.Errorf("populated row dims = %d, want 4000", dims)
+	}
+	var first float64
+	if err := pool.QueryRow(ctx,
+		`SELECT (embedding::real[])[1] FROM chat_memories WHERE id = $1`,
+		populatedID).Scan(&first); err != nil {
+		t.Fatalf("read first element: %v", err)
+	}
+	if first < 0.49 || first > 0.51 {
+		t.Errorf("padded leading value = %v, want ~0.5", first)
+	}
+	var trailing float64
+	if err := pool.QueryRow(ctx,
+		`SELECT (embedding::real[])[4000] FROM chat_memories WHERE id = $1`,
+		populatedID).Scan(&trailing); err != nil {
+		t.Fatalf("read trailing element: %v", err)
+	}
+	if trailing != 0 {
+		t.Errorf("trailing pad value = %v, want 0", trailing)
+	}
+	var isNull bool
+	if err := pool.QueryRow(ctx,
+		`SELECT embedding IS NULL FROM chat_memories WHERE id = $1`,
+		nullID).Scan(&isNull); err != nil {
+		t.Fatalf("read null row: %v", err)
+	}
+	if !isNull {
+		t.Errorf("NULL embedding row was not preserved as NULL")
+	}
+
+	// Re-running migration #6 must be a clean no-op: the columns are
+	// already halfvec, so the type probe short-circuits without touching
+	// the data or index.
+	runV6()
+	for _, l := range legacy {
+		typeName := columnTypeName(ctx, t, pool, l.table, "embedding")
+		if !strings.HasPrefix(typeName, "halfvec") {
+			t.Errorf("after re-run %s.embedding type = %q, want halfvec", l.table, typeName)
+		}
+	}
+	// The padded row must be untouched by the no-op re-run.
+	if err := pool.QueryRow(ctx,
+		`SELECT vector_dims(embedding) FROM chat_memories WHERE id = $1`,
+		populatedID).Scan(&dims); err != nil {
+		t.Fatalf("re-read padded dims: %v", err)
+	}
+	if dims != 4000 {
+		t.Errorf("after re-run populated row dims = %d, want 4000", dims)
+	}
+}
+
+// TestUpgradeEmbeddingColumn_AbsentAndUnexpectedType covers the two
+// non-conversion branches of upgradeEmbeddingColumnToHalfvec: a missing
+// table/column is a clean no-op, and a column of an unexpected type is
+// refused rather than cast destructively.
+func TestUpgradeEmbeddingColumn_AbsentAndUnexpectedType(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	// Absent table: embeddingColumnTypeName returns "" so the upgrade is
+	// a no-op and commits cleanly.
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := upgradeEmbeddingColumnToHalfvec(ctx, tx,
+		"no_such_table", "embedding", "no_such_index",
+		"CREATE INDEX IF NOT EXISTS no_such_index ON no_such_table USING hnsw (embedding halfvec_cosine_ops)",
+	); err != nil {
+		if rbErr := tx.Rollback(ctx); rbErr != nil {
+			t.Logf("rollback absent-table tx: %v", rbErr)
+		}
+		t.Fatalf("absent table should be a no-op, got: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit absent-table no-op: %v", err)
+	}
+
+	// Type probe must also report "" for a wholly absent table.
+	tx2, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin probe: %v", err)
+	}
+	got, err := embeddingColumnTypeName(ctx, tx2, "still_missing", "embedding")
+	if err != nil {
+		if rbErr := tx2.Rollback(ctx); rbErr != nil {
+			t.Logf("rollback probe tx: %v", rbErr)
+		}
+		t.Fatalf("type probe of missing table: %v", err)
+	}
+	if got != "" {
+		t.Errorf("missing table type = %q, want empty", got)
+	}
+	if rbErr := tx2.Rollback(ctx); rbErr != nil {
+		t.Logf("rollback probe tx: %v", rbErr)
+	}
+
+	// Unexpected type: a non-vector embedding column must be refused.
+	if _, err := pool.Exec(ctx, `
+		DROP TABLE IF EXISTS weird_embed CASCADE;
+		CREATE TABLE weird_embed (id BIGSERIAL PRIMARY KEY, embedding INTEGER)
+	`); err != nil {
+		t.Fatalf("create weird_embed: %v", err)
+	}
+	defer func() {
+		if _, err := pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS weird_embed CASCADE`); err != nil {
+			t.Logf("drop weird_embed: %v", err)
+		}
+	}()
+
+	tx3, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin unexpected-type: %v", err)
+	}
+	err = upgradeEmbeddingColumnToHalfvec(ctx, tx3,
+		"weird_embed", "embedding", "weird_embed_idx",
+		"CREATE INDEX IF NOT EXISTS weird_embed_idx ON weird_embed USING hnsw (embedding halfvec_cosine_ops)",
+	)
+	if err == nil {
+		t.Errorf("expected refusal for unexpected column type")
+	}
+	if rbErr := tx3.Rollback(ctx); rbErr != nil {
+		t.Logf("rollback unexpected-type tx: %v", rbErr)
+	}
+}
+
+// TestUpgradeEmbeddingColumn_StepFailures covers the conversion error
+// branches: a malformed CREATE INDEX statement after a successful column
+// conversion, and an ALTER that cannot complete because a stored vector
+// already exceeds the 4000-dim target (array_fill would need a negative
+// length). Both run inside their own SAVEPOINT, so the failure rolls
+// back cleanly and the outer transaction stays usable.
+func TestUpgradeEmbeddingColumn_StepFailures(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		t.Skipf("pgvector not installable: %v", err)
+	}
+	if !pgvectorHasHalfvec(ctx, t, pool) {
+		t.Skip("pgvector build lacks halfvec; skipping")
+	}
+
+	// Recreate-index failure: a small vector(3) table converts fine, but
+	// a syntactically broken CREATE INDEX statement triggers the
+	// recreate-index error return.
+	if _, err := pool.Exec(ctx, `
+		DROP TABLE IF EXISTS recreate_fail CASCADE;
+		CREATE TABLE recreate_fail (id BIGSERIAL PRIMARY KEY, embedding vector(3))
+	`); err != nil {
+		t.Fatalf("create recreate_fail: %v", err)
+	}
+	defer func() {
+		if _, err := pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS recreate_fail CASCADE`); err != nil {
+			t.Logf("drop recreate_fail: %v", err)
+		}
+	}()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	err = upgradeEmbeddingColumnToHalfvec(ctx, tx,
+		"recreate_fail", "embedding", "recreate_fail_idx",
+		"CREATE INDEX recreate_fail_idx ON recreate_fail USING hnsw "+
+			"(embedding NOT_A_REAL_OPCLASS)",
+	)
+	if err == nil {
+		t.Errorf("expected recreate-index failure")
+	}
+	if rbErr := tx.Rollback(ctx); rbErr != nil {
+		t.Logf("rollback recreate-fail tx: %v", rbErr)
+	}
+
+	// Drop-index failure: a syntactically invalid index name makes the
+	// DROP INDEX statement itself error, covering that guard. The column
+	// is a valid vector(3) so the type probe passes and the DROP runs.
+	if _, err := pool.Exec(ctx, `
+		DROP TABLE IF EXISTS drop_fail CASCADE;
+		CREATE TABLE drop_fail (id BIGSERIAL PRIMARY KEY, embedding vector(3))
+	`); err != nil {
+		t.Fatalf("create drop_fail: %v", err)
+	}
+	defer func() {
+		if _, err := pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS drop_fail CASCADE`); err != nil {
+			t.Logf("drop drop_fail: %v", err)
+		}
+	}()
+	txd, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin drop-fail: %v", err)
+	}
+	err = upgradeEmbeddingColumnToHalfvec(ctx, txd,
+		"drop_fail", "embedding", "bad index name );DROP",
+		"CREATE INDEX IF NOT EXISTS drop_fail_idx ON drop_fail USING hnsw "+
+			"(embedding halfvec_cosine_ops)",
+	)
+	if err == nil {
+		t.Errorf("expected drop-index failure for invalid index name")
+	}
+	if rbErr := txd.Rollback(ctx); rbErr != nil {
+		t.Logf("rollback drop-fail tx: %v", rbErr)
+	}
+
+	// Alter failure: store a vector wider than the 4000-dim target so the
+	// padding expression's array_fill receives a negative length and the
+	// ALTER ... USING cast errors out.
+	wide := "[" + strings.Repeat("0.1,", 4099) + "0.1]"
+	if _, err := pool.Exec(ctx, `
+		DROP TABLE IF EXISTS alter_fail CASCADE;
+		CREATE TABLE alter_fail (id BIGSERIAL PRIMARY KEY, embedding vector(4100))
+	`); err != nil {
+		t.Fatalf("create alter_fail: %v", err)
+	}
+	defer func() {
+		if _, err := pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS alter_fail CASCADE`); err != nil {
+			t.Logf("drop alter_fail: %v", err)
+		}
+	}()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO alter_fail (embedding) VALUES ($1::vector)`, wide); err != nil {
+		t.Fatalf("seed wide vector: %v", err)
+	}
+
+	tx2, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin alter-fail: %v", err)
+	}
+	err = upgradeEmbeddingColumnToHalfvec(ctx, tx2,
+		"alter_fail", "embedding", "alter_fail_idx",
+		"CREATE INDEX IF NOT EXISTS alter_fail_idx ON alter_fail USING hnsw "+
+			"(embedding halfvec_cosine_ops)",
+	)
+	if err == nil {
+		t.Errorf("expected alter-column failure for over-width vector")
+	}
+	if rbErr := tx2.Rollback(ctx); rbErr != nil {
+		t.Logf("rollback alter-fail tx: %v", rbErr)
+	}
+}
+
+// TestMigrationV6_Idempotent verifies the full migration runner applies
+// version 6 exactly once and that a second Migrate call skips it.
+func TestMigrationV6_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	pool, conn := getTestConnection(t)
+	if pool == nil {
+		return
+	}
+	defer pool.Close()
+	defer conn.Release()
+
+	cleanupTestSchema(t, pool)
+	defer cleanupTestSchema(t, pool)
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("second Migrate: %v", err)
+	}
+
+	var v6Count int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM schema_version WHERE version = 6`).Scan(&v6Count); err != nil {
+		t.Fatalf("count v6 rows: %v", err)
+	}
+	if v6Count != 1 {
+		t.Errorf("expected exactly one schema_version row for v6, got %d", v6Count)
+	}
+}

--- a/collector/src/database/migration_v6_test.go
+++ b/collector/src/database/migration_v6_test.go
@@ -147,11 +147,8 @@ func TestMigrationV6_FreshSchemaUsesHalfvec(t *testing.T) {
 		{"anomaly_embeddings", "idx_anomaly_embeddings_vector"},
 	} {
 		typeName := columnTypeName(ctx, t, pool, tc.table, "embedding")
-		if !strings.HasPrefix(typeName, "halfvec") {
-			t.Errorf("%s.embedding type = %q, want halfvec(...)", tc.table, typeName)
-		}
-		if !strings.Contains(typeName, "4000") {
-			t.Errorf("%s.embedding type = %q, want width 4000", tc.table, typeName)
+		if typeName != "halfvec(4000)" {
+			t.Errorf("%s.embedding type = %q, want halfvec(4000)", tc.table, typeName)
 		}
 		def := indexDef(ctx, t, pool, tc.index)
 		if def == "" {
@@ -281,7 +278,7 @@ func TestMigrationV6_UpgradesLegacyVectorColumns(t *testing.T) {
 	// Columns must now be halfvec(4000) with rebuilt halfvec indexes.
 	for _, l := range legacy {
 		typeName := columnTypeName(ctx, t, pool, l.table, "embedding")
-		if !strings.HasPrefix(typeName, "halfvec") || !strings.Contains(typeName, "4000") {
+		if typeName != "halfvec(4000)" {
 			t.Errorf("%s.embedding type = %q, want halfvec(4000)", l.table, typeName)
 		}
 		def := indexDef(ctx, t, pool, l.index)

--- a/collector/src/database/migration_v6_test.go
+++ b/collector/src/database/migration_v6_test.go
@@ -80,8 +80,8 @@ func columnTypeName(ctx context.Context, t *testing.T, pool *pgxpool.Pool, table
 	return typeName
 }
 
-// indexAccessMethod returns the access method (e.g. "hnsw") and the
-// indexdef for the named index, or empty strings when it is absent.
+// indexDef returns the indexdef for the named index, or an empty
+// string when the index is absent.
 func indexDef(ctx context.Context, t *testing.T, pool *pgxpool.Pool, name string) string {
 	t.Helper()
 	var def string

--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -3455,8 +3455,15 @@ func embeddingColumnTypeName(
 // the migration loudly is the safer outcome.
 //
 // The function is fully idempotent. It first reads the current column
-// type; it skips every table whose column is already halfvec (or whose
-// table/column does not exist), so re-running migration #6 is a no-op.
+// type; it skips every table whose column is already the exact target
+// type halfvec(4000) (or whose table/column does not exist), so
+// re-running migration #6 is a no-op. A column already sitting at a
+// different halfvec width (for example a partially migrated or manually
+// created halfvec(1536)) is not treated as done: the application pads
+// and casts every embedding to halfvec(4000) on insert and search, so a
+// mismatched width would only break at runtime. The function therefore
+// fails loudly on any halfvec width other than 4000 rather than
+// silently skipping it.
 //
 // The padding expression mirrors the cast the application performs, so
 // stored vectors and freshly inserted vectors share an identical layout:
@@ -3474,12 +3481,22 @@ func upgradeEmbeddingColumnToHalfvec(
 		}
 
 		// Nothing to do when the table/column is absent (fresh installs
-		// already create halfvec) or the column is already halfvec.
+		// already create halfvec) or the column is already the exact
+		// target type.
 		if typeName == "" {
 			return nil
 		}
-		if strings.HasPrefix(typeName, "halfvec") {
+		if typeName == "halfvec(4000)" {
 			return nil
+		}
+		if strings.HasPrefix(typeName, "halfvec") {
+			// Some other halfvec width: a partial or manual migration
+			// left the column at the wrong dimension. The application
+			// casts every embedding to halfvec(4000), so a mismatched
+			// width would only break at runtime; fail loudly here.
+			return fmt.Errorf(
+				"unexpected halfvec width %q for %s.%s; expected halfvec(4000)",
+				typeName, table, column)
 		}
 		if !strings.HasPrefix(typeName, "vector") {
 			// An unexpected type: leave it untouched rather than risk a

--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -3440,10 +3440,19 @@ func embeddingColumnTypeName(
 
 // upgradeEmbeddingColumnToHalfvec converts a vector(N) embedding column
 // to halfvec(4000) in place, zero-padding existing rows and rebuilding
-// the HNSW index, all inside a SAVEPOINT. The work is guarded the same
-// way the original migration #1 setup is: a database without pgvector,
-// or with a pgvector too old to support halfvec, degrades to a logged
-// no-op rather than aborting the surrounding migration transaction.
+// the HNSW index, all inside a SAVEPOINT. The SAVEPOINT prevents a
+// failure here from poisoning the outer migration transaction (which
+// would otherwise surface as the opaque SQLSTATE 25P02 on the following
+// statement); it does not swallow the error. A database without pgvector
+// has no embedding column, so the type probe returns an empty string and
+// the upgrade is a clean no-op. A database whose pgvector is too old to
+// provide the halfvec type (halfvec requires pgvector 0.7.0 or newer) but
+// which already holds a vector(N) column is different: the ALTER to
+// halfvec(4000) fails and that error is propagated, aborting migration
+// #6. This is deliberate, because silently leaving the column as
+// vector(N) would only defer the breakage to runtime (the application
+// casts every embedding to ::halfvec on insert and search), so failing
+// the migration loudly is the safer outcome.
 //
 // The function is fully idempotent. It first reads the current column
 // type; it skips every table whose column is already halfvec (or whose

--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -3035,6 +3035,42 @@ func (sm *SchemaManager) registerMigrations() {
 		},
 	})
 
+	// Migration #6 widens the two embedding columns from the original
+	// vector(1536) declaration to halfvec(4000), so non-OpenAI providers
+	// (Gemini 3072, Voyage, Ollama) can store embeddings of any size up
+	// to 4000 dimensions. The application zero-pads every vector to 4000
+	// before storage and searching, which leaves cosine distance
+	// unchanged. See GitHub issue #294.
+	sm.migrations = append(sm.migrations, Migration{
+		Version:     6,
+		Description: "Widen embedding columns to halfvec(4000) for multi-provider support",
+		Up: func(tx pgx.Tx) error {
+			ctx := context.Background()
+
+			if err := upgradeEmbeddingColumnToHalfvec(ctx, tx,
+				"chat_memories", "embedding",
+				"idx_chat_memories_embedding",
+				"CREATE INDEX IF NOT EXISTS idx_chat_memories_embedding "+
+					"ON chat_memories USING hnsw (embedding halfvec_cosine_ops)",
+			); err != nil {
+				return fmt.Errorf(
+					"failed to widen chat_memories.embedding: %w", err)
+			}
+
+			if err := upgradeEmbeddingColumnToHalfvec(ctx, tx,
+				"anomaly_embeddings", "embedding",
+				"idx_anomaly_embeddings_vector",
+				"CREATE INDEX IF NOT EXISTS idx_anomaly_embeddings_vector "+
+					"ON anomaly_embeddings USING hnsw (embedding halfvec_cosine_ops)",
+			); err != nil {
+				return fmt.Errorf(
+					"failed to widen anomaly_embeddings.embedding: %w", err)
+			}
+
+			return nil
+		},
+	})
+
 }
 
 // Migrate applies all pending migrations
@@ -3306,7 +3342,7 @@ func runPgVectorSetup(ctx context.Context, tx pgx.Tx) error {
 			CREATE TABLE IF NOT EXISTS anomaly_embeddings (
 				id BIGSERIAL PRIMARY KEY,
 				candidate_id BIGINT REFERENCES anomaly_candidates(id) ON DELETE CASCADE,
-				embedding vector(1536),
+				embedding halfvec(4000),
 				model_name TEXT NOT NULL,
 				created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 				UNIQUE(candidate_id)
@@ -3318,7 +3354,7 @@ func runPgVectorSetup(ctx context.Context, tx pgx.Tx) error {
 			CREATE INDEX IF NOT EXISTS idx_anomaly_embeddings_candidate
 				ON anomaly_embeddings(candidate_id);
 			CREATE INDEX IF NOT EXISTS idx_anomaly_embeddings_vector
-				ON anomaly_embeddings USING hnsw (embedding vector_cosine_ops);
+				ON anomaly_embeddings USING hnsw (embedding halfvec_cosine_ops);
 		`); err != nil {
 			return fmt.Errorf("pgvector schema setup: %w", err)
 		}
@@ -3346,18 +3382,132 @@ func runChatMemoryEmbeddingSetup(ctx context.Context, tx pgx.Tx) error {
 	return runSavepointed(ctx, tx, "chat_memories_embedding_setup", func() error {
 		_, err := tx.Exec(ctx, `
 			ALTER TABLE chat_memories
-				ADD COLUMN IF NOT EXISTS embedding vector(1536);
+				ADD COLUMN IF NOT EXISTS embedding halfvec(4000);
 
 			COMMENT ON COLUMN chat_memories.embedding IS
-				'Vector embedding (1536 dimensions) for similarity search';
+				'Vector embedding for similarity search, zero-padded to a fixed width';
 
 			CREATE INDEX IF NOT EXISTS idx_chat_memories_embedding
-				ON chat_memories USING hnsw (embedding vector_cosine_ops);
+				ON chat_memories USING hnsw (embedding halfvec_cosine_ops);
 		`)
 		if err != nil {
 			return fmt.Errorf(
 				"add chat_memories embedding column/index: %w", err)
 		}
+		return nil
+	})
+}
+
+// rowQuerier is the minimal QueryRow contract embeddingColumnTypeName
+// needs. Narrowing from pgx.Tx keeps the helper unit-testable with a
+// tiny fake; every production call site passes a real pgx.Tx.
+type rowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// embeddingColumnTypeName returns the format_type() name of the named
+// column (for example "vector(1536)" or "halfvec(4000)"). It returns an
+// empty string when the table or column does not exist, which lets the
+// caller treat a missing column as "nothing to upgrade" rather than an
+// error. The lookup joins pg_attribute against pg_class/pg_namespace and
+// resolves the type modifier so the dimension is included.
+func embeddingColumnTypeName(
+	ctx context.Context,
+	q rowQuerier,
+	table, column string,
+) (string, error) {
+	var typeName string
+	err := q.QueryRow(ctx, `
+		SELECT format_type(a.atttypid, a.atttypmod)
+		FROM pg_attribute a
+		JOIN pg_class c ON c.oid = a.attrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public'
+		  AND c.relname = $1
+		  AND a.attname = $2
+		  AND a.attnum > 0
+		  AND NOT a.attisdropped
+	`, table, column).Scan(&typeName)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf(
+			"failed to read type of %s.%s: %w", table, column, err)
+	}
+	return typeName, nil
+}
+
+// upgradeEmbeddingColumnToHalfvec converts a vector(N) embedding column
+// to halfvec(4000) in place, zero-padding existing rows and rebuilding
+// the HNSW index, all inside a SAVEPOINT. The work is guarded the same
+// way the original migration #1 setup is: a database without pgvector,
+// or with a pgvector too old to support halfvec, degrades to a logged
+// no-op rather than aborting the surrounding migration transaction.
+//
+// The function is fully idempotent. It first reads the current column
+// type; it skips every table whose column is already halfvec (or whose
+// table/column does not exist), so re-running migration #6 is a no-op.
+//
+// The padding expression mirrors the cast the application performs, so
+// stored vectors and freshly inserted vectors share an identical layout:
+// short vectors are right-padded with zeros to 4000 dimensions and NULLs
+// are preserved as NULL.
+func upgradeEmbeddingColumnToHalfvec(
+	ctx context.Context,
+	tx pgx.Tx,
+	table, column, indexName, createIndexSQL string,
+) error {
+	return runSavepointed(ctx, tx, "upgrade_"+table+"_"+column, func() error {
+		typeName, err := embeddingColumnTypeName(ctx, tx, table, column)
+		if err != nil {
+			return err
+		}
+
+		// Nothing to do when the table/column is absent (fresh installs
+		// already create halfvec) or the column is already halfvec.
+		if typeName == "" {
+			return nil
+		}
+		if strings.HasPrefix(typeName, "halfvec") {
+			return nil
+		}
+		if !strings.HasPrefix(typeName, "vector") {
+			// An unexpected type: leave it untouched rather than risk a
+			// destructive cast. This should never happen in practice.
+			return fmt.Errorf(
+				"unexpected type %q for %s.%s; refusing to convert",
+				typeName, table, column)
+		}
+
+		// Drop the old vector_cosine_ops HNSW index before changing the
+		// column type; the operator class no longer matches afterwards.
+		if _, err := tx.Exec(ctx,
+			fmt.Sprintf("DROP INDEX IF EXISTS %s", indexName)); err != nil {
+			return fmt.Errorf("drop index %s: %w", indexName, err)
+		}
+
+		// Convert the column, zero-padding each non-NULL vector to 4000
+		// dimensions and preserving NULLs. The cast goes through the
+		// real[] representation so array_fill can append the padding.
+		alter := fmt.Sprintf(`
+			ALTER TABLE %s
+				ALTER COLUMN %s TYPE halfvec(4000)
+				USING CASE
+					WHEN %s IS NULL THEN NULL
+					ELSE (%s::real[] || array_fill(0::real,
+						ARRAY[4000 - vector_dims(%s)]))::halfvec(4000)
+				END
+		`, table, column, column, column, column)
+		if _, err := tx.Exec(ctx, alter); err != nil {
+			return fmt.Errorf("alter column %s.%s: %w", table, column, err)
+		}
+
+		// Recreate the HNSW index with the halfvec operator class.
+		if _, err := tx.Exec(ctx, createIndexSQL); err != nil {
+			return fmt.Errorf("recreate index %s: %w", indexName, err)
+		}
+
 		return nil
 	})
 }

--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -3051,7 +3051,7 @@ func (sm *SchemaManager) registerMigrations() {
 				"chat_memories", "embedding",
 				"idx_chat_memories_embedding",
 				"CREATE INDEX IF NOT EXISTS idx_chat_memories_embedding "+
-					"ON chat_memories USING hnsw (embedding halfvec_cosine_ops)",
+					"ON public.chat_memories USING hnsw (embedding halfvec_cosine_ops)",
 			); err != nil {
 				return fmt.Errorf(
 					"failed to widen chat_memories.embedding: %w", err)
@@ -3061,7 +3061,7 @@ func (sm *SchemaManager) registerMigrations() {
 				"anomaly_embeddings", "embedding",
 				"idx_anomaly_embeddings_vector",
 				"CREATE INDEX IF NOT EXISTS idx_anomaly_embeddings_vector "+
-					"ON anomaly_embeddings USING hnsw (embedding halfvec_cosine_ops)",
+					"ON public.anomaly_embeddings USING hnsw (embedding halfvec_cosine_ops)",
 			); err != nil {
 				return fmt.Errorf(
 					"failed to widen anomaly_embeddings.embedding: %w", err)
@@ -3339,7 +3339,7 @@ func runPgVectorSetup(ctx context.Context, tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `
 			CREATE EXTENSION IF NOT EXISTS vector;
 
-			CREATE TABLE IF NOT EXISTS anomaly_embeddings (
+			CREATE TABLE IF NOT EXISTS public.anomaly_embeddings (
 				id BIGSERIAL PRIMARY KEY,
 				candidate_id BIGINT REFERENCES anomaly_candidates(id) ON DELETE CASCADE,
 				embedding halfvec(4000),
@@ -3348,13 +3348,13 @@ func runPgVectorSetup(ctx context.Context, tx pgx.Tx) error {
 				UNIQUE(candidate_id)
 			);
 
-			COMMENT ON TABLE anomaly_embeddings IS
+			COMMENT ON TABLE public.anomaly_embeddings IS
 				'Embeddings for anomaly candidates used in Tier 2 similarity matching';
 
 			CREATE INDEX IF NOT EXISTS idx_anomaly_embeddings_candidate
-				ON anomaly_embeddings(candidate_id);
+				ON public.anomaly_embeddings(candidate_id);
 			CREATE INDEX IF NOT EXISTS idx_anomaly_embeddings_vector
-				ON anomaly_embeddings USING hnsw (embedding halfvec_cosine_ops);
+				ON public.anomaly_embeddings USING hnsw (embedding halfvec_cosine_ops);
 		`); err != nil {
 			return fmt.Errorf("pgvector schema setup: %w", err)
 		}
@@ -3381,14 +3381,14 @@ func runPgVectorSetup(ctx context.Context, tx pgx.Tx) error {
 func runChatMemoryEmbeddingSetup(ctx context.Context, tx pgx.Tx) error {
 	return runSavepointed(ctx, tx, "chat_memories_embedding_setup", func() error {
 		_, err := tx.Exec(ctx, `
-			ALTER TABLE chat_memories
+			ALTER TABLE public.chat_memories
 				ADD COLUMN IF NOT EXISTS embedding halfvec(4000);
 
-			COMMENT ON COLUMN chat_memories.embedding IS
+			COMMENT ON COLUMN public.chat_memories.embedding IS
 				'Vector embedding for similarity search, zero-padded to a fixed width';
 
 			CREATE INDEX IF NOT EXISTS idx_chat_memories_embedding
-				ON chat_memories USING hnsw (embedding halfvec_cosine_ops);
+				ON public.chat_memories USING hnsw (embedding halfvec_cosine_ops);
 		`)
 		if err != nil {
 			return fmt.Errorf(
@@ -3509,7 +3509,7 @@ func upgradeEmbeddingColumnToHalfvec(
 		// Drop the old vector_cosine_ops HNSW index before changing the
 		// column type; the operator class no longer matches afterwards.
 		if _, err := tx.Exec(ctx,
-			fmt.Sprintf("DROP INDEX IF EXISTS %s", indexName)); err != nil {
+			fmt.Sprintf("DROP INDEX IF EXISTS public.%s", indexName)); err != nil {
 			return fmt.Errorf("drop index %s: %w", indexName, err)
 		}
 
@@ -3517,7 +3517,7 @@ func upgradeEmbeddingColumnToHalfvec(
 		// dimensions and preserving NULLs. The cast goes through the
 		// real[] representation so array_fill can append the padding.
 		alter := fmt.Sprintf(`
-			ALTER TABLE %s
+			ALTER TABLE public.%s
 				ALTER COLUMN %s TYPE halfvec(4000)
 				USING CASE
 					WHEN %s IS NULL THEN NULL

--- a/collector/src/database/schema_test.go
+++ b/collector/src/database/schema_test.go
@@ -283,7 +283,7 @@ func TestNewSchemaManager(t *testing.T) {
 	}
 
 	// Verify all migrations are registered
-	expectedVersions := []int{1, 2, 3, 4, 5}
+	expectedVersions := []int{1, 2, 3, 4, 5, 6}
 	if len(sm.migrations) != len(expectedVersions) {
 		t.Fatalf("Expected %d migrations, got %d", len(expectedVersions), len(sm.migrations))
 	}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,6 +78,19 @@ project adheres to
   dead-tuple ratio metric for tables, reusing the rate and ratio
   calculations already applied elsewhere in the product. (#342)
 
+- Fix embedding storage rejecting non-OpenAI providers with a
+  dimension-mismatch error. The chat memory and anomaly detection
+  embedding columns were hardcoded to `vector(1536)`, OpenAI's
+  dimension, which broke Gemini (3072), Voyage (1024 or 512), and
+  Ollama (384, 768, or 1024). The columns are now `halfvec(4000)`,
+  and the workbench zero-pads every embedding to 4000 dimensions, so
+  embeddings from any supported provider store and compare correctly.
+  This widening introduces a hard ceiling: an embedding model that
+  produces vectors with more than 4000 dimensions is not supported,
+  because 4000 is pgvector's HNSW index limit for the `halfvec` type.
+  The workbench rejects such a model with a clear error rather than
+  truncating the vector. (#294)
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/docs/getting-started/configuration/alerter.md
+++ b/docs/getting-started/configuration/alerter.md
@@ -309,7 +309,9 @@ than 4000 dimensions. The alerter stores anomaly embeddings as
 `halfvec(4000)` and zero-pads each embedding to 4000 dimensions; 4000
 is pgvector's HNSW index limit for the `halfvec` type. The alerter
 rejects a model that exceeds 4000 dimensions with a clear error rather
-than truncating the vector.
+than truncating the vector. Storing embeddings as `halfvec` requires
+pgvector `0.7.0` or newer; upgrading an existing installation against
+an older pgvector causes the embedding-column migration to fail.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/docs/getting-started/configuration/alerter.md
+++ b/docs/getting-started/configuration/alerter.md
@@ -304,6 +304,13 @@ across metrics.
 The `llm` section configures LLM providers for tier 3
 anomaly detection and embedding generation.
 
+The configured embedding model must not produce vectors with more
+than 4000 dimensions. The alerter stores anomaly embeddings as
+`halfvec(4000)` and zero-pads each embedding to 4000 dimensions; 4000
+is pgvector's HNSW index limit for the `halfvec` type. The alerter
+rejects a model that exceeds 4000 dimensions with a clear error rather
+than truncating the vector.
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `embedding_provider` | string | `ollama` | Embedding provider |

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -381,7 +381,9 @@ dimensions. The server stores chat memory embeddings as `halfvec(4000)`
 and zero-pads each embedding to 4000 dimensions; 4000 is pgvector's
 HNSW index limit for the `halfvec` type. The server rejects a model
 that exceeds 4000 dimensions with a clear error rather than truncating
-the vector.
+the vector. Storing embeddings as `halfvec` requires pgvector `0.7.0`
+or newer; upgrading an existing installation against an older pgvector
+causes the embedding-column migration to fail.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -376,6 +376,13 @@ default, 3072 dimensions), `gemini-embedding-2`, and
 availability varies by Gemini API key tier; run ListModels to verify
 which embedding models a given key can access.
 
+The configured `model` must not produce vectors with more than 4000
+dimensions. The server stores chat memory embeddings as `halfvec(4000)`
+and zero-pads each embedding to 4000 dimensions; 4000 is pgvector's
+HNSW index limit for the `halfvec` type. The server rejects a model
+that exceeds 4000 dimensions with a clear error rather than truncating
+the vector.
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable embeddings |

--- a/examples/ai-dba-alerter.yaml
+++ b/examples/ai-dba-alerter.yaml
@@ -310,6 +310,13 @@ llm:
   # Provider to use for generating embeddings (tier 2)
   # Options: ollama, openai, gemini, voyage
   # Default: ollama
+  #
+  # The configured embedding model must not produce vectors with
+  # more than 4000 dimensions. Anomaly embeddings are stored as
+  # halfvec(4000) and zero-padded to 4000 dimensions, which is
+  # pgvector's HNSW index limit for the halfvec type. Models that
+  # exceed 4000 dimensions are not supported; such a model is rejected
+  # with an error rather than truncating the vector.
   embedding_provider: ollama
 
   # Provider to use for reasoning/classification (tier 3)

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -214,6 +214,13 @@ embedding:
   #   - openai: text-embedding-3-small
   #   - gemini: gemini-embedding-001
   #   - ollama: nomic-embed-text
+  #
+  # The configured embedding model must not produce vectors with
+  # more than 4000 dimensions. Embeddings are stored as halfvec(4000)
+  # and zero-padded to 4000 dimensions, which is pgvector's HNSW index
+  # limit for the halfvec type. Models that exceed 4000 dimensions are
+  # not supported; the server rejects such a model with an error rather
+  # than truncating the vector.
   model: "nomic-embed-text"
 
   #-----------------------------------------------------------------------

--- a/pkg/embedding/pad.go
+++ b/pkg/embedding/pad.go
@@ -1,0 +1,54 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package embedding
+
+import "fmt"
+
+// MaxDimensions is the fixed width of the halfvec columns used to store
+// embeddings. The vector tables (chat_memories.embedding and
+// anomaly_embeddings.embedding) are declared as halfvec(4000); every
+// embedding is right-padded with zeros to exactly this width before it
+// is stored or used as a query vector. The halfvec HNSW index supports
+// up to 4000 dimensions, which covers every provider currently in use
+// (the largest, Gemini, emits 3072). Trailing zeros do not change the
+// cosine distance between two equally padded vectors, so similarity
+// search results are unaffected.
+const MaxDimensions = 4000
+
+// PadTo returns a new slice containing vec right-padded with zeros to
+// exactly dim elements. It is the single point that enforces the
+// MaxDimensions ceiling for both stored and query vectors.
+//
+// A nil or empty input returns nil: callers treat a missing embedding
+// as "no vector available" and must not fabricate an all-zero vector,
+// which would otherwise pollute similarity search.
+//
+// PadTo returns an error when len(vec) > dim. Models that emit more
+// than dim dimensions are unsupported; the embedding must be rejected
+// rather than silently truncated, because truncation would discard
+// signal and corrupt distances.
+func PadTo(vec []float32, dim int) ([]float32, error) {
+	if len(vec) == 0 {
+		return nil, nil
+	}
+	if len(vec) > dim {
+		return nil, fmt.Errorf(
+			"embedding has %d dimensions, exceeds maximum supported %d",
+			len(vec), dim)
+	}
+	// A new slice of len dim is already zero-filled; copying the input
+	// over the leading elements right-pads with zeros. Returning a copy
+	// (never the caller's slice) keeps the result independent of the
+	// input even when len(vec) == dim.
+	out := make([]float32, dim)
+	copy(out, vec)
+	return out, nil
+}

--- a/pkg/embedding/pad_test.go
+++ b/pkg/embedding/pad_test.go
@@ -1,0 +1,104 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package embedding
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPadTo_NilAndEmpty(t *testing.T) {
+	for _, in := range [][]float32{nil, {}} {
+		out, err := PadTo(in, MaxDimensions)
+		if err != nil {
+			t.Fatalf("PadTo(%v): unexpected error: %v", in, err)
+		}
+		if out != nil {
+			t.Errorf("PadTo(%v) = %v, want nil", in, out)
+		}
+	}
+}
+
+func TestPadTo_RightPadsWithZeros(t *testing.T) {
+	in := []float32{1, 2, 3}
+	out, err := PadTo(in, 5)
+	if err != nil {
+		t.Fatalf("PadTo: unexpected error: %v", err)
+	}
+	if len(out) != 5 {
+		t.Fatalf("len(out) = %d, want 5", len(out))
+	}
+	want := []float32{1, 2, 3, 0, 0}
+	for i := range want {
+		if out[i] != want[i] {
+			t.Errorf("out[%d] = %v, want %v", i, out[i], want[i])
+		}
+	}
+}
+
+func TestPadTo_ExactLengthReturnsIndependentCopy(t *testing.T) {
+	in := []float32{1, 2, 3}
+	out, err := PadTo(in, 3)
+	if err != nil {
+		t.Fatalf("PadTo: unexpected error: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3", len(out))
+	}
+	for i := range in {
+		if out[i] != in[i] {
+			t.Errorf("out[%d] = %v, want %v", i, out[i], in[i])
+		}
+	}
+	// Mutating the result must not affect the caller's input.
+	out[0] = 99
+	if in[0] != 1 {
+		t.Errorf("input mutated through returned slice: in[0] = %v", in[0])
+	}
+}
+
+func TestPadTo_RejectsOversizedVector(t *testing.T) {
+	in := []float32{1, 2, 3, 4, 5}
+	out, err := PadTo(in, 4)
+	if err == nil {
+		t.Fatalf("expected error for oversized vector, got out=%v", out)
+	}
+	if out != nil {
+		t.Errorf("expected nil slice on error, got %v", out)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "5") || !strings.Contains(msg, "4") {
+		t.Errorf("error message %q should mention input (5) and limit (4)", msg)
+	}
+	if !strings.Contains(msg, "exceeds maximum supported") {
+		t.Errorf("error message %q missing expected wording", msg)
+	}
+}
+
+func TestPadTo_MaxDimensionsValue(t *testing.T) {
+	if MaxDimensions != 4000 {
+		t.Errorf("MaxDimensions = %d, want 4000", MaxDimensions)
+	}
+	// A vector at exactly the ceiling is accepted and padded to itself.
+	in := make([]float32, MaxDimensions)
+	in[0] = 1
+	out, err := PadTo(in, MaxDimensions)
+	if err != nil {
+		t.Fatalf("PadTo at ceiling: %v", err)
+	}
+	if len(out) != MaxDimensions {
+		t.Errorf("len(out) = %d, want %d", len(out), MaxDimensions)
+	}
+	// One element beyond the ceiling is rejected.
+	if _, err := PadTo(make([]float32, MaxDimensions+1), MaxDimensions); err == nil {
+		t.Errorf("expected error for vector exceeding MaxDimensions")
+	}
+}

--- a/server/src/internal/memory/store.go
+++ b/server/src/internal/memory/store.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"time"
 
+	embeddingpkg "github.com/pgedge/ai-workbench/pkg/embedding"
+
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -75,7 +77,14 @@ func (s *Store) Store(
 
 	var embeddingArg any
 	if embedding != nil {
-		embeddingArg = formatEmbedding(embedding)
+		// Zero-pad to the fixed halfvec width so any provider's
+		// dimensionality fits the column; reject vectors larger than
+		// the supported maximum rather than truncating them.
+		padded, err := embeddingpkg.PadTo(embedding, embeddingpkg.MaxDimensions)
+		if err != nil {
+			return nil, err
+		}
+		embeddingArg = formatEmbedding(padded)
 	}
 
 	mem := &Memory{
@@ -93,7 +102,7 @@ func (s *Store) Store(
 		`INSERT INTO chat_memories
              (username, scope, category, content, pinned, embedding,
               model_name, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6::vector, $7, $8, $9)
+         VALUES ($1, $2, $3, $4, $5, $6::halfvec, $7, $8, $9)
          RETURNING id`,
 		mem.Username, mem.Scope, mem.Category, mem.Content,
 		mem.Pinned, embeddingArg, mem.ModelName,
@@ -156,7 +165,13 @@ func (s *Store) searchByVector(
 	limit int,
 	embedding []float32,
 ) ([]Memory, error) {
-	embStr := formatEmbedding(embedding)
+	// Pad the query vector to the same fixed width as the stored
+	// vectors so cosine distance is computed over identical layouts.
+	padded, err := embeddingpkg.PadTo(embedding, embeddingpkg.MaxDimensions)
+	if err != nil {
+		return nil, err
+	}
+	embStr := formatEmbedding(padded)
 
 	var conditions []string
 	args := []any{embStr}
@@ -193,7 +208,7 @@ func (s *Store) searchByVector(
                 model_name, created_at, updated_at
          FROM chat_memories
          WHERE %s
-         ORDER BY embedding <=> $1::vector
+         ORDER BY embedding <=> $1::halfvec
          LIMIT $%d`,
 		whereClause, paramIdx)
 

--- a/server/src/internal/memory/store_db_test.go
+++ b/server/src/internal/memory/store_db_test.go
@@ -19,9 +19,10 @@ import (
 )
 
 // memoryTestSchema mirrors the chat_memories table that store.go reads
-// from and writes to. The vector dimension is intentionally small (3) so
-// tests can supply tiny float slices and still exercise the cosine
-// distance ordering branch.
+// from and writes to. The embedding column is halfvec(4000) to match the
+// production schema; store.go zero-pads every short test vector to that
+// width before insertion, so the tests can still supply tiny float
+// slices and exercise the cosine distance ordering branch.
 const memoryTestSchema = `
 CREATE EXTENSION IF NOT EXISTS vector;
 DROP TABLE IF EXISTS chat_memories CASCADE;
@@ -32,7 +33,7 @@ CREATE TABLE chat_memories (
     category TEXT NOT NULL,
     content TEXT NOT NULL,
     pinned BOOLEAN NOT NULL DEFAULT FALSE,
-    embedding vector(3),
+    embedding halfvec(4000),
     model_name TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -178,13 +179,31 @@ func TestStore_Store(t *testing.T) {
 		}
 	})
 
-	t.Run("insert error surfaces wrapped", func(t *testing.T) {
-		// Force a DB-side failure by passing a wrong-length vector.
+	t.Run("oversized embedding is rejected", func(t *testing.T) {
+		// A short vector now pads cleanly to the halfvec width and
+		// inserts successfully, so the failure case is a vector that
+		// exceeds the maximum supported dimensions. Store must reject it
+		// via the PadTo guard before reaching the database.
 		truncateMemories(t, pool)
+		oversized := make([]float32, 4001)
 		_, err := store.Store(ctx, "alice", "user", "c", "hi",
-			false, []float32{1, 2, 3, 4, 5}, "m")
+			false, oversized, "m")
 		if err == nil {
-			t.Fatalf("expected wrapped insert error for bad vector dim")
+			t.Fatalf("expected error for oversized embedding")
+		}
+	})
+
+	t.Run("short embedding pads and inserts", func(t *testing.T) {
+		// A 5-element vector used to fail against vector(3); under
+		// halfvec(4000) with application padding it must now succeed.
+		truncateMemories(t, pool)
+		mem, err := store.Store(ctx, "alice", "user", "c", "hi",
+			false, []float32{1, 2, 3, 4, 5}, "m")
+		if err != nil {
+			t.Fatalf("expected short embedding to pad and insert: %v", err)
+		}
+		if mem.ID == 0 {
+			t.Errorf("expected non-zero id")
 		}
 	})
 }
@@ -692,6 +711,18 @@ func TestStore_Search(t *testing.T) {
 		}
 		if len(got) > 100 {
 			t.Errorf("expected <=100 rows, got %d", len(got))
+		}
+	})
+
+	t.Run("oversized query vector is rejected", func(t *testing.T) {
+		// The vector-search path pads the query vector identically to
+		// stored vectors; a query vector beyond the supported width must
+		// surface the PadTo error rather than reach the database.
+		seed(t)
+		oversized := make([]float32, 4001)
+		if _, err := store.Search(ctx, "alice", "", "", "", 0,
+			oversized); err == nil {
+			t.Fatalf("expected error for oversized query vector")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `chat_memories.embedding` and `anomaly_embeddings.embedding` were hardcoded to `vector(1536)` (OpenAI's dimension), so Gemini (3072), Voyage (1024/512), and Ollama (384/768/1024) embedding providers failed with `expected 1536 dimensions, not N (SQLSTATE 22000)`.
- Both columns are now `halfvec(4000)` and every embedding is zero-padded to a fixed 4000-dimension width before storage and search. `halfvec`'s HNSW index supports up to 4000 dimensions (plain `vector` caps at 2000), so the ANN index is retained and the schema stays decoupled from the configured provider. Trailing zeros leave cosine distance unchanged.
- Models that emit more than 4000 dimensions are rejected with a clear error rather than silently truncated; this ceiling is documented in the config examples and configuration docs.

## Changes

- New `pkg/embedding.PadTo` + `MaxDimensions` — the single point that pads vectors and enforces the 4000-dim ceiling.
- Migration #6 upgrades existing `vector(1536)` columns in place: it zero-pads rows, preserves `NULL`s, and rebuilds the HNSW index with `halfvec_cosine_ops`. It is savepoint-guarded (degrades to a no-op without pgvector) and idempotent.
- Server memory store and alerter anomaly queries pad on store and on query, and cast values to `::halfvec`.
- Config examples (`examples/ai-dba-server.yaml`, `examples/ai-dba-alerter.yaml`) and configuration docs note the 4000-dimension limit; changelog updated.

## Test plan

- [x] `make test-all` passes (collector, server, alerter, client) against local PostgreSQL 18 + pgvector 0.8.2.
- [x] New `collector/src/database/migration_v6_test.go` proves: fresh schema creates `halfvec(4000)` columns; a pre-seeded legacy `vector(1536)` DB is upgraded (rows padded, `NULL`s preserved, index rebuilt); re-running the migration is a no-op.
- [x] `pkg/embedding` `PadTo` unit tests (pad, exact-length copy, nil/empty, oversized rejection); 100% coverage.
- [x] Server/alerter store + search tests updated to `halfvec(4000)`, including oversized-vector rejection; touched units ≥90% coverage.
- [x] Verified on pgvector 0.8.2 that cosine distance is preserved under identical zero-padding.

Closes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized embedding storage and similarity search on `halfvec(4000)` with automatic zero-padding; embeddings exceeding 4000 dimensions are now rejected to prevent incorrect similarity behavior.
* **Chores**
  * Added a forward migration to widen existing embedding columns to `halfvec(4000)` and rebuild HNSW indexes, with safe idempotent upgrade behavior.
* **Tests**
  * Expanded coverage for padding/limits, migration upgrade and idempotency, and error handling during similarity lookup.
* **Documentation**
  * Updated changelog, configuration docs, and examples to clearly state the 4000-dimension cap and padding/migration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->