### PR TITLE
Fix flaky E2E failure from collector schema-migration poll race

### DIFF
--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -114,6 +114,27 @@ func NewSchemaManager() *SchemaManager {
 	return sm
 }
 
+// LatestVersion returns the highest migration version registered with
+// the schema manager. It reflects the newest schema the collector will
+// converge to once NewDatastore() has applied every pending migration,
+// so callers that need "the version the collector will end up at" can
+// read it without a live database connection or a running migration.
+//
+// The value is derived from the registered migrations, so it stays
+// correct automatically as new migrations are added; nothing needs to
+// track the count separately. It returns 0 when no migrations are
+// registered, which never happens for a SchemaManager built by
+// NewSchemaManager but keeps the helper safe for a zero-value receiver.
+func (sm *SchemaManager) LatestVersion() int {
+	latest := 0
+	for _, m := range sm.migrations {
+		if m.Version > latest {
+			latest = m.Version
+		}
+	}
+	return latest
+}
+
 // registerMigrations registers all available migrations
 func (sm *SchemaManager) registerMigrations() {
 	// Consolidated Migration #1

--- a/collector/src/database/schema_test.go
+++ b/collector/src/database/schema_test.go
@@ -304,29 +304,23 @@ func TestNewSchemaManager(t *testing.T) {
 	}
 }
 
-// TestLatestVersion verifies that LatestVersion reports the highest
-// version among the registered migrations and that it matches the
-// maximum version discovered by scanning the migration slice directly.
-// This keeps the e2e harness's "wait for full convergence" signal
-// correct automatically as migrations are added.
+// TestLatestVersion verifies that LatestVersion computes the maximum
+// registered migration version rather than trusting registration order.
+// The migrations are deliberately supplied out of order (2, 5, 3) so a
+// regression that simply returned the last-registered version would fail
+// this test; only a real max scan yields 5. This keeps the e2e harness's
+// "wait for full convergence" signal correct as migrations are added.
 func TestLatestVersion(t *testing.T) {
-	sm := NewSchemaManager()
-
-	// Derive the expected maximum straight from the registered
-	// migrations so the assertion never needs a hardcoded number.
-	want := 0
-	for _, m := range sm.migrations {
-		if m.Version > want {
-			want = m.Version
-		}
+	sm := &SchemaManager{
+		migrations: []Migration{
+			{Version: 2},
+			{Version: 5},
+			{Version: 3},
+		},
 	}
 
-	if want == 0 {
-		t.Fatal("no migrations registered; cannot validate LatestVersion")
-	}
-
-	if got := sm.LatestVersion(); got != want {
-		t.Errorf("LatestVersion() = %d, want %d", got, want)
+	if got := sm.LatestVersion(); got != 5 {
+		t.Errorf("LatestVersion() = %d, want 5", got)
 	}
 }
 

--- a/collector/src/database/schema_test.go
+++ b/collector/src/database/schema_test.go
@@ -304,6 +304,42 @@ func TestNewSchemaManager(t *testing.T) {
 	}
 }
 
+// TestLatestVersion verifies that LatestVersion reports the highest
+// version among the registered migrations and that it matches the
+// maximum version discovered by scanning the migration slice directly.
+// This keeps the e2e harness's "wait for full convergence" signal
+// correct automatically as migrations are added.
+func TestLatestVersion(t *testing.T) {
+	sm := NewSchemaManager()
+
+	// Derive the expected maximum straight from the registered
+	// migrations so the assertion never needs a hardcoded number.
+	want := 0
+	for _, m := range sm.migrations {
+		if m.Version > want {
+			want = m.Version
+		}
+	}
+
+	if want == 0 {
+		t.Fatal("no migrations registered; cannot validate LatestVersion")
+	}
+
+	if got := sm.LatestVersion(); got != want {
+		t.Errorf("LatestVersion() = %d, want %d", got, want)
+	}
+}
+
+// TestLatestVersionEmpty verifies the zero-value / no-migration guard so
+// a manager with no registered migrations reports 0 rather than
+// panicking or returning a stale value.
+func TestLatestVersionEmpty(t *testing.T) {
+	sm := &SchemaManager{}
+	if got := sm.LatestVersion(); got != 0 {
+		t.Errorf("LatestVersion() with no migrations = %d, want 0", got)
+	}
+}
+
 func TestMigrateFromScratch(t *testing.T) {
 	ctx := context.Background()
 	pool, conn := getTestConnection(t)

--- a/collector/src/main.go
+++ b/collector/src/main.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -29,6 +30,14 @@ var (
 	// Command line flags
 	configFile = flag.String("config", "", "Path to configuration file")
 	verbose    = flag.Bool("v", false, "Enable verbose logging")
+
+	// printSchemaVersion, when set, makes the collector print the newest
+	// datastore schema version it knows about and exit without touching
+	// the database. The e2e harness uses this to learn the version the
+	// collector will converge to so it can wait for every migration to
+	// finish rather than guessing at a hardcoded count.
+	printSchemaVersion = flag.Bool("print-latest-schema-version", false,
+		"Print the latest datastore schema version this collector knows about and exit")
 
 	// Datastore connection flags
 	pgHost         = flag.String("pg-host", "", "PostgreSQL server hostname or IP address")
@@ -45,6 +54,13 @@ var (
 
 func main() {
 	flag.Parse()
+
+	// Handle --print-latest-schema-version before any logging or
+	// datastore initialization so the number is the only thing written
+	// to stdout and the query needs no live database.
+	if maybePrintSchemaVersion(os.Stdout, *printSchemaVersion) {
+		return
+	}
 
 	// Initialize logger
 	logger.Init()
@@ -114,6 +130,23 @@ func main() {
 	logger.Info("Datastore connection pool closed")
 
 	logger.Startup("Collector stopped")
+}
+
+// maybePrintSchemaVersion writes the latest datastore schema version the
+// collector will converge to onto w and reports whether the caller
+// should exit early. When enabled is false it writes nothing and returns
+// false so main proceeds with normal startup.
+//
+// The logic lives here rather than inline in main so it can be unit-
+// tested without invoking the full daemon startup path. The version is
+// obtained from the schema manager's registered migrations, so it stays
+// correct automatically as new migrations are added.
+func maybePrintSchemaVersion(w io.Writer, enabled bool) bool {
+	if !enabled {
+		return false
+	}
+	fmt.Fprintln(w, database.NewSchemaManager().LatestVersion())
+	return true
 }
 
 // loadConfiguration loads configuration from file, environment, and command line.

--- a/collector/src/main.go
+++ b/collector/src/main.go
@@ -57,8 +57,15 @@ func main() {
 
 	// Handle --print-latest-schema-version before any logging or
 	// datastore initialization so the number is the only thing written
-	// to stdout and the query needs no live database.
-	if maybePrintSchemaVersion(os.Stdout, *printSchemaVersion) {
+	// to stdout and the query needs no live database. A write failure
+	// must exit non-zero: the e2e harness reads this number from stdout
+	// and a silent exit 0 with no output would hide the failure from
+	// the collector's own side.
+	if handled, err := maybePrintSchemaVersion(os.Stdout, *printSchemaVersion); handled {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to print latest schema version: %v\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 
@@ -134,19 +141,22 @@ func main() {
 
 // maybePrintSchemaVersion writes the latest datastore schema version the
 // collector will converge to onto w and reports whether the caller
-// should exit early. When enabled is false it writes nothing and returns
-// false so main proceeds with normal startup.
+// should exit early along with any write error. When enabled is false it
+// writes nothing and returns (false, nil) so main proceeds with normal
+// startup.
 //
 // The logic lives here rather than inline in main so it can be unit-
 // tested without invoking the full daemon startup path. The version is
 // obtained from the schema manager's registered migrations, so it stays
-// correct automatically as new migrations are added.
-func maybePrintSchemaVersion(w io.Writer, enabled bool) bool {
+// correct automatically as new migrations are added. The write error is
+// propagated so the caller can exit non-zero: the e2e harness relies on
+// this stdout value, so a swallowed failure would mislead it.
+func maybePrintSchemaVersion(w io.Writer, enabled bool) (bool, error) {
 	if !enabled {
-		return false
+		return false, nil
 	}
-	fmt.Fprintln(w, database.NewSchemaManager().LatestVersion())
-	return true
+	_, err := fmt.Fprintln(w, database.NewSchemaManager().LatestVersion())
+	return true, err
 }
 
 // loadConfiguration loads configuration from file, environment, and command line.

--- a/collector/src/main_test.go
+++ b/collector/src/main_test.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -328,7 +329,11 @@ func TestLoadConfiguration_DefaultConfigFromUserDir(t *testing.T) {
 func TestMaybePrintSchemaVersion_Enabled(t *testing.T) {
 	var buf bytes.Buffer
 
-	if got := maybePrintSchemaVersion(&buf, true); !got {
+	handled, err := maybePrintSchemaVersion(&buf, true)
+	if err != nil {
+		t.Fatalf("maybePrintSchemaVersion(enabled=true) error = %v, want nil", err)
+	}
+	if !handled {
 		t.Fatal("maybePrintSchemaVersion(enabled=true) = false, want true")
 	}
 
@@ -352,11 +357,41 @@ func TestMaybePrintSchemaVersion_Enabled(t *testing.T) {
 func TestMaybePrintSchemaVersion_Disabled(t *testing.T) {
 	var buf bytes.Buffer
 
-	if got := maybePrintSchemaVersion(&buf, false); got {
+	handled, err := maybePrintSchemaVersion(&buf, false)
+	if err != nil {
+		t.Errorf("maybePrintSchemaVersion(enabled=false) error = %v, want nil", err)
+	}
+	if handled {
 		t.Error("maybePrintSchemaVersion(enabled=false) = true, want false")
 	}
 	if buf.Len() != 0 {
 		t.Errorf("expected no output, got %q", buf.String())
+	}
+}
+
+// failingWriter is an io.Writer whose Write always fails. It lets the
+// test drive the error path of maybePrintSchemaVersion without needing
+// a real closed file descriptor or broken pipe.
+type failingWriter struct{}
+
+func (failingWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestMaybePrintSchemaVersion_WriteError verifies that a write failure is
+// surfaced to the caller: the helper still reports the request was
+// handled (so main does not fall through to normal startup) but returns
+// the underlying error so main can exit non-zero.
+func TestMaybePrintSchemaVersion_WriteError(t *testing.T) {
+	handled, err := maybePrintSchemaVersion(failingWriter{}, true)
+	if !handled {
+		t.Error("maybePrintSchemaVersion(enabled=true) handled = false, want true")
+	}
+	if err == nil {
+		t.Fatal("maybePrintSchemaVersion(enabled=true) error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "write failed") {
+		t.Errorf("error = %v, want it to contain 'write failed'", err)
 	}
 }
 

--- a/collector/src/main_test.go
+++ b/collector/src/main_test.go
@@ -10,13 +10,16 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/pgedge/ai-workbench/collector/src/database"
 	"github.com/pgedge/ai-workbench/pkg/fileutil"
 )
 
@@ -315,6 +318,45 @@ func TestLoadConfiguration_DefaultConfigFromUserDir(t *testing.T) {
 	if cfg.GetServerSecret() != "auto-discovered-secret" {
 		t.Errorf("Secret: got %q, want auto-discovered-secret",
 			cfg.GetServerSecret())
+	}
+}
+
+// TestMaybePrintSchemaVersion_Enabled verifies that when the flag is
+// enabled the helper prints exactly the collector's latest schema
+// version (matching database.SchemaManager.LatestVersion) followed by a
+// newline, and reports that the caller should exit early.
+func TestMaybePrintSchemaVersion_Enabled(t *testing.T) {
+	var buf bytes.Buffer
+
+	if got := maybePrintSchemaVersion(&buf, true); !got {
+		t.Fatal("maybePrintSchemaVersion(enabled=true) = false, want true")
+	}
+
+	want := database.NewSchemaManager().LatestVersion()
+	printed := strings.TrimSpace(buf.String())
+	got, err := strconv.Atoi(printed)
+	if err != nil {
+		t.Fatalf("printed value %q is not an integer: %v", printed, err)
+	}
+	if got != want {
+		t.Errorf("printed version = %d, want %d", got, want)
+	}
+	if buf.String() != strconv.Itoa(want)+"\n" {
+		t.Errorf("output = %q, want %q", buf.String(), strconv.Itoa(want)+"\n")
+	}
+}
+
+// TestMaybePrintSchemaVersion_Disabled verifies that when the flag is
+// not set the helper writes nothing and tells the caller to continue
+// normal startup.
+func TestMaybePrintSchemaVersion_Disabled(t *testing.T) {
+	var buf bytes.Buffer
+
+	if got := maybePrintSchemaVersion(&buf, false); got {
+		t.Error("maybePrintSchemaVersion(enabled=false) = true, want false")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got %q", buf.String())
 	}
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,6 @@ project adheres to
 
 ### Fixed
 
-<<<<<<< HEAD
 - Fix the metrics time-series API (`GET /api/v1/metrics/query`)
   silently returning an empty HTTP 200 response, which the web UI
   rendered as a generic "No data available" message, whenever a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ project adheres to
 
 ### Fixed
 
+<<<<<<< HEAD
 - Fix the metrics time-series API (`GET /api/v1/metrics/query`)
   silently returning an empty HTTP 200 response, which the web UI
   rendered as a generic "No data available" message, whenever a
@@ -46,6 +47,20 @@ project adheres to
   these parameters and returns the most recent raw stat rows as
   real column values, validating `order_by` against the table's
   known columns before use.
+
+- Fix the end-to-end test suite intermittently failing at the "Start
+  stack" step. The server logged "collector schema is at v2, server
+  requires at least v4" and then timed out waiting for its health
+  endpoint. The harness script that applies the collector schema
+  stopped the collector as soon as it observed any recorded schema
+  version. A poll that landed between two migrations killed the
+  collector mid-migration, leaving the datastore below the version the
+  server requires. The collector now accepts a
+  `--print-latest-schema-version` flag that reports the newest known
+  schema version without touching any database. The harness asks for
+  that target up front and waits for the datastore to reach it. This
+  change affects test infrastructure only and does not alter
+  application behavior.
 
 ## [1.0.0] - 2026-06-08
 

--- a/e2e/scripts/apply-collector-schema.sh
+++ b/e2e/scripts/apply-collector-schema.sh
@@ -49,10 +49,26 @@ if [ ! -x "${COLLECTOR_BIN}" ]; then
     )
 fi
 
+# Ask the collector which schema version it will converge to. This is a
+# database-free query: the binary just reports the highest migration it
+# was built with, so the target stays correct automatically as new
+# migrations are added -- no version number is hardcoded in this script.
+TARGET_VERSION="$("${COLLECTOR_BIN}" --print-latest-schema-version \
+    2>/dev/null || echo "")"
+if ! printf '%s' "${TARGET_VERSION}" | grep -Eq '^[1-9][0-9]*$'; then
+    echo "ERROR: could not determine target schema version from" \
+        "collector (got: '${TARGET_VERSION}')" >&2
+    exit 1
+fi
+echo "==> Collector target schema version: ${TARGET_VERSION}"
+
 # Run the collector long enough for NewDatastore() to apply the
-# migrations, then stop it. We poll for `schema_version` to converge
-# rather than parse log output (more robust against logger format
-# changes).
+# migrations, then stop it. We poll for `schema_version` to converge to
+# the target version above rather than parse log output (more robust
+# against logger format changes). Waiting for the full target -- not
+# merely the first non-zero row -- avoids a race where the collector is
+# killed after an early migration commits but before it finishes the
+# rest, leaving the datastore below the version the server requires.
 echo "==> Running collector to apply datastore schema"
 "${COLLECTOR_BIN}" --config="${COLLECTOR_CONFIG}" \
     > "${COLLECTOR_LOG}" 2>&1 &
@@ -91,15 +107,20 @@ while :; do
         exit 1
     fi
 
-    # Has the schema_version table been populated yet?
+    # Has the collector applied every migration yet? Compare the
+    # recorded MAX(version) against the target the binary reported.
+    # A missing table or a failed query yields an empty string, which
+    # the numeric guard below treats as "not ready yet".
     version="$("${PSQL_BIN}" \
         -h "${E2E_DB_HOST}" -p "${E2E_DB_PORT}" \
         -U "${E2E_DB_USER}" -d "${E2E_DB_NAME}" \
         -tAc "SELECT COALESCE(MAX(version), 0) FROM schema_version" \
         2>/dev/null || echo "")"
 
-    if [ -n "${version}" ] && [ "${version}" != "0" ]; then
-        echo "==> Collector schema version: ${version}"
+    if printf '%s' "${version}" | grep -Eq '^[0-9]+$' \
+        && [ "${version}" -ge "${TARGET_VERSION}" ]; then
+        echo "==> Collector schema version: ${version}" \
+            "(target ${TARGET_VERSION})"
         break
     fi
 


### PR DESCRIPTION
## Symptom

The E2E test suite intermittently fails at the "Start stack" step. The server logs:

```
[ERROR] datastore schema health check failed: datastore at postgres@127.0.0.1:5432/postgres:
collector schema is at v2, server requires at least v4; upgrade the collector and restart:
collector schema below minimum required version
```

...and the job then times out waiting for `/health`. This is flaky and unrelated to whatever a given PR actually changes — I observed it fail on the `chromium` browser job while `firefox` and `webkit` passed in the exact same run (each browser job spins up its own independent stack), which is the signature of a race condition rather than a deterministic bug (see [run 29427201083](https://github.com/pgEdge/ai-dba-workbench/actions/runs/29427201083)).

## Root cause

The E2E harness script (`e2e/scripts/apply-collector-schema.sh`) starts the collector in the background so its embedded schema migrations create the operational tables the server needs, then polls the datastore and stops the collector once migrations have landed. The poll condition was:

```bash
if [ -n "${version}" ] && [ "${version}" != "0" ]; then
    echo "==> Collector schema version: ${version}"
    break
fi
```

This declares success as soon as `schema_version` has **any** row — not once the collector has applied **all** of its migrations. The collector applies a sequence of numbered migrations, committing a new `schema_version` row after each one. If the poll happens to land in the window between migration 2 committing and migration 3 starting, the script sees `version=2`, declares victory, and immediately SIGTERMs the collector — killing it mid-migration, before the datastore reaches the version the server's `MinCollectorSchemaVersion` requires.

## Fix

- Added a `--print-latest-schema-version` flag to the collector that reports the newest schema version it knows about (derived from its registered migrations) without touching any database.
- The harness script now asks for that target version up front and waits for `MAX(version)` to actually reach it, instead of stopping at the first non-zero value.
- The target is derived from the collector's own migration registry, so this stays correct automatically as new migrations are added — nothing is hardcoded.
- No change to the collector's actual migration-running logic (`NewDatastore()` etc.) — this is a test-harness fix only.

## Test plan

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass for the full `collector` module
- [x] New unit tests: `LatestVersion` (including the empty/zero-value case) and `maybePrintSchemaVersion` (enabled/disabled), both at 100% function coverage
- [x] `gofmt` clean; `bash -n` clean on the modified script
- [x] Verified end-to-end against a live Postgres instance: built the collector, ran the modified script against a fresh throwaway database. It correctly reported "target schema version: 5", waited until the datastore actually reached version 5 (applying all 5 current migrations), then stopped the collector cleanly. Confirmed the old poll condition would have been eligible to stop as early as version 2.
- [x] Re-ran against an already-migrated database to confirm the script remains a fast, correct no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--print-latest-schema-version` CLI option to output the newest known schema version without starting normal operation.

- **Bug Fixes**
  - Improved end-to-end migration readiness by targeting the exact latest schema version and polling until the datastore reaches it.

- **Tests**
  - Added unit test coverage for computing the latest registered schema version and for the new print flag behavior.

- **Documentation**
  - Updated the changelog to reflect the end-to-end reliability improvement around schema convergence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->