### PR TITLE
Fix blank object dashboards: add latest-row metrics query mode

### DIFF
--- a/.claude/golang-expert/metrics-queries.md
+++ b/.claude/golang-expert/metrics-queries.md
@@ -71,6 +71,57 @@ Metrics tables live under the `metrics` schema
 both read from `connections` by unqualified name; do not add schema
 qualifiers unless the caller's search_path requires it.
 
+## Latest-Row Queries (server)
+
+`server/src/internal/metrics/query.go` exposes a latest-row query path
+alongside the bucketed `QueryTimeSeries`. It returns the most recent raw
+rows of a probe table as flat `map[string]any` objects keyed by real
+column name, so dashboards can read individual dimension and timestamp
+values directly. The public entry point is `QueryLatestRows`; it is
+decomposed into small, separately testable helpers:
+
+- `validateLatestRowParams` validates the probe name, sort direction, and
+  connection list, and clamps the limit to `[1, maxLatestRowLimit]` (100).
+- `discoverLatestRowColumns` confirms the probe exists, discovers its
+  columns via `GetProbeAllColumns`, strips bookkeeping columns with
+  `selectLatestOutputColumns` (`connection_id`, `collected_at`,
+  `inserted_at`), resolves `order_by` against the discovered columns with
+  `ResolveOrderByColumn`, and resolves the database filter column with
+  `ResolveDatabaseColumn` when a `DatabaseName` filter is set.
+- `buildLatestRowsQuery` assembles the SQL; `scanLatestRows` reads rows
+  into flat maps, normalising each value through `normalizeLatestValue`
+  (RFC3339 for `time.Time`, `sanitizeFloat` dropping NaN/Inf to JSON
+  null, `pgtype.Numeric`/`pgtype.Interval` collapsed to seconds/float).
+
+### Identifier safety and the Codacy suppression
+
+Latest-row SQL interpolates only identifiers drawn from a live-discovered
+allow-list: the probe name is checked against
+`information_schema.tables`, the `order_by` column against
+`GetProbeAllColumns`, and every one is `QuoteIdentifier`-wrapped. All
+runtime values bind through `$N` placeholders. golangci-lint/gosec is
+satisfied without a `//nolint`, but Codacy's Opengrep flags the
+`pool.Query(ctx, query, args...)` call in `QueryLatestRows` as
+`go_sql_rule-concat-sqli`. That is a false positive; it is cleared with a
+`// nosemgrep: go_sql_rule-concat-sqli` line immediately above the call,
+kept alongside the existing justification comment. Use `nosemgrep`, not
+`//nolint:gosec`, for Opengrep-only findings.
+
+### Integration tests
+
+DB-executing metrics functions are covered by integration tests in
+`server/src/internal/metrics/query_db_test.go` (package `metrics`, so
+they can exercise unexported helpers). They follow the api package's
+gating convention: skip when `SKIP_DB_TESTS` is set or
+`TEST_AI_WORKBENCH_SERVER` is unset, connect via `pgxpool`, and skip on
+ping failure, so they run in the Server CI jobs and skip cleanly with no
+database. Each test builds its own fixture probe table in the `metrics`
+schema with a representative column mix and drops it on cleanup. Error
+paths that need a failing query (for example the exists-check branch in
+`discoverLatestRowColumns`) are driven with an already-cancelled context;
+the scan-error branch in `scanLatestRows` is driven by passing fewer
+output columns than the query returns.
+
 ## Related Issues
 
 - #56: Alerter FK violations when calculating baselines for deleted

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,16 @@ project adheres to
   failure on this path is now logged loudly rather than silently
   swallowed, so any future occurrence surfaces in the server logs.
 
+- Fix blank overview tiles and a Maintenance Info panel stuck on
+  "Never" in the Table and Index object-detail dashboards of the
+  web client. These panels requested the single most recent row of
+  stats through the `limit`, `order_by`, and `order` query
+  parameters, but the metrics API ignored those parameters and
+  returned time-bucketed chart data instead. The API now honors
+  these parameters and returns the most recent raw stat rows as
+  real column values, validating `order_by` against the table's
+  known columns before use.
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/server/src/internal/api/metrics_handlers.go
+++ b/server/src/internal/api/metrics_handlers.go
@@ -99,6 +99,16 @@ func (h *MetricsHandler) handleMetricsQuery(
 		return
 	}
 
+	// Latest-row mode: when the caller supplies limit and/or order_by,
+	// return the most recent raw rows instead of a bucketed time series.
+	// The two modes produce genuinely different response shapes.
+	limitStr := ParseQueryString(r, "limit")
+	orderByParam := ParseQueryString(r, "order_by")
+	if limitStr != "" || orderByParam != "" {
+		h.handleLatestRows(w, r, connectionIDs, probeName, limitStr, orderByParam)
+		return
+	}
+
 	// Parse time_range (default "1h")
 	timeRange := ParseQueryString(r, "time_range")
 	if timeRange == "" {
@@ -163,6 +173,72 @@ func (h *MetricsHandler) handleMetricsQuery(
 	result, err := metrics.QueryTimeSeries(
 		ctx, pool, probeName, connectionIDs, timeRange,
 		filters, buckets, aggregation, requestedMetrics)
+	if err != nil {
+		RespondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, result)
+}
+
+// handleLatestRows serves the latest-row variant of GET
+// /api/v1/metrics/query, returning the most recent raw rows for the probe
+// table as flat JSON objects keyed by column name.
+func (h *MetricsHandler) handleLatestRows(
+	w http.ResponseWriter,
+	r *http.Request,
+	connectionIDs []int,
+	probeName string,
+	limitStr string,
+	orderByParam string,
+) {
+	// Parse limit (default 1) following the bounds-checking style used
+	// for buckets: reject anything outside the accepted range.
+	limit := 1
+	if limitStr != "" {
+		l, err := strconv.Atoi(limitStr)
+		if err != nil || l < 1 || l > 100 {
+			RespondError(w, http.StatusBadRequest,
+				"Invalid limit: must be between 1 and 100")
+			return
+		}
+		limit = l
+	}
+
+	// Reject syntactically invalid order_by before column discovery; the
+	// semantic column-existence check happens against discovered columns
+	// inside QueryLatestRows.
+	if orderByParam != "" && !metrics.IsValidIdentifier(orderByParam) {
+		RespondError(w, http.StatusBadRequest,
+			"Invalid order_by: must contain only letters, numbers, and underscores")
+		return
+	}
+
+	// Parse order (default "desc") against an asc/desc allow-list.
+	order := strings.ToLower(ParseQueryString(r, "order"))
+	if order == "" {
+		order = "desc"
+	}
+	if order != "asc" && order != "desc" {
+		RespondError(w, http.StatusBadRequest,
+			"Invalid order: must be asc or desc")
+		return
+	}
+
+	filters := metrics.MetricFilters{
+		DatabaseName: ParseQueryString(r, "database_name"),
+		SchemaName:   ParseQueryString(r, "schema_name"),
+		TableName:    ParseQueryString(r, "table_name"),
+		IndexName:    ParseQueryString(r, "index_name"),
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	pool := h.datastore.GetPool()
+	result, err := metrics.QueryLatestRows(
+		ctx, pool, probeName, connectionIDs, filters,
+		orderByParam, order, limit)
 	if err != nil {
 		RespondError(w, http.StatusBadRequest, err.Error())
 		return

--- a/server/src/internal/api/metrics_handlers_test.go
+++ b/server/src/internal/api/metrics_handlers_test.go
@@ -1,0 +1,193 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewMetricsHandler(t *testing.T) {
+	handler := NewMetricsHandler(nil, nil)
+	if handler == nil {
+		t.Fatal("NewMetricsHandler returned nil")
+	}
+	if handler.datastore != nil {
+		t.Error("expected nil datastore")
+	}
+	if handler.authStore != nil {
+		t.Error("expected nil authStore")
+	}
+}
+
+func TestMetricsHandler_RegisterRoutes_NotConfigured(t *testing.T) {
+	handler := NewMetricsHandler(nil, nil)
+	mux := http.NewServeMux()
+	noopWrapper := func(h http.HandlerFunc) http.HandlerFunc { return h }
+	handler.RegisterRoutes(mux, noopWrapper)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics/query", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status %d, got %d",
+			http.StatusServiceUnavailable, rec.Code)
+	}
+}
+
+// decodeError reads an ErrorResponse from the recorder.
+func decodeError(t *testing.T, rec *httptest.ResponseRecorder) ErrorResponse {
+	t.Helper()
+	var response ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return response
+}
+
+func TestHandleMetricsQuery_MissingConnectionID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/query?probe_name=pg_stat_all_tables", nil)
+	rec := httptest.NewRecorder()
+
+	handler := &MetricsHandler{}
+	handler.handleMetricsQuery(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d",
+			http.StatusBadRequest, rec.Code)
+	}
+	if resp := decodeError(t, rec); resp.Error !=
+		"Either connection_id or connection_ids is required" {
+		t.Errorf("unexpected error: %q", resp.Error)
+	}
+}
+
+func TestHandleMetricsQuery_MissingProbeName(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/query?connection_id=1", nil)
+	rec := httptest.NewRecorder()
+
+	// With nil authStore the RBAC checker treats the caller as a
+	// superuser, so we reach probe_name validation.
+	handler := &MetricsHandler{}
+	handler.handleMetricsQuery(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d",
+			http.StatusBadRequest, rec.Code)
+	}
+	if resp := decodeError(t, rec); resp.Error != "probe_name is required" {
+		t.Errorf("unexpected error: %q", resp.Error)
+	}
+}
+
+func TestHandleMetricsQuery_InvalidProbeName(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/query?connection_id=1&probe_name=bad;name", nil)
+	rec := httptest.NewRecorder()
+
+	handler := &MetricsHandler{}
+	handler.handleMetricsQuery(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d",
+			http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestHandleMetricsQuery_LatestMode_InvalidLimit(t *testing.T) {
+	cases := []string{"0", "-1", "101", "abc"}
+	for _, limit := range cases {
+		t.Run("limit="+limit, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/metrics/query?connection_id=1"+
+					"&probe_name=pg_stat_all_tables&limit="+limit, nil)
+			rec := httptest.NewRecorder()
+
+			handler := &MetricsHandler{}
+			handler.handleMetricsQuery(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d",
+					http.StatusBadRequest, rec.Code)
+			}
+			if resp := decodeError(t, rec); resp.Error !=
+				"Invalid limit: must be between 1 and 100" {
+				t.Errorf("unexpected error: %q", resp.Error)
+			}
+		})
+	}
+}
+
+func TestHandleMetricsQuery_LatestMode_InvalidOrderBy(t *testing.T) {
+	// A syntactically invalid order_by is rejected at the handler before
+	// any column discovery or SQL execution occurs.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/query?connection_id=1"+
+			"&probe_name=pg_stat_all_tables&order_by=bad-column", nil)
+	rec := httptest.NewRecorder()
+
+	handler := &MetricsHandler{}
+	handler.handleMetricsQuery(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d",
+			http.StatusBadRequest, rec.Code)
+	}
+	if resp := decodeError(t, rec); resp.Error !=
+		"Invalid order_by: must contain only letters, numbers, and underscores" {
+		t.Errorf("unexpected error: %q", resp.Error)
+	}
+}
+
+func TestHandleMetricsQuery_LatestMode_InvalidOrder(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/query?connection_id=1"+
+			"&probe_name=pg_stat_all_tables&limit=1"+
+			"&order_by=n_live_tup&order=sideways", nil)
+	rec := httptest.NewRecorder()
+
+	handler := &MetricsHandler{}
+	handler.handleMetricsQuery(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d",
+			http.StatusBadRequest, rec.Code)
+	}
+	if resp := decodeError(t, rec); resp.Error !=
+		"Invalid order: must be asc or desc" {
+		t.Errorf("unexpected error: %q", resp.Error)
+	}
+}
+
+func TestHandleMetricsQuery_TimeSeriesMode_InvalidTimeRange(t *testing.T) {
+	// Without limit/order_by the handler stays on the time-series path;
+	// an invalid time_range is rejected there.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/query?connection_id=1"+
+			"&probe_name=pg_stat_all_tables&time_range=99z", nil)
+	rec := httptest.NewRecorder()
+
+	handler := &MetricsHandler{}
+	handler.handleMetricsQuery(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d",
+			http.StatusBadRequest, rec.Code)
+	}
+	if resp := decodeError(t, rec); resp.Error !=
+		"Invalid time_range: must be one of 1h, 6h, 24h, 7d, 30d" {
+		t.Errorf("unexpected error: %q", resp.Error)
+	}
+}

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -26,6 +26,20 @@ type MetricFilters struct {
 	DatabaseColumn string // Resolved column name: "datname", "database_name", or ""
 	SchemaName     string
 	TableName      string
+	IndexName      string
+}
+
+// maxLatestRowLimit bounds the number of rows a latest-row query may
+// return, mirroring the bound-checking style applied to bucket counts.
+const maxLatestRowLimit = 100
+
+// latestRowInternalColumns lists bookkeeping columns excluded from
+// latest-row results because callers only need the collected metrics
+// and their dimension keys, not internal storage fields.
+var latestRowInternalColumns = map[string]bool{
+	"connection_id": true,
+	"collected_at":  true,
+	"inserted_at":   true,
 }
 
 // MetricDataPoint represents a single time-value pair in a metric series.
@@ -701,6 +715,310 @@ func resolveMetricValue(raw any, lkKey string, lastKnown map[string]float64) (fl
 	}
 	lastKnown[lkKey] = val
 	return val, true
+}
+
+// ValidateOrder normalizes and validates a sort direction. It accepts
+// "asc" or "desc" case-insensitively and defaults to "desc" when empty.
+func ValidateOrder(order string) (string, error) {
+	order = strings.ToLower(strings.TrimSpace(order))
+	if order == "" {
+		return "desc", nil
+	}
+	if order != "asc" && order != "desc" {
+		return "", fmt.Errorf("invalid order %q: must be asc or desc", order)
+	}
+	return order, nil
+}
+
+// ResolveOrderByColumn validates an order_by request against the
+// discovered metric columns of a probe table and returns the column to
+// sort by. An empty request defaults to collected_at.
+//
+// order_by is validated against the discovered columns here, before the
+// caller quotes it and interpolates it into an ORDER BY clause, because
+// PostgreSQL parameter placeholders cannot bind identifiers; only values
+// drawn from the trusted, discovered column set may reach the SQL text.
+func ResolveOrderByColumn(orderBy string, metricCols []string) (string, error) {
+	orderBy = strings.TrimSpace(orderBy)
+	if orderBy == "" || orderBy == "collected_at" {
+		return "collected_at", nil
+	}
+	for _, col := range metricCols {
+		if col == orderBy {
+			return orderBy, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"invalid order_by %q: must be a metric column of the probe or collected_at",
+		orderBy)
+}
+
+// GetProbeAllColumns discovers every column of a probe table in the
+// metrics schema, returning the column names in ordinal order and a map
+// from column name to its PostgreSQL data type.
+func GetProbeAllColumns(ctx context.Context, pool *pgxpool.Pool, probeName string) ([]string, map[string]string, error) {
+	query := `
+        SELECT column_name, data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'metrics'
+            AND table_name = $1
+        ORDER BY ordinal_position
+    `
+
+	rows, err := pool.Query(ctx, query, probeName)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	var allCols []string
+	colTypes := make(map[string]string)
+	for rows.Next() {
+		var name, dataType string
+		if err := rows.Scan(&name, &dataType); err != nil {
+			return nil, nil, err
+		}
+		allCols = append(allCols, name)
+		colTypes[name] = dataType
+	}
+
+	return allCols, colTypes, rows.Err()
+}
+
+// buildLatestRowsQuery constructs a SQL statement that returns the most
+// recent rows of a probe table for the given connections and filters,
+// ordered by the validated orderCol and direction. collected_at DESC is
+// appended as a tiebreaker so equal-ranked rows favor the newest sample.
+func buildLatestRowsQuery(
+	probeName string,
+	outputCols []string,
+	connectionIDs []int,
+	filters MetricFilters,
+	orderCol string,
+	order string,
+	limit int,
+) (string, []any) {
+	var selectParts []string
+	for _, col := range outputCols {
+		selectParts = append(selectParts, QuoteIdentifier(col))
+	}
+
+	var whereClauses []string
+	var args []any
+	argNum := 1
+
+	var connPlaceholders []string
+	for _, id := range connectionIDs {
+		connPlaceholders = append(connPlaceholders, fmt.Sprintf("$%d", argNum))
+		args = append(args, id)
+		argNum++
+	}
+	whereClauses = append(whereClauses,
+		fmt.Sprintf("connection_id IN (%s)", strings.Join(connPlaceholders, ", ")))
+
+	if filters.DatabaseName != "" && filters.DatabaseColumn != "" {
+		whereClauses = append(whereClauses,
+			fmt.Sprintf("%s = $%d", QuoteIdentifier(filters.DatabaseColumn), argNum))
+		args = append(args, filters.DatabaseName)
+		argNum++
+	}
+
+	if filters.SchemaName != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("schemaname = $%d", argNum))
+		args = append(args, filters.SchemaName)
+		argNum++
+	}
+
+	if filters.TableName != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("relname = $%d", argNum))
+		args = append(args, filters.TableName)
+		argNum++
+	}
+
+	if filters.IndexName != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("indexrelname = $%d", argNum))
+		args = append(args, filters.IndexName)
+		argNum++
+	}
+
+	query := fmt.Sprintf(`
+        SELECT %s
+        FROM metrics.%s
+        WHERE %s
+        ORDER BY %s %s, collected_at DESC
+        LIMIT $%d
+    `,
+		strings.Join(selectParts, ", "),
+		QuoteIdentifier(probeName),
+		strings.Join(whereClauses, " AND "),
+		QuoteIdentifier(orderCol),
+		order,
+		argNum,
+	)
+	args = append(args, limit)
+
+	return query, args
+}
+
+// QueryLatestRows returns the most recent rows of a probe table as flat
+// maps keyed by column name. Unlike QueryTimeSeries it produces raw row
+// objects rather than bucketed series, so dashboards can read individual
+// column values (including dimension and timestamp columns) directly.
+func QueryLatestRows(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	probeName string,
+	connectionIDs []int,
+	filters MetricFilters,
+	orderBy string,
+	order string,
+	limit int,
+) ([]map[string]any, error) {
+	if !IsValidIdentifier(probeName) {
+		return nil, fmt.Errorf("invalid probe name %q", probeName)
+	}
+
+	order, err := ValidateOrder(order)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(connectionIDs) == 0 {
+		return nil, fmt.Errorf("at least one connection ID is required")
+	}
+
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > maxLatestRowLimit {
+		limit = maxLatestRowLimit
+	}
+
+	var count int
+	existsQuery := `
+        SELECT COUNT(*) FROM information_schema.tables
+        WHERE table_schema = 'metrics'
+            AND table_name = $1
+            AND table_type = 'BASE TABLE'
+    `
+	if err := pool.QueryRow(ctx, existsQuery, probeName).Scan(&count); err != nil {
+		return nil, fmt.Errorf("failed to verify probe: %w", err)
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("probe %q not found", probeName)
+	}
+
+	metricCols, _, err := GetProbeMetricColumns(ctx, pool, probeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get probe columns: %w", err)
+	}
+
+	orderCol, err := ResolveOrderByColumn(orderBy, metricCols)
+	if err != nil {
+		return nil, err
+	}
+
+	allCols, _, err := GetProbeAllColumns(ctx, pool, probeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get probe columns: %w", err)
+	}
+
+	var outputCols []string
+	for _, col := range allCols {
+		if latestRowInternalColumns[col] {
+			continue
+		}
+		outputCols = append(outputCols, col)
+	}
+	if len(outputCols) == 0 {
+		return nil, fmt.Errorf("no columns found in probe %q", probeName)
+	}
+
+	if filters.DatabaseName != "" && filters.DatabaseColumn == "" {
+		dbCol, err := ResolveDatabaseColumn(ctx, pool, probeName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve database column: %w", err)
+		}
+		filters.DatabaseColumn = dbCol
+	}
+
+	query, args := buildLatestRowsQuery(
+		probeName, outputCols, connectionIDs, filters, orderCol, order, limit)
+
+	rows, err := pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latest rows: %w", err)
+	}
+	defer rows.Close()
+
+	var result []map[string]any
+	for rows.Next() {
+		values := make([]any, len(outputCols))
+		valuePtrs := make([]any, len(outputCols))
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+
+		if err := rows.Scan(valuePtrs...); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		row := make(map[string]any, len(outputCols))
+		for i, col := range outputCols {
+			row[col] = normalizeLatestValue(values[i])
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	if result == nil {
+		result = []map[string]any{}
+	}
+
+	return result, nil
+}
+
+// sanitizeFloat returns nil for non-finite floats. Go's encoding/json
+// cannot marshal NaN or +/-Inf and errors out on the whole payload, so
+// such values are dropped to null to keep the response well-formed.
+func sanitizeFloat(f float64) any {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return nil
+	}
+	return f
+}
+
+// normalizeLatestValue converts a scanned database value into a
+// JSON-friendly representation, applying non-finite float protection.
+func normalizeLatestValue(v any) any {
+	switch val := v.(type) {
+	case nil:
+		return nil
+	case float64:
+		return sanitizeFloat(val)
+	case float32:
+		return sanitizeFloat(float64(val))
+	case time.Time:
+		return val.Format(time.RFC3339)
+	case []byte:
+		return string(val)
+	case pgtype.Numeric:
+		f, ok := toFloat64(val)
+		if !ok {
+			return nil
+		}
+		return sanitizeFloat(f)
+	case pgtype.Interval:
+		f, ok := toFloat64(val)
+		if !ok {
+			return nil
+		}
+		return sanitizeFloat(f)
+	default:
+		return val
+	}
 }
 
 // toFloat64 converts a scanned database value to float64. It returns

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -860,31 +861,26 @@ func buildLatestRowsQuery(
 	return query, args
 }
 
-// QueryLatestRows returns the most recent rows of a probe table as flat
-// maps keyed by column name. Unlike QueryTimeSeries it produces raw row
-// objects rather than bucketed series, so dashboards can read individual
-// column values (including dimension and timestamp columns) directly.
-func QueryLatestRows(
-	ctx context.Context,
-	pool *pgxpool.Pool,
+// validateLatestRowParams validates and normalizes the caller-supplied
+// parameters for a latest-rows query. It returns the normalized sort
+// direction and the row limit clamped to [1, maxLatestRowLimit].
+func validateLatestRowParams(
 	probeName string,
 	connectionIDs []int,
-	filters MetricFilters,
-	orderBy string,
 	order string,
 	limit int,
-) ([]map[string]any, error) {
+) (string, int, error) {
 	if !IsValidIdentifier(probeName) {
-		return nil, fmt.Errorf("invalid probe name %q", probeName)
+		return "", 0, fmt.Errorf("invalid probe name %q", probeName)
 	}
 
-	order, err := ValidateOrder(order)
+	normalizedOrder, err := ValidateOrder(order)
 	if err != nil {
-		return nil, err
+		return "", 0, err
 	}
 
 	if len(connectionIDs) == 0 {
-		return nil, fmt.Errorf("at least one connection ID is required")
+		return "", 0, fmt.Errorf("at least one connection ID is required")
 	}
 
 	if limit < 1 {
@@ -894,6 +890,33 @@ func QueryLatestRows(
 		limit = maxLatestRowLimit
 	}
 
+	return normalizedOrder, limit, nil
+}
+
+// selectLatestOutputColumns filters bookkeeping columns out of a probe's
+// full column set, leaving only the columns returned to callers.
+func selectLatestOutputColumns(allCols []string) []string {
+	var outputCols []string
+	for _, col := range allCols {
+		if latestRowInternalColumns[col] {
+			continue
+		}
+		outputCols = append(outputCols, col)
+	}
+	return outputCols
+}
+
+// discoverLatestRowColumns verifies the probe table exists, discovers its
+// output columns, resolves the order_by column against them, and resolves
+// the database filter column. It mutates filters.DatabaseColumn in place
+// when a database filter is requested but the column is not yet known.
+func discoverLatestRowColumns(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	probeName string,
+	orderBy string,
+	filters *MetricFilters,
+) ([]string, string, error) {
 	var count int
 	existsQuery := `
         SELECT COUNT(*) FROM information_schema.tables
@@ -902,26 +925,20 @@ func QueryLatestRows(
             AND table_type = 'BASE TABLE'
     `
 	if err := pool.QueryRow(ctx, existsQuery, probeName).Scan(&count); err != nil {
-		return nil, fmt.Errorf("failed to verify probe: %w", err)
+		return nil, "", fmt.Errorf("failed to verify probe: %w", err)
 	}
 	if count == 0 {
-		return nil, fmt.Errorf("probe %q not found", probeName)
+		return nil, "", fmt.Errorf("probe %q not found", probeName)
 	}
 
 	allCols, _, err := GetProbeAllColumns(ctx, pool, probeName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get probe columns: %w", err)
+		return nil, "", fmt.Errorf("failed to get probe columns: %w", err)
 	}
 
-	var outputCols []string
-	for _, col := range allCols {
-		if latestRowInternalColumns[col] {
-			continue
-		}
-		outputCols = append(outputCols, col)
-	}
+	outputCols := selectLatestOutputColumns(allCols)
 	if len(outputCols) == 0 {
-		return nil, fmt.Errorf("no columns found in probe %q", probeName)
+		return nil, "", fmt.Errorf("no columns found in probe %q", probeName)
 	}
 
 	// order_by is validated against the full set of returned columns, not
@@ -929,27 +946,26 @@ func QueryLatestRows(
 	// timestamp columns (e.g. last_vacuum) that appear in the response.
 	orderCol, err := ResolveOrderByColumn(orderBy, outputCols)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if filters.DatabaseName != "" && filters.DatabaseColumn == "" {
 		dbCol, err := ResolveDatabaseColumn(ctx, pool, probeName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve database column: %w", err)
+			return nil, "", fmt.Errorf("failed to resolve database column: %w", err)
 		}
 		filters.DatabaseColumn = dbCol
 	}
 
-	query, args := buildLatestRowsQuery(
-		probeName, outputCols, connectionIDs, filters, orderCol, order, limit)
+	return outputCols, orderCol, nil
+}
 
-	rows, err := pool.Query(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query latest rows: %w", err)
-	}
-	defer rows.Close()
-
-	var result []map[string]any
+// scanLatestRows reads every row from rows into flat maps keyed by the
+// given output columns, normalizing each scanned value for JSON output.
+// It always returns a non-nil slice so callers emit an empty JSON array
+// rather than null when the query yields no rows.
+func scanLatestRows(rows pgx.Rows, outputCols []string) ([]map[string]any, error) {
+	result := []map[string]any{}
 	for rows.Next() {
 		values := make([]any, len(outputCols))
 		valuePtrs := make([]any, len(outputCols))
@@ -971,11 +987,52 @@ func QueryLatestRows(
 		return nil, fmt.Errorf("error iterating rows: %w", err)
 	}
 
-	if result == nil {
-		result = []map[string]any{}
+	return result, nil
+}
+
+// QueryLatestRows returns the most recent rows of a probe table as flat
+// maps keyed by column name. Unlike QueryTimeSeries it produces raw row
+// objects rather than bucketed series, so dashboards can read individual
+// column values (including dimension and timestamp columns) directly.
+func QueryLatestRows(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	probeName string,
+	connectionIDs []int,
+	filters MetricFilters,
+	orderBy string,
+	order string,
+	limit int,
+) ([]map[string]any, error) {
+	order, limit, err := validateLatestRowParams(probeName, connectionIDs, order, limit)
+	if err != nil {
+		return nil, err
 	}
 
-	return result, nil
+	outputCols, orderCol, err := discoverLatestRowColumns(
+		ctx, pool, probeName, orderBy, &filters)
+	if err != nil {
+		return nil, err
+	}
+
+	query, args := buildLatestRowsQuery(
+		probeName, outputCols, connectionIDs, filters, orderCol, order, limit)
+
+	// This is not a SQL injection risk despite passing a non-literal query
+	// string: the only identifiers interpolated into the text are probeName,
+	// orderCol, and the output column names, each of which is validated
+	// against a live-discovered allow-list (the information_schema.tables
+	// existence check, ResolveOrderByColumn, and GetProbeAllColumns) and then
+	// QuoteIdentifier-wrapped before it reaches the query. Every runtime
+	// value (connection IDs, filter strings, and the limit) is bound through
+	// $N placeholders in args and is never concatenated into the SQL text.
+	rows, err := pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latest rows: %w", err)
+	}
+	defer rows.Close()
+
+	return scanLatestRows(rows, outputCols)
 }
 
 // sanitizeFloat returns nil for non-finite floats. Go's encoding/json

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -1026,6 +1026,7 @@ func QueryLatestRows(
 	// QuoteIdentifier-wrapped before it reaches the query. Every runtime
 	// value (connection IDs, filter strings, and the limit) is bound through
 	// $N placeholders in args and is never concatenated into the SQL text.
+	// nosemgrep: go_sql_rule-concat-sqli
 	rows, err := pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query latest rows: %w", err)

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -908,16 +908,6 @@ func QueryLatestRows(
 		return nil, fmt.Errorf("probe %q not found", probeName)
 	}
 
-	metricCols, _, err := GetProbeMetricColumns(ctx, pool, probeName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get probe columns: %w", err)
-	}
-
-	orderCol, err := ResolveOrderByColumn(orderBy, metricCols)
-	if err != nil {
-		return nil, err
-	}
-
 	allCols, _, err := GetProbeAllColumns(ctx, pool, probeName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get probe columns: %w", err)
@@ -932,6 +922,14 @@ func QueryLatestRows(
 	}
 	if len(outputCols) == 0 {
 		return nil, fmt.Errorf("no columns found in probe %q", probeName)
+	}
+
+	// order_by is validated against the full set of returned columns, not
+	// just the numeric metrics, so callers can sort by dimension and
+	// timestamp columns (e.g. last_vacuum) that appear in the response.
+	orderCol, err := ResolveOrderByColumn(orderBy, outputCols)
+	if err != nil {
+		return nil, err
 	}
 
 	if filters.DatabaseName != "" && filters.DatabaseColumn == "" {
@@ -1085,8 +1083,7 @@ func toFloat64(v any) (float64, bool) {
 			// NULL interval means no lag reported; treat as zero
 			return 0, true
 		}
-		// Convert interval to total seconds
-		return float64(val.Microseconds) / 1_000_000.0, true
+		return intervalToSeconds(val), true
 	case *pgtype.Interval:
 		if val == nil {
 			return 0, true
@@ -1095,8 +1092,22 @@ func toFloat64(v any) (float64, bool) {
 			// NULL interval means no lag reported; treat as zero
 			return 0, true
 		}
-		return float64(val.Microseconds) / 1_000_000.0, true
+		return intervalToSeconds(*val), true
 	default:
 		return 0, false
 	}
+}
+
+// intervalToSeconds converts a pgtype.Interval to total seconds. It
+// follows PostgreSQL's interval-to-scalar convention where one day is
+// 86400 seconds and one month is 30 days; the Days and Months components
+// are included so intervals larger than a day are not silently truncated.
+func intervalToSeconds(iv pgtype.Interval) float64 {
+	const (
+		secondsPerDay   = 86_400.0
+		secondsPerMonth = 30.0 * secondsPerDay
+	)
+	return float64(iv.Microseconds)/1_000_000.0 +
+		float64(iv.Days)*secondsPerDay +
+		float64(iv.Months)*secondsPerMonth
 }

--- a/server/src/internal/metrics/query_db_test.go
+++ b/server/src/internal/metrics/query_db_test.go
@@ -1,0 +1,546 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package metrics
+
+import (
+	"context"
+	"math"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// These integration tests exercise the DB-executing latest-row query
+// functions against a real PostgreSQL instance. They follow the gating
+// convention used by the api package: they connect to the instance named
+// by TEST_AI_WORKBENCH_SERVER, skip cleanly when it is unset or when
+// SKIP_DB_TESTS is set, and skip on any connection or ping failure. The
+// Server CI jobs set TEST_AI_WORKBENCH_SERVER, so these run in CI and are
+// skipped locally when no database is available.
+
+const (
+	latestRowsTestProbe    = "pg_stat_all_tables_latest_test"
+	latestRowsInternalOnly = "internal_only_latest_test"
+)
+
+// newLatestRowsTestPool connects to the test database named by
+// TEST_AI_WORKBENCH_SERVER. It skips the calling test when the env var is
+// missing, SKIP_DB_TESTS is set, or the connection cannot be established.
+// The returned cleanup closes the pool.
+func newLatestRowsTestPool(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping metrics query integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	return pool, pool.Close
+}
+
+// fixtureRow describes one row inserted into the latest-rows fixture table.
+type fixtureRow struct {
+	collectedAt time.Time
+	dbName      string
+	schema      string
+	relname     string
+	nLiveTup    int64
+	nDeadTup    int64
+	seqScan     int64
+	someRatio   float64
+	lastVacuum  any
+	replayLag   any
+	nanMetric   float64
+}
+
+// setupLatestRowsFixture creates the metrics schema (if absent) and a probe
+// table with a representative column mix: bookkeeping columns, dimension
+// columns, numeric metrics, a timestamp column, an interval column, a
+// numeric column, and a double-precision column able to hold NaN. It
+// inserts three connection-1 rows and returns a cleanup that drops the
+// table. The three rows are:
+//
+//	A: collected_at now-2m, n_live_tup 100, last_vacuum set, replay_lag 1s, nan 1.0
+//	B: collected_at now-1m, n_live_tup 300, last_vacuum set, replay_lag NULL, nan NaN
+//	C: collected_at now,    n_live_tup 200, last_vacuum NULL, replay_lag NULL, nan 2.0
+func setupLatestRowsFixture(t *testing.T, pool *pgxpool.Pool) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS metrics"); err != nil {
+		t.Fatalf("failed to create metrics schema: %v", err)
+	}
+
+	dropTable(ctx, pool, latestRowsTestProbe)
+
+	ddl := `CREATE TABLE metrics."` + latestRowsTestProbe + `" (
+        connection_id integer NOT NULL,
+        collected_at  timestamp with time zone NOT NULL,
+        inserted_at   timestamp without time zone NOT NULL DEFAULT now(),
+        database_name text,
+        schemaname    name,
+        relname       name,
+        n_live_tup    bigint,
+        n_dead_tup    bigint,
+        seq_scan      bigint,
+        some_ratio    numeric,
+        last_vacuum   timestamp with time zone,
+        replay_lag    interval,
+        nan_metric    double precision
+    )`
+	if _, err := pool.Exec(ctx, ddl); err != nil {
+		t.Fatalf("failed to create fixture table: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	rows := []fixtureRow{
+		{
+			collectedAt: now.Add(-2 * time.Minute),
+			dbName:      "northwind", schema: "public", relname: "orders",
+			nLiveTup: 100, nDeadTup: 10, seqScan: 5, someRatio: 1.25,
+			lastVacuum: now.Add(-time.Hour),
+			replayLag:  pgtype.Interval{Microseconds: 1_000_000, Valid: true},
+			nanMetric:  1.0,
+		},
+		{
+			collectedAt: now.Add(-1 * time.Minute),
+			dbName:      "northwind", schema: "public", relname: "orders",
+			nLiveTup: 300, nDeadTup: 30, seqScan: 15, someRatio: 3.5,
+			lastVacuum: now.Add(-30 * time.Minute),
+			replayLag:  nil,
+			nanMetric:  math.NaN(),
+		},
+		{
+			collectedAt: now,
+			dbName:      "northwind", schema: "public", relname: "orders",
+			nLiveTup: 200, nDeadTup: 20, seqScan: 10, someRatio: 2.0,
+			lastVacuum: nil,
+			replayLag:  nil,
+			nanMetric:  2.0,
+		},
+	}
+
+	insert := `INSERT INTO metrics."` + latestRowsTestProbe + `"
+        (connection_id, collected_at, database_name, schemaname, relname,
+         n_live_tup, n_dead_tup, seq_scan, some_ratio, last_vacuum,
+         replay_lag, nan_metric)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
+	for i, r := range rows {
+		_, err := pool.Exec(ctx, insert,
+			1, r.collectedAt, r.dbName, r.schema, r.relname,
+			r.nLiveTup, r.nDeadTup, r.seqScan, r.someRatio, r.lastVacuum,
+			r.replayLag, r.nanMetric)
+		if err != nil {
+			dropTable(ctx, pool, latestRowsTestProbe)
+			t.Fatalf("failed to insert fixture row %d: %v", i, err)
+		}
+	}
+
+	return func() { dropTable(context.Background(), pool, latestRowsTestProbe) }
+}
+
+// dropTable removes a probe table from the metrics schema, ignoring errors.
+func dropTable(ctx context.Context, pool *pgxpool.Pool, name string) {
+	// name is a compile-time-constant test probe name, QuoteIdentifier-wrapped;
+	// DROP TABLE cannot bind an identifier as a placeholder, so the interpolation
+	// is safe and this Opengrep SQLi flag is a false positive.
+	// nosemgrep: go_sql_rule-concat-sqli
+	_, _ = pool.Exec(ctx, "DROP TABLE IF EXISTS metrics."+QuoteIdentifier(name)+" CASCADE")
+}
+
+func TestQueryLatestRows_Integration(t *testing.T) {
+	pool, closePool := newLatestRowsTestPool(t)
+	defer closePool()
+	cleanup := setupLatestRowsFixture(t, pool)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("happy path single newest row", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{}, "", "desc", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(result))
+		}
+		row := result[0]
+
+		// Internal bookkeeping columns must be excluded.
+		for _, col := range []string{"connection_id", "collected_at", "inserted_at"} {
+			if _, ok := row[col]; ok {
+				t.Errorf("internal column %q must not appear in result", col)
+			}
+		}
+
+		// The newest row (collected_at now) has n_live_tup 200.
+		if got := toInt64(t, row["n_live_tup"]); got != 200 {
+			t.Errorf("n_live_tup = %v, want 200 (newest row)", row["n_live_tup"])
+		}
+		if row["relname"] != "orders" {
+			t.Errorf("relname = %v, want orders", row["relname"])
+		}
+		if _, ok := row["seq_scan"]; !ok {
+			t.Error("expected seq_scan column in result")
+		}
+	})
+
+	t.Run("limit honored and order by collected_at desc", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{}, "", "desc", 3)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 3 {
+			t.Fatalf("expected 3 rows, got %d", len(result))
+		}
+		// collected_at DESC => C(200), B(300), A(100)
+		want := []int64{200, 300, 100}
+		for i, w := range want {
+			if got := toInt64(t, result[i]["n_live_tup"]); got != w {
+				t.Errorf("row %d n_live_tup = %d, want %d", i, got, w)
+			}
+		}
+	})
+
+	t.Run("order_by real column honored", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{}, "n_live_tup", "desc", 3)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 3 {
+			t.Fatalf("expected 3 rows, got %d", len(result))
+		}
+		// n_live_tup DESC => 300, 200, 100
+		want := []int64{300, 200, 100}
+		for i, w := range want {
+			if got := toInt64(t, result[i]["n_live_tup"]); got != w {
+				t.Errorf("row %d n_live_tup = %d, want %d", i, got, w)
+			}
+		}
+	})
+
+	t.Run("limit clamped above max still returns all rows", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{}, "", "asc", maxLatestRowLimit+10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 3 {
+			t.Fatalf("expected 3 rows, got %d", len(result))
+		}
+		// asc by collected_at => A(100), B(300), C(200)
+		if got := toInt64(t, result[0]["n_live_tup"]); got != 100 {
+			t.Errorf("first row n_live_tup = %d, want 100", got)
+		}
+	})
+
+	t.Run("database filter resolves and matches", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{DatabaseName: "northwind"}, "", "desc", 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 3 {
+			t.Fatalf("expected 3 rows for northwind, got %d", len(result))
+		}
+
+		none, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{DatabaseName: "no_such_db"}, "", "desc", 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(none) != 0 {
+			t.Fatalf("expected 0 rows for unknown database, got %d", len(none))
+		}
+	})
+
+	t.Run("unknown order_by rejected before SQL runs", func(t *testing.T) {
+		_, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{}, "not_a_real_column", "desc", 1)
+		if err == nil {
+			t.Fatal("expected error for unknown order_by column")
+		}
+	})
+
+	t.Run("missing probe rejected", func(t *testing.T) {
+		_, err := QueryLatestRows(ctx, pool, "does_not_exist_probe",
+			[]int{1}, MetricFilters{}, "", "desc", 1)
+		if err == nil {
+			t.Fatal("expected error for missing probe")
+		}
+	})
+}
+
+func TestDiscoverLatestRowColumns_Integration(t *testing.T) {
+	pool, closePool := newLatestRowsTestPool(t)
+	defer closePool()
+	cleanup := setupLatestRowsFixture(t, pool)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("resolves output and order_by columns", func(t *testing.T) {
+		filters := MetricFilters{}
+		outputCols, orderCol, err := discoverLatestRowColumns(
+			ctx, pool, latestRowsTestProbe, "n_live_tup", &filters)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if orderCol != "n_live_tup" {
+			t.Errorf("orderCol = %q, want n_live_tup", orderCol)
+		}
+		for _, col := range []string{"connection_id", "collected_at", "inserted_at"} {
+			if contains(outputCols, col) {
+				t.Errorf("output columns must exclude internal column %q", col)
+			}
+		}
+		for _, col := range []string{"relname", "n_live_tup", "last_vacuum", "replay_lag"} {
+			if !contains(outputCols, col) {
+				t.Errorf("output columns should include %q", col)
+			}
+		}
+	})
+
+	t.Run("resolves database filter column", func(t *testing.T) {
+		filters := MetricFilters{DatabaseName: "northwind"}
+		_, _, err := discoverLatestRowColumns(
+			ctx, pool, latestRowsTestProbe, "", &filters)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if filters.DatabaseColumn != "database_name" {
+			t.Errorf("DatabaseColumn = %q, want database_name", filters.DatabaseColumn)
+		}
+	})
+
+	t.Run("unknown order_by rejected", func(t *testing.T) {
+		filters := MetricFilters{}
+		_, _, err := discoverLatestRowColumns(
+			ctx, pool, latestRowsTestProbe, "nope", &filters)
+		if err == nil {
+			t.Fatal("expected error for unknown order_by")
+		}
+	})
+
+	t.Run("missing probe rejected", func(t *testing.T) {
+		filters := MetricFilters{}
+		_, _, err := discoverLatestRowColumns(
+			ctx, pool, "does_not_exist_probe", "", &filters)
+		if err == nil {
+			t.Fatal("expected error for missing probe")
+		}
+	})
+
+	t.Run("probe with only internal columns rejected", func(t *testing.T) {
+		dropTable(ctx, pool, latestRowsInternalOnly)
+		internalDDL := `CREATE TABLE metrics."` + latestRowsInternalOnly + `" (
+            connection_id integer NOT NULL,
+            collected_at  timestamp with time zone NOT NULL,
+            inserted_at   timestamp without time zone NOT NULL DEFAULT now()
+        )`
+		if _, err := pool.Exec(ctx, internalDDL); err != nil {
+			t.Fatalf("failed to create internal-only table: %v", err)
+		}
+		defer dropTable(ctx, pool, latestRowsInternalOnly)
+
+		filters := MetricFilters{}
+		_, _, err := discoverLatestRowColumns(
+			ctx, pool, latestRowsInternalOnly, "", &filters)
+		if err == nil {
+			t.Fatal("expected error for probe with no output columns")
+		}
+	})
+
+	t.Run("canceled context surfaces query error", func(t *testing.T) {
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		filters := MetricFilters{}
+		_, _, err := discoverLatestRowColumns(
+			cctx, pool, latestRowsTestProbe, "", &filters)
+		if err == nil {
+			t.Fatal("expected error from canceled context")
+		}
+	})
+}
+
+func TestScanLatestRows_Integration(t *testing.T) {
+	pool, closePool := newLatestRowsTestPool(t)
+	defer closePool()
+	cleanup := setupLatestRowsFixture(t, pool)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("normalizes real scanned values", func(t *testing.T) {
+		outputCols := []string{
+			"relname", "some_ratio", "last_vacuum", "replay_lag", "nan_metric",
+		}
+		query := `SELECT relname, some_ratio, last_vacuum, replay_lag, nan_metric
+            FROM metrics."` + latestRowsTestProbe + `"
+            WHERE connection_id = 1
+            ORDER BY collected_at ASC`
+		rows, err := pool.Query(ctx, query)
+		if err != nil {
+			t.Fatalf("failed to query fixture: %v", err)
+		}
+		result, err := scanLatestRows(rows, outputCols)
+		if err != nil {
+			t.Fatalf("scanLatestRows error: %v", err)
+		}
+		if len(result) != 3 {
+			t.Fatalf("expected 3 rows, got %d", len(result))
+		}
+
+		// Row A: numeric, timestamp (RFC3339 string), interval normalization.
+		rowA := result[0]
+		if got, ok := rowA["some_ratio"].(float64); !ok || got != 1.25 {
+			t.Errorf("some_ratio = %v (%T), want float64 1.25", rowA["some_ratio"], rowA["some_ratio"])
+		}
+		ts, ok := rowA["last_vacuum"].(string)
+		if !ok {
+			t.Fatalf("last_vacuum = %v (%T), want RFC3339 string", rowA["last_vacuum"], rowA["last_vacuum"])
+		}
+		if _, err := time.Parse(time.RFC3339, ts); err != nil {
+			t.Errorf("last_vacuum %q is not RFC3339: %v", ts, err)
+		}
+		if got, ok := rowA["replay_lag"].(float64); !ok || got != 1.0 {
+			t.Errorf("replay_lag = %v (%T), want float64 1.0", rowA["replay_lag"], rowA["replay_lag"])
+		}
+
+		// Row B: NaN normalizes to JSON null.
+		if rowB := result[1]; rowB["nan_metric"] != nil {
+			t.Errorf("nan_metric = %v, want nil (NaN sanitized)", rowB["nan_metric"])
+		}
+
+		// Row C: NULL timestamp/interval normalize to nil.
+		rowC := result[2]
+		if rowC["last_vacuum"] != nil {
+			t.Errorf("NULL last_vacuum = %v, want nil", rowC["last_vacuum"])
+		}
+		if rowC["replay_lag"] != nil {
+			t.Errorf("NULL replay_lag = %v, want nil", rowC["replay_lag"])
+		}
+	})
+
+	t.Run("scan error when destinations mismatch columns", func(t *testing.T) {
+		rows, err := pool.Query(ctx, "SELECT 1, 2")
+		if err != nil {
+			t.Fatalf("failed to query: %v", err)
+		}
+		_, err = scanLatestRows(rows, []string{"only_one"})
+		if err == nil {
+			t.Fatal("expected scan error for mismatched destination count")
+		}
+	})
+}
+
+func TestGetProbeAllColumns_Integration(t *testing.T) {
+	pool, closePool := newLatestRowsTestPool(t)
+	defer closePool()
+	cleanup := setupLatestRowsFixture(t, pool)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("returns columns in ordinal order with types", func(t *testing.T) {
+		cols, colTypes, err := GetProbeAllColumns(ctx, pool, latestRowsTestProbe)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wantOrder := []string{
+			"connection_id", "collected_at", "inserted_at", "database_name",
+			"schemaname", "relname", "n_live_tup", "n_dead_tup", "seq_scan",
+			"some_ratio", "last_vacuum", "replay_lag", "nan_metric",
+		}
+		if len(cols) != len(wantOrder) {
+			t.Fatalf("got %d columns %v, want %d", len(cols), cols, len(wantOrder))
+		}
+		for i, w := range wantOrder {
+			if cols[i] != w {
+				t.Errorf("column %d = %q, want %q (ordinal order)", i, cols[i], w)
+			}
+		}
+
+		wantTypes := map[string]string{
+			"connection_id": "integer",
+			"collected_at":  "timestamp with time zone",
+			"inserted_at":   "timestamp without time zone",
+			"database_name": "text",
+			"schemaname":    "name",
+			"relname":       "name",
+			"n_live_tup":    "bigint",
+			"some_ratio":    "numeric",
+			"last_vacuum":   "timestamp with time zone",
+			"replay_lag":    "interval",
+			"nan_metric":    "double precision",
+		}
+		for col, want := range wantTypes {
+			if got := colTypes[col]; got != want {
+				t.Errorf("colTypes[%q] = %q, want %q", col, got, want)
+			}
+		}
+	})
+
+	t.Run("canceled context surfaces query error", func(t *testing.T) {
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, _, err := GetProbeAllColumns(cctx, pool, latestRowsTestProbe)
+		if err == nil {
+			t.Fatal("expected error from canceled context")
+		}
+	})
+}
+
+// contains reports whether s is present in the slice.
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// toInt64 coerces a scanned/normalized value to int64 for assertions,
+// accepting the int64 and float64 shapes pgx may yield for bigint columns.
+func toInt64(t *testing.T, v any) int64 {
+	t.Helper()
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int32:
+		return int64(n)
+	case float64:
+		return int64(n)
+	default:
+		t.Fatalf("value %v (%T) is not a numeric type", v, v)
+		return 0
+	}
+}

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -10,10 +10,14 @@
 package metrics
 
 import (
+	"context"
 	"math"
+	"math/big"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func TestParseTimeRange(t *testing.T) {
@@ -501,4 +505,300 @@ func TestToFloat64(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateOrder(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"asc", "asc", false},
+		{"desc", "desc", false},
+		{"ASC", "asc", false},
+		{"DESC", "desc", false},
+		{"  desc  ", "desc", false},
+		{"", "desc", false},
+		{"sideways", "", true},
+		{"asc; DROP TABLE", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ValidateOrder(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ValidateOrder(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ValidateOrder(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ValidateOrder(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveOrderByColumn(t *testing.T) {
+	metricCols := []string{"n_live_tup", "n_dead_tup", "seq_scan"}
+
+	t.Run("empty defaults to collected_at", func(t *testing.T) {
+		got, err := ResolveOrderByColumn("", metricCols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "collected_at" {
+			t.Errorf("got %q, want collected_at", got)
+		}
+	})
+
+	t.Run("collected_at is accepted", func(t *testing.T) {
+		got, err := ResolveOrderByColumn("collected_at", metricCols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "collected_at" {
+			t.Errorf("got %q, want collected_at", got)
+		}
+	})
+
+	t.Run("whitespace trimmed", func(t *testing.T) {
+		got, err := ResolveOrderByColumn("  n_live_tup  ", metricCols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "n_live_tup" {
+			t.Errorf("got %q, want n_live_tup", got)
+		}
+	})
+
+	t.Run("valid metric column accepted", func(t *testing.T) {
+		got, err := ResolveOrderByColumn("seq_scan", metricCols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "seq_scan" {
+			t.Errorf("got %q, want seq_scan", got)
+		}
+	})
+
+	t.Run("unknown column rejected", func(t *testing.T) {
+		_, err := ResolveOrderByColumn("not_a_column", metricCols)
+		if err == nil {
+			t.Fatal("expected error for unknown column")
+		}
+	})
+
+	t.Run("injection attempt rejected", func(t *testing.T) {
+		// A crafted ORDER BY payload must never resolve to a column; it is
+		// not in the discovered metric set, so it is rejected before any
+		// SQL text is built.
+		_, err := ResolveOrderByColumn("1; DROP TABLE metrics.pg_stat_all_tables", metricCols)
+		if err == nil {
+			t.Fatal("expected error for injection attempt")
+		}
+	})
+}
+
+func TestBuildLatestRowsQuery(t *testing.T) {
+	t.Run("connection filter and limit only", func(t *testing.T) {
+		query, args := buildLatestRowsQuery(
+			"pg_stat_all_tables",
+			[]string{"relname", "n_live_tup"},
+			[]int{1},
+			MetricFilters{},
+			"n_live_tup", "desc", 1,
+		)
+
+		if !strings.Contains(query, `metrics."pg_stat_all_tables"`) {
+			t.Error("query should reference the probe table")
+		}
+		if !strings.Contains(query, "connection_id IN ($1)") {
+			t.Error("query should filter by connection_id")
+		}
+		if !strings.Contains(query, `ORDER BY "n_live_tup" desc, collected_at DESC`) {
+			t.Errorf("query should order by quoted column then collected_at, got: %s", query)
+		}
+		if !strings.Contains(query, "LIMIT $2") {
+			t.Error("query should apply LIMIT placeholder")
+		}
+		if len(args) != 2 {
+			t.Fatalf("expected 2 args, got %d", len(args))
+		}
+		if args[0] != 1 || args[1] != 1 {
+			t.Errorf("unexpected args: %v", args)
+		}
+	})
+
+	t.Run("all filters applied", func(t *testing.T) {
+		query, args := buildLatestRowsQuery(
+			"pg_stat_all_indexes",
+			[]string{"indexrelname", "idx_scan"},
+			[]int{2, 3},
+			MetricFilters{
+				DatabaseName:   "northwind",
+				DatabaseColumn: "database_name",
+				SchemaName:     "public",
+				TableName:      "orders",
+				IndexName:      "orders_pkey",
+			},
+			"idx_scan", "asc", 5,
+		)
+
+		if !strings.Contains(query, "connection_id IN ($1, $2)") {
+			t.Error("query should list multiple connection placeholders")
+		}
+		if !strings.Contains(query, `"database_name" = $3`) {
+			t.Error("query should filter by database_name")
+		}
+		if !strings.Contains(query, "schemaname = $4") {
+			t.Error("query should filter by schemaname")
+		}
+		if !strings.Contains(query, "relname = $5") {
+			t.Error("query should filter by relname")
+		}
+		if !strings.Contains(query, "indexrelname = $6") {
+			t.Error("query should filter by indexrelname")
+		}
+		if !strings.Contains(query, `ORDER BY "idx_scan" asc, collected_at DESC`) {
+			t.Errorf("query should order by idx_scan asc, got: %s", query)
+		}
+		if !strings.Contains(query, "LIMIT $7") {
+			t.Error("query should apply LIMIT placeholder at $7")
+		}
+		// 2 connections + 4 filters + 1 limit
+		if len(args) != 7 {
+			t.Fatalf("expected 7 args, got %d", len(args))
+		}
+		if args[6] != 5 {
+			t.Errorf("expected limit arg 5, got %v", args[6])
+		}
+	})
+
+	t.Run("database filter skipped without resolved column", func(t *testing.T) {
+		query, args := buildLatestRowsQuery(
+			"pg_sys_cpu_info",
+			[]string{"cpu_user"},
+			[]int{1},
+			MetricFilters{DatabaseName: "northwind", DatabaseColumn: ""},
+			"collected_at", "desc", 1,
+		)
+
+		if strings.Contains(query, "database_name") || strings.Contains(query, "datname") {
+			t.Error("query should not filter by database when column unresolved")
+		}
+		// 1 connection + 1 limit only
+		if len(args) != 2 {
+			t.Fatalf("expected 2 args, got %d", len(args))
+		}
+	})
+}
+
+func TestQueryLatestRows_ValidationBeforeDB(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("invalid probe name", func(t *testing.T) {
+		_, err := QueryLatestRows(ctx, nil, "bad;name", []int{1},
+			MetricFilters{}, "", "desc", 1)
+		if err == nil {
+			t.Fatal("expected error for invalid probe name")
+		}
+	})
+
+	t.Run("invalid order", func(t *testing.T) {
+		_, err := QueryLatestRows(ctx, nil, "pg_stat_all_tables", []int{1},
+			MetricFilters{}, "", "sideways", 1)
+		if err == nil {
+			t.Fatal("expected error for invalid order")
+		}
+	})
+
+	t.Run("no connections", func(t *testing.T) {
+		_, err := QueryLatestRows(ctx, nil, "pg_stat_all_tables", nil,
+			MetricFilters{}, "", "desc", 1)
+		if err == nil {
+			t.Fatal("expected error for missing connections")
+		}
+	})
+}
+
+func TestSanitizeFloat(t *testing.T) {
+	if got := sanitizeFloat(1.5); got != 1.5 {
+		t.Errorf("sanitizeFloat(1.5) = %v, want 1.5", got)
+	}
+	if got := sanitizeFloat(math.NaN()); got != nil {
+		t.Errorf("sanitizeFloat(NaN) = %v, want nil", got)
+	}
+	if got := sanitizeFloat(math.Inf(1)); got != nil {
+		t.Errorf("sanitizeFloat(+Inf) = %v, want nil", got)
+	}
+	if got := sanitizeFloat(math.Inf(-1)); got != nil {
+		t.Errorf("sanitizeFloat(-Inf) = %v, want nil", got)
+	}
+}
+
+func TestNormalizeLatestValue(t *testing.T) {
+	ts := time.Date(2026, 7, 15, 10, 40, 47, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		input any
+		want  any
+	}{
+		{"nil", nil, nil},
+		{"int64", int64(1363), int64(1363)},
+		{"float64", float64(2.5), float64(2.5)},
+		{"float32", float32(2.5), float64(2.5)},
+		{"nan float", math.NaN(), nil},
+		{"inf float", math.Inf(1), nil},
+		{"string", "public", "public"},
+		{"bytes", []byte("orders"), "orders"},
+		{"time", ts, ts.Format(time.RFC3339)},
+		{"bool", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeLatestValue(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeLatestValue(%v) = %v (%T), want %v (%T)",
+					tt.input, got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeLatestValue_PgtypeValues(t *testing.T) {
+	t.Run("valid numeric", func(t *testing.T) {
+		num := pgtype.Numeric{Int: big.NewInt(1363), Exp: 0, Valid: true}
+		got := normalizeLatestValue(num)
+		if got != float64(1363) {
+			t.Errorf("got %v, want 1363", got)
+		}
+	})
+
+	t.Run("null numeric", func(t *testing.T) {
+		got := normalizeLatestValue(pgtype.Numeric{Valid: false})
+		if got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("valid interval", func(t *testing.T) {
+		iv := pgtype.Interval{Microseconds: 2_500_000, Valid: true}
+		got := normalizeLatestValue(iv)
+		if got != float64(2.5) {
+			t.Errorf("got %v, want 2.5", got)
+		}
+	})
+
+	t.Run("null interval treated as zero", func(t *testing.T) {
+		got := normalizeLatestValue(pgtype.Interval{Valid: false})
+		if got != float64(0) {
+			t.Errorf("got %v, want 0", got)
+		}
+	})
 }

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -507,6 +507,154 @@ func TestToFloat64(t *testing.T) {
 	}
 }
 
+func TestToFloat64_PointerAndNumeric(t *testing.T) {
+	var wrapped any = float64(3.5)
+	var wrappedNil any
+
+	tests := []struct {
+		name       string
+		input      any
+		expected   float64
+		expectedOk bool
+	}{
+		{"any pointer to float64", &wrapped, 3.5, true},
+		{"any pointer to nil", &wrappedNil, 0, false},
+		{"nil any pointer", (*any)(nil), 0, false},
+		{
+			name:       "valid numeric",
+			input:      pgtype.Numeric{Int: big.NewInt(42), Exp: 0, Valid: true},
+			expected:   42,
+			expectedOk: true,
+		},
+		{
+			name:       "invalid numeric",
+			input:      pgtype.Numeric{Valid: false},
+			expected:   0,
+			expectedOk: false,
+		},
+		{
+			name:       "pointer valid numeric",
+			input:      &pgtype.Numeric{Int: big.NewInt(7), Exp: 0, Valid: true},
+			expected:   7,
+			expectedOk: true,
+		},
+		{
+			name:       "pointer invalid numeric",
+			input:      &pgtype.Numeric{Valid: false},
+			expected:   0,
+			expectedOk: false,
+		},
+		{"nil numeric pointer", (*pgtype.Numeric)(nil), 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := toFloat64(tt.input)
+			if ok != tt.expectedOk {
+				t.Errorf("toFloat64(%v) ok = %v, want %v",
+					tt.input, ok, tt.expectedOk)
+			}
+			if result != tt.expected {
+				t.Errorf("toFloat64(%v) = %v, want %v",
+					tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToFloat64_Interval(t *testing.T) {
+	const (
+		secondsPerDay   = 86_400.0
+		secondsPerMonth = 30.0 * secondsPerDay
+	)
+
+	tests := []struct {
+		name       string
+		input      any
+		expected   float64
+		expectedOk bool
+	}{
+		{
+			name:       "microseconds only",
+			input:      pgtype.Interval{Microseconds: 2_500_000, Valid: true},
+			expected:   2.5,
+			expectedOk: true,
+		},
+		{
+			name:       "days included",
+			input:      pgtype.Interval{Days: 2, Valid: true},
+			expected:   2 * secondsPerDay,
+			expectedOk: true,
+		},
+		{
+			name:       "months included",
+			input:      pgtype.Interval{Months: 3, Valid: true},
+			expected:   3 * secondsPerMonth,
+			expectedOk: true,
+		},
+		{
+			name: "combined micros days months",
+			input: pgtype.Interval{
+				Microseconds: 1_500_000,
+				Days:         2,
+				Months:       1,
+				Valid:        true,
+			},
+			expected:   1.5 + 2*secondsPerDay + secondsPerMonth,
+			expectedOk: true,
+		},
+		{
+			name:       "null interval treated as zero",
+			input:      pgtype.Interval{Valid: false},
+			expected:   0,
+			expectedOk: true,
+		},
+		{
+			name: "pointer combined micros days months",
+			input: &pgtype.Interval{
+				Microseconds: 500_000,
+				Days:         1,
+				Months:       2,
+				Valid:        true,
+			},
+			expected:   0.5 + secondsPerDay + 2*secondsPerMonth,
+			expectedOk: true,
+		},
+		{
+			name:       "pointer days and months",
+			input:      &pgtype.Interval{Days: 5, Months: 1, Valid: true},
+			expected:   5*secondsPerDay + secondsPerMonth,
+			expectedOk: true,
+		},
+		{
+			name:       "nil pointer treated as zero",
+			input:      (*pgtype.Interval)(nil),
+			expected:   0,
+			expectedOk: true,
+		},
+		{
+			name:       "pointer null interval treated as zero",
+			input:      &pgtype.Interval{Valid: false},
+			expected:   0,
+			expectedOk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := toFloat64(tt.input)
+			if ok != tt.expectedOk {
+				t.Errorf("toFloat64(%v) ok = %v, want %v",
+					tt.input, ok, tt.expectedOk)
+			}
+			if result != tt.expected {
+				t.Errorf("toFloat64(%v) = %v, want %v",
+					tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestValidateOrder(t *testing.T) {
 	tests := []struct {
 		input   string
@@ -543,7 +691,12 @@ func TestValidateOrder(t *testing.T) {
 }
 
 func TestResolveOrderByColumn(t *testing.T) {
-	metricCols := []string{"n_live_tup", "n_dead_tup", "seq_scan"}
+	// The caller passes the full set of returned columns, which mixes
+	// numeric metrics with dimension and timestamp columns.
+	metricCols := []string{
+		"n_live_tup", "n_dead_tup", "seq_scan",
+		"relname", "schemaname", "last_vacuum", "last_autovacuum",
+	}
 
 	t.Run("empty defaults to collected_at", func(t *testing.T) {
 		got, err := ResolveOrderByColumn("", metricCols)
@@ -582,6 +735,26 @@ func TestResolveOrderByColumn(t *testing.T) {
 		}
 		if got != "seq_scan" {
 			t.Errorf("got %q, want seq_scan", got)
+		}
+	})
+
+	t.Run("dimension column accepted", func(t *testing.T) {
+		got, err := ResolveOrderByColumn("relname", metricCols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "relname" {
+			t.Errorf("got %q, want relname", got)
+		}
+	})
+
+	t.Run("timestamp column accepted", func(t *testing.T) {
+		got, err := ResolveOrderByColumn("last_vacuum", metricCols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "last_vacuum" {
+			t.Errorf("got %q, want last_vacuum", got)
 		}
 	})
 

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -975,3 +975,112 @@ func TestNormalizeLatestValue_PgtypeValues(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateLatestRowParams(t *testing.T) {
+	t.Run("invalid probe name", func(t *testing.T) {
+		_, _, err := validateLatestRowParams("bad;name", []int{1}, "desc", 1)
+		if err == nil {
+			t.Fatal("expected error for invalid probe name")
+		}
+	})
+
+	t.Run("invalid order", func(t *testing.T) {
+		_, _, err := validateLatestRowParams("pg_stat_all_tables", []int{1}, "sideways", 1)
+		if err == nil {
+			t.Fatal("expected error for invalid order")
+		}
+	})
+
+	t.Run("no connections", func(t *testing.T) {
+		_, _, err := validateLatestRowParams("pg_stat_all_tables", nil, "desc", 1)
+		if err == nil {
+			t.Fatal("expected error for missing connections")
+		}
+	})
+
+	t.Run("empty order defaults to desc", func(t *testing.T) {
+		order, _, err := validateLatestRowParams("pg_stat_all_tables", []int{1}, "", 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if order != "desc" {
+			t.Errorf("got order %q, want desc", order)
+		}
+	})
+
+	t.Run("order normalized to lowercase", func(t *testing.T) {
+		order, _, err := validateLatestRowParams("pg_stat_all_tables", []int{1}, "ASC", 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if order != "asc" {
+			t.Errorf("got order %q, want asc", order)
+		}
+	})
+
+	t.Run("limit below one clamped up", func(t *testing.T) {
+		_, limit, err := validateLatestRowParams("pg_stat_all_tables", []int{1}, "desc", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if limit != 1 {
+			t.Errorf("got limit %d, want 1", limit)
+		}
+	})
+
+	t.Run("limit above max clamped down", func(t *testing.T) {
+		_, limit, err := validateLatestRowParams(
+			"pg_stat_all_tables", []int{1}, "desc", maxLatestRowLimit+50)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if limit != maxLatestRowLimit {
+			t.Errorf("got limit %d, want %d", limit, maxLatestRowLimit)
+		}
+	})
+
+	t.Run("valid limit passes through", func(t *testing.T) {
+		_, limit, err := validateLatestRowParams("pg_stat_all_tables", []int{1, 2}, "desc", 25)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if limit != 25 {
+			t.Errorf("got limit %d, want 25", limit)
+		}
+	})
+}
+
+func TestSelectLatestOutputColumns(t *testing.T) {
+	t.Run("internal columns removed", func(t *testing.T) {
+		allCols := []string{
+			"connection_id", "collected_at", "inserted_at",
+			"relname", "n_live_tup",
+		}
+		got := selectLatestOutputColumns(allCols)
+		want := []string{"relname", "n_live_tup"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("index %d: got %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("order preserved and no columns filtered", func(t *testing.T) {
+		allCols := []string{"a", "b", "c"}
+		got := selectLatestOutputColumns(allCols)
+		if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+			t.Errorf("got %v, want [a b c]", got)
+		}
+	})
+
+	t.Run("all internal columns yields empty", func(t *testing.T) {
+		allCols := []string{"connection_id", "collected_at", "inserted_at"}
+		got := selectLatestOutputColumns(allCols)
+		if len(got) != 0 {
+			t.Errorf("got %v, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
## Symptom

The Table and Index object-detail dashboards in the web client showed blank overview tiles (Live Tuples, Dead Tuples, Table Size, Sequential Scans for tables; equivalent stats for indexes) and a Maintenance Info panel permanently stuck on "Never" for Last Vacuum / Last Autovacuum / Last Analyze / Last Autoanalyze — even against a monitored server with completely normal, healthy activity and confirmed-good underlying data.

## Root cause

Those dashboard panels fetch data by calling `GET /api/v1/metrics/query` with `limit=1&order_by=<column>&order=desc`, expecting a single flat row of real column values back. The metrics API never parsed those three parameters — it silently ignored them and fell through to its normal bucketed time-series behavior, returning `[{name, metric, data: [...]}]` (chart-shaped data) instead. The client's `rows[0]` then picked out a chart-series object instead of a table row, so every field the UI wanted read as `undefined`.

## Fix

- Added a "latest row" query mode (`metrics.QueryLatestRows`, dispatched from `handleMetricsQuery` when `limit`/`order_by` are present) that returns the actual most-recent row(s) of raw probe-table data as flat JSON objects keyed by real column name.
- `order_by` is validated in two layers before it can reach SQL text: a syntactic identifier check, then a semantic check against the probe table's actual discovered columns (or `collected_at`) — only a legitimate, real column name can ever be used, and it's still quoted via the existing `QuoteIdentifier` helper as defense in depth. `order` is allow-listed to exactly `asc`/`desc`. All filter values (connection IDs, database/schema/table/index name) remain fully parameterized.
- Reused the NaN/Infinity-safe float handling from the recent `pg_stat_statements`/`system_stats` dashboard fix so this new path can't reintroduce that class of bug.
- No client changes were needed — the client already sent the correct request and already handled the correct response shape.

## Test plan

- [x] `go build ./...` and `go test ./...` pass for the full `server` module
- [x] New unit tests: valid limit/order_by/order combinations return correctly shaped rows; an `order_by` referencing a non-existent column is rejected with 400 before reaching SQL; an invalid `order` value is rejected with 400; default behavior when `order_by`/`order` are omitted
- [x] New pure/validation logic (`ValidateOrder`, `ResolveOrderByColumn`, `buildLatestRowsQuery`, `sanitizeFloat`) at 100% function coverage; DB-orchestration functions mirror the pre-existing untested-without-a-live-pool condition of `QueryTimeSeries`
- [x] `gofmt` clean
- [x] Security review completed — traced the full `order_by` validation path end to end (including case/whitespace/Unicode/NULL-byte bypass attempts), confirmed RBAC is inherited correctly before this code path is reached, confirmed `limit` is bounded server-side in two places — no blocking findings
- [x] Reproduced the original bug against a live instance (curl with `limit=1&order_by=n_live_tup&order=desc` returned bucketed chart data instead of a row before the fix) and confirmed a real row comes back after

Related: a second, separate bug was found in the same investigation (the Activity Charts on these same dashboards, plus the Estate and Cluster dashboards, request derived/computed metrics like `*_per_sec` and `dead_tuple_ratio` that the metrics API doesn't support) — that will be a follow-up PR, intentionally not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Table and Index detail dashboards where overview tiles and the “Maintenance Info” panel could show “Never”.
* **New Features**
  * Added a “latest rows” mode to the metrics API that honors `limit`, `order_by`, and `order`, returning the newest raw values with correct ordering and safe value formatting.
* **Tests**
  * Added unit and database integration coverage for validation, limits/sorting, filtering, and value normalization.
* **Documentation**
  * Updated the unreleased changelog and added guidance for latest-row query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->