### PR TITLE
chore(collector): harden shutdown diagnostics, timeouts and compose (#308)

### DIFF
--- a/collector/src/config.go
+++ b/collector/src/config.go
@@ -70,7 +70,7 @@ func NewConfig() *Config {
 			DatastoreMaxWaitSeconds: 60,
 			MaxConnectionsPerServer: 3,
 			MonitoredMaxIdleSeconds: 300,
-			MonitoredMaxWaitSeconds: 60,
+			MonitoredMaxWaitSeconds: 120,
 		},
 	}
 }

--- a/collector/src/config_test.go
+++ b/collector/src/config_test.go
@@ -37,8 +37,8 @@ func TestNewConfig(t *testing.T) {
 		t.Errorf("Expected default Pool.DatastoreMaxWaitSeconds to be 60, got %d", config.Pool.DatastoreMaxWaitSeconds)
 	}
 
-	if config.Pool.MonitoredMaxWaitSeconds != 60 {
-		t.Errorf("Expected default Pool.MonitoredMaxWaitSeconds to be 60, got %d", config.Pool.MonitoredMaxWaitSeconds)
+	if config.Pool.MonitoredMaxWaitSeconds != 120 {
+		t.Errorf("Expected default Pool.MonitoredMaxWaitSeconds to be 120, got %d", config.Pool.MonitoredMaxWaitSeconds)
 	}
 
 	if config.Pool.MaxConnectionsPerServer != 3 {

--- a/collector/src/main.go
+++ b/collector/src/main.go
@@ -112,9 +112,9 @@ func main() {
 	logger.Startup("Collector is running. Press Ctrl+C to stop.")
 
 	// Wait for shutdown signal
-	waitForShutdown()
+	sig := waitForShutdown()
 
-	logger.Startup("Shutdown signal received, stopping...")
+	logger.Startupf("Received signal %q, shutting down...", sig)
 
 	// Shutdown in proper order to ensure clean connection closure
 	// 1. Stop probe scheduler (no new probe queries)
@@ -230,9 +230,13 @@ func loadConfiguration() (*Config, error) {
 	return config, nil
 }
 
-// waitForShutdown waits for an interrupt signal
-func waitForShutdown() {
+// waitForShutdown waits for an interrupt signal and returns the
+// signal that was received, so the caller can log which signal
+// triggered the shutdown. A clean exit that was previously silent
+// now records the delivered signal, making a future recurrence of
+// the reported clean-exit restart loop diagnosable.
+func waitForShutdown() os.Signal {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	<-sigChan
+	return <-sigChan
 }

--- a/collector/src/main_test.go
+++ b/collector/src/main_test.go
@@ -396,11 +396,10 @@ func TestMaybePrintSchemaVersion_WriteError(t *testing.T) {
 }
 
 func TestWaitForShutdown(t *testing.T) {
-	done := make(chan struct{})
+	got := make(chan os.Signal, 1)
 
 	go func() {
-		waitForShutdown()
-		close(done)
+		got <- waitForShutdown()
 	}()
 
 	// Give the goroutine time to install its signal handler before we
@@ -416,8 +415,10 @@ func TestWaitForShutdown(t *testing.T) {
 	}
 
 	select {
-	case <-done:
-		// ok
+	case sig := <-got:
+		if sig != syscall.SIGTERM {
+			t.Errorf("waitForShutdown returned %v, want SIGTERM", sig)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("waitForShutdown did not return after SIGTERM")
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,17 @@ services:
       - ./docker/config/ai-dba-collector.yaml:/etc/pgedge/ai-dba-collector.yaml:ro
       - ./docker/secret/ai-dba.secret:/etc/pgedge/ai-dba.secret:ro
       - ./docker/secret/pg-password:/etc/pgedge/pg-password:ro
+    # Run an init process as PID 1 for robust signal forwarding and
+    # zombie reaping.
+    init: true
+    # Give the collector time to close its connection pools during its
+    # multi-step graceful shutdown before the container is killed.
+    stop_grace_period: 30s
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
 
   server:
     build:

--- a/docker/config/ai-dba-collector.yaml
+++ b/docker/config/ai-dba-collector.yaml
@@ -9,5 +9,15 @@ datastore:
 pool:
   datastore_max_connections: 25
   max_connections_per_server: 3
+  # Seconds an idle datastore connection is kept before being closed.
+  datastore_max_idle_seconds: 300
+  # Max seconds to wait to acquire a datastore connection.
+  datastore_max_wait_seconds: 60
+  # Seconds an idle monitored-server connection is kept before closing.
+  monitored_max_idle_seconds: 300
+  # Per-probe execution timeout (seconds) for monitored servers; raise
+  # this for large or slow monitored databases where probes such as
+  # pg_stat_statements can take longer to complete.
+  monitored_max_wait_seconds: 120
 
 secret_file: /etc/pgedge/ai-dba.secret

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -204,6 +204,20 @@ project adheres to
   previously appeared empty or unchecked and were lost when editing;
   the share flag is now persisted by the API. (#304)
 
+- Harden the collector against clean-exit restart loops that could
+  stop the Dashboard from showing Top Queries. The collector now
+  logs which signal triggered its shutdown, rather than exiting
+  silently, and the default monitored probe and pool wait timeout
+  (`monitored_max_wait_seconds`) was raised from 60 to 120 seconds
+  to give slow probes such as `pg_stat_statements` on large
+  monitored databases more headroom before timing out. (#308)
+
+- Harden the shipped Docker Compose collector service by running an
+  init process as PID 1, adding a stop grace period for graceful
+  shutdown, and raising the memory limit modestly from 256M to
+  512M; the collector connection-pool and timeout options are now
+  documented in the sample configuration. (#308)
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/examples/docker-compose.production.yml
+++ b/examples/docker-compose.production.yml
@@ -59,12 +59,18 @@ services:
             - ../docker/config/ai-dba-collector.yaml:/etc/pgedge/ai-dba-collector.yaml:ro
             - ../docker/secret/ai-dba.secret:/etc/pgedge/ai-dba.secret:ro
             - ../docker/secret/pg-password:/etc/pgedge/pg-password:ro
+        # Run an init process as PID 1 for robust signal forwarding
+        # and zombie reaping.
+        init: true
+        # Give the collector time to close its connection pools during
+        # its multi-step graceful shutdown before the container is killed.
+        stop_grace_period: 30s
         restart: unless-stopped
         deploy:
             resources:
                 limits:
                     cpus: '0.5'
-                    memory: 256M
+                    memory: 512M
         logging:
             driver: json-file
             options:


### PR DESCRIPTION
## Summary

Addresses #308, where the `ai-dba-collector` container entered a clean-exit (`ExitCode=0`) restart loop after the upgrade to 1.0.0, which stopped the Dashboard from showing Top Queries.

**Important framing:** investigation found the collector's signal handling is correct and nothing in its running path can force an exit (probe timeouts, pool exhaustion, and GC errors are all handled gracefully; the only `Fatal` calls are at startup and exit with code 1). `ExitCode=0` therefore means a signal was actually delivered to the process, and the *source* of that signal could not be determined from the codebase (it needs deployment data we don't have: Docker/runc versions, launch mode, whether the shutdown log line appeared). Rather than guess at a root cause, this PR ships low-risk hardening agreed with the maintainer and leaves the signal source as a documented known-unknown.

## Changes

- **Diagnosable shutdown**: `waitForShutdown` now returns the received signal and `main` logs *which* signal triggered shutdown, instead of exiting silently. If the loop recurs, the logs will show whether it was SIGTERM/SIGINT rather than being opaque.
- **Timeout headroom**: default `monitored_max_wait_seconds` raised 60 → 120. This value also bounds each probe's execution deadline, and the report observed `pg_stat_statements` timing out at 60s on a large monitored database.
- **Compose hardening** (`examples/docker-compose.production.yml` and `docker-compose.yml`): the collector service now runs an init as PID 1 (`init: true`) for robust signal handling, has a `stop_grace_period: 30s` for its multi-step graceful shutdown, and a modestly higher memory limit (256M → 512M, precautionary headroom; the report was **not** OOM). `stdin_open`/`tty` were **deliberately not** added — they mask the symptom and are wrong for a background daemon.
- **Config documentation**: the collector pool/timeout knobs are now spelled out with comments in the sample `docker/config/ai-dba-collector.yaml`, so operators can discover and tune them.

## Test plan

- [x] `waitForShutdown` returns the signal (`main_test.go` asserts SIGTERM); `config_test.go` asserts the new 120s default. `waitForShutdown` and `NewConfig` at 100% coverage.
- [x] `gofmt` clean, `go build ./...` and the collector unit tests pass (against local Postgres).
- [x] Both compose files and the config YAML parse cleanly (validated with a YAML parser; `docker` was unavailable on the dev host to run `docker compose config -q`).

## Known-unknown

The precise reason the collector process received a shutdown signal in the reporter's environment is not identified; this PR makes any recurrence diagnosable rather than silent, and does not claim to fix that underlying cause.

Closes #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None

* **Bug Fixes**
  * Improved collector shutdown by logging the exact OS signal that triggered termination.
  * Increased the default maximum wait time for monitored connections (from 60s to 120s) to help avoid interruptions during clean-exit restart loops.
  * Hardened container shutdown behavior with a 30s stop grace period and Docker init enabled for better signal handling.

* **Documentation**
  * Updated the changelog and sample configuration to include the new connection timing options and revised deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->