### PR TITLE
fix(cluster-groups): populate and persist description and share flag

### DIFF
--- a/client/src/components/ClusterNavigator/GroupItem.tsx
+++ b/client/src/components/ClusterNavigator/GroupItem.tsx
@@ -119,12 +119,15 @@ interface UserInfo {
 interface GroupData {
     id: string;
     name: string;
+    description?: string;
+    is_shared?: boolean;
     auto_group_key?: string;
     is_default?: boolean;
     // The server may emit `clusters: null` for an empty group (Go
     // nil-slice JSON marshaling). All consumers must tolerate null;
     // see issue #242.
     clusters?: (Cluster & { cluster_type?: string; replication_type?: string | null })[] | null;
+    [key: string]: unknown;
 }
 
 interface GroupItemProps {
@@ -147,7 +150,7 @@ interface GroupItemProps {
     onEditServer?: (server: Server) => void;
     onDeleteServer?: (server: Server) => void;
     onDeleteGroup?: (group: GroupData) => void;
-    onConfigureGroup?: (group: GroupData) => void;
+    onConfigureGroup?: (group: GroupData) => void | Promise<void>;
     onConfigureCluster?: (cluster: Cluster) => void;
     onDeleteCluster?: (cluster: Cluster) => void;
     getServerAlertCount?: (serverId: number) => number;
@@ -249,7 +252,7 @@ const GroupItem = memo<GroupItemProps>(({
                             size="small"
                             onClick={(e) => {
                                 e.stopPropagation();
-                                onConfigureGroup?.(group);
+                                void onConfigureGroup?.(group);
                             }}
                             sx={settingsButtonSx}
                         >

--- a/client/src/components/ClusterNavigator/index.tsx
+++ b/client/src/components/ClusterNavigator/index.tsx
@@ -48,7 +48,7 @@ import GroupDialog from '../GroupDialog';
 import ClusterConfigDialog from '../ClusterConfigDialog';
 import DeleteConfirmationDialog from '../DeleteConfirmationDialog';
 import AddMenu from '../AddMenu';
-import { apiFetch } from '../../utils/apiClient';
+import { apiFetch, apiGet } from '../../utils/apiClient';
 import { logger } from '../../utils/logger';
 
 // Import sub-components
@@ -60,6 +60,7 @@ import {
     loadFromStorage,
     saveToStorage,
     formatRelativeTime,
+    parseGroupNumericId,
 } from './utils';
 import StatusIndicator from './StatusIndicator';
 import GroupItem from './GroupItem';
@@ -437,6 +438,7 @@ const ClusterNavigator: React.FC<ClusterNavigatorProps> = ({
     const { user } = useAuth();
     const {
         updateGroupName,
+        updateGroup,
         updateClusterName,
         updateServerName,
         getServer,
@@ -547,8 +549,12 @@ const ClusterNavigator: React.FC<ClusterNavigatorProps> = ({
         if (groupDialogMode === 'create') {
             await createGroup(groupData);
         } else {
-            // For edit, we just update the name using existing function
-            await updateGroupName(editingGroup!.id, groupData.name);
+            // For edit, persist the name, description, and sharing flag.
+            await updateGroup(editingGroup!.id, {
+                name: groupData.name,
+                description: groupData.description,
+                is_shared: groupData.is_shared,
+            });
         }
         setGroupDialogOpen(false);
     };
@@ -565,9 +571,36 @@ const ClusterNavigator: React.FC<ClusterNavigatorProps> = ({
         setDeleteDialogOpen(true);
     };
 
-    // Handler for configuring a group (opens edit dialog on Alert Overrides tab)
-    const handleConfigureGroup = (group: GroupData) => {
-        setEditingGroup(group);
+    // Handler for configuring a group (opens edit dialog on the Details tab).
+    // The topology tree (GET /api/v1/clusters) never carries a group's
+    // description or is_shared flag, so for database-backed groups we fetch
+    // the full detail row first and seed the dialog with it. Auto-detected
+    // groups have no detail endpoint, so the passed-in object is used as-is.
+    const handleConfigureGroup = async (group: GroupData) => {
+        let editing: GroupData & { id: string } = group;
+
+        const numericId = parseGroupNumericId(group.id);
+        if (numericId !== undefined) {
+            try {
+                const detail = await apiGet<{
+                    name?: string;
+                    description?: string;
+                    is_shared?: boolean;
+                }>(`/api/v1/cluster-groups/${numericId}`);
+                editing = {
+                    ...group,
+                    name: detail.name ?? group.name,
+                    description: detail.description,
+                    is_shared: detail.is_shared,
+                };
+            } catch (err) {
+                logger.error('Failed to get group details:', err);
+                // Fall back to the limited topology data we already have.
+                editing = group;
+            }
+        }
+
+        setEditingGroup(editing);
         setGroupDialogMode('edit');
         setGroupDialogInitialTab(0);
         setGroupDialogOpen(true);

--- a/client/src/components/__tests__/ClusterNavigator.test.tsx
+++ b/client/src/components/__tests__/ClusterNavigator.test.tsx
@@ -22,6 +22,7 @@ const darkTheme = createPgedgeTheme('dark');
 // inside the component.
 const {
     mockUpdateGroupName,
+    mockUpdateGroup,
     mockUpdateClusterName,
     mockUpdateServerName,
     mockDeleteCluster,
@@ -29,9 +30,12 @@ const {
     mockDeleteGroup,
     mockMoveClusterToGroup,
     mockFetchClusterData,
+    mockApiGet,
+    mockApiFetch,
     mockUseAuth,
 } = vi.hoisted(() => ({
     mockUpdateGroupName: vi.fn(),
+    mockUpdateGroup: vi.fn(),
     mockUpdateClusterName: vi.fn(),
     mockUpdateServerName: vi.fn(),
     mockDeleteCluster: vi.fn(),
@@ -39,6 +43,8 @@ const {
     mockDeleteGroup: vi.fn(),
     mockMoveClusterToGroup: vi.fn(),
     mockFetchClusterData: vi.fn(),
+    mockApiGet: vi.fn(),
+    mockApiFetch: vi.fn(),
     mockUseAuth: vi.fn((): {
         user: { isSuperuser: boolean };
         hasPermission: (perm: string) => boolean;
@@ -46,6 +52,13 @@ const {
         user: { isSuperuser: false },
         hasPermission: () => false,
     })),
+}));
+
+// Mock the API client. handleConfigureGroup fetches the full group detail
+// via apiGet; other handlers (add server/cluster) use apiFetch.
+vi.mock('../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }));
 
 // Mock the AuthContext
@@ -57,6 +70,7 @@ vi.mock('../../contexts/useAuth', () => ({
 vi.mock('../../contexts/useCluster', () => ({
     useCluster: () => ({
         updateGroupName: mockUpdateGroupName,
+        updateGroup: mockUpdateGroup,
         updateClusterName: mockUpdateClusterName,
         updateServerName: mockUpdateServerName,
         deleteCluster: mockDeleteCluster,
@@ -178,6 +192,7 @@ describe('ClusterNavigator', () => {
         onSelectServer = vi.fn();
         onRefresh = vi.fn();
         mockUpdateGroupName.mockReset().mockResolvedValue(undefined);
+        mockUpdateGroup.mockReset().mockResolvedValue(undefined);
         mockUpdateClusterName.mockReset().mockResolvedValue(undefined);
         mockUpdateServerName.mockReset().mockResolvedValue(undefined);
         mockDeleteCluster.mockReset().mockResolvedValue(undefined);
@@ -185,6 +200,11 @@ describe('ClusterNavigator', () => {
         mockDeleteGroup.mockReset().mockResolvedValue(undefined);
         mockMoveClusterToGroup.mockReset().mockResolvedValue(undefined);
         mockFetchClusterData.mockReset().mockResolvedValue(undefined);
+        mockApiGet.mockReset().mockResolvedValue({});
+        mockApiFetch.mockReset().mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+        });
         mockUseAuth.mockReset().mockReturnValue({
             user: { isSuperuser: false },
             hasPermission: () => false,
@@ -502,11 +522,20 @@ describe('ClusterNavigator', () => {
 
         const WAIT_TIMEOUT = 15000;
 
-        it('passes the unchanged "group-{id}" string from configure to updateGroupName', async () => {
+        it('fetches full detail, populates the dialog, and saves all fields via updateGroup', async () => {
             // Superuser is required to see the settings (configure) button
+            // and the "Share with all users" checkbox.
             mockUseAuth.mockReturnValue({
                 user: { isSuperuser: true },
                 hasPermission: () => true,
+            });
+
+            // The topology tree omits description/is_shared; the single-group
+            // detail endpoint supplies them. Verify they flow into the dialog.
+            mockApiGet.mockResolvedValue({
+                name: 'Production',
+                description: 'The production estate',
+                is_shared: true,
             });
 
             renderWithTheme(
@@ -536,9 +565,22 @@ describe('ClusterNavigator', () => {
                 { timeout: WAIT_TIMEOUT }
             );
 
-            // Name field should be pre-populated from the group data
+            // The detail endpoint must have been queried by numeric id.
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/cluster-groups/1');
+
+            // Name field should be pre-populated from the group data.
             const nameField = screen.getByRole('textbox', { name: /^name/i });
             expect(nameField).toHaveValue('Production');
+
+            // Description and the share checkbox come from the fetched detail.
+            const descriptionField = screen.getByRole('textbox', {
+                name: /description/i,
+            });
+            expect(descriptionField).toHaveValue('The production estate');
+            const shareCheckbox = screen.getByRole('checkbox', {
+                name: /share with all users/i,
+            });
+            expect(shareCheckbox).toBeChecked();
 
             // Change the name and submit. fireEvent.change is a single
             // synchronous update that bypasses per-keystroke instrumentation
@@ -551,21 +593,85 @@ describe('ClusterNavigator', () => {
             const saveButton = screen.getByRole('button', { name: /^save$/i });
             fireEvent.click(saveButton);
 
-            // Root-cause check: updateGroupName must receive the original
-            // "group-1" string, not "1" and not the number 1.
+            // Root-cause check: updateGroup receives the original "group-1"
+            // string plus all three fields, so nothing is discarded on save.
             await waitFor(
                 () => {
-                    expect(mockUpdateGroupName).toHaveBeenCalledWith(
-                        'group-1',
-                        'Production Renamed'
-                    );
+                    expect(mockUpdateGroup).toHaveBeenCalledWith('group-1', {
+                        name: 'Production Renamed',
+                        description: 'The production estate',
+                        is_shared: true,
+                    });
                 },
                 { timeout: WAIT_TIMEOUT }
             );
-            // Type-level sanity: the first argument must be a string.
-            const [firstArg] = mockUpdateGroupName.mock.calls[0];
+            // The old name-only path must not be used on the edit branch.
+            expect(mockUpdateGroupName).not.toHaveBeenCalled();
+            const [firstArg] = mockUpdateGroup.mock.calls[0];
             expect(typeof firstArg).toBe('string');
             expect(firstArg).toBe('group-1');
+        }, 20000);
+
+        it('falls back to the passed group when the detail fetch fails', async () => {
+            mockUseAuth.mockReturnValue({
+                user: { isSuperuser: true },
+                hasPermission: () => true,
+            });
+
+            // Simulate a failing detail endpoint; the dialog must still open.
+            mockApiGet.mockRejectedValue(new Error('boom'));
+
+            renderWithTheme(
+                <ClusterNavigator
+                    data={mockClusterData}
+                    onSelectServer={onSelectServer}
+                    onRefresh={onRefresh}
+                />
+            );
+
+            const settingsButtons = document.querySelectorAll(
+                '.action-buttons button'
+            );
+            fireEvent.click(settingsButtons[0]);
+
+            // The dialog opens on the fallback path using the topology data.
+            await waitFor(
+                () => {
+                    expect(
+                        screen.getByText(/Group Settings: Production/)
+                    ).toBeInTheDocument();
+                },
+                { timeout: WAIT_TIMEOUT }
+            );
+
+            const nameField = screen.getByRole('textbox', { name: /^name/i });
+            expect(nameField).toHaveValue('Production');
+
+            // No detail was available, so description stays empty and the
+            // share checkbox unchecked; the fetch was still attempted.
+            expect(mockApiGet).toHaveBeenCalledWith('/api/v1/cluster-groups/1');
+            const descriptionField = screen.getByRole('textbox', {
+                name: /description/i,
+            });
+            expect(descriptionField).toHaveValue('');
+            const shareCheckbox = screen.getByRole('checkbox', {
+                name: /share with all users/i,
+            });
+            expect(shareCheckbox).not.toBeChecked();
+
+            const saveButton = screen.getByRole('button', { name: /^save$/i });
+            fireEvent.click(saveButton);
+
+            await waitFor(
+                () => {
+                    expect(mockUpdateGroup).toHaveBeenCalledWith('group-1', {
+                        name: 'Production',
+                        description: '',
+                        is_shared: false,
+                    });
+                },
+                { timeout: WAIT_TIMEOUT }
+            );
         }, 20000);
 
         it('calls createGroup (not updateGroupName) when saving from the Add Group flow', async () => {

--- a/client/src/components/__tests__/GroupDialog.test.tsx
+++ b/client/src/components/__tests__/GroupDialog.test.tsx
@@ -189,6 +189,22 @@ describe('GroupDialog', () => {
             );
         });
 
+        it('pre-populates the share checkbox from is_shared for superusers', () => {
+            renderWithTheme(
+                <GroupDialog
+                    {...defaultProps}
+                    mode="edit"
+                    isSuperuser={true}
+                    group={editGroup}
+                />
+            );
+            expect(
+                screen.getByRole('checkbox', {
+                    name: /share with all users/i,
+                })
+            ).toBeChecked();
+        });
+
         it('shows AlertOverridesPanel with numeric scope id when Alert overrides tab is clicked', async () => {
             const user = userEvent.setup({ delay: null });
             renderWithTheme(

--- a/client/src/contexts/ClusterActionsContext.tsx
+++ b/client/src/contexts/ClusterActionsContext.tsx
@@ -29,6 +29,7 @@ export interface GroupData {
 
 export interface ClusterActionsContextValue {
     updateGroupName: (groupId: string, newName: string) => Promise<void>;
+    updateGroup: (groupId: string, data: { name: string; description?: string; is_shared?: boolean }) => Promise<void>;
     updateClusterName: (clusterId: string, newName: string, groupId: string, autoClusterKey?: string) => Promise<void>;
     updateServerName: (serverId: number, newName: string) => Promise<void>;
     getServer: (serverId: number) => Promise<unknown>;
@@ -80,6 +81,36 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
         }
 
         await apiPut(`/api/v1/cluster-groups/${groupId}`, { name: newName });
+
+        // Refresh cluster data to reflect the change
+        await fetchClusterData();
+    }, [user, fetchClusterData]);
+
+    /**
+     * Update a cluster group's full details (name, description, sharing).
+     *
+     * Mirrors the id handling of `updateGroupName`: database-backed groups
+     * are addressed by their bare numeric id, whilst auto-detected buckets
+     * are forwarded in their full "group-auto..." form. Every other shape is
+     * rejected so the server never receives an unknown id.
+     */
+    const updateGroup = useCallback(async (groupId: string, data: { name: string; description?: string; is_shared?: boolean }): Promise<void> => {
+        if (!user) {throw new Error('Not authenticated');}
+
+        // Database-backed id: address the server row by its numeric id.
+        const numericId = parseGroupNumericId(groupId);
+        if (numericId !== undefined) {
+            await apiPut(`/api/v1/cluster-groups/${numericId}`, data);
+            await fetchClusterData();
+            return;
+        }
+
+        // Auto-detected bucket: forward the full "group-auto..." token.
+        if (!isAutoGroupId(groupId)) {
+            throw new Error('Invalid group ID');
+        }
+
+        await apiPut(`/api/v1/cluster-groups/${groupId}`, data);
 
         // Refresh cluster data to reflect the change
         await fetchClusterData();
@@ -282,6 +313,7 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
     const value: ClusterActionsContextValue = useMemo(() => ({
         // Update functions
         updateGroupName,
+        updateGroup,
         updateClusterName,
         updateServerName,
         // CRUD functions
@@ -295,6 +327,7 @@ export const ClusterActionsProvider = ({ children }: ClusterActionsProviderProps
         moveClusterToGroup,
     }), [
         updateGroupName,
+        updateGroup,
         updateClusterName,
         updateServerName,
         getServer,

--- a/client/src/contexts/ClusterContext.tsx
+++ b/client/src/contexts/ClusterContext.tsx
@@ -71,6 +71,7 @@ const ClusterCombinedProvider = ({ children }: ClusterProviderProps): React.Reac
 
         // From ClusterActionsContext
         updateGroupName: actionsContext.updateGroupName,
+        updateGroup: actionsContext.updateGroup,
         updateClusterName: actionsContext.updateClusterName,
         updateServerName: actionsContext.updateServerName,
         getServer: actionsContext.getServer,

--- a/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
+++ b/client/src/contexts/__tests__/ClusterActionsContext.test.tsx
@@ -82,6 +82,7 @@ describe('ClusterActionsContext', () => {
     describe('auth gating', () => {
         it.each([
             ['updateGroupName', ['group-1', 'new']],
+            ['updateGroup', ['group-1', { name: 'new' }]],
             ['updateClusterName', ['cluster-1', 'x', 'group-1']],
             ['updateServerName', [1, 'x']],
             ['getServer', [1]],
@@ -213,6 +214,57 @@ describe('ClusterActionsContext', () => {
                 '/api/v1/cluster-groups/group-auto-some_key-123',
                 { name: 'X' },
             );
+        });
+    });
+
+    describe('updateGroup', () => {
+        it('PUTs the full body to the numeric id and refetches', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateGroup('group-42', {
+                    name: 'Prod',
+                    description: 'The production estate',
+                    is_shared: true,
+                });
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/cluster-groups/42',
+                {
+                    name: 'Prod',
+                    description: 'The production estate',
+                    is_shared: true,
+                },
+            );
+            expect(mockFetchClusterData).toHaveBeenCalled();
+        });
+
+        it('forwards the full "group-auto..." token for auto-detected groups', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await act(async () => {
+                await result.current.updateGroup('group-auto-key', {
+                    name: 'Auto',
+                    description: '',
+                    is_shared: false,
+                });
+            });
+
+            expect(mockApiPut).toHaveBeenCalledWith(
+                '/api/v1/cluster-groups/group-auto-key',
+                { name: 'Auto', description: '', is_shared: false },
+            );
+            expect(mockFetchClusterData).toHaveBeenCalled();
+        });
+
+        it('rejects ids that are neither numeric nor auto-detected', async () => {
+            const { result } = renderHook(() => useClusterActions(), { wrapper });
+
+            await expect(
+                result.current.updateGroup('group-named', { name: 'Bad' }),
+            ).rejects.toThrow('Invalid group ID');
+            expect(mockApiPut).not.toHaveBeenCalled();
         });
     });
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -199,6 +199,11 @@ project adheres to
   for zero-anchored charts, such as bars and stacked or area fills, so
   their fill still renders from zero. (#336)
 
+- Fix the Cluster Group settings dialog so it shows and preserves a
+  group's description and its "Share with all users" setting, which
+  previously appeared empty or unchecked and were lost when editing;
+  the share flag is now persisted by the API. (#304)
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/server/src/internal/api/cluster_handlers.go
+++ b/server/src/internal/api/cluster_handlers.go
@@ -39,10 +39,15 @@ func NewClusterHandler(datastore *database.Datastore, authStore *auth.AuthStore,
 	}
 }
 
-// ClusterGroupRequest is the request body for creating/updating cluster groups
+// ClusterGroupRequest is the request body for creating/updating cluster
+// groups. IsShared is a pointer so an omitted field (nil) can be
+// distinguished from an explicit false, which matters for partial updates:
+// on update, a nil IsShared preserves the group's current visibility rather
+// than forcing it private (issue #304).
 type ClusterGroupRequest struct {
 	Name        string  `json:"name"`
 	Description *string `json:"description,omitempty"`
+	IsShared    *bool   `json:"is_shared,omitempty"`
 }
 
 // ClusterRequest is the request body for creating/updating clusters
@@ -536,10 +541,24 @@ func (h *ClusterHandler) createClusterGroup(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Resolve the creating user so the new group records its owner. This
+	// mirrors updateClusterGroup's use of getUserInfoCompat and lets the
+	// owner-fallback authorization on update/delete apply to groups the
+	// user creates (issue #304).
+	username, _, err := getUserInfoCompat(r, h.authStore)
+	if err != nil {
+		RespondError(w, http.StatusUnauthorized, "Invalid or missing authentication token")
+		return
+	}
+
+	// is_shared defaults to false when the field is omitted; only an
+	// explicit true opts the group into visibility for all users.
+	isShared := req.IsShared != nil && *req.IsShared
+
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	group, err := h.datastore.CreateClusterGroup(ctx, req.Name, req.Description)
+	group, err := h.datastore.CreateClusterGroupWithOwner(ctx, req.Name, req.Description, &username, isShared)
 	if err != nil {
 		log.Printf("[ERROR] Failed to create cluster group %s: %v", req.Name, err)
 		RespondError(w, http.StatusInternalServerError, "Failed to create cluster group")
@@ -589,7 +608,13 @@ func (h *ClusterHandler) updateClusterGroup(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	group, err := h.datastore.UpdateClusterGroup(ctx, id, req.Name, req.Description)
+	// Partial-update semantics: a nil Description or IsShared preserves the
+	// existing column value rather than clearing it, so a client that sends
+	// only some fields does not accidentally null the others (issue #304).
+	// The owner/manage_connections permission check above has already run,
+	// so no is_shared visibility change reaches the datastore for a caller
+	// who is neither the owner nor an admin.
+	group, err := h.datastore.UpdateClusterGroup(ctx, id, req.Name, req.Description, req.IsShared)
 	if err != nil {
 		log.Printf("[ERROR] Failed to update cluster group (id=%d): %v", id, err)
 		RespondError(w, http.StatusInternalServerError, "Failed to update cluster group")

--- a/server/src/internal/api/cluster_handlers_test.go
+++ b/server/src/internal/api/cluster_handlers_test.go
@@ -316,27 +316,32 @@ func TestClusterHandler_HandleCreateCluster_NameTooLong(t *testing.T) {
 }
 
 // TestClusterHandler_CreateClusterGroup_NameAtLimit confirms the boundary:
-// a Name of exactly maxFieldLength bytes passes validation and reaches the
-// datastore (which panics on the nil datastore, proving the length check
-// did not short-circuit at the limit).
+// a Name of exactly maxFieldLength bytes passes validation and is created.
+// It is a DB-backed integration test because createClusterGroup now resolves
+// the creating user (issue #304), so a real auth token and datastore are
+// needed to reach the create call rather than a nil-datastore panic.
 func TestClusterHandler_CreateClusterGroup_NameAtLimit(t *testing.T) {
-	handler := permissionSatisfiedHandler()
+	ds, _, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
 
 	atLimit := strings.Repeat("a", maxFieldLength)
 	body, _ := json.Marshal(ClusterGroupRequest{Name: atLimit})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
 		bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
 	rec := httptest.NewRecorder()
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("Expected nil-datastore panic past validation, got none; status=%d body=%s",
-				rec.Code, rec.Body.String())
-		}
-	}()
-
 	handler.createClusterGroup(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Expected status %d for name at limit, got %d. Body: %s",
+			http.StatusCreated, rec.Code, rec.Body.String())
+	}
 }
 
 // assertLengthRejected asserts that the recorded response is a 400 whose
@@ -1322,11 +1327,10 @@ func TestClusterHandler_UpdateClusterGroup_Integration_NameOnly(t *testing.T) {
 			http.StatusOK, rec.Code, rec.Body.String())
 	}
 
-	// The UpdateClusterGroup SQL sets description to the value in the
-	// request. With description omitted from the JSON body, the request
-	// struct's Description pointer is nil, so the row's description
-	// becomes NULL. Capture the current contract so any future change
-	// is deliberate.
+	// Partial-update contract (issue #304): with description omitted from
+	// the JSON body, the request struct's Description pointer is nil, and
+	// UpdateClusterGroup's COALESCE leaves the existing description in
+	// place rather than nulling it. Confirm the original value survives.
 	var dbName string
 	var dbDesc *string
 	err = pool.QueryRow(ctx,
@@ -1338,9 +1342,9 @@ func TestClusterHandler_UpdateClusterGroup_Integration_NameOnly(t *testing.T) {
 	if dbName != "Name Only Renamed" {
 		t.Errorf("Persisted name = %q, want %q", dbName, "Name Only Renamed")
 	}
-	if dbDesc != nil {
-		t.Errorf("Persisted description = %v, want nil (omitted fields "+
-			"are cleared by current handler contract)", *dbDesc)
+	if dbDesc == nil || *dbDesc != origDesc {
+		t.Errorf("Persisted description = %v, want %q (omitted fields are "+
+			"preserved by the partial-update contract)", dbDesc, origDesc)
 	}
 }
 
@@ -2386,5 +2390,423 @@ func assertInvalidNameRejected(t *testing.T, rec *httptest.ResponseRecorder) {
 	}
 	if response.Error != issue269InvalidCharsMessage {
 		t.Errorf("Expected %q, got %q", issue269InvalidCharsMessage, response.Error)
+	}
+}
+
+// =============================================================================
+// Issue #304: "Share with all users" (is_shared) persistence and owner
+// recording on create / update. These are DB-backed integration tests; they
+// skip when TEST_AI_WORKBENCH_SERVER is unset.
+// =============================================================================
+
+// issue304Bool returns a pointer to b, for populating the optional
+// ClusterGroupRequest.IsShared field in table-driven tests.
+func issue304Bool(b bool) *bool { return &b }
+
+// TestClusterHandler_CreateClusterGroup_Issue304_RecordsOwnerAndShared
+// confirms that creating a group records the creating user as owner and
+// persists is_shared = true when the request asks for it.
+func TestClusterHandler_CreateClusterGroup_Issue304_RecordsOwnerAndShared(t *testing.T) {
+	ds, pool, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
+
+	body, _ := json.Marshal(ClusterGroupRequest{
+		Name:     "Shared Group",
+		IsShared: issue304Bool(true),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createClusterGroup(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	var resp database.ClusterGroup
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if !resp.IsShared {
+		t.Errorf("Response IsShared = false, want true")
+	}
+	if !resp.OwnerUsername.Valid || resp.OwnerUsername.String != "group_updater" {
+		t.Errorf("Response OwnerUsername = %v, want %q", resp.OwnerUsername, "group_updater")
+	}
+
+	// Verify persistence directly.
+	var dbShared bool
+	var dbOwner *string
+	err := pool.QueryRow(context.Background(),
+		"SELECT is_shared, owner_username FROM cluster_groups WHERE id = $1",
+		resp.ID).Scan(&dbShared, &dbOwner)
+	if err != nil {
+		t.Fatalf("Failed to read created row: %v", err)
+	}
+	if !dbShared {
+		t.Errorf("Persisted is_shared = false, want true")
+	}
+	if dbOwner == nil || *dbOwner != "group_updater" {
+		t.Errorf("Persisted owner_username = %v, want %q", dbOwner, "group_updater")
+	}
+}
+
+// TestClusterHandler_CreateClusterGroup_Issue304_DefaultsSharedFalse confirms
+// that an omitted is_shared defaults the new group to private (is_shared =
+// false) whilst still recording the owner.
+func TestClusterHandler_CreateClusterGroup_Issue304_DefaultsSharedFalse(t *testing.T) {
+	ds, pool, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: "Private Group"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createClusterGroup(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	var resp database.ClusterGroup
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if resp.IsShared {
+		t.Errorf("Response IsShared = true, want false (default when omitted)")
+	}
+
+	var dbShared bool
+	var dbOwner *string
+	err := pool.QueryRow(context.Background(),
+		"SELECT is_shared, owner_username FROM cluster_groups WHERE id = $1",
+		resp.ID).Scan(&dbShared, &dbOwner)
+	if err != nil {
+		t.Fatalf("Failed to read created row: %v", err)
+	}
+	if dbShared {
+		t.Errorf("Persisted is_shared = true, want false")
+	}
+	if dbOwner == nil || *dbOwner != "group_updater" {
+		t.Errorf("Persisted owner_username = %v, want %q", dbOwner, "group_updater")
+	}
+}
+
+// TestClusterHandler_CreateClusterGroup_Issue304_NoAuth confirms the create
+// handler rejects a request with no bearer token now that it must resolve the
+// creating user. The permission gate is satisfied via a nil auth store (which
+// treats every caller as permitted), so the 401 comes from the owner lookup.
+func TestClusterHandler_CreateClusterGroup_Issue304_NoAuth(t *testing.T) {
+	handler := permissionSatisfiedHandler()
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: "No Auth Group"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.createClusterGroup(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusUnauthorized, rec.Code, rec.Body.String())
+	}
+}
+
+// TestClusterHandler_UpdateClusterGroup_Issue304_ToggleShared drives is_shared
+// through both transitions (true->false and false->true) and confirms each is
+// persisted.
+func TestClusterHandler_UpdateClusterGroup_Issue304_ToggleShared(t *testing.T) {
+	ds, pool, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
+
+	ctx := context.Background()
+	owner := "group_updater"
+	// Start shared = true.
+	created, err := ds.CreateClusterGroupWithOwner(ctx, "Toggle Group", nil, &owner, true)
+	if err != nil {
+		t.Fatalf("Failed to create cluster group: %v", err)
+	}
+
+	doUpdate := func(shared bool) database.ClusterGroup {
+		body, _ := json.Marshal(ClusterGroupRequest{
+			Name:     "Toggle Group",
+			IsShared: issue304Bool(shared),
+		})
+		req := httptest.NewRequest(http.MethodPut,
+			"/api/v1/cluster-groups/"+strconv.Itoa(created.ID), bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = withBearer(req, token)
+		req = withUser(req, userID)
+		rec := httptest.NewRecorder()
+
+		handler.handleClusterGroupSubpath(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("Update to shared=%v: expected status %d, got %d. Body: %s",
+				shared, http.StatusOK, rec.Code, rec.Body.String())
+		}
+		var resp database.ClusterGroup
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+		return resp
+	}
+
+	// true -> false
+	resp := doUpdate(false)
+	if resp.IsShared {
+		t.Errorf("After update to false: response IsShared = true, want false")
+	}
+	var dbShared bool
+	if err := pool.QueryRow(ctx,
+		"SELECT is_shared FROM cluster_groups WHERE id = $1", created.ID).Scan(&dbShared); err != nil {
+		t.Fatalf("Failed to read row: %v", err)
+	}
+	if dbShared {
+		t.Errorf("After update to false: persisted is_shared = true, want false")
+	}
+
+	// false -> true
+	resp = doUpdate(true)
+	if !resp.IsShared {
+		t.Errorf("After update to true: response IsShared = false, want true")
+	}
+	if err := pool.QueryRow(ctx,
+		"SELECT is_shared FROM cluster_groups WHERE id = $1", created.ID).Scan(&dbShared); err != nil {
+		t.Fatalf("Failed to read row: %v", err)
+	}
+	if !dbShared {
+		t.Errorf("After update to true: persisted is_shared = false, want true")
+	}
+}
+
+// TestClusterHandler_UpdateClusterGroup_Issue304_PreservesSharedWhenOmitted
+// confirms the partial-update contract: omitting is_shared from the body
+// leaves the group's current visibility untouched (does not force it false).
+func TestClusterHandler_UpdateClusterGroup_Issue304_PreservesSharedWhenOmitted(t *testing.T) {
+	ds, pool, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
+
+	ctx := context.Background()
+	owner := "group_updater"
+	created, err := ds.CreateClusterGroupWithOwner(ctx, "Preserve Shared", nil, &owner, true)
+	if err != nil {
+		t.Fatalf("Failed to create cluster group: %v", err)
+	}
+
+	// Rename only; is_shared omitted must not clear the true flag.
+	body := `{"name": "Preserve Shared Renamed"}`
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/cluster-groups/"+strconv.Itoa(created.ID), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterGroupSubpath(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var dbShared bool
+	var dbName string
+	if err := pool.QueryRow(ctx,
+		"SELECT is_shared, name FROM cluster_groups WHERE id = $1",
+		created.ID).Scan(&dbShared, &dbName); err != nil {
+		t.Fatalf("Failed to read row: %v", err)
+	}
+	if !dbShared {
+		t.Errorf("Persisted is_shared = false, want true (omitted field must be preserved)")
+	}
+	if dbName != "Preserve Shared Renamed" {
+		t.Errorf("Persisted name = %q, want %q", dbName, "Preserve Shared Renamed")
+	}
+}
+
+// TestClusterHandler_UpdateClusterGroup_Issue304_ForbiddenDoesNotShare
+// confirms that a non-owner without manage_connections is rejected with 403
+// and, crucially, that the is_shared flag is NOT changed as a side effect of
+// the denied request.
+func TestClusterHandler_UpdateClusterGroup_Issue304_ForbiddenDoesNotShare(t *testing.T) {
+	ds, pool, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	_, store, cleanupStore := createTestRBACHandler(t)
+	defer cleanupStore()
+
+	if err := store.CreateUser("outsider304", "Password1234", "", "", ""); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	userID, err := store.GetUserID("outsider304")
+	if err != nil {
+		t.Fatalf("Failed to get user id: %v", err)
+	}
+	token, _, err := store.AuthenticateUser("outsider304", "Password1234")
+	if err != nil {
+		t.Fatalf("Failed to authenticate: %v", err)
+	}
+
+	checker := auth.NewRBACChecker(store)
+	handler := NewClusterHandler(ds, store, checker)
+
+	ctx := context.Background()
+	// Owned by someone else, currently private.
+	other := "someone_else"
+	created, err := ds.CreateClusterGroupWithOwner(ctx, "Locked Group", nil, &other, false)
+	if err != nil {
+		t.Fatalf("Failed to create cluster group: %v", err)
+	}
+
+	// Attempt to flip it to shared as a non-owner without manage_connections.
+	body, _ := json.Marshal(ClusterGroupRequest{
+		Name:     "Locked Group",
+		IsShared: issue304Bool(true),
+	})
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/cluster-groups/"+strconv.Itoa(created.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterGroupSubpath(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+
+	// The denied request must not have shared the group.
+	var dbShared bool
+	if err := pool.QueryRow(ctx,
+		"SELECT is_shared FROM cluster_groups WHERE id = $1", created.ID).Scan(&dbShared); err != nil {
+		t.Fatalf("Failed to read row: %v", err)
+	}
+	if dbShared {
+		t.Errorf("Persisted is_shared = true after a denied update; visibility must be unchanged")
+	}
+}
+
+// TestClusterHandler_UpdateClusterGroup_Issue304_InvalidName confirms the
+// update handler rejects a name with disallowed characters with 400, after
+// the ownership/permission check has passed. This covers the on-update
+// ValidateDisplayName branch.
+func TestClusterHandler_UpdateClusterGroup_Issue304_InvalidName(t *testing.T) {
+	ds, _, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
+
+	ctx := context.Background()
+	created, err := ds.CreateClusterGroup(ctx, "Valid Original", nil)
+	if err != nil {
+		t.Fatalf("Failed to create cluster group: %v", err)
+	}
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: issue269InvalidName})
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/cluster-groups/"+strconv.Itoa(created.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterGroupSubpath(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Expected status %d, got %d. Body: %s",
+			http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+}
+
+// TestClusterHandler_CreateClusterGroup_Issue304_DuplicateNameError forces the
+// CreateClusterGroupWithOwner datastore call to fail via the unique-name
+// constraint, exercising the handler's 500 error branch.
+func TestClusterHandler_CreateClusterGroup_Issue304_DuplicateNameError(t *testing.T) {
+	ds, _, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
+
+	ctx := context.Background()
+	if _, err := ds.CreateClusterGroup(ctx, "Dup Name", nil); err != nil {
+		t.Fatalf("Failed to seed cluster group: %v", err)
+	}
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: "Dup Name"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.createClusterGroup(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("Expected status %d for duplicate name, got %d. Body: %s",
+			http.StatusInternalServerError, rec.Code, rec.Body.String())
+	}
+}
+
+// TestClusterHandler_UpdateClusterGroup_Issue304_DuplicateNameError forces the
+// UpdateClusterGroup datastore call to fail by renaming a group to a name
+// already taken by another group, exercising the handler's 500 error branch.
+func TestClusterHandler_UpdateClusterGroup_Issue304_DuplicateNameError(t *testing.T) {
+	ds, _, cleanupDS := newTestDatastore(t)
+	defer cleanupDS()
+
+	handler, _, userID, token, cleanupStore := setupGroupUpdateHandler(t, ds)
+	defer cleanupStore()
+
+	ctx := context.Background()
+	if _, err := ds.CreateClusterGroup(ctx, "Existing Name", nil); err != nil {
+		t.Fatalf("Failed to seed first group: %v", err)
+	}
+	target, err := ds.CreateClusterGroup(ctx, "Target Group", nil)
+	if err != nil {
+		t.Fatalf("Failed to seed target group: %v", err)
+	}
+
+	body, _ := json.Marshal(ClusterGroupRequest{Name: "Existing Name"})
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/cluster-groups/"+strconv.Itoa(target.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
+	req = withUser(req, userID)
+	rec := httptest.NewRecorder()
+
+	handler.handleClusterGroupSubpath(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("Expected status %d for duplicate rename, got %d. Body: %s",
+			http.StatusInternalServerError, rec.Code, rec.Body.String())
 	}
 }

--- a/server/src/internal/api/rbac_issue207_clusters_test.go
+++ b/server/src/internal/api/rbac_issue207_clusters_test.go
@@ -160,23 +160,39 @@ func TestClusterHandler_CreateClusterGroup_Issue207_DeniedSkipsDecode(t *testing
 // datastore deliberately panics if the handler reaches the datastore
 // call, so this test additionally proves the gate path returns to the
 // caller before any datastore work.
+//
+// Since issue #304, createClusterGroup also resolves the creating user
+// via the bearer token to record group ownership, so the request must
+// carry a valid session token in addition to the superuser context that
+// satisfies the admin gate. The token identifies the owner; the context
+// value drives HasAdminPermission.
 func TestClusterHandler_CreateClusterGroup_Issue207_SuperuserAllowed(t *testing.T) {
-	handler, _, cleanup := newIssue207Handler(t)
+	handler, store, cleanup := newIssue207Handler(t)
 	defer cleanup()
+
+	if err := store.CreateUser("issue207_super", "Password1234", "", "", ""); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	token, _, err := store.AuthenticateUser("issue207_super", "Password1234")
+	if err != nil {
+		t.Fatalf("Failed to authenticate user: %v", err)
+	}
 
 	body, _ := json.Marshal(ClusterGroupRequest{Name: "AdminGroup"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-groups",
 		bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withBearer(req, token)
 	req = withSuperuser(req)
 	rec := httptest.NewRecorder()
 
 	defer func() {
 		// We intentionally allow a panic here: the nil datastore will
-		// blow up when the handler reaches CreateClusterGroup. The
-		// security contract we are testing is that the handler PASSES
-		// the gate (i.e., does NOT return 403). The integration tests
-		// against a real Postgres cover the success-write path.
+		// blow up when the handler reaches CreateClusterGroupWithOwner.
+		// The security contract we are testing is that the handler
+		// PASSES the gate (i.e., does NOT return 403) and resolves the
+		// owner (does NOT return 401). The integration tests against a
+		// real Postgres cover the success-write path.
 		_ = recover()
 	}()
 	handler.createClusterGroup(rec, req)

--- a/server/src/internal/database/cluster_group_share_integration_test.go
+++ b/server/src/internal/database/cluster_group_share_integration_test.go
@@ -1,0 +1,213 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// clusterGroupShareTestSchema creates the minimum cluster_groups table
+// exercised by CreateClusterGroupWithOwner and UpdateClusterGroup. It mirrors
+// the production shape (collector/src/database/schema.go), limited to the
+// columns those two functions read, write, and RETURN. The owner_username,
+// owner_token, and is_shared columns are required because both functions
+// reference them in their RETURNING clauses (issue #304).
+const clusterGroupShareTestSchema = `
+DROP TABLE IF EXISTS cluster_groups CASCADE;
+CREATE TABLE cluster_groups (
+    id SERIAL PRIMARY KEY,
+    owner_username VARCHAR(255),
+    owner_token VARCHAR(255),
+    is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    auto_group_key VARCHAR(255) UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT cluster_groups_share_name_unique UNIQUE (name)
+);
+`
+
+const clusterGroupShareTestTeardown = `DROP TABLE IF EXISTS cluster_groups CASCADE;`
+
+// newClusterGroupShareTestDatastore wires up a *Datastore against the
+// TEST_AI_WORKBENCH_SERVER Postgres instance with only the cluster_groups
+// table the share/owner path needs. The caller receives a cleanup that drops
+// the schema and closes the pool.
+func newClusterGroupShareTestDatastore(t *testing.T) (*Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping cluster group share integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, clusterGroupShareTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create cluster group share test schema: %v", err)
+	}
+
+	ds := NewTestDatastore(pool)
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), clusterGroupShareTestTeardown); err != nil {
+			t.Logf("cluster group share teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return ds, pool, cleanup
+}
+
+// TestCreateClusterGroupWithOwner_Integration confirms the owner and shared
+// flag are persisted for both the shared and private cases.
+func TestCreateClusterGroupWithOwner_Integration(t *testing.T) {
+	ds, _, cleanup := newClusterGroupShareTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	owner := "alice"
+
+	shared, err := ds.CreateClusterGroupWithOwner(ctx, "Shared", nil, &owner, true)
+	if err != nil {
+		t.Fatalf("CreateClusterGroupWithOwner (shared) failed: %v", err)
+	}
+	if !shared.IsShared {
+		t.Errorf("shared.IsShared = false, want true")
+	}
+	if !shared.OwnerUsername.Valid || shared.OwnerUsername.String != owner {
+		t.Errorf("shared.OwnerUsername = %v, want %q", shared.OwnerUsername, owner)
+	}
+
+	desc := "a private group"
+	private, err := ds.CreateClusterGroupWithOwner(ctx, "Private", &desc, &owner, false)
+	if err != nil {
+		t.Fatalf("CreateClusterGroupWithOwner (private) failed: %v", err)
+	}
+	if private.IsShared {
+		t.Errorf("private.IsShared = true, want false")
+	}
+	if private.Description == nil || *private.Description != desc {
+		t.Errorf("private.Description = %v, want %q", private.Description, desc)
+	}
+}
+
+// TestUpdateClusterGroup_Integration_PartialSemantics drives the partial
+// update behavior of UpdateClusterGroup directly: is_shared and description
+// change when a non-nil pointer is supplied and are preserved when nil.
+func TestUpdateClusterGroup_Integration_PartialSemantics(t *testing.T) {
+	ds, _, cleanup := newClusterGroupShareTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	owner := "bob"
+	origDesc := "keep me"
+	created, err := ds.CreateClusterGroupWithOwner(ctx, "Partial", &origDesc, &owner, true)
+	if err != nil {
+		t.Fatalf("seed create failed: %v", err)
+	}
+
+	// Rename only: nil description and nil is_shared must preserve both.
+	got, err := ds.UpdateClusterGroup(ctx, created.ID, "Partial Renamed", nil, nil)
+	if err != nil {
+		t.Fatalf("UpdateClusterGroup (name only) failed: %v", err)
+	}
+	if got.Name != "Partial Renamed" {
+		t.Errorf("Name = %q, want %q", got.Name, "Partial Renamed")
+	}
+	if got.Description == nil || *got.Description != origDesc {
+		t.Errorf("Description = %v, want preserved %q", got.Description, origDesc)
+	}
+	if !got.IsShared {
+		t.Errorf("IsShared = false, want preserved true")
+	}
+
+	// Flip is_shared to false and set a new description.
+	newDesc := "changed"
+	shared := false
+	got, err = ds.UpdateClusterGroup(ctx, created.ID, "Partial Renamed", &newDesc, &shared)
+	if err != nil {
+		t.Fatalf("UpdateClusterGroup (full) failed: %v", err)
+	}
+	if got.IsShared {
+		t.Errorf("IsShared = true, want false")
+	}
+	if got.Description == nil || *got.Description != newDesc {
+		t.Errorf("Description = %v, want %q", got.Description, newDesc)
+	}
+
+	// Flip is_shared back to true, leaving description untouched (nil).
+	shared = true
+	got, err = ds.UpdateClusterGroup(ctx, created.ID, "Partial Renamed", nil, &shared)
+	if err != nil {
+		t.Fatalf("UpdateClusterGroup (share back) failed: %v", err)
+	}
+	if !got.IsShared {
+		t.Errorf("IsShared = false, want true")
+	}
+	if got.Description == nil || *got.Description != newDesc {
+		t.Errorf("Description = %v, want preserved %q", got.Description, newDesc)
+	}
+}
+
+// TestUpdateClusterGroup_Integration_Error confirms the error path: renaming
+// a group to a name already taken by another group violates the unique
+// constraint and returns a wrapped error.
+func TestUpdateClusterGroup_Integration_Error(t *testing.T) {
+	ds, _, cleanup := newClusterGroupShareTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := ds.CreateClusterGroupWithOwner(ctx, "Taken", nil, nil, false); err != nil {
+		t.Fatalf("seed create failed: %v", err)
+	}
+	target, err := ds.CreateClusterGroupWithOwner(ctx, "Mover", nil, nil, false)
+	if err != nil {
+		t.Fatalf("seed create failed: %v", err)
+	}
+
+	if _, err := ds.UpdateClusterGroup(ctx, target.ID, "Taken", nil, nil); err == nil {
+		t.Fatalf("expected error renaming to a duplicate name, got nil")
+	}
+}
+
+// TestCreateClusterGroupWithOwner_Integration_Error confirms the create error
+// path: inserting a second group with a duplicate name violates the unique
+// constraint and returns a wrapped error.
+func TestCreateClusterGroupWithOwner_Integration_Error(t *testing.T) {
+	ds, _, cleanup := newClusterGroupShareTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := ds.CreateClusterGroupWithOwner(ctx, "OnlyOne", nil, nil, false); err != nil {
+		t.Fatalf("seed create failed: %v", err)
+	}
+	if _, err := ds.CreateClusterGroupWithOwner(ctx, "OnlyOne", nil, nil, false); err == nil {
+		t.Fatalf("expected error on duplicate name, got nil")
+	}
+}

--- a/server/src/internal/database/cluster_queries.go
+++ b/server/src/internal/database/cluster_queries.go
@@ -174,21 +174,29 @@ func (d *Datastore) CreateClusterGroupWithOwner(ctx context.Context, name string
 	return &g, nil
 }
 
-// UpdateClusterGroup updates an existing cluster group
-func (d *Datastore) UpdateClusterGroup(ctx context.Context, id int, name string, description *string) (*ClusterGroup, error) {
+// UpdateClusterGroup updates an existing cluster group. The name is always
+// applied; description and isShared use partial-update semantics so that a
+// nil pointer preserves the column's current value. This lets callers that
+// omit a field (for example the CLI, or an older client) leave it unchanged
+// rather than nulling it, which matters for the is_shared visibility flag
+// (issue #304). COALESCE keeps the current value when the argument is NULL.
+func (d *Datastore) UpdateClusterGroup(ctx context.Context, id int, name string, description *string, isShared *bool) (*ClusterGroup, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	query := `
         UPDATE cluster_groups
-        SET name = $2, description = $3, updated_at = CURRENT_TIMESTAMP
+        SET name = $2,
+            description = COALESCE($3, description),
+            is_shared = COALESCE($4, is_shared),
+            updated_at = CURRENT_TIMESTAMP
         WHERE id = $1
         RETURNING id, name, description, owner_username, owner_token, is_shared,
                   created_at, updated_at
     `
 
 	var g ClusterGroup
-	err := d.pool.QueryRow(ctx, query, id, name, description).Scan(
+	err := d.pool.QueryRow(ctx, query, id, name, description, isShared).Scan(
 		&g.ID, &g.Name, &g.Description, &g.OwnerUsername, &g.OwnerToken,
 		&g.IsShared, &g.CreatedAt, &g.UpdatedAt,
 	)


### PR DESCRIPTION
## Summary

Fixes #304: the Group Settings dialog showed an empty Description and an unchecked "Share with all users" box for groups that had them set, and editing a group silently discarded both. The root causes span client and server; the reported diagnosis (three frontend bugs) was correct for Description but the backend could not persist `is_shared` at all, so this fixes both sides.

**Client**
- `GroupData` lacked `description`/`is_shared`, dropping them at the topology-tree boundary that fed the edit dialog.
- `handleConfigureGroup` now fetches the full group via `GET /api/v1/cluster-groups/{id}` before opening the dialog (the topology object never carries those fields), with a graceful fallback on fetch failure.
- The edit save path sent only the name; a new `updateGroup` context method sends `name`, `description`, and `is_shared` together.

**Server**
- `ClusterGroupRequest` gained `is_shared` (a `*bool`, so omitted ≠ explicit false). `createClusterGroup` now records the creator as `owner_username` and honours `is_shared` (default false) via `CreateClusterGroupWithOwner`; `UpdateClusterGroup` accepts `is_shared`.
- Both use `COALESCE` partial-update semantics, so an omitted `description` or `is_shared` preserves the existing value rather than clearing it (this also fixes a latent bug where sending only `{name}` would null the description).
- The existing permission checks are unchanged: `manage_connections` gates create, and owner-or-`manage_connections` gates update, both before any datastore write.

## Security review

Reviewed by the security-auditor — **no findings** at any severity. Identity is derived solely from the authenticated token (not spoofable via the body), the `is_shared` visibility toggle is gated before every datastore write, queries are parameterised, and `COALESCE` against the `NOT NULL` column is type-safe. Two non-blocking NOTES for awareness:
1. A non-admin *owner* of a group can set `is_shared=true` (share to all users), since the owner branch satisfies the update gate. This matches the chosen ownership model; if sharing-to-all should be admin-only, gating the `is_shared`-changing case on `manage_connections` is a one-line follow-up.
2. The legacy `CreateClusterGroup` datastore wrapper defaults `isShared=true`, but it now has **only test callers** — no production path uses it (production create goes through the owner variant with an explicit flag).

## Test plan

- [x] Backend: handler + datastore tests for create (records owner; `is_shared` true when requested, false when omitted; 401 without auth), update (toggles `is_shared` both ways; omitting `is_shared`/`description` preserves them; non-owner without `manage_connections` denied), and error paths. Changed functions at 96–100% coverage. Run against local Postgres.
- [x] Frontend: `updateGroup` PUTs the full body; `handleConfigureGroup` fetches detail and populates the dialog (plus fetch-failure fallback); edit save routes through `updateGroup`; dialog pre-populates the share checkbox. Full client suite passes; touched units at 100% line coverage.
- [x] `gofmt`/`go build` clean; client lint clean (no new warnings).

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group settings now support editing/saving a group description.
  * Groups can be marked “shared with all users,” and that preference is persisted.
  * The configuration dialog now preloads the full saved group details before editing.

* **Bug Fixes**
  * Fixed cases where description and sharing settings could be lost or reset during updates.
  * Improved partial-update behavior so omitted fields remain unchanged.

* **Tests**
  * Expanded client and server test coverage for group configuration, sharing, and partial-update semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->