### PR TITLE
Update binary_install.md

### DIFF
--- a/docs/getting-started/binary_install.md
+++ b/docs/getting-started/binary_install.md
@@ -528,8 +528,7 @@ sudo nginx -t
 sudo systemctl restart nginx
 ```
 
-Open a browser and navigate to `http://<server-ip>`; provide
-authentication details when the Workbench opens.
+Open a browser and navigate to `http://<server-ip>`; and log in with the username and password you created when you ran the `add-user` command.
 
 ![Log in to the AI DBA Workbench](../images/workbench_login.png)
 

--- a/docs/getting-started/binary_install.md
+++ b/docs/getting-started/binary_install.md
@@ -528,7 +528,8 @@ sudo nginx -t
 sudo systemctl restart nginx
 ```
 
-Open a browser and navigate to `http://<server-ip>`; and log in with the username and password you created when you ran the `add-user` command.
+Open a browser and navigate to `http://<server-ip>`; log in with the
+username and password you created when you ran the `-add-user` command.
 
 ![Log in to the AI DBA Workbench](../images/workbench_login.png)
 


### PR DESCRIPTION
Clarified which login details to use when accessing the workbench for the first time based on user feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the Workbench startup login steps.
  * Users are now explicitly instructed to sign in at `http://<server-ip>` using the username and password created via the server’s `-add-user` command.
  * The guidance is now more direct and easier to follow when first accessing the Workbench.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->