### PR TITLE
fix(client): show group-inherited admin privileges on the Users tab

### DIFF
--- a/client/src/components/AdminPanel/EffectivePermissionsPanel.tsx
+++ b/client/src/components/AdminPanel/EffectivePermissionsPanel.tsx
@@ -146,7 +146,7 @@ const EffectivePermissionsPanel: React.FC<EffectivePermissionsPanelProps> = ({
                     )}
                 </CategoryCard>
 
-                {isSuperuser && (
+                {(isSuperuser || (adminPermissions && adminPermissions.length > 0)) && (
                     <CategoryCard icon={AdminIcon} label="Admin" testId="admin-permissions-section">
                         {adminPermissions && adminPermissions.length > 0 ? (
                             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>

--- a/client/src/components/AdminPanel/__tests__/EffectivePermissionsPanel.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/EffectivePermissionsPanel.test.tsx
@@ -111,7 +111,7 @@ describe('EffectivePermissionsPanel', () => {
         expect(screen.getByText('Manage Groups')).toBeInTheDocument();
     });
 
-    it('does not display admin permissions when isSuperuser is false', () => {
+    it('displays group-inherited admin permissions for a non-superuser', () => {
         const adminPermissions = ['manage_users', 'manage_groups'];
 
         renderWithTheme(
@@ -121,7 +121,26 @@ describe('EffectivePermissionsPanel', () => {
             />
         );
 
+        // A non-superuser who has admin permissions inherited via group
+        // membership must still see the Admin section and its chips.
+        const adminSection = screen.getByTestId('admin-permissions-section');
+        expect(screen.getByText('Admin')).toBeInTheDocument();
+        expect(within(adminSection).getByText('Manage Users')).toBeInTheDocument();
+        expect(within(adminSection).getByText('Manage Groups')).toBeInTheDocument();
+    });
+
+    it('does not display admin section for a non-superuser with no admin permissions', () => {
+        renderWithTheme(
+            <EffectivePermissionsPanel
+                adminPermissions={[]}
+                isSuperuser={false}
+            />
+        );
+
+        // With neither superuser status nor any admin permissions there is
+        // nothing to show, so the Admin card is omitted entirely.
         expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('admin-permissions-section')).not.toBeInTheDocument();
     });
 
     it('displays "All Admin Permissions" for wildcard permission', () => {


### PR DESCRIPTION
## Summary

- On the Users tab, a user's ADMIN privileges **inherited through group membership** were not displayed under their name (per #296, Alice had several inherited ADMIN privileges that were omitted).
- Root cause is purely client-side: in `EffectivePermissionsPanel.tsx` the Admin permissions card was gated on `isSuperuser`, so a non-superuser whose admin permissions come from a group (where `isSuperuser` is `false` but `adminPermissions` is non-empty) never saw the Admin section. The server already returns the correct effective `admin_permissions` (including group-inherited ones) from `/api/v1/rbac/users/{id}/privileges`.
- The fix gates the Admin card on `isSuperuser || adminPermissions.length > 0`. The superuser path is byte-for-byte unchanged (superusers still receive the `"*"` wildcard and render as before), and a non-superuser with no admin permissions still shows no Admin card, matching the sibling cards' intent of not adding noise for the common case.

This is a **display-only** change; server-side enforcement and effective-privilege computation are untouched.

## Test plan

- [x] Replaced the test that codified the old behaviour with two tests: a non-superuser with inherited admin permissions now shows the Admin section and its chips; a non-superuser with no admin permissions shows no Admin card. Existing superuser/wildcard tests still pass (19/19).
- [x] `npm run lint` clean (no new warnings on the touched files).
- [x] `EffectivePermissionsPanel.tsx` at 100% line coverage (above the 90% floor).

Closes #296