### PR TITLE
docs(examples): document supported embedding providers in server sample

### DIFF
--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -387,7 +387,7 @@ knowledgebase:
   #-----------------------------------------------------------------------
 
   # Embedding provider for knowledgebase similarity search
-  # The Embedding provider must be one of the following: ollama, voyage, openai
+  # The Embedding provider must be one of the following: ollama, voyage, openai, gemini
   # Default: ollama
   embedding_provider: "ollama"
 

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -387,7 +387,7 @@ knowledgebase:
   #-----------------------------------------------------------------------
 
   # Embedding provider for knowledgebase similarity search
-  # Options: ollama, voyage, openai
+  # The Embedding provider must be one of the following: ollama, voyage, openai
   # Default: ollama
   embedding_provider: "ollama"
 

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -387,6 +387,7 @@ knowledgebase:
   #-----------------------------------------------------------------------
 
   # Embedding provider for knowledgebase similarity search
+  # Options: ollama, voyage, openai
   # Default: ollama
   embedding_provider: "ollama"
 


### PR DESCRIPTION
## Summary

- Adds `# Options: ollama, voyage, openai` comment to the `embedding_provider` field in `examples/ai-dba-server.yaml` so users know which providers are supported for knowledgebase similarity search embeddings.

## Test plan

- [ ] Review the comment in `examples/ai-dba-server.yaml` around the `embedding_provider` field to confirm the options are listed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the allowed embedding provider values in the knowledgebase configuration example (`ollama`, `voyage`, `openai`, or `gemini`) to make setup guidance easier to follow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->