### PR TITLE
fix(rbac): preserve specific connection grants when granting All Connections

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -140,6 +140,14 @@ project adheres to
   retry is pending, distinguishing that state from genuinely empty
   data.
 
+- Granting "All Connections" access no longer deletes a group's
+  specific per-connection grants. Previously, adding an All
+  Connections READ grant destructively removed existing
+  per-connection grants, silently reducing a connection's
+  READ/WRITE access to READ; specific and wildcard grants now
+  coexist, and the effective access for each connection is the
+  higher of the two. (#302)
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/server/src/internal/auth/access_test.go
+++ b/server/src/internal/auth/access_test.go
@@ -618,6 +618,55 @@ func TestRBACCheckerAllConnectionsHigherLevel(t *testing.T) {
 	}
 }
 
+// TestRBACCheckerSpecificThenAllConnections covers issue #302 at the
+// resolver level: when specific grants are made FIRST and the wildcard is
+// granted afterwards, the specific access levels must still apply. This is
+// the reverse grant order of TestRBACCheckerAllConnectionsHigherLevel and is
+// the sequence that previously wiped the specific grants.
+func TestRBACCheckerSpecificThenAllConnections(t *testing.T) {
+	store, cleanup := createTestAuthStoreForAccess(t)
+	defer cleanup()
+
+	checker := NewRBACChecker(store)
+
+	store.CreateUser("testuser", "Password1234", "Test user", "", "")
+	userID, _ := store.GetUserID("testuser")
+	groupID, _ := store.CreateGroup("test-group", "Test")
+	store.AddUserToGroup(groupID, userID)
+
+	const (
+		connA = 1
+		connB = 2
+		connC = 3
+	)
+
+	// Specific grants first, wildcard last (reverse of the sibling test).
+	store.GrantConnectionPrivilege(groupID, connA, AccessLevelRead)
+	store.GrantConnectionPrivilege(groupID, connB, AccessLevelReadWrite)
+	store.GrantConnectionPrivilege(groupID, ConnectionIDAll, AccessLevelRead)
+
+	ctx := context.WithValue(context.Background(), IsSuperuserContextKey, false)
+	ctx = context.WithValue(ctx, UserIDContextKey, userID)
+
+	// Connection B keeps read_write (specific grant survives the wildcard).
+	canAccess, level := checker.CanAccessConnection(ctx, connB)
+	if !canAccess || level != AccessLevelReadWrite {
+		t.Errorf("Expected read_write for connection B, got canAccess=%v level=%q", canAccess, level)
+	}
+
+	// Connection A keeps read (specific grant survives the wildcard).
+	canAccess, level = checker.CanAccessConnection(ctx, connA)
+	if !canAccess || level != AccessLevelRead {
+		t.Errorf("Expected read for connection A, got canAccess=%v level=%q", canAccess, level)
+	}
+
+	// Connection C has no specific grant and falls back to the wildcard read.
+	canAccess, level = checker.CanAccessConnection(ctx, connC)
+	if !canAccess || level != AccessLevelRead {
+		t.Errorf("Expected read for connection C via wildcard, got canAccess=%v level=%q", canAccess, level)
+	}
+}
+
 // =============================================================================
 // GetEffectivePrivileges with Token Scoping Tests
 // =============================================================================

--- a/server/src/internal/auth/privileges.go
+++ b/server/src/internal/auth/privileges.go
@@ -334,17 +334,6 @@ func (s *AuthStore) GrantConnectionPrivilege(groupID int64, connectionID int, ac
 		return fmt.Errorf("failed to grant connection privilege: %w", err)
 	}
 
-	// If granting "All Connections", remove individual connection grants
-	if connectionID == ConnectionIDAll {
-		_, err = s.db.Exec(
-			"DELETE FROM connection_privileges WHERE group_id = ? AND connection_id != ?",
-			groupID, ConnectionIDAll,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to clean up individual connection privileges: %w", err)
-		}
-	}
-
 	return nil
 }
 

--- a/server/src/internal/auth/privileges_test.go
+++ b/server/src/internal/auth/privileges_test.go
@@ -440,6 +440,88 @@ func TestGrantConnectionPrivilegeUpgrade(t *testing.T) {
 	}
 }
 
+// TestGrantConnectionPrivilegeAllConnectionsPreservesSpecific reproduces
+// issue #302: granting "All Connections" must not delete pre-existing
+// per-connection grants. The specific grants (read on A, read_write on B)
+// must survive a subsequent wildcard read grant.
+func TestGrantConnectionPrivilegeAllConnectionsPreservesSpecific(t *testing.T) {
+	store, cleanup := createTestAuthStoreForPrivileges(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("test-group", "Test group")
+
+	const (
+		connA = 1
+		connB = 2
+	)
+
+	// Specific grants first: read on A, read_write on B.
+	if err := store.GrantConnectionPrivilege(groupID, connA, AccessLevelRead); err != nil {
+		t.Fatalf("Failed to grant read on connection A: %v", err)
+	}
+	if err := store.GrantConnectionPrivilege(groupID, connB, AccessLevelReadWrite); err != nil {
+		t.Fatalf("Failed to grant read_write on connection B: %v", err)
+	}
+
+	// Then grant "All Connections / READ".
+	if err := store.GrantConnectionPrivilege(groupID, ConnectionIDAll, AccessLevelRead); err != nil {
+		t.Fatalf("Failed to grant All Connections read: %v", err)
+	}
+
+	// All three rows must still exist with their original access levels.
+	privA, err := store.GetConnectionPrivilege(groupID, connA)
+	if err != nil {
+		t.Fatalf("Failed to get connection A privilege: %v", err)
+	}
+	if privA == nil || privA.AccessLevel != AccessLevelRead {
+		t.Errorf("Expected connection A = read, got %+v", privA)
+	}
+
+	privB, err := store.GetConnectionPrivilege(groupID, connB)
+	if err != nil {
+		t.Fatalf("Failed to get connection B privilege: %v", err)
+	}
+	if privB == nil || privB.AccessLevel != AccessLevelReadWrite {
+		t.Errorf("Expected connection B = read_write, got %+v", privB)
+	}
+
+	privAll, err := store.GetConnectionPrivilege(groupID, ConnectionIDAll)
+	if err != nil {
+		t.Fatalf("Failed to get All Connections privilege: %v", err)
+	}
+	if privAll == nil || privAll.AccessLevel != AccessLevelRead {
+		t.Errorf("Expected All Connections = read, got %+v", privAll)
+	}
+
+	// The full listing should contain exactly the three grants.
+	privileges, err := store.ListGroupConnectionPrivileges(groupID)
+	if err != nil {
+		t.Fatalf("Failed to list connection privileges: %v", err)
+	}
+	if len(privileges) != 3 {
+		t.Errorf("Expected 3 connection privileges after wildcard grant, got %d", len(privileges))
+	}
+}
+
+// TestGrantConnectionPrivilegeExecError exercises the error path when the
+// underlying upsert fails. Closing the database makes Exec return an error.
+func TestGrantConnectionPrivilegeExecError(t *testing.T) {
+	store, cleanup := createTestAuthStoreForPrivileges(t)
+	defer cleanup()
+
+	groupID, _ := store.CreateGroup("test-group", "Test group")
+
+	// Close the underlying DB so the upsert Exec fails.
+	if err := store.db.Close(); err != nil {
+		t.Fatalf("Failed to close store db: %v", err)
+	}
+
+	err := store.GrantConnectionPrivilege(groupID, 1, AccessLevelRead)
+	if err == nil {
+		t.Error("Expected error when granting against a closed database")
+	}
+}
+
 func TestGrantConnectionPrivilegeInvalidLevel(t *testing.T) {
 	store, cleanup := createTestAuthStoreForPrivileges(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

- Fixes #302: a group with specific per-connection grants (e.g. READ on one connection, READ/WRITE on another) silently lost the READ/WRITE when an operator added an "All Connections / READ" grant.
- Root cause was server-side: `AuthStore.GrantConnectionPrivilege` ran a destructive `DELETE FROM connection_privileges WHERE group_id = ? AND connection_id != 0` whenever the "All Connections" wildcard (`connection_id 0`) was granted, wiping every specific grant. This contradicted the effective-access resolver `resolveConnectionAccess`, which is designed for wildcard and specific grants to coexist and resolve to the higher level per connection.
- The fix removes that destructive cleanup so the wildcard grant is additive. A specific READ/WRITE is preserved when All Connections READ is added, and All Connections applies as the default for connections that have no specific grant. Behaviour is unchanged where only one grant exists.

## Scope notes

- **Server-only.** The client dialog already sends single-grant requests and the resolver already implements the intended max-semantics; only the destructive grant-side cleanup was wrong.
- The matching "grant all" cleanups for **MCP privileges** and **admin permissions** are intentionally left untouched: their resolvers treat `*` as subsuming specific grants, so the cleanup is correct there, unlike connection privileges.
- Reviewed by the security-auditor: no escalation, injection, stale-grant, or error-handling regressions. One non-blocking UX note: a lower-level wildcard does not *cap* a higher specific grant (the wildcard is additive); to downgrade a specific connection an operator revokes/re-grants that connection's row via the existing per-row revoke (UI, `DELETE .../privileges/connections/{id}`, or CLI). No change required for #302.

## Test plan

- [x] `TestGrantConnectionPrivilegeAllConnectionsPreservesSpecific` — grants READ on conn A and READ/WRITE on conn B, then All Connections READ, and asserts all three rows survive with original levels.
- [x] `TestRBACCheckerSpecificThenAllConnections` — resolver-level test in the reverse grant order (specific first, then wildcard): conn B resolves read_write, conn A read, an ungranted conn C read via the wildcard.
- [x] Added an error-path test; `GrantConnectionPrivilege` and `resolveConnectionAccess` both at 100% line coverage. `gofmt` clean, `go build ./...` and `go test ./internal/auth/...` pass (in-process SQLite store, no external DB).

Closes #302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Granting access to “All Connections” no longer removes existing per-connection permissions.
  * Specific per-connection access and wildcard (“All Connections”) access now coexist, with the higher permission taking effect.
  * Added regression tests to verify mixed specific + wildcard grant behavior and preserve existing levels.
  * Improved coverage for error scenarios when permission updates fail (including database execution failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->