### PR TITLE
fix(client): clarify token scope "All" label as owner-scoped

### DIFF
--- a/client/src/components/AdminPanel/AdminTokenScopes.tsx
+++ b/client/src/components/AdminPanel/AdminTokenScopes.tsx
@@ -100,7 +100,7 @@ const AdminTokenScopes: React.FC = () => {
 
     const getMcpPrivilegeName = useCallback((id: number) => {
         if (id === -1) {
-            return 'All MCP Privileges';
+            return "All the owner's MCP privileges";
         }
         const priv = mcpPrivileges.find((p) => p.id === id);
         return priv ? priv.identifier : `Privilege ${id}`;

--- a/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
+++ b/client/src/components/AdminPanel/__tests__/AdminTokenScopes.test.tsx
@@ -426,7 +426,7 @@ describe('AdminTokenScopes', () => {
 
         const mcpListbox = await screen.findByRole('listbox');
         expect(
-            within(mcpListbox).getByRole('option', { name: 'All MCP Privileges' }),
+            within(mcpListbox).getByRole('option', { name: "All the owner's MCP privileges" }),
         ).toBeInTheDocument();
         for (const priv of MCP_PRIVILEGES) {
             expect(
@@ -443,7 +443,7 @@ describe('AdminTokenScopes', () => {
 
         const adminListbox = await screen.findByRole('listbox');
         expect(
-            within(adminListbox).getByRole('option', { name: 'All Admin Permissions' }),
+            within(adminListbox).getByRole('option', { name: "All the owner's admin permissions" }),
         ).toBeInTheDocument();
         for (const label of expectedAdminLabels) {
             expect(
@@ -508,7 +508,7 @@ describe('AdminTokenScopes', () => {
 
         const mcpListbox = await screen.findByRole('listbox');
         expect(
-            within(mcpListbox).getByRole('option', { name: 'All MCP Privileges' }),
+            within(mcpListbox).getByRole('option', { name: "All the owner's MCP privileges" }),
         ).toBeInTheDocument();
         for (const priv of MCP_PRIVILEGES) {
             expect(
@@ -525,7 +525,7 @@ describe('AdminTokenScopes', () => {
 
         const adminListbox = await screen.findByRole('listbox');
         expect(
-            within(adminListbox).getByRole('option', { name: 'All Admin Permissions' }),
+            within(adminListbox).getByRole('option', { name: "All the owner's admin permissions" }),
         ).toBeInTheDocument();
         for (const label of expectedAdminLabels) {
             expect(
@@ -810,12 +810,13 @@ describe('AdminTokenScopes - additional coverage', () => {
         const aliceOption = await screen.findByRole('option', { name: 'alice' });
         await user.click(aliceOption);
 
-        // Confirm the MCP combobox now has the "All MCP Privileges" option.
+        // Confirm the MCP combobox now has the "All the owner's MCP
+        // privileges" option.
         const mcpCombo = await screen.findByRole('combobox', {
             name: /allowed mcp privileges/i,
         });
         await user.click(mcpCombo);
-        await screen.findByRole('option', { name: 'All MCP Privileges' });
+        await screen.findByRole('option', { name: "All the owner's MCP privileges" });
         await user.keyboard('{Escape}');
 
         // Clear the owner via the Autocomplete clear button.
@@ -832,7 +833,7 @@ describe('AdminTokenScopes - additional coverage', () => {
         if (listbox) {
             expect(
                 within(listbox).queryByRole('option', {
-                    name: /All MCP Privileges/,
+                    name: /All the owner's MCP privileges/,
                 }),
             ).not.toBeInTheDocument();
         }
@@ -1099,7 +1100,7 @@ describe('AdminTokenScopes - additional coverage', () => {
         // Click the Name field to take focus away from the multi-select.
         await user.click(screen.getByLabelText(/^Name/i));
 
-        // Add the "All Admin Permissions" wildcard to exercise the _isAll
+        // Add the "All the owner's admin permissions" wildcard to exercise the _isAll
         // mapping path (line 220-221).
         const adminCombo = screen.getByRole('combobox', {
             name: /allowed admin permissions/i,
@@ -1108,7 +1109,7 @@ describe('AdminTokenScopes - additional coverage', () => {
         const adminListbox = await screen.findByRole('listbox');
         await user.click(
             within(adminListbox).getByRole('option', {
-                name: 'All Admin Permissions',
+                name: "All the owner's admin permissions",
             }),
         );
         await user.click(screen.getByLabelText(/^Name/i));
@@ -1134,7 +1135,7 @@ describe('AdminTokenScopes - additional coverage', () => {
         );
     }, 15000);
 
-    it('creates a token with the "All MCP Privileges" wildcard via the _isAll mapping', async () => {
+    it('creates a token with the "All the owner\'s MCP privileges" wildcard via the _isAll mapping', async () => {
         mockApiGet.mockImplementation((url: string) => {
             if (url === '/api/v1/rbac/tokens') {
                 return Promise.resolve({ tokens: [] });
@@ -1185,7 +1186,7 @@ describe('AdminTokenScopes - additional coverage', () => {
         await user.click(mcpCombo);
         const mcpListbox = await screen.findByRole('listbox');
         await user.click(
-            within(mcpListbox).getByRole('option', { name: 'All MCP Privileges' }),
+            within(mcpListbox).getByRole('option', { name: "All the owner's MCP privileges" }),
         );
         await user.click(screen.getByLabelText(/^Name/i));
 

--- a/client/src/components/AdminPanel/tokens/CreateTokenDialog.tsx
+++ b/client/src/components/AdminPanel/tokens/CreateTokenDialog.tsx
@@ -287,7 +287,7 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({
                     onChange={onMcpPrivilegesChange}
                     getOptionLabel={(option) =>
                         option._isAll
-                            ? 'All MCP Privileges'
+                            ? "All the owner's MCP privileges"
                             : option.identifier || ''
                     }
                     allOption={ALL_MCP_OPTION}
@@ -301,7 +301,7 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({
                     onChange={onAdminPermissionsChange}
                     getOptionLabel={(option) =>
                         option._isAll
-                            ? 'All Admin Permissions'
+                            ? "All the owner's admin permissions"
                             : option.label || option.id || ''
                     }
                     allOption={ALL_ADMIN_OPTION}

--- a/client/src/components/AdminPanel/tokens/EditTokenDialog.tsx
+++ b/client/src/components/AdminPanel/tokens/EditTokenDialog.tsx
@@ -221,7 +221,7 @@ const EditTokenDialog: React.FC<EditTokenDialogProps> = ({
                     onChange={onMcpPrivilegesChange}
                     getOptionLabel={(option) =>
                         option._isAll
-                            ? 'All MCP Privileges'
+                            ? "All the owner's MCP privileges"
                             : option.identifier || ''
                     }
                     allOption={ALL_MCP_OPTION}
@@ -242,7 +242,7 @@ const EditTokenDialog: React.FC<EditTokenDialogProps> = ({
                     onChange={onAdminPermissionsChange}
                     getOptionLabel={(option) =>
                         option._isAll
-                            ? 'All Admin Permissions'
+                            ? "All the owner's admin permissions"
                             : option.label || option.id || ''
                     }
                     allOption={ALL_ADMIN_OPTION}

--- a/client/src/components/AdminPanel/tokens/TokensTable.tsx
+++ b/client/src/components/AdminPanel/tokens/TokensTable.tsx
@@ -239,7 +239,7 @@ const TokensTable: React.FC<TokensTableProps> = ({
                                                                         ) === '*'
                                                                 )
                                                                     ? [
-                                                                          'All MCP Privileges',
+                                                                          "All the owner's MCP privileges",
                                                                       ]
                                                                     : token.scope?.mcp_privileges?.map(
                                                                           (
@@ -255,7 +255,7 @@ const TokensTable: React.FC<TokensTableProps> = ({
                                                                     '*'
                                                                 )
                                                                     ? [
-                                                                          'All Admin Permissions',
+                                                                          "All the owner's admin permissions",
                                                                       ]
                                                                     : token.scope
                                                                           ?.admin_permissions

--- a/client/src/components/AdminPanel/tokens/__tests__/EditTokenDialog.test.tsx
+++ b/client/src/components/AdminPanel/tokens/__tests__/EditTokenDialog.test.tsx
@@ -231,7 +231,7 @@ describe('EditTokenDialog', () => {
         fireEvent.keyDown(mcpInput, { key: 'ArrowDown' });
 
         await waitFor(() => {
-            expect(screen.getByRole('option', { name: 'All MCP Privileges' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: "All the owner's MCP privileges" })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: 'query_read' })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: 'query_write' })).toBeInTheDocument();
         });
@@ -244,7 +244,7 @@ describe('EditTokenDialog', () => {
         fireEvent.keyDown(adminInput, { key: 'ArrowDown' });
 
         await waitFor(() => {
-            expect(screen.getByRole('option', { name: 'All Admin Permissions' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: "All the owner's admin permissions" })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: 'Manage Users' })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: 'Manage Groups' })).toBeInTheDocument();
         });

--- a/client/src/components/AdminPanel/tokens/__tests__/TokensTable.test.tsx
+++ b/client/src/components/AdminPanel/tokens/__tests__/TokensTable.test.tsx
@@ -67,7 +67,7 @@ const renderComponent = (props: Partial<React.ComponentProps<typeof TokensTable>
         onRowClick: vi.fn(),
         onEdit: vi.fn(),
         onDelete: vi.fn(),
-        getMcpPrivilegeName: (id: number) => id === -1 ? 'All MCP Privileges' : `Privilege ${id}`,
+        getMcpPrivilegeName: (id: number) => id === -1 ? "All the owner's MCP privileges" : `Privilege ${id}`,
     };
     return render(
         <ThemeProvider theme={theme}>

--- a/client/src/components/AdminPanel/tokens/__tests__/tokenTypes.test.ts
+++ b/client/src/components/AdminPanel/tokens/__tests__/tokenTypes.test.ts
@@ -51,7 +51,7 @@ describe('tokenTypes', () => {
 
         it('exports ALL_ADMIN_OPTION with correct sentinel values', () => {
             expect(ALL_ADMIN_OPTION.id).toBe('*');
-            expect(ALL_ADMIN_OPTION.label).toBe('All Admin Permissions');
+            expect(ALL_ADMIN_OPTION.label).toBe("All the owner's admin permissions");
             expect(ALL_ADMIN_OPTION._isAll).toBe(true);
         });
     });

--- a/client/src/components/AdminPanel/tokens/tokenTypes.ts
+++ b/client/src/components/AdminPanel/tokens/tokenTypes.ts
@@ -135,7 +135,7 @@ export const ALL_MCP_OPTION: McpPrivilegeOption = {
 /** Sentinel option for selecting all admin permissions. */
 export const ALL_ADMIN_OPTION: AdminPermissionOption = {
     id: '*',
-    label: 'All Admin Permissions',
+    label: "All the owner's admin permissions",
     _isAll: true,
 };
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,13 @@ project adheres to
   named `kb-<provider>-<model>.db`, and the built-in default
   still points at the legacy `postgres-mcp-kb` path. (#293)
 
+- Relabel the token scope options in the API token create and edit
+  screens so they now read "All the owner's MCP privileges" and
+  "All the owner's admin permissions" rather than "All MCP
+  Privileges" and "All Admin Permissions"; the new wording clarifies
+  that a token grants the owner's privileges rather than all system
+  privileges. (#323)
+
 ### Fixed
 
 - Connection-privilege chips in the Admin Groups and Users panels


### PR DESCRIPTION
## Summary

Fixes #323. In the API token create/edit screens, the MCP-privilege and admin-permission scope dropdowns offered an "All" option labelled "All MCP Privileges" / "All Admin Permissions". For a token that actually means **all of the token owner's** privileges — a token can never exceed its owner — so the wording wrongly implied unrestricted system-wide access.

- Relabelled the token-context option, selected-chip, and token-table strings to **"All the owner's MCP privileges"** and **"All the owner's admin permissions"** (`AdminTokenScopes.tsx`, `tokens/tokenTypes.ts`, `tokens/CreateTokenDialog.tsx`, `tokens/EditTokenDialog.tsx`, `tokens/TokensTable.tsx`).

## Scope note

Deliberately **not** changed: `EffectivePermissionsPanel.tsx` and `AdminPermissions.tsx`. Those render a group's or user's *effective* permissions, where the `*` wildcard genuinely denotes all system MCP privileges / admin permissions (e.g. a superuser, or a group granted the wildcard). "All …" is accurate there, so only the token UI was relabelled.

## Test plan

- [x] Updated the token tests that assert these labels to expect the new wording (assertions kept strict, not weakened): `AdminTokenScopes.test.tsx`, `tokens/__tests__/EditTokenDialog.test.tsx`, `tokens/__tests__/TokensTable.test.tsx`, `tokens/__tests__/tokenTypes.test.ts`.
- [x] `npm run lint` clean; affected vitest files pass (124 tests). Pure string change, so coverage is unaffected.
- [x] Grep confirms zero remaining "All MCP Privileges"/"All Admin Permissions" in the token files, and the group/effective-permissions files are untouched.

Closes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Clarified API token scope labels to indicate that “All” options apply to the token owner’s MCP privileges and admin permissions.
  * Updated labels consistently across token creation, editing, and permission displays.

* **Documentation**
  * Added the change to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->