### PR TITLE
fix(client): resolve connection names in admin privilege chips

### DIFF
--- a/client/src/components/AdminPanel/AdminGroups.tsx
+++ b/client/src/components/AdminPanel/AdminGroups.tsx
@@ -118,10 +118,10 @@ const AdminGroups: React.FC = () => {
     const fetchGroupsAndConnections = useCallback(async (): Promise<RbacGroup[]> => {
         const [groupsData, connResult] = await Promise.all([
             apiGet<{ groups: RbacGroup[] }>('/api/v1/rbac/groups'),
-            apiGet<{ connections?: { id: number; name: string }[] }>('/api/v1/connections').catch(() => null),
+            apiGet<{ id: number; name: string }[]>('/api/v1/connections').catch(() => null),
         ]);
         if (connResult) {
-            setConnections(connResult.connections ?? []);
+            setConnections(connResult ?? []);
         }
         return groupsData.groups || [];
     }, []);

--- a/client/src/components/AdminPanel/AdminUsers.tsx
+++ b/client/src/components/AdminPanel/AdminUsers.tsx
@@ -154,11 +154,11 @@ const AdminUsers: React.FC = () => {
             setError(null);
             const [usersData, connResult] = await Promise.all([
                 apiGet<{ users: RbacUser[] }>('/api/v1/rbac/users'),
-                apiGet<{ connections: { id: number; name: string }[] }>('/api/v1/connections').catch(() => null),
+                apiGet<{ id: number; name: string }[]>('/api/v1/connections').catch(() => null),
             ]);
             setUsers(usersData.users || []);
             if (connResult) {
-                setConnections(connResult.connections || []);
+                setConnections(connResult ?? []);
             }
         } catch (err: unknown) {
             setError(extractErrorMessage(err));

--- a/client/src/components/AdminPanel/__tests__/AdminGroups.connectionNames.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminGroups.connectionNames.test.tsx
@@ -1,0 +1,99 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+// Regression coverage for issue #309: expanding a group row showed
+// connection-privilege chips as "Connection 3 (read)" (the numeric DB
+// id) instead of the resolved connection name. The root cause was in
+// AdminGroups' fetch of GET /api/v1/connections, which decoded the
+// endpoint's bare JSON array as a wrapped `{ connections: [...] }`
+// object and always read `undefined`. The real EffectivePermissionsPanel
+// is intentionally NOT mocked here so the rendered chip label is
+// asserted end-to-end.
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+const mockApiPut = vi.fn();
+const mockApiDelete = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+}));
+
+vi.mock('../../../contexts/useAuth', () => ({
+    useAuth: () => ({ user: { isSuperuser: false } }),
+}));
+
+import AdminGroups from '../AdminGroups';
+
+const GROUPS = [{ id: 1, name: 'eng', description: 'Engineering', member_count: 1 }];
+
+// The connections endpoint returns a bare array (see
+// connection_handlers.go RespondJSON). A wrapped object here would mask
+// the regression, so the fixture uses the real shape.
+const CONNECTIONS = [{ id: 3, name: 'primary-node' }];
+
+function setupRouter() {
+    const routes: Record<string, unknown> = {
+        '/api/v1/rbac/groups': { groups: GROUPS },
+        '/api/v1/connections': CONNECTIONS,
+        '/api/v1/rbac/groups/1': { user_members: ['alice'], group_members: [] },
+        '/api/v1/rbac/groups/1/effective-privileges': {
+            connection_privileges: [{ connection_id: 3, access_level: 'read' }],
+            admin_permissions: [],
+            mcp_privileges: [],
+        },
+    };
+    mockApiGet.mockImplementation((url: string) => {
+        const keys = Object.keys(routes).sort((a, b) => b.length - a.length);
+        const matchKey = keys.find((k) => url === k || url.startsWith(`${k}/`));
+        if (!matchKey) {
+            return Promise.reject(new Error(`No fixture for ${url}`));
+        }
+        return Promise.resolve(routes[matchKey]);
+    });
+}
+
+describe('AdminGroups connection-name resolution (issue #309)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('resolves the connection id to its name in the effective-permissions chip', async () => {
+        setupRouter();
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminGroups />);
+        await waitFor(() => {
+            expect(screen.getByText('eng')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByText('eng'));
+
+        // The chip should show the resolved connection name, not the id.
+        await waitFor(() => {
+            expect(
+                screen.getByText('primary-node (read)'),
+            ).toBeInTheDocument();
+        });
+        expect(screen.queryByText('Connection 3 (read)')).not.toBeInTheDocument();
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminGroups.test.tsx
@@ -62,7 +62,11 @@ const CONNECTIONS = [{ id: 11, name: 'prod-db' }];
 function setupApiGetRouter(overrides: Record<string, unknown> = {}) {
     const defaults: Record<string, unknown> = {
         '/api/v1/rbac/groups': { groups: GROUPS },
-        '/api/v1/connections': { connections: CONNECTIONS },
+        // The server returns a bare JSON array of connections (see
+        // connection_handlers.go). The fixture must mirror that shape;
+        // a wrapped `{ connections: [...] }` object would mask the
+        // issue #309 regression where the parent decoded the wrong shape.
+        '/api/v1/connections': CONNECTIONS,
     };
     const routes = { ...defaults, ...overrides };
     mockApiGet.mockImplementation((url: string) => {
@@ -521,7 +525,7 @@ describe('AdminGroups', () => {
                     return Promise.resolve({ groups: GROUPS });
                 }
                 if (url === '/api/v1/connections') {
-                    return Promise.resolve({ connections: CONNECTIONS });
+                    return Promise.resolve(CONNECTIONS);
                 }
                 if (url.startsWith('/api/v1/rbac/groups/1/effective')) {
                     return Promise.reject(new Error('perm fail'));
@@ -785,7 +789,7 @@ describe('AdminGroups', () => {
                     return Promise.resolve({ groups: GROUPS });
                 }
                 if (url === '/api/v1/connections') {
-                    return Promise.resolve({ connections: CONNECTIONS });
+                    return Promise.resolve(CONNECTIONS);
                 }
                 if (url === '/api/v1/rbac/groups/1') {
                     return Promise.resolve({

--- a/client/src/components/AdminPanel/__tests__/AdminUsers.connectionNames.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminUsers.connectionNames.test.tsx
@@ -1,0 +1,105 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import renderWithTheme from '../../../test/renderWithTheme';
+
+// Regression coverage for issue #309 in the users panel: the
+// connection-privilege chip must resolve the numeric connection id to
+// its name when GET /api/v1/connections returns a bare array. The real
+// EffectivePermissionsPanel is intentionally NOT mocked here.
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+const mockApiPut = vi.fn();
+const mockApiDelete = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
+    apiPut: (...args: unknown[]) => mockApiPut(...args),
+    apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+}));
+
+vi.mock('../../../contexts/useAuth', () => ({
+    useAuth: () => ({ user: { username: 'alice', isSuperuser: true } }),
+}));
+
+import AdminUsers from '../AdminUsers';
+
+const USERS = [
+    {
+        id: 2,
+        username: 'bob',
+        display_name: 'Bob',
+        email: 'bob@example.com',
+        annotation: '',
+        is_service_account: false,
+        is_superuser: false,
+        enabled: true,
+    },
+];
+
+// The connections endpoint returns a bare array (see
+// connection_handlers.go). A wrapped object here would mask the bug.
+const CONNECTIONS = [{ id: 3, name: 'primary-node' }];
+
+function setupRouter() {
+    mockApiGet.mockImplementation((url: string) => {
+        if (url === '/api/v1/rbac/users') {
+            return Promise.resolve({ users: USERS });
+        }
+        if (url === '/api/v1/connections') {
+            return Promise.resolve(CONNECTIONS);
+        }
+        if (/^\/api\/v1\/rbac\/users\/\d+\/privileges$/.test(url)) {
+            return Promise.resolve({
+                connection_privileges: [
+                    { connection_id: 3, access_level: 'read' },
+                ],
+                admin_permissions: [],
+                mcp_privileges: [],
+                groups: [],
+            });
+        }
+        return Promise.resolve({});
+    });
+}
+
+describe('AdminUsers connection-name resolution (issue #309)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('resolves the connection id to its name in the effective-permissions chip', async () => {
+        setupRouter();
+        const user = userEvent.setup({ delay: null });
+
+        renderWithTheme(<AdminUsers />);
+        await waitFor(() => {
+            expect(screen.getByText('bob')).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByText('bob'));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('primary-node (read)'),
+            ).toBeInTheDocument();
+        });
+        expect(screen.queryByText('Connection 3 (read)')).not.toBeInTheDocument();
+    });
+});

--- a/client/src/components/AdminPanel/__tests__/AdminUsers.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminUsers.test.tsx
@@ -90,7 +90,10 @@ function installListMocks(overrides?: ListMockOverrides): void {
             return Promise.resolve({ users: overrides?.users ?? mockUsers });
         }
         if (url === '/api/v1/connections') {
-            return Promise.resolve({ connections: [] });
+            // The server returns a bare JSON array of connections (see
+            // connection_handlers.go); mirror that shape so the fixture
+            // does not mask the issue #309 regression.
+            return Promise.resolve([]);
         }
         if (/^\/api\/v1\/rbac\/users\/\d+\/privileges$/.test(url)) {
             if (overrides?.privilegesRejection) {
@@ -991,7 +994,7 @@ describe('AdminUsers', () => {
                     return Promise.resolve({ users: mockUsers });
                 }
                 if (url === '/api/v1/connections') {
-                    return Promise.resolve({ connections: [] });
+                    return Promise.resolve([]);
                 }
                 if (/^\/api\/v1\/rbac\/users\/\d+\/privileges$/.test(url)) {
                     return Promise.reject('plain string reject');

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,10 @@ project adheres to
 
 ### Fixed
 
+- Connection-privilege chips in the Admin Groups and Users panels
+  now show the connection name instead of the internal numeric
+  connection id. (#309)
+
 - Fix the metrics time-series API (`GET /api/v1/metrics/query`)
   silently returning an empty HTTP 200 response, which the web UI
   rendered as a generic "No data available" message, whenever a


### PR DESCRIPTION
## Summary

Fixes #309: connection-privilege chips in Admin → Groups (expanded row) and Admin → Users showed the internal numeric id, e.g. `Connection 3 (read)`, instead of the connection name like `primary-node (read)`.

`EffectivePermissionsPanel` already resolves the name from a `connections` lookup (falling back to `Connection {id}` only when the id is absent). The real bug was upstream in the fetch: `GET /api/v1/connections` returns a **bare JSON array**, but `AdminGroups.tsx` and `AdminUsers.tsx` decoded it as `{ connections: [...] }` and read `.connections` — always `undefined` for a bare array — so the lookup was empty and every chip hit the fallback. (`AdminTokenScopes.tsx` already handled the bare-array shape, and `ClusterDataContext` decodes it as an array, confirming the shape.)

- Decode the response as an array in both panels so names resolve. One-line change each; `EffectivePermissionsPanel` and `AdminTokenScopes` untouched.

## Scope note

#309 reports the Groups panel; `AdminUsers.tsx` had the **identical** mismatch (its connection chips were silently showing ids too — the same `EffectivePermissionsPanel` is used there), so it's fixed in the same PR for consistency. `AdminTokenScopes.tsx` already coped with the bare array and is left as-is.

## Test plan

- [x] The existing `AdminGroups`/`AdminUsers` tests had mocked `/api/v1/connections` with the **wrong wrapped shape**, which masked the bug; corrected to the real bare-array shape.
- [x] Added regression tests (`AdminGroups.connectionNames.test.tsx`, `AdminUsers.connectionNames.test.tsx`) that render the real `EffectivePermissionsPanel` with a bare-array connections mock, expand a row with `connection_id: 3`, and assert `primary-node (read)` renders while `Connection 3 (read)` does not.
- [x] `npm run lint` clean; affected vitest files pass (84 tests). `AdminGroups.tsx`/`AdminUsers.tsx` ~95% line coverage.

Closes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin Groups and Users panels now display connection names in privilege indicators instead of numeric connection IDs.
  * Updated connection data handling to ensure names resolve correctly in administrative views.

* **Documentation**
  * Added an Unreleased changelog entry describing the corrected connection-privilege display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->