### PR TITLE
Remove runtime pgedge-ai-kb dependency

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,19 @@ The format is based on
 project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Drop the runtime dependency on a knowledgebase package from the
+  `pgedge-ai-dba-server` package in both the Debian and RPM
+  packaging. The knowledgebase is now published as co-installable
+  `pgedge-ai-kb-<provider>-<model>` packages, one per embedding
+  provider and model, and it remains opt-in and disabled by
+  default. Operators who want the knowledgebase install the
+  package matching their chosen embedding provider and model, and
+  set `database_path` themselves. (#316)
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/pgEdge/ai-dba-workbench
 
 Package: pgedge-ai-dba-server
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, pgedge-ai-kb, openssl
+Depends: ${shlibs:Depends}, ${misc:Depends}, openssl
 Description: pgEdge AI DBA Server
  Core AI DBA server providing REST API and AI-powered analysis for
  PostgreSQL databases.

--- a/packaging/rpm/ai-dba-workbench.spec
+++ b/packaging/rpm/ai-dba-workbench.spec
@@ -31,7 +31,7 @@ management for PostgreSQL databases.
 # ============================================================================
 %package -n pgedge-ai-dba-server
 Summary:        pgEdge AI DBA Server
-Requires:       pgedge-ai-kb openssl
+Requires:       openssl
 
 %description -n pgedge-ai-dba-server
 Core AI DBA server providing REST API and AI-powered analysis for


### PR DESCRIPTION
Remove pgedge-ai-kb dependency because now user will install dependency based on model he/she selects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies for Debian and RPM builds of the server package.
  * Dropped the previous explicit dependency on the knowledgebase package while retaining the OpenSSL requirement.
* **Documentation**
  * Updated the changelog to reflect that knowledgebase is now delivered as opt-in, co-installable packages (configured by operators).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->