### PR TITLE
feat(cli): surface group admin permissions and members in the CLI

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,15 @@ project adheres to
   description when creating it with `-add-group`, matching the
   description support already available in the web console. (#301)
 
+- Add a `-list-members` CLI flag to the server, which lists the
+  members of the group named with `-group`, including both member
+  users and nested member groups. (#303)
+
 ### Changed
+
+- Extend the `-show-group-privileges` CLI command to also display a
+  group's admin permissions, alongside the MCP and connection
+  privileges it already reports. (#303)
 
 - Drop the runtime dependency on a knowledgebase package from the
   `pgedge-ai-dba-server` package in both the Debian and RPM

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -254,6 +254,7 @@ builtins:
 | `-add-group` | Add a new RBAC group |
 | `-delete-group` | Delete an RBAC group |
 | `-list-groups` | List all RBAC groups |
+| `-list-members` | List the members of a group |
 | `-add-member` | Add a user or group to a group |
 | `-remove-member` | Remove a member from a group |
 | `-group string` | Group name for group commands |

--- a/server/src/cmd/mcp-server/commands.go
+++ b/server/src/cmd/mcp-server/commands.go
@@ -160,6 +160,14 @@ func RunCLICommands(f *Flags, dataDir string) bool {
 			return true
 		}
 
+		if f.ListMembersCmd {
+			if err := listGroupMembersCommand(dataDir, f.GroupName); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+				os.Exit(1)
+			}
+			return true
+		}
+
 		if f.SetSuperuserCmd {
 			if err := setSuperuserCommand(dataDir, f.Username, true); err != nil {
 				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)

--- a/server/src/cmd/mcp-server/flags.go
+++ b/server/src/cmd/mcp-server/flags.go
@@ -72,6 +72,7 @@ type Flags struct {
 	ListGroupsCmd     bool
 	AddMemberCmd      bool
 	RemoveMemberCmd   bool
+	ListMembersCmd    bool
 	GroupName         string
 	GroupDescription  string
 	MemberGroup       string
@@ -157,6 +158,7 @@ func ParseFlags(defaultConfigPath string) *Flags {
 	flag.BoolVar(&f.ListGroupsCmd, "list-groups", false, "List all RBAC groups")
 	flag.BoolVar(&f.AddMemberCmd, "add-member", false, "Add a user or group to a group")
 	flag.BoolVar(&f.RemoveMemberCmd, "remove-member", false, "Remove a user or group from a group")
+	flag.BoolVar(&f.ListMembersCmd, "list-members", false, "List members of a specific group")
 	flag.StringVar(&f.GroupName, "group", "", "Group name for group management commands")
 	flag.StringVar(&f.GroupDescription, "group-description", "", "Group description for add-group")
 	flag.StringVar(&f.MemberGroup, "member-group", "", "Member group name (for nested group membership)")
@@ -287,7 +289,7 @@ func (f *Flags) HasUserCommand() bool {
 // HasGroupCommand returns true if any group management command was specified
 func (f *Flags) HasGroupCommand() bool {
 	return f.AddGroupCmd || f.DeleteGroupCmd || f.ListGroupsCmd ||
-		f.AddMemberCmd || f.RemoveMemberCmd ||
+		f.AddMemberCmd || f.RemoveMemberCmd || f.ListMembersCmd ||
 		f.SetSuperuserCmd || f.UnsetSuperuserCmd
 }
 

--- a/server/src/cmd/mcp-server/flags_test.go
+++ b/server/src/cmd/mcp-server/flags_test.go
@@ -170,6 +170,7 @@ func TestHasGroupCommand(t *testing.T) {
 		{"list groups", Flags{ListGroupsCmd: true}, true},
 		{"add member", Flags{AddMemberCmd: true}, true},
 		{"remove member", Flags{RemoveMemberCmd: true}, true},
+		{"list members", Flags{ListMembersCmd: true}, true},
 		{"set superuser", Flags{SetSuperuserCmd: true}, true},
 		{"unset superuser", Flags{UnsetSuperuserCmd: true}, true},
 	}

--- a/server/src/cmd/mcp-server/groups.go
+++ b/server/src/cmd/mcp-server/groups.go
@@ -235,6 +235,60 @@ func removeMemberCommand(dataDir, groupName, memberUsername, memberGroupName str
 	return nil
 }
 
+// listGroupMembersCommand lists the direct members of a group
+func listGroupMembersCommand(dataDir, groupName string) error {
+	if groupName == "" {
+		return fmt.Errorf("group name is required")
+	}
+
+	// Open auth store
+	store, err := openAuthStoreCLI(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to open auth store: %w", err)
+	}
+	defer store.Close()
+
+	// Get group
+	group, err := store.GetGroupByName(groupName)
+	if err != nil {
+		return fmt.Errorf("failed to find group: %w", err)
+	}
+	if group == nil {
+		return fmt.Errorf("group '%s' not found", groupName)
+	}
+
+	// Get members
+	members, err := store.GetGroupMembers(group.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get group members: %w", err)
+	}
+
+	fmt.Printf("\nMembers of group '%s':\n", groupName)
+	fmt.Println(strings.Repeat("=", 70))
+
+	if len(members.UserMembers) == 0 {
+		fmt.Println("Users: None")
+	} else {
+		fmt.Println("\nUsers:")
+		for _, username := range members.UserMembers {
+			fmt.Printf("  - %s\n", username)
+		}
+	}
+
+	if len(members.GroupMembers) == 0 {
+		fmt.Println("\nGroups: None")
+	} else {
+		fmt.Println("\nGroups:")
+		for _, childGroup := range members.GroupMembers {
+			fmt.Printf("  - %s\n", childGroup)
+		}
+	}
+
+	fmt.Println(strings.Repeat("=", 70) + "\n")
+
+	return nil
+}
+
 // setSuperuserCommand handles the set-superuser command for users
 func setSuperuserCommand(dataDir, username string, isSuperuser bool) error {
 	if username == "" {

--- a/server/src/cmd/mcp-server/groups_cli_test.go
+++ b/server/src/cmd/mcp-server/groups_cli_test.go
@@ -1,0 +1,266 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+)
+
+// captureStdout runs fn while capturing everything written to os.Stdout and
+// returns the captured output. Stderr is left untouched so the auth-store path
+// message emitted by openAuthStoreCLI does not pollute the captured stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("failed to read captured stdout: %v", err)
+	}
+
+	return buf.String()
+}
+
+// newCLITestStore creates an auth store in a fresh temp directory, returning the
+// data directory (for use by the CLI commands, which open the store by path) and
+// the open store for direct population. The caller must close the store before
+// invoking a CLI command so the two do not contend for the SQLite database.
+func newCLITestStore(t *testing.T) (string, *auth.AuthStore) {
+	t.Helper()
+
+	dataDir := t.TempDir()
+	store, err := auth.NewAuthStore(dataDir, 0, 0)
+	if err != nil {
+		t.Fatalf("failed to create auth store: %v", err)
+	}
+	return dataDir, store
+}
+
+// blockingDataDir returns a data-dir path that cannot be created because a
+// regular file sits where a parent directory would need to be, forcing
+// openAuthStoreCLI (via NewAuthStore) to fail.
+func blockingDataDir(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	blockingFile := tmpDir + "/blocking"
+	if err := os.WriteFile(blockingFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create blocking file: %v", err)
+	}
+	return blockingFile + "/subdir"
+}
+
+func TestListGroupMembersCommand(t *testing.T) {
+	t.Run("empty group name returns error", func(t *testing.T) {
+		if err := listGroupMembersCommand(t.TempDir(), ""); err == nil {
+			t.Fatal("expected error for empty group name")
+		}
+	})
+
+	t.Run("unopenable data dir returns error", func(t *testing.T) {
+		if err := listGroupMembersCommand(blockingDataDir(t), "any"); err == nil {
+			t.Fatal("expected error when auth store cannot be opened")
+		}
+	})
+
+	t.Run("non-existent group returns error", func(t *testing.T) {
+		dataDir, store := newCLITestStore(t)
+		store.Close()
+
+		err := listGroupMembersCommand(dataDir, "does-not-exist")
+		if err == nil {
+			t.Fatal("expected error for non-existent group")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' error, got %v", err)
+		}
+	})
+
+	t.Run("lists user and group members", func(t *testing.T) {
+		dataDir, store := newCLITestStore(t)
+
+		parentID, err := store.CreateGroup("parent", "Parent group")
+		if err != nil {
+			t.Fatalf("failed to create parent group: %v", err)
+		}
+		childID, err := store.CreateGroup("child", "Child group")
+		if err != nil {
+			t.Fatalf("failed to create child group: %v", err)
+		}
+		if err := store.CreateUser("alice", "Password1234", "", "", ""); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		user, err := store.GetUser("alice")
+		if err != nil {
+			t.Fatalf("failed to get user: %v", err)
+		}
+		if err := store.AddUserToGroup(parentID, user.ID); err != nil {
+			t.Fatalf("failed to add user to group: %v", err)
+		}
+		if err := store.AddGroupToGroup(parentID, childID); err != nil {
+			t.Fatalf("failed to add child group: %v", err)
+		}
+		store.Close()
+
+		var cmdErr error
+		out := captureStdout(t, func() {
+			cmdErr = listGroupMembersCommand(dataDir, "parent")
+		})
+		if cmdErr != nil {
+			t.Fatalf("listGroupMembersCommand returned error: %v", cmdErr)
+		}
+
+		if !strings.Contains(out, "Members of group 'parent'") {
+			t.Errorf("expected header in output, got:\n%s", out)
+		}
+		if !strings.Contains(out, "- alice") {
+			t.Errorf("expected user member 'alice' in output, got:\n%s", out)
+		}
+		if !strings.Contains(out, "- child") {
+			t.Errorf("expected group member 'child' in output, got:\n%s", out)
+		}
+	})
+
+	t.Run("empty members show None", func(t *testing.T) {
+		dataDir, store := newCLITestStore(t)
+		if _, err := store.CreateGroup("empty", "Empty group"); err != nil {
+			t.Fatalf("failed to create group: %v", err)
+		}
+		store.Close()
+
+		var cmdErr error
+		out := captureStdout(t, func() {
+			cmdErr = listGroupMembersCommand(dataDir, "empty")
+		})
+		if cmdErr != nil {
+			t.Fatalf("listGroupMembersCommand returned error: %v", cmdErr)
+		}
+
+		if !strings.Contains(out, "Users: None") {
+			t.Errorf("expected 'Users: None' in output, got:\n%s", out)
+		}
+		if !strings.Contains(out, "Groups: None") {
+			t.Errorf("expected 'Groups: None' in output, got:\n%s", out)
+		}
+	})
+}
+
+func TestShowGroupPrivilegesCommandAdminPermissions(t *testing.T) {
+	t.Run("shows granted admin permissions", func(t *testing.T) {
+		dataDir, store := newCLITestStore(t)
+
+		groupID, err := store.CreateGroup("admins", "Admin group")
+		if err != nil {
+			t.Fatalf("failed to create group: %v", err)
+		}
+		if err := store.GrantAdminPermission(groupID, "manage_users"); err != nil {
+			t.Fatalf("failed to grant admin permission: %v", err)
+		}
+		// Also grant an MCP privilege and a connection privilege so the
+		// populated (non-None) branches of the command are exercised.
+		if _, err := store.RegisterMCPPrivilege("query_database", "tool", "Run queries", false); err != nil {
+			t.Fatalf("failed to register MCP privilege: %v", err)
+		}
+		if err := store.GrantMCPPrivilegeByName(groupID, "query_database"); err != nil {
+			t.Fatalf("failed to grant MCP privilege: %v", err)
+		}
+		if err := store.GrantConnectionPrivilege(groupID, 7, "read_write"); err != nil {
+			t.Fatalf("failed to grant connection privilege: %v", err)
+		}
+		store.Close()
+
+		var cmdErr error
+		out := captureStdout(t, func() {
+			cmdErr = showGroupPrivilegesCommand(dataDir, "admins")
+		})
+		if cmdErr != nil {
+			t.Fatalf("showGroupPrivilegesCommand returned error: %v", cmdErr)
+		}
+
+		if !strings.Contains(out, "Admin Permissions:") {
+			t.Errorf("expected 'Admin Permissions:' header in output, got:\n%s", out)
+		}
+		if !strings.Contains(out, "- manage_users") {
+			t.Errorf("expected 'manage_users' in output, got:\n%s", out)
+		}
+		if !strings.Contains(out, "query_database") {
+			t.Errorf("expected MCP privilege 'query_database' in output, got:\n%s", out)
+		}
+		if !strings.Contains(out, "Connection 7") {
+			t.Errorf("expected 'Connection 7' in output, got:\n%s", out)
+		}
+	})
+
+	t.Run("shows None when no admin permissions", func(t *testing.T) {
+		dataDir, store := newCLITestStore(t)
+		if _, err := store.CreateGroup("plain", "Plain group"); err != nil {
+			t.Fatalf("failed to create group: %v", err)
+		}
+		store.Close()
+
+		var cmdErr error
+		out := captureStdout(t, func() {
+			cmdErr = showGroupPrivilegesCommand(dataDir, "plain")
+		})
+		if cmdErr != nil {
+			t.Fatalf("showGroupPrivilegesCommand returned error: %v", cmdErr)
+		}
+
+		if !strings.Contains(out, "Admin Permissions: None") {
+			t.Errorf("expected 'Admin Permissions: None' in output, got:\n%s", out)
+		}
+	})
+
+	t.Run("empty group name returns error", func(t *testing.T) {
+		if err := showGroupPrivilegesCommand(t.TempDir(), ""); err == nil {
+			t.Fatal("expected error for empty group name")
+		}
+	})
+
+	t.Run("unopenable data dir returns error", func(t *testing.T) {
+		if err := showGroupPrivilegesCommand(blockingDataDir(t), "any"); err == nil {
+			t.Fatal("expected error when auth store cannot be opened")
+		}
+	})
+
+	t.Run("non-existent group returns error", func(t *testing.T) {
+		dataDir, store := newCLITestStore(t)
+		store.Close()
+
+		err := showGroupPrivilegesCommand(dataDir, "missing")
+		if err == nil {
+			t.Fatal("expected error for non-existent group")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' error, got %v", err)
+		}
+	})
+}

--- a/server/src/cmd/mcp-server/privileges.go
+++ b/server/src/cmd/mcp-server/privileges.go
@@ -268,6 +268,22 @@ func showGroupPrivilegesCommand(dataDir, groupName string) error {
 		}
 	}
 
+	// Admin permissions are stored separately from GroupWithPrivileges,
+	// so fetch them with a dedicated store call (mirroring the API handler).
+	adminPerms, err := store.ListGroupAdminPermissions(group.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get admin permissions: %w", err)
+	}
+
+	if len(adminPerms) == 0 {
+		fmt.Println("\nAdmin Permissions: None")
+	} else {
+		fmt.Println("\nAdmin Permissions:")
+		for _, perm := range adminPerms {
+			fmt.Printf("  - %s\n", perm)
+		}
+	}
+
 	fmt.Println(strings.Repeat("=", 70) + "\n")
 
 	return nil


### PR DESCRIPTION
## Summary

Closes #303 by filling two gaps in the server's CLI group introspection. Both are read-only additions to the CLI surface (the HTTP API already exposed this data); they follow the existing `-list-groups` / `-show-group-privileges` command patterns.

- `-show-group-privileges` now also displays a group's **admin permissions**, alongside the MCP and connection privileges it already showed. `ListGroupAdminPermissions` existed in the auth store but was never wired to the CLI; it is fetched with a dedicated store call (mirroring the HTTP handler in `rbac_group_handlers.go`), so the `GroupWithPrivileges` struct is left unchanged.
- New `-list-members` flag lists the members of the group named with `-group`, including both member users and nested member groups, via the existing `GetGroupMembers` store function.

## Test plan

- [x] New `groups_cli_test.go` covers `listGroupMembersCommand` (populated users + child groups, empty-members "None", empty-name, non-existent group, unopenable store) and the admin-permissions additions to `showGroupPrivilegesCommand` (permissions present, "Admin Permissions: None", plus the error paths). `flags_test.go` gains a `-list-members` case in `TestHasGroupCommand`.
- [x] `listGroupMembersCommand` at 92.9% and `showGroupPrivilegesCommand` at 91.7% line coverage (both above the 90% floor).
- [x] `gofmt` clean, `go build ./...` succeeds, `go test ./cmd/mcp-server/...` passes. CLI tests use a temp SQLite auth store only (no external database).

Closes #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new server CLI flag/command to list members of a group, including both direct users and nested sub-groups.
  * Group privilege output now includes an “Admin Permissions” section.

* **Documentation**
  * Updated the server configuration guide to document the new member-listing flag.
  * Updated the changelog with entries for both the new flag and the enhanced privilege output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->