### PR TITLE
ci(walkthrough): fix smoke test failing on empty LLM key

### DIFF
--- a/.github/workflows/ci-walkthrough.yml
+++ b/.github/workflows/ci-walkthrough.yml
@@ -54,7 +54,10 @@ jobs:
                   mkdir -p examples/walkthrough/secret
                   openssl rand -base64 32 > examples/walkthrough/secret/ai-dba.secret
                   echo "postgres" > examples/walkthrough/secret/pg-password
-                  echo "" > examples/walkthrough/secret/llm-api-key
+                  # The server treats a configured-but-empty LLM key file as a
+                  # fatal config error, so write a clearly-fake placeholder. The
+                  # smoke test never calls the LLM, so the value is irrelevant.
+                  echo "ci-placeholder-llm-key" > examples/walkthrough/secret/llm-api-key
 
             - name: Start services
               run: docker compose -f examples/walkthrough/docker-compose.yml up -d


### PR DESCRIPTION
The walkthrough `Smoke Test` job has been red since early June (exposed on `main` by the recent `actions/checkout` v7 bump, which touched this workflow file and re-triggered it).

## Root cause
The job writes an **empty** `llm-api-key` secret file. The server now treats a configured-but-empty key file as a fatal config error (`server/src/internal/config/config.go` `ReadSecretFile` rejects empty/whitespace content), so `wt-server` fails config load, becomes unhealthy, and `docker compose up` aborts with `container wt-server is unhealthy`. This is unrelated to Dependabot; it fails on `main` pushes too.

## Fix
Write a clearly-fake, non-credential-shaped placeholder (`ci-placeholder-llm-key`) instead of an empty file. The smoke test never calls the LLM, so the value is irrelevant; a non-empty file just satisfies the server's config validation so the stack can start.

Opened as a PR (rather than pushed straight to main) so the walkthrough workflow validates the fix before it lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the smoke-test setup by ensuring required placeholder secret values are populated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->