### PR TITLE
fix(server): reject blank connection password on update

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -229,6 +229,15 @@ project adheres to
   512M; the collector connection-pool and timeout options are now
   documented in the sample configuration. (#308)
 
+### Security
+
+- Ignore a blank password when updating a database connection, so an
+  empty or whitespace-only password can no longer overwrite the stored
+  credential. The datastore now enforces the "leave blank to keep
+  unchanged" rule server-side as defence-in-depth, rather than relying
+  on the web client alone. The create path, which still requires a
+  non-empty password, is unaffected. (#332)
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/server/src/internal/database/connection_queries.go
+++ b/server/src/internal/database/connection_queries.go
@@ -531,7 +531,16 @@ func (d *Datastore) UpdateConnectionFull(ctx context.Context, id int, params Con
 		args = append(args, *params.Username)
 		argNum++
 	}
-	if params.Password != nil {
+	// On update, a nil, empty, or whitespace-only password means "keep the
+	// existing password unchanged"; we silently skip the password_encrypted
+	// column rather than overwriting it with an encrypted blank value. This
+	// mirrors the documented "leave blank to keep unchanged" client behavior,
+	// but is enforced here at the datastore layer as defense-in-depth so a
+	// direct API call with a blank password can never clobber the stored
+	// credential. A genuinely all-whitespace Postgres password is not a
+	// credible real-world case, so treating it as "keep unchanged" is the
+	// safer default.
+	if params.Password != nil && strings.TrimSpace(*params.Password) != "" {
 		if d.serverSecret == "" {
 			return nil, fmt.Errorf("server secret is required to encrypt password")
 		}

--- a/server/src/internal/database/connection_update_password_integration_test.go
+++ b/server/src/internal/database/connection_update_password_integration_test.go
@@ -1,0 +1,246 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgedge/ai-workbench/pkg/crypto"
+)
+
+// connUpdatePasswordTestSchema creates the minimum subset of the connection
+// hierarchy tables exercised by CreateConnection and UpdateConnectionFull.
+// It mirrors the shape used in production (collector/src/database/schema.go),
+// limited to the columns referenced by those two queries and by
+// scanFullConnection.
+const connUpdatePasswordTestSchema = `
+DROP TABLE IF EXISTS connections CASCADE;
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    host VARCHAR(255) NOT NULL DEFAULT '',
+    hostaddr VARCHAR(255),
+    port INTEGER NOT NULL DEFAULT 5432,
+    database_name VARCHAR(255) NOT NULL DEFAULT '',
+    username VARCHAR(255) NOT NULL DEFAULT '',
+    password_encrypted TEXT,
+    sslmode VARCHAR(32),
+    sslcert TEXT,
+    sslkey TEXT,
+    sslrootcert TEXT,
+    owner_username VARCHAR(255),
+    owner_token VARCHAR(255),
+    is_monitored BOOLEAN NOT NULL DEFAULT TRUE,
+    is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+    membership_source VARCHAR(16) NOT NULL DEFAULT 'auto',
+    cluster_id INTEGER,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+const connUpdatePasswordTestTeardown = `
+DROP TABLE IF EXISTS connections CASCADE;
+`
+
+// connUpdatePasswordTestSecret is a fixed 32-byte server secret so the
+// encrypt/decrypt round-trip runs end-to-end in these tests.
+const connUpdatePasswordTestSecret = "test-server-secret-32-bytes-long!"
+
+// newConnUpdatePasswordTestDatastore wires up a *Datastore against the
+// TEST_AI_WORKBENCH_SERVER Postgres instance with only the connections
+// table the update-password path needs, and a fixed serverSecret so the
+// password encryption path runs. The caller receives a cleanup that drops
+// the schema and closes the pool.
+func newConnUpdatePasswordTestDatastore(t *testing.T) (*Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping connection update password integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, connUpdatePasswordTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create connection update password test schema: %v", err)
+	}
+
+	ds := NewTestDatastoreWithSecret(pool, connUpdatePasswordTestSecret)
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(), connUpdatePasswordTestTeardown); err != nil {
+			t.Logf("connection update password teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return ds, pool, cleanup
+}
+
+// readEncryptedPassword returns the raw password_encrypted column for a
+// connection row, distinguishing SQL NULL (returns "", false) from a
+// present value (returns the ciphertext, true).
+func readEncryptedPassword(t *testing.T, pool *pgxpool.Pool, id int) (string, bool) {
+	t.Helper()
+	var enc *string
+	err := pool.QueryRow(context.Background(),
+		`SELECT password_encrypted FROM connections WHERE id = $1`, id).Scan(&enc)
+	if err != nil {
+		t.Fatalf("read password_encrypted (id=%d): %v", id, err)
+	}
+	if enc == nil {
+		return "", false
+	}
+	return *enc, true
+}
+
+// TestUpdateConnectionFullPasswordGuard verifies the defense-in-depth guard
+// added for issue #331: on update, a nil, empty, or whitespace-only password
+// must leave the stored password_encrypted column untouched, while a
+// non-blank password must re-encrypt and replace it. This mirrors the
+// documented "leave blank to keep unchanged" client behavior, enforced here
+// at the datastore layer so a direct API call cannot clobber a real
+// credential with an encrypted blank value.
+func TestUpdateConnectionFullPasswordGuard(t *testing.T) {
+	ds, pool, cleanup := newConnUpdatePasswordTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	emptyStr := ""
+	whitespaceStr := "   "
+	newPassword := "brand-new-secret"
+	seedDesc := "seed description"
+
+	tests := []struct {
+		name string
+		// password is the pointer supplied in the update params; a nil
+		// pointer models an omitted field.
+		password *string
+		// wantChanged indicates whether the stored ciphertext is expected
+		// to differ from the original after the update.
+		wantChanged bool
+		// wantPlaintext, when non-empty, is the plaintext the stored
+		// ciphertext must decrypt to after the update.
+		wantPlaintext string
+	}{
+		{
+			name:          "nil password leaves stored password unchanged",
+			password:      nil,
+			wantChanged:   false,
+			wantPlaintext: "original-secret",
+		},
+		{
+			name:          "empty string password leaves stored password unchanged",
+			password:      &emptyStr,
+			wantChanged:   false,
+			wantPlaintext: "original-secret",
+		},
+		{
+			name:          "whitespace-only password leaves stored password unchanged",
+			password:      &whitespaceStr,
+			wantChanged:   false,
+			wantPlaintext: "original-secret",
+		},
+		{
+			name:          "non-empty password re-encrypts and replaces",
+			password:      &newPassword,
+			wantChanged:   true,
+			wantPlaintext: newPassword,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Seed a fresh connection with a known, non-empty password so
+			// each case starts from an encrypted credential on disk.
+			created, err := ds.CreateConnection(ctx, ConnectionCreateParams{
+				Name:          "guard-conn",
+				Description:   &seedDesc,
+				Host:          "127.0.0.1",
+				Port:          5432,
+				DatabaseName:  "db",
+				Username:      "user",
+				Password:      "original-secret",
+				OwnerUsername: "alice",
+			})
+			if err != nil {
+				t.Fatalf("CreateConnection failed: %v", err)
+			}
+			t.Cleanup(func() {
+				if _, err := pool.Exec(context.Background(),
+					`DELETE FROM connections WHERE id = $1`, created.ID); err != nil {
+					t.Logf("cleanup delete conn %d: %v", created.ID, err)
+				}
+			})
+
+			originalCipher, ok := readEncryptedPassword(t, pool, created.ID)
+			if !ok {
+				t.Fatalf("expected seeded connection to have an encrypted password")
+			}
+
+			// Change an unrelated field alongside the password so the
+			// UPDATE statement always has at least one column to set,
+			// matching how the API sends partial updates.
+			newDesc := "updated description"
+			if _, err := ds.UpdateConnectionFull(ctx, created.ID, ConnectionUpdateParams{
+				Description: &newDesc,
+				Password:    tc.password,
+			}); err != nil {
+				t.Fatalf("UpdateConnectionFull failed: %v", err)
+			}
+
+			afterCipher, ok := readEncryptedPassword(t, pool, created.ID)
+			if !ok {
+				t.Fatalf("password_encrypted became NULL after update; the "+
+					"column must never be cleared by an update (case %q)", tc.name)
+			}
+
+			if tc.wantChanged {
+				if afterCipher == originalCipher {
+					t.Errorf("expected stored ciphertext to change, but it was unchanged")
+				}
+			} else {
+				if afterCipher != originalCipher {
+					t.Errorf("expected stored ciphertext to be unchanged, got a different value")
+				}
+			}
+
+			// The ciphertext must always decrypt back to the plaintext we
+			// expect: the original for the "keep unchanged" cases, the new
+			// value for the replace case.
+			plaintext, err := crypto.DecryptPassword(afterCipher, connUpdatePasswordTestSecret)
+			if err != nil {
+				t.Fatalf("DecryptPassword failed: %v", err)
+			}
+			if plaintext != tc.wantPlaintext {
+				t.Errorf("stored password decrypted to %q, want %q", plaintext, tc.wantPlaintext)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The connection-update datastore guard in `UpdateConnectionFull` only checked that the password pointer was non-nil, so a direct API call with `"password": ""` (or a whitespace-only value) would encrypt and store a blank password, overwriting the real stored credential. The "leave blank to keep unchanged" behaviour was previously enforced only by the web client, leaving a defense-in-depth gap.
- Harden the guard to treat a nil, empty, or whitespace-only password as "keep unchanged", enforced at the datastore layer so no current or future caller can clobber a stored credential with a blank value. The create path, which correctly requires a non-empty password and returns a 400, is unchanged.

## Test plan

- [x] New table-driven integration test `TestUpdateConnectionFullPasswordGuard` covers nil, empty-string, whitespace-only, and non-empty password updates against local Postgres; verified load-bearing (reverting the guard reproduces the overwrite).
- [x] `gofmt -l` clean on changed files; `golangci-lint run ./internal/database/...` reports 0 issues.
- [x] Reviewed by security-auditor: closes the gap with no regression; create/update behaviour is now consistent.

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updating a database connection now preserves the saved password when the provided password is empty or whitespace-only.
  - Providing a non-empty password still replaces the stored value as expected.
- **Security**
  - Server-side password updates now follow “leave blank to keep unchanged,” preventing accidental overwrites.
- **Tests**
  - Added end-to-end integration coverage to verify password preservation for `nil`, empty, and whitespace-only inputs, and correct updates for non-empty passwords.
- **Documentation**
  - Updated the changelog in the Security section to reflect the behavior change (referencing issue `#332`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->