### PR TITLE
package cells: native arm64 runners to avoid QEMU ldconfig segfault

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,7 +432,10 @@ jobs:
             needs.build-client.result == 'success' &&
             needs.build-go.result == 'success' &&
             needs.detect-matrix.outputs.has_rpm == 'true'
-        runs-on: ubuntu-latest
+        # arm64 cells run on native arm64 runners to avoid QEMU emulation
+        # (emulated glibc ldconfig segfaults during build-env setup); amd64
+        # stays on the standard x86_64 runner.
+        runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
         strategy:
             fail-fast: false
             matrix: ${{ fromJSON(needs.detect-matrix.outputs.rpm_matrix) }}
@@ -646,7 +649,10 @@ jobs:
             needs.build-client.result == 'success' &&
             needs.build-go.result == 'success' &&
             needs.detect-matrix.outputs.has_deb == 'true'
-        runs-on: ubuntu-latest
+        # arm64 cells run on native arm64 runners to avoid QEMU emulation
+        # (emulated glibc ldconfig segfaults during build-env setup); amd64
+        # stays on the standard x86_64 runner.
+        runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
         strategy:
             fail-fast: false
             matrix: ${{ fromJSON(needs.detect-matrix.outputs.deb_matrix) }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build infrastructure by using native arm64 runners for ARM builds while maintaining standard runners for other architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->