### PR TITLE
Fix metrics API returning empty response on NaN/Inf samples

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,22 @@ project adheres to
   package matching their chosen embedding provider and model, and
   set `database_path` themselves. (#316)
 
+### Fixed
+
+- Fix the metrics time-series API (`GET /api/v1/metrics/query`)
+  silently returning an empty HTTP 200 response, which the web UI
+  rendered as a generic "No data available" message, whenever a
+  monitored server's metric sample contained a NaN or Infinity value.
+  Go's JSON encoder cannot serialize non-finite floats, so the encode
+  failed silently after the response status had already been sent. The
+  query path now treats a non-finite sample the same way it already
+  treats a missing value from an underlying LEFT JOIN gap; the code
+  carries the last known good value forward when one exists and skips
+  the sample when none does, so a single bad reading degrades
+  gracefully instead of blanking the whole chart. A JSON-encoding
+  failure on this path is now logged loudly rather than silently
+  swallowed, so any future occurrence surfaces in the server logs.
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/server/src/internal/api/response.go
+++ b/server/src/internal/api/response.go
@@ -14,8 +14,8 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
-	"os"
 
 	"github.com/pgedge/ai-workbench/server/internal/apiconst"
 )
@@ -31,7 +31,12 @@ func RespondJSON(w http.ResponseWriter, status int, data any) {
 	w.Header().Set("Link", fmt.Sprintf("<%s>; rel=\"service-desc\"", apiconst.OpenAPISpecPath))
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Failed to encode JSON response: %v\n", err)
+		// The status line and headers are already flushed, so the client will
+		// receive this status with a truncated or empty body. Log loudly: an
+		// encode failure here (for example an unmarshalable NaN/Inf float that
+		// slipped through upstream sanitization) is a real bug that otherwise
+		// manifests only as a mysterious empty 200 response.
+		log.Printf("[ERROR] RespondJSON: failed to encode response body (status %d): %v", status, err)
 	}
 }
 

--- a/server/src/internal/api/response_test.go
+++ b/server/src/internal/api/response_test.go
@@ -10,7 +10,10 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
+	"log"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -112,6 +115,49 @@ func TestRespondJSON(t *testing.T) {
 
 			if tt.checkBody != nil {
 				tt.checkBody(t, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRespondJSON_EncodeError(t *testing.T) {
+	// json cannot marshal NaN/Inf; RespondJSON must not panic and must log
+	// the failure loudly rather than swallowing it into a silent empty body.
+	nonEncodable := []struct {
+		name string
+		data any
+	}{
+		{"NaN", map[string]float64{"value": math.NaN()}},
+		{"+Inf", map[string]float64{"value": math.Inf(1)}},
+		{"-Inf", map[string]float64{"value": math.Inf(-1)}},
+	}
+
+	for _, tc := range nonEncodable {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			origOut := log.Writer()
+			origFlags := log.Flags()
+			log.SetOutput(&logBuf)
+			log.SetFlags(0)
+			t.Cleanup(func() {
+				log.SetOutput(origOut)
+				log.SetFlags(origFlags)
+			})
+
+			rec := httptest.NewRecorder()
+
+			RespondJSON(rec, http.StatusOK, tc.data)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+			}
+
+			logged := logBuf.String()
+			if !strings.Contains(logged, "[ERROR]") {
+				t.Errorf("expected an [ERROR] log entry, got %q", logged)
+			}
+			if !strings.Contains(logged, "RespondJSON") {
+				t.Errorf("expected log to name RespondJSON, got %q", logged)
 			}
 		})
 	}

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -12,6 +12,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -507,18 +508,10 @@ func QueryTimeSeries(
 			}
 
 			for i, col := range metricCols {
-				val, ok := toFloat64(values[i+1])
+				lkKey := fmt.Sprintf("%d:%s", connID, col)
+				val, ok := resolveMetricValue(values[i+1], lkKey, lastKnown)
 				if !ok {
-					// Empty bucket from LEFT JOIN gap - apply LOCF
-					lkKey := fmt.Sprintf("%d:%s", connID, col)
-					if prev, exists := lastKnown[lkKey]; exists {
-						val = prev
-					} else {
-						continue
-					}
-				} else {
-					lkKey := fmt.Sprintf("%d:%s", connID, col)
-					lastKnown[lkKey] = val
+					continue
 				}
 				key := seriesKey{metric: col, connectionID: connID}
 				dataMap[key] = append(dataMap[key], MetricDataPoint{
@@ -683,6 +676,31 @@ func QueryBaselines(
 	}
 
 	return result, nil
+}
+
+// resolveMetricValue converts a scanned bucket value into a plottable float,
+// applying last-observation-carried-forward (LOCF) for gaps. A gap is either a
+// NULL bucket produced by the LEFT JOIN or a non-finite sample (NaN/Inf).
+//
+// Non-finite samples must be treated as gaps rather than plotted: the
+// system_stats extension can emit NaN percentages from a 0/0 delta division,
+// and encoding/json cannot marshal NaN or Inf. Letting such a value through
+// would break the JSON response for every metric in the request, not just the
+// affected bucket. The second return value reports whether a point should be
+// appended; when false the caller skips the bucket.
+func resolveMetricValue(raw any, lkKey string, lastKnown map[string]float64) (float64, bool) {
+	val, ok := toFloat64(raw)
+	if ok && (math.IsNaN(val) || math.IsInf(val, 0)) {
+		ok = false
+	}
+	if !ok {
+		if prev, exists := lastKnown[lkKey]; exists {
+			return prev, true
+		}
+		return 0, false
+	}
+	lastKnown[lkKey] = val
+	return val, true
 }
 
 // toFloat64 converts a scanned database value to float64. It returns

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -10,6 +10,7 @@
 package metrics
 
 import (
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -399,6 +400,70 @@ func TestGetCoalescedSelectCols(t *testing.T) {
 			t.Errorf("interval col should use interval default, got %s", cols[1])
 		}
 	})
+}
+
+func TestResolveMetricValue(t *testing.T) {
+	t.Run("finite value is recorded as last known", func(t *testing.T) {
+		lastKnown := map[string]float64{}
+		val, ok := resolveMetricValue(float64(3.5), "1:cpu", lastKnown)
+		if !ok || val != 3.5 {
+			t.Fatalf("got (%v, %v), want (3.5, true)", val, ok)
+		}
+		if lastKnown["1:cpu"] != 3.5 {
+			t.Errorf("lastKnown not updated: %v", lastKnown["1:cpu"])
+		}
+	})
+
+	t.Run("null bucket with no prior value is skipped", func(t *testing.T) {
+		lastKnown := map[string]float64{}
+		_, ok := resolveMetricValue(nil, "1:cpu", lastKnown)
+		if ok {
+			t.Fatalf("expected skip for null with no prior value")
+		}
+		if _, exists := lastKnown["1:cpu"]; exists {
+			t.Errorf("lastKnown should not be populated by a skipped bucket")
+		}
+	})
+
+	t.Run("null bucket carries forward prior value", func(t *testing.T) {
+		lastKnown := map[string]float64{"1:cpu": 7.25}
+		val, ok := resolveMetricValue(nil, "1:cpu", lastKnown)
+		if !ok || val != 7.25 {
+			t.Fatalf("got (%v, %v), want (7.25, true)", val, ok)
+		}
+	})
+
+	nonFinite := []struct {
+		name string
+		in   float64
+	}{
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+	}
+	for _, nf := range nonFinite {
+		t.Run(nf.name+" with no prior value is skipped", func(t *testing.T) {
+			lastKnown := map[string]float64{}
+			_, ok := resolveMetricValue(nf.in, "1:cpu", lastKnown)
+			if ok {
+				t.Fatalf("expected %s to be skipped when no prior value", nf.name)
+			}
+			if _, exists := lastKnown["1:cpu"]; exists {
+				t.Errorf("%s must not poison lastKnown", nf.name)
+			}
+		})
+
+		t.Run(nf.name+" carries forward prior value", func(t *testing.T) {
+			lastKnown := map[string]float64{"1:cpu": 42}
+			val, ok := resolveMetricValue(nf.in, "1:cpu", lastKnown)
+			if !ok || val != 42 {
+				t.Fatalf("got (%v, %v), want (42, true)", val, ok)
+			}
+			if lastKnown["1:cpu"] != 42 {
+				t.Errorf("%s overwrote the last known good value: %v", nf.name, lastKnown["1:cpu"])
+			}
+		})
+	}
 }
 
 func TestToFloat64(t *testing.T) {


### PR DESCRIPTION
## Summary

- The metrics time-series API (`GET /api/v1/metrics/query`) could silently return an empty HTTP 200 response instead of chart data whenever a monitored server's metric sample contained NaN/Infinity (e.g. from a 0/0 division in a system-stats collection function), because Go's JSON encoder cannot marshal non-finite floats and the response status was already written before encoding failed.
- Non-finite samples are now treated the same way the query path already treats missing/NULL data: carried forward from the last known good value, or skipped if none exists yet, so a single bad sample degrades gracefully instead of blanking the entire response.
- `RespondJSON` now logs an encode failure loudly instead of silently swallowing it, so future issues are visible in server logs rather than only manifesting as a mysterious empty UI panel.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes for the full `server` module
- [x] New unit tests added: `TestResolveMetricValue` (NULL gaps and NaN/+Inf/-Inf, both with and without a prior carried-forward value) and `TestRespondJSON_EncodeError` (NaN/+Inf/-Inf)
- [x] `resolveMetricValue` and `RespondJSON` both at 100% function coverage
- [x] `gofmt -l .` clean
- [x] Security review completed (query construction, LOCF staleness risk, log information-disclosure risk) — no blocking findings
- [x] Reproduced the original bug against a live instance (curl against `/api/v1/metrics/query` returned `200` with `Content-Length: 0` for a probe with real NaN samples) before the fix, confirmed real data is returned after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metrics time-series queries that returned empty responses when samples contained `NaN` or infinite values.
  * Non-finite samples are now skipped or replaced with the last known valid value.
  * Improved error logging when JSON responses cannot be encoded.

* **Documentation**
  * Added changelog documentation describing the metrics query fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This fix was prompted by persistent display of an error message in charts - the message is always there on the Mac, and intermittently on Ubuntu (when not all the servers are hosted on the Ubuntu host):

<img width="934" height="341" alt="Screenshot 2026-07-15 at 11 16 56 AM" src="https://github.com/user-attachments/assets/2d2a14f8-3f66-413f-a10f-05f9a3eb34b3" />

