### PR TITLE
docs(config): update knowledgebase database_path for pgedge-ai-kb

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,13 @@ project adheres to
   package matching their chosen embedding provider and model, and
   set `database_path` themselves. (#316)
 
+- Update the knowledgebase `database_path` documentation and the
+  example server configuration for the renamed `pgedge-ai-kb`
+  package. The packages install one database per embedding
+  provider and model under `/usr/share/pgedge/pgedge-ai-kb/`,
+  named `kb-<provider>-<model>.db`, and the built-in default
+  still points at the legacy `postgres-mcp-kb` path. (#293)
+
 ### Fixed
 
 - Fix the metrics time-series API (`GET /api/v1/metrics/query`)

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -556,7 +556,7 @@ similarity search.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable knowledgebase |
-| `database_path` | string | `/usr/share/pgedge/postgres-mcp-kb/kb.db` (legacy default; set to the installed `pgedge-ai-kb` file such as `/usr/share/pgedge/pgedge-ai-kb/kb-ollama-nomic-embed-text.db`) | SQLite knowledgebase database path |
+| `database_path` | string | `/usr/share/pgedge/postgres-mcp-kb/kb.db` (legacy; see note above) | SQLite knowledgebase database path |
 | `embedding_provider` | string | `ollama` | Embedding provider |
 | `embedding_model` | string | `nomic-embed-text` | Embedding model |
 | `embedding_ollama_url` | string | `http://localhost:11434` | Ollama URL |

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -137,7 +137,7 @@ llm:
 #=====================================================
 knowledgebase:
   enabled: false
-  # database_path: "/usr/share/pgedge/postgres-mcp-kb/kb.db"
+  # database_path: "/usr/share/pgedge/pgedge-ai-kb/kb-ollama-nomic-embed-text.db"
   embedding_provider: "ollama"
   embedding_model: "nomic-embed-text"
   embedding_ollama_url: "http://localhost:11434"
@@ -522,6 +522,24 @@ llm:
 
 ### Knowledgebase (`knowledgebase`)
 
+The `pgedge-ai-kb` packages install one knowledgebase database
+per embedding provider and model. On Linux these files live in
+`/usr/share/pgedge/pgedge-ai-kb/`, and each file is named
+`kb-<provider>-<model>.db`. The `<provider>` and `<model>` parts
+match the configured `embedding_provider` and `embedding_model`
+values. For the default ollama provider with the
+`nomic-embed-text` model, the file is
+`kb-ollama-nomic-embed-text.db`. The full default path is
+therefore
+`/usr/share/pgedge/pgedge-ai-kb/kb-ollama-nomic-embed-text.db`.
+The exact location can vary by deployment method and operating
+system.
+
+The built-in `database_path` default still points at the legacy
+`/usr/share/pgedge/postgres-mcp-kb/kb.db` location. Set
+`database_path` explicitly when you use the current
+`pgedge-ai-kb` packages, so the server reads the installed file.
+
 The `embedding_provider` option accepts `voyage`, `openai`, `gemini`,
 or `ollama`. The Gemini provider supports `gemini-embedding-001` (the
 default, 3072 dimensions), `gemini-embedding-2`, and
@@ -538,7 +556,7 @@ similarity search.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable knowledgebase |
-| `database_path` | string | `/usr/share/pgedge/postgres-mcp-kb/kb.db` | SQLite database path |
+| `database_path` | string | `/usr/share/pgedge/postgres-mcp-kb/kb.db` (legacy default; set to the installed `pgedge-ai-kb` file such as `/usr/share/pgedge/pgedge-ai-kb/kb-ollama-nomic-embed-text.db`) | SQLite knowledgebase database path |
 | `embedding_provider` | string | `ollama` | Embedding provider |
 | `embedding_model` | string | `nomic-embed-text` | Embedding model |
 | `embedding_ollama_url` | string | `http://localhost:11434` | Ollama URL |

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -383,10 +383,23 @@ knowledgebase:
   enabled: false
 
   # Path to SQLite knowledgebase database
-  # Defaults to the pgEdge package install path; only set this to
-  # override the default location.
+  #
+  # The pgedge-ai-kb packages install one database file per
+  # embedding provider and model into
+  # /usr/share/pgedge/pgedge-ai-kb/ on Linux. Each file is named
+  # kb-<provider>-<model>.db, where <provider> and <model> match
+  # the embedding_provider and embedding_model configured below.
+  # For the default ollama provider with the nomic-embed-text
+  # model, the file is kb-ollama-nomic-embed-text.db, giving the
+  # path /usr/share/pgedge/pgedge-ai-kb/kb-ollama-nomic-embed-text.db.
+  # The exact location can vary by deployment method (native
+  # package, Docker, or manual install) and operating system.
+  #
+  # The built-in default still points at the legacy
+  # postgres-mcp-kb location, so set database_path explicitly when
+  # using the current pgedge-ai-kb packages.
   # Default: /usr/share/pgedge/postgres-mcp-kb/kb.db
-  # database_path: "/usr/share/pgedge/postgres-mcp-kb/kb.db"
+  # database_path: "/usr/share/pgedge/pgedge-ai-kb/kb-ollama-nomic-embed-text.db"
 
   #-----------------------------------------------------------------------
   # Knowledgebase Embedding Configuration


### PR DESCRIPTION
## Summary

- The knowledgebase SQLite database was repackaged when the builder was renamed from `postgres-mcp-kb` to `pgedge-ai-kb`. The `pgedge-ai-kb` packages install one database **per embedding provider and model** under `/usr/share/pgedge/pgedge-ai-kb/`, named `kb-<provider>-<model>.db` (e.g. `kb-ollama-nomic-embed-text.db`), rather than a single `/usr/share/pgedge/postgres-mcp-kb/kb.db`. Verified against the packaging in [`pgEdge/pgedge-ai-kb`](https://github.com/pgEdge/pgedge-ai-kb) (`pkg/rpm/pgedge-ai-kb.spec`, `pkg/deb/debian/rules`).
- `examples/ai-dba-server.yaml` and the configuration guide still referenced the old path, which is the subject of #293.
- This updates the example config and `docs/getting-started/configuration/server.md` to document the new directory and per-provider/model filename convention, note that the path can vary by deployment method and OS, and add a changelog entry.

## Scope notes

- **Docs and example only — no code or runtime behaviour change**, per the issue owner's direction. The KB schema is unchanged (bar a previously added `gemini` column), so the consumption code needs no migration here.
- The server code's built-in `database_path` default (`server/src/internal/config/config.go`) is **deliberately left at the legacy `/usr/share/pgedge/postgres-mcp-kb/kb.db`**. The docs therefore state the legacy default honestly and instruct users to set `database_path` explicitly to the installed `pgedge-ai-kb` file. Updating that built-in default is a behaviour change left for a follow-up.
- The `gemini` embedding-column read in `search_knowledgebase` is tracked separately in #297; out of scope here.

## Test plan

- [x] No test loads `examples/ai-dba-server.yaml` (grep over `server/src` is empty), and the YAML edits are comment-only, so parsing is unaffected.
- [x] No `mkdocs`/`markdownlint`/`docs` target exists in the Makefile; new prose wraps within 79 chars (only an unwrappable code-path line and a table row exceed it, consistent with the file's existing style).
- [x] No production code changed (`git diff` touches only `.md`/`.yaml`).

Closes #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated server configuration and example files to reflect updated knowledgebase behavior for `pgedge-ai-kb`.
  * Documented the provider/model-specific SQLite database layout under `/usr/share/pgedge/pgedge-ai-kb/` using the `kb-<provider>-<model>.db` naming pattern.
  * Clarified that the built-in `knowledgebase.database_path` default remains the legacy `postgres-mcp-kb` location unless explicitly set.
  * Refreshed the “Unreleased” changelog entry to match the new guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->