### PR TITLE
feat(cli): add -group-description flag for creating groups

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add a `-group-description` CLI flag that sets a group's
+  description when creating it with `-add-group`, matching the
+  description support already available in the web console. (#301)
+
 ### Changed
 
 - Drop the runtime dependency on a knowledgebase package from the

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -257,6 +257,7 @@ builtins:
 | `-add-member` | Add a user or group to a group |
 | `-remove-member` | Remove a member from a group |
 | `-group string` | Group name for group commands |
+| `-group-description string` | Group description for add-group |
 | `-member-group string` | Member group for nesting |
 | `-set-superuser` | Set superuser status |
 | `-unset-superuser` | Remove superuser status |

--- a/server/src/cmd/mcp-server/commands.go
+++ b/server/src/cmd/mcp-server/commands.go
@@ -121,7 +121,7 @@ func RunCLICommands(f *Flags, dataDir string) bool {
 	// Handle group management commands
 	if f.HasGroupCommand() {
 		if f.AddGroupCmd {
-			if err := addGroupCommand(dataDir, f.GroupName, ""); err != nil {
+			if err := addGroupCommand(dataDir, f.GroupName, f.GroupDescription); err != nil {
 				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 				os.Exit(1)
 			}

--- a/server/src/cmd/mcp-server/flags.go
+++ b/server/src/cmd/mcp-server/flags.go
@@ -73,6 +73,7 @@ type Flags struct {
 	AddMemberCmd      bool
 	RemoveMemberCmd   bool
 	GroupName         string
+	GroupDescription  string
 	MemberGroup       string
 	SetSuperuserCmd   bool
 	UnsetSuperuserCmd bool
@@ -157,6 +158,7 @@ func ParseFlags(defaultConfigPath string) *Flags {
 	flag.BoolVar(&f.AddMemberCmd, "add-member", false, "Add a user or group to a group")
 	flag.BoolVar(&f.RemoveMemberCmd, "remove-member", false, "Remove a user or group from a group")
 	flag.StringVar(&f.GroupName, "group", "", "Group name for group management commands")
+	flag.StringVar(&f.GroupDescription, "group-description", "", "Group description for add-group")
 	flag.StringVar(&f.MemberGroup, "member-group", "", "Member group name (for nested group membership)")
 	flag.BoolVar(&f.SetSuperuserCmd, "set-superuser", false, "Set superuser status for a user")
 	flag.BoolVar(&f.UnsetSuperuserCmd, "unset-superuser", false, "Remove superuser status from a user")

--- a/server/src/cmd/mcp-server/groups_test.go
+++ b/server/src/cmd/mcp-server/groups_test.go
@@ -1,0 +1,103 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+)
+
+// TestAddGroupCommand verifies that addGroupCommand creates a group and that
+// the supplied description is persisted and round-trips through the auth store.
+func TestAddGroupCommand(t *testing.T) {
+	t.Run("persists non-empty description", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		const (
+			groupName = "platform-team"
+			groupDesc = "Owners of the platform connections"
+		)
+
+		if err := addGroupCommand(tmpDir, groupName, groupDesc); err != nil {
+			t.Fatalf("addGroupCommand returned error: %v", err)
+		}
+
+		store, err := auth.NewAuthStore(tmpDir, 0, 0)
+		if err != nil {
+			t.Fatalf("failed to open auth store: %v", err)
+		}
+		defer store.Close()
+
+		group, err := store.GetGroupByName(groupName)
+		if err != nil {
+			t.Fatalf("GetGroupByName returned error: %v", err)
+		}
+		if group == nil {
+			t.Fatalf("expected group %q to exist, got nil", groupName)
+		}
+		if group.Name != groupName {
+			t.Errorf("expected name %q, got %q", groupName, group.Name)
+		}
+		if group.Description != groupDesc {
+			t.Errorf("expected description %q, got %q", groupDesc, group.Description)
+		}
+	})
+
+	t.Run("persists empty description", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		const groupName = "no-description-team"
+
+		if err := addGroupCommand(tmpDir, groupName, ""); err != nil {
+			t.Fatalf("addGroupCommand returned error: %v", err)
+		}
+
+		store, err := auth.NewAuthStore(tmpDir, 0, 0)
+		if err != nil {
+			t.Fatalf("failed to open auth store: %v", err)
+		}
+		defer store.Close()
+
+		group, err := store.GetGroupByName(groupName)
+		if err != nil {
+			t.Fatalf("GetGroupByName returned error: %v", err)
+		}
+		if group == nil {
+			t.Fatalf("expected group %q to exist, got nil", groupName)
+		}
+		if group.Description != "" {
+			t.Errorf("expected empty description, got %q", group.Description)
+		}
+	})
+
+	t.Run("requires group name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		err := addGroupCommand(tmpDir, "", "some description")
+		if err == nil {
+			t.Fatal("expected error for empty group name, got nil")
+		}
+	})
+
+	t.Run("returns error when auth store cannot be opened", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		blockingFile := tmpDir + "/blocking"
+		if err := os.WriteFile(blockingFile, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create blocking file: %v", err)
+		}
+
+		err := addGroupCommand(blockingFile+"/subdir", "any-group", "desc")
+		if err == nil {
+			t.Fatal("expected error when auth store path is invalid, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- The server CLI could create an RBAC group (`-add-group -group <name>`), and `addGroupCommand`/`CreateGroup` already accepted a description, but no flag was wired up — `commands.go` hardcoded the description to `""`. The web console could set a group description at creation time whilst the CLI could not, the divergence reported in #301.
- Adds a `-group-description string` flag (mirroring the existing `-privilege-description` flag) and passes it through to `addGroupCommand`, so a description can now be set when creating a group from the command line.
- Updates the CLI flag reference in the configuration docs and adds a changelog entry.

## Test plan

- [x] New `groups_test.go` covers `addGroupCommand`: a non-empty description round-trips via `GetGroupByName`, an empty description persists as empty, and the error paths (empty name, unopenable store) are exercised. `addGroupCommand` at 90.9% line coverage (the one uncovered line is the success `fmt.Printf`).
- [x] `gofmt` clean, `go build ./...` succeeds, `go test ./cmd/mcp-server/...` passes. Unit tests use a temp SQLite auth store only (no shared database).

Closes #301