### PR TITLE
Fix blank Activity Charts: add per-second rate and dead-tuple-ratio metrics

### DIFF
--- a/.claude/golang-expert/metrics-queries.md
+++ b/.claude/golang-expert/metrics-queries.md
@@ -122,7 +122,72 @@ paths that need a failing query (for example the exists-check branch in
 the scan-error branch in `scanLatestRows` is driven by passing fewer
 output columns than the query returns.
 
+## Derived Metrics in QueryTimeSeries (server)
+
+`QueryTimeSeries` in `server/src/internal/metrics/query.go` serves both raw
+stored columns and computed (derived) metrics from a single request.
+`classifyMetrics` splits the requested metric names, preserving request
+order, into three results: raw column names, a `[]DerivedMetric`, and the
+combined output order. The routing rules are deliberate and order-sensitive:
+
+- A name matching a real numeric column is always a raw metric; a real
+  column wins even when it ends in `_per_sec`.
+- A name ending in `_per_sec` whose prefix is a real numeric column becomes
+  a `DerivedPerSec` rate (delta of the counter over elapsed seconds).
+- The literal `dead_tuple_ratio` is accepted only when the probe exposes
+  both `n_live_tup` and `n_dead_tup`; it is a 0-100 percentage.
+- A repeated name is silently de-duplicated; anything else is a client
+  error.
+
+`BuildDerivedMetricsQuery` builds the derived SQL. It shares the bucketing,
+gap-filling (`generate_series`), filtering, and `$N` argument layout of
+`BuildMetricsQuery`, so the caller scans and applies LOCF identically for
+raw and derived series. Per-second base columns must stay validated against
+the discovered column set and `QuoteIdentifier`-wrapped; never interpolate a
+caller-supplied metric name that has not passed `classifyMetrics`. Negative
+counter deltas (resets/restarts) and non-positive elapsed times are dropped
+to NULL so they never yield a bogus rate.
+
+Both the raw and derived branches feed the shared `scanSeriesRows` helper,
+which scans a bucket-time-plus-N-values result set, applies LOCF per
+connection and metric name via `lastKnown`, and treats a NULL bucket or a
+non-finite sample as a gap.
+
+### NaN/Inf handling: finiteFloat, not resolveMetricValue
+
+Non-finite samples (NaN, +/-Inf) must be treated as gaps, never plotted,
+because `encoding/json` cannot marshal them and one bad value would blank
+the whole response. This guard lives in `toFloat64` via the `finiteFloat`
+helper: `toFloat64` returns `(0, false)` for a non-finite float64/float32/
+`pgtype.Numeric`, and `scanSeriesRows` then treats `!ok` as a gap (LOCF
+carry-forward, or skip when there is no prior value). An earlier design
+(#339) guarded NaN/Inf in a `resolveMetricValue` helper inside the scan
+loop; that was retired in favour of guarding inside `toFloat64`, because the
+`toFloat64` guard is broader and benefits every caller, including the
+latest-row path's `normalizeLatestValue`/`sanitizeFloat`. Do not
+reintroduce `resolveMetricValue`. Note that `toFloat64` still converts
+`pgtype.Interval` through `intervalToSeconds` (handling Days/Months); the
+`finiteFloat` guard and `intervalToSeconds` are independent and both must
+remain.
+
+### Derived-path integration tests
+
+The derived path and `scanSeriesRows` are covered by
+`server/src/internal/metrics/query_timeseries_db_test.go` (same gating
+convention as `query_db_test.go`). Its fixture inserts minute-spaced samples
+with counters rising 60 per minute (a clean 1.0/sec rate) and constant
+live/dead tuple counts (a steady 10% ratio), then exercises raw, `_per_sec`,
+`dead_tuple_ratio`, and mixed requests end-to-end. The two `scanSeriesRows`
+error returns in `QueryTimeSeries` are driven deterministically by passing
+an aggregation that names no SQL function, which makes the built query fail
+at execution; `scanSeriesRows`'s own `pool.Query` and `rows.Scan` error
+branches are driven by a cancelled context and a destination-count mismatch
+respectively.
+
 ## Related Issues
 
 - #56: Alerter FK violations when calculating baselines for deleted
   connections.
+- #342: Derived metrics (`_per_sec` rates and `dead_tuple_ratio`) added to
+  `QueryTimeSeries` to fix blank Activity Charts; retired #339's
+  `resolveMetricValue` in favour of the `finiteFloat` guard in `toFloat64`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,23 @@ project adheres to
   change affects test infrastructure only and does not alter
   application behavior.
 
+- Fix the Activity Charts on the Table and Index object-detail
+  dashboards rendering permanently blank, with the messages "No tuple
+  operation data available", "No scan data available", and "No dead
+  tuple data available" appearing even when the monitored server had
+  completely normal, healthy activity. Those charts request computed
+  metrics, including per-second rates such as sequential scans, index
+  scans, and inserted, updated, or deleted rows, together with a
+  dead-tuple percentage. The metrics API understood only literal, raw
+  stored columns and could not compute a rate or a ratio, so it
+  rejected these requests with an error that the web client silently
+  rendered as missing data. The metrics API now computes a per-second
+  rate for any counter column a dashboard requests by name; a request
+  for `seq_scan_per_sec` computes the rate of change of the underlying
+  `seq_scan` counter between samples. The API also computes a
+  dead-tuple ratio metric for tables, reusing the rate and ratio
+  calculations already applied elsewhere in the product. (#342)
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -462,6 +462,20 @@ func rateAggExpr(aggregation string, idx int, outputName string) string {
 	return fmt.Sprintf("%s(rate_%d) AS %s", aggregation, idx, alias)
 }
 
+// ratioTupleExpr builds the bucket-level aggregation expression for one
+// tuple-count column feeding the dead-tuple ratio. Only "last" needs
+// distinct handling, mirroring rateAggExpr: it picks the latest sample's
+// value in the bucket so the ratio reflects the most recent live/dead
+// counts. Every other aggregation collapses the bucket with SUM, matching
+// the prior behavior.
+func ratioTupleExpr(aggregation, column string) string {
+	q := QuoteIdentifier(column)
+	if aggregation == "last" {
+		return fmt.Sprintf("(array_agg(%s ORDER BY collected_at DESC))[1]", q)
+	}
+	return fmt.Sprintf("SUM(%s)", q)
+}
+
 // BuildDerivedMetricsQuery constructs a time-bucketed SQL query for the
 // derived metrics (per-second rates and the dead-tuple ratio) of a probe.
 // It shares the same bucketing, gap-filling (generate_series), filtering,
@@ -570,20 +584,22 @@ func BuildDerivedMetricsQuery(
 	if hasRatio {
 		// The ratio is expressed on a 0-100 percentage scale (not a 0-1
 		// fraction) to match what the client dashboards render.
+		liveExpr := ratioTupleExpr(aggregation, "n_live_tup")
+		deadExpr := ratioTupleExpr(aggregation, "n_dead_tup")
 		ctes = append(ctes, fmt.Sprintf(`
         ratio_buckets AS (
             SELECT
                 date_bin($1::interval, collected_at, $3) AS bucket_time,
-                CASE WHEN SUM(%[1]s) + SUM(%[2]s) = 0 THEN 0
-                     ELSE SUM(%[2]s)::float
-                          / (SUM(%[1]s) + SUM(%[2]s))::float * 100.0
+                CASE WHEN %[1]s + %[2]s = 0 THEN 0
+                     ELSE %[2]s::float
+                          / (%[1]s + %[2]s)::float * 100.0
                 END AS dead_tuple_ratio
             FROM metrics.%[3]s
             WHERE %[4]s
             GROUP BY date_bin($1::interval, collected_at, $3)
         )`,
-			QuoteIdentifier("n_live_tup"),
-			QuoteIdentifier("n_dead_tup"),
+			liveExpr,
+			deadExpr,
 			QuoteIdentifier(probeName),
 			whereSQL,
 		))
@@ -653,11 +669,20 @@ func classifyMetrics(
 	var derived []DerivedMetric
 	var outputOrder []string
 
+	// A repeated metric name would otherwise be scanned twice and emit
+	// duplicate data points under the same series key; silently drop the
+	// repeat rather than erroring, since the client's intent is unambiguous.
+	seen := make(map[string]struct{}, len(requestedMetrics))
+
 	for _, m := range requestedMetrics {
 		m = strings.TrimSpace(m)
 		if !IsValidIdentifier(m) {
 			return nil, nil, nil, fmt.Errorf("invalid metric name %q", m)
 		}
+		if _, exists := seen[m]; exists {
+			continue
+		}
+		seen[m] = struct{}{}
 
 		switch {
 		case available[m]:

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -21,6 +21,31 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// DerivedMetricKind enumerates the computed metric types the generic
+// time-series query path supports in addition to raw columns.
+type DerivedMetricKind int
+
+const (
+	// DerivedPerSec is a per-second rate computed from the delta of a
+	// cumulative counter column between consecutive samples.
+	DerivedPerSec DerivedMetricKind = iota
+	// DerivedDeadTupleRatio is the dead-tuple percentage computed from the
+	// n_live_tup and n_dead_tup columns.
+	DerivedDeadTupleRatio
+)
+
+// DerivedMetric describes a single computed metric to include in a query.
+type DerivedMetric struct {
+	// OutputName is the metric name returned to the client, e.g.
+	// "seq_scan_per_sec" or "dead_tuple_ratio".
+	OutputName string
+	// BaseColumn is the source counter column for a per-second rate. It is
+	// empty for DerivedDeadTupleRatio.
+	BaseColumn string
+	// Kind selects how the metric is computed.
+	Kind DerivedMetricKind
+}
+
 // MetricFilters holds optional dimension filters for metric queries.
 type MetricFilters struct {
 	DatabaseName   string
@@ -342,40 +367,8 @@ func BuildMetricsQuery(
 		bucketWidth = time.Second
 	}
 
-	// Build WHERE clause
-	var whereClauses []string
-	queryArgs := []any{
-		fmt.Sprintf("%d seconds", int(bucketWidth.Seconds())),
-		connectionID,
-		timeStart,
-		timeEnd,
-	}
-	argNum := 5
-
-	whereClauses = append(whereClauses, "connection_id = $2")
-	whereClauses = append(whereClauses, "collected_at >= $3")
-	whereClauses = append(whereClauses, "collected_at <= $4")
-
-	// Add optional filters
-	if filters.DatabaseName != "" && filters.DatabaseColumn != "" {
-		whereClauses = append(whereClauses,
-			fmt.Sprintf("%s = $%d", QuoteIdentifier(filters.DatabaseColumn), argNum))
-		queryArgs = append(queryArgs, filters.DatabaseName)
-		argNum++
-	}
-
-	if filters.SchemaName != "" {
-		whereClauses = append(whereClauses,
-			fmt.Sprintf("schemaname = $%d", argNum))
-		queryArgs = append(queryArgs, filters.SchemaName)
-		argNum++
-	}
-
-	if filters.TableName != "" {
-		whereClauses = append(whereClauses,
-			fmt.Sprintf("relname = $%d", argNum))
-		queryArgs = append(queryArgs, filters.TableName)
-	}
+	whereSQL, queryArgs := metricQueryBase(
+		connectionID, timeStart, timeEnd, bucketWidth, filters)
 
 	query := fmt.Sprintf(`
         WITH data_buckets AS (
@@ -398,11 +391,309 @@ func BuildMetricsQuery(
     `,
 		strings.Join(GetAggSelectCols(metricCols, aggregation), ", "),
 		QuoteIdentifier(probeName),
-		strings.Join(whereClauses, " AND "),
+		whereSQL,
 		strings.Join(GetQualifiedSelectCols(metricCols, "data_buckets"), ", "),
 	)
 
 	return query, queryArgs, nil
+}
+
+// metricQueryBase builds the shared WHERE clause and the leading query
+// arguments used by both the raw-column and derived-metric query builders.
+// The returned args are, in order: the bucket interval string, the
+// connection ID, the start time, the end time, and then any filter values.
+// The WHERE clause references $2, $3, $4 and any filter placeholders from $5.
+func metricQueryBase(
+	connectionID int,
+	timeStart, timeEnd time.Time,
+	bucketWidth time.Duration,
+	filters MetricFilters,
+) (string, []any) {
+	queryArgs := []any{
+		fmt.Sprintf("%d seconds", int(bucketWidth.Seconds())),
+		connectionID,
+		timeStart,
+		timeEnd,
+	}
+	argNum := 5
+
+	whereClauses := []string{
+		"connection_id = $2",
+		"collected_at >= $3",
+		"collected_at <= $4",
+	}
+
+	if filters.DatabaseName != "" && filters.DatabaseColumn != "" {
+		whereClauses = append(whereClauses,
+			fmt.Sprintf("%s = $%d", QuoteIdentifier(filters.DatabaseColumn), argNum))
+		queryArgs = append(queryArgs, filters.DatabaseName)
+		argNum++
+	}
+
+	if filters.SchemaName != "" {
+		whereClauses = append(whereClauses,
+			fmt.Sprintf("schemaname = $%d", argNum))
+		queryArgs = append(queryArgs, filters.SchemaName)
+		argNum++
+	}
+
+	if filters.TableName != "" {
+		whereClauses = append(whereClauses,
+			fmt.Sprintf("relname = $%d", argNum))
+		queryArgs = append(queryArgs, filters.TableName)
+	}
+
+	return strings.Join(whereClauses, " AND "), queryArgs
+}
+
+// rateAggExpr builds the bucket-level aggregation expression for one
+// per-second rate column. The inner per-sample rate is exposed as rate_<idx>
+// in the rate_samples CTE. NULL per-sample rates (counter resets or invalid
+// elapsed times) are ignored by the standard aggregates; for "last" they are
+// filtered out explicitly so a reset never becomes the reported value.
+func rateAggExpr(aggregation string, idx int, outputName string) string {
+	alias := QuoteIdentifier(outputName)
+	if aggregation == "last" {
+		return fmt.Sprintf(
+			"(array_agg(rate_%d ORDER BY collected_at DESC) "+
+				"FILTER (WHERE rate_%d IS NOT NULL))[1] AS %s",
+			idx, idx, alias)
+	}
+	return fmt.Sprintf("%s(rate_%d) AS %s", aggregation, idx, alias)
+}
+
+// BuildDerivedMetricsQuery constructs a time-bucketed SQL query for the
+// derived metrics (per-second rates and the dead-tuple ratio) of a probe.
+// It shares the same bucketing, gap-filling (generate_series), filtering,
+// and argument layout as BuildMetricsQuery, so the caller can scan and apply
+// LOCF identically. Output columns follow the order of the derived slice.
+func BuildDerivedMetricsQuery(
+	probeName string,
+	derived []DerivedMetric,
+	connectionID int,
+	timeStart, timeEnd time.Time,
+	buckets int,
+	aggregation string,
+	filters MetricFilters,
+) (string, []any, error) {
+	if len(derived) == 0 {
+		return "", nil, fmt.Errorf("no derived metrics requested")
+	}
+
+	duration := timeEnd.Sub(timeStart)
+	bucketWidth := duration / time.Duration(buckets)
+	if bucketWidth < time.Second {
+		bucketWidth = time.Second
+	}
+
+	whereSQL, queryArgs := metricQueryBase(
+		connectionID, timeStart, timeEnd, bucketWidth, filters)
+
+	var perSec []DerivedMetric
+	hasRatio := false
+	for _, d := range derived {
+		switch d.Kind {
+		case DerivedPerSec:
+			perSec = append(perSec, d)
+		case DerivedDeadTupleRatio:
+			hasRatio = true
+		default:
+			return "", nil, fmt.Errorf(
+				"unknown derived metric kind for %q", d.OutputName)
+		}
+	}
+
+	var ctes []string
+	var joins []string
+
+	if len(perSec) > 0 {
+		var innerCols []string
+		var sampleCols []string
+		var bucketCols []string
+		for i, d := range perSec {
+			qb := QuoteIdentifier(d.BaseColumn)
+			innerCols = append(innerCols,
+				fmt.Sprintf("SUM(%s) AS total_%d", qb, i),
+				fmt.Sprintf(
+					"LAG(SUM(%s)) OVER (ORDER BY collected_at) AS prev_%d",
+					qb, i))
+			// Discard negative deltas (a counter reset from pg_stat_reset()
+			// or a server restart) and non-positive elapsed times (duplicate
+			// or out-of-order samples) so neither yields a bogus rate; such
+			// rows become NULL and are dropped by the bucket aggregate.
+			sampleCols = append(sampleCols, fmt.Sprintf(
+				"CASE WHEN (total_%d - prev_%d) >= 0 AND elapsed_sec > 0 "+
+					"THEN (total_%d - prev_%d)::float / elapsed_sec "+
+					"END AS rate_%d", i, i, i, i, i))
+			bucketCols = append(bucketCols,
+				rateAggExpr(aggregation, i, d.OutputName))
+		}
+
+		ctes = append(ctes, fmt.Sprintf(`
+        rate_samples AS (
+            SELECT
+                collected_at,
+                %s
+            FROM (
+                SELECT
+                    collected_at,
+                    %s,
+                    EXTRACT(EPOCH FROM collected_at
+                        - LAG(collected_at) OVER (ORDER BY collected_at)
+                    ) AS elapsed_sec
+                FROM metrics.%s
+                WHERE %s
+                GROUP BY collected_at
+            ) samples
+        )`,
+			strings.Join(sampleCols, ",\n                "),
+			strings.Join(innerCols, ",\n                    "),
+			QuoteIdentifier(probeName),
+			whereSQL,
+		))
+
+		ctes = append(ctes, fmt.Sprintf(`
+        rate_buckets AS (
+            SELECT
+                date_bin($1::interval, collected_at, $3) AS bucket_time,
+                %s
+            FROM rate_samples
+            GROUP BY date_bin($1::interval, collected_at, $3)
+        )`,
+			strings.Join(bucketCols, ",\n                "),
+		))
+
+		joins = append(joins,
+			"LEFT JOIN rate_buckets ON all_buckets.bucket_time = rate_buckets.bucket_time")
+	}
+
+	if hasRatio {
+		// The ratio is expressed on a 0-100 percentage scale (not a 0-1
+		// fraction) to match what the client dashboards render.
+		ctes = append(ctes, fmt.Sprintf(`
+        ratio_buckets AS (
+            SELECT
+                date_bin($1::interval, collected_at, $3) AS bucket_time,
+                CASE WHEN SUM(%[1]s) + SUM(%[2]s) = 0 THEN 0
+                     ELSE SUM(%[2]s)::float
+                          / (SUM(%[1]s) + SUM(%[2]s))::float * 100.0
+                END AS dead_tuple_ratio
+            FROM metrics.%[3]s
+            WHERE %[4]s
+            GROUP BY date_bin($1::interval, collected_at, $3)
+        )`,
+			QuoteIdentifier("n_live_tup"),
+			QuoteIdentifier("n_dead_tup"),
+			QuoteIdentifier(probeName),
+			whereSQL,
+		))
+
+		joins = append(joins,
+			"LEFT JOIN ratio_buckets ON all_buckets.bucket_time = ratio_buckets.bucket_time")
+	}
+
+	var selectCols []string
+	for _, d := range derived {
+		switch d.Kind {
+		case DerivedPerSec:
+			selectCols = append(selectCols,
+				"rate_buckets."+QuoteIdentifier(d.OutputName))
+		case DerivedDeadTupleRatio:
+			selectCols = append(selectCols, "ratio_buckets.dead_tuple_ratio")
+		}
+	}
+
+	ctes = append(ctes, `
+        all_buckets AS (
+            SELECT generate_series($3::timestamptz, $4::timestamptz, $1::interval) AS bucket_time
+        )`)
+
+	query := fmt.Sprintf(`
+        WITH %s
+        SELECT
+            all_buckets.bucket_time,
+            %s
+        FROM all_buckets
+        %s
+        ORDER BY all_buckets.bucket_time
+    `,
+		strings.Join(ctes, ","),
+		strings.Join(selectCols, ",\n            "),
+		strings.Join(joins, "\n        "),
+	)
+
+	return query, queryArgs, nil
+}
+
+// classifyMetrics splits the requested metric names into raw columns and
+// derived metrics while preserving request order. When no metrics are
+// requested, all discovered numeric columns are treated as raw metrics.
+//
+// A name that matches a real numeric column is a raw metric (a real column
+// always wins, even if it happens to end in "_per_sec"). A name ending in
+// "_per_sec" whose prefix is a real numeric column becomes a per-second
+// rate. The literal name "dead_tuple_ratio" is accepted only when the probe
+// exposes both n_live_tup and n_dead_tup. Anything else is a client error.
+func classifyMetrics(
+	requestedMetrics []string,
+	metricCols []string,
+	probeName string,
+) ([]string, []DerivedMetric, []string, error) {
+	available := make(map[string]bool, len(metricCols))
+	for _, c := range metricCols {
+		available[c] = true
+	}
+
+	if len(requestedMetrics) == 0 {
+		order := append([]string(nil), metricCols...)
+		return metricCols, nil, order, nil
+	}
+
+	var rawCols []string
+	var derived []DerivedMetric
+	var outputOrder []string
+
+	for _, m := range requestedMetrics {
+		m = strings.TrimSpace(m)
+		if !IsValidIdentifier(m) {
+			return nil, nil, nil, fmt.Errorf("invalid metric name %q", m)
+		}
+
+		switch {
+		case available[m]:
+			rawCols = append(rawCols, m)
+			outputOrder = append(outputOrder, m)
+		case strings.HasSuffix(m, "_per_sec"):
+			base := strings.TrimSuffix(m, "_per_sec")
+			if !available[base] {
+				return nil, nil, nil, fmt.Errorf(
+					"metric %q not found in probe %q: no numeric column %q "+
+						"to compute a per-second rate", m, probeName, base)
+			}
+			derived = append(derived, DerivedMetric{
+				OutputName: m,
+				BaseColumn: base,
+				Kind:       DerivedPerSec,
+			})
+			outputOrder = append(outputOrder, m)
+		case m == "dead_tuple_ratio":
+			if !available["n_live_tup"] || !available["n_dead_tup"] {
+				return nil, nil, nil, fmt.Errorf(
+					"metric %q not supported for probe %q: requires "+
+						"n_live_tup and n_dead_tup columns", m, probeName)
+			}
+			derived = append(derived, DerivedMetric{
+				OutputName: m,
+				Kind:       DerivedDeadTupleRatio,
+			})
+			outputOrder = append(outputOrder, m)
+		default:
+			return nil, nil, nil, fmt.Errorf(
+				"metric %q not found in probe %q", m, probeName)
+		}
+	}
+
+	return rawCols, derived, outputOrder, nil
 }
 
 // QueryTimeSeries executes a metrics query and returns the results as
@@ -449,28 +740,14 @@ func QueryTimeSeries(
 		return nil, fmt.Errorf("failed to get probe columns: %w", err)
 	}
 
-	// Filter to requested metrics if specified
-	if len(requestedMetrics) > 0 {
-		available := make(map[string]bool, len(metricCols))
-		for _, col := range metricCols {
-			available[col] = true
-		}
-
-		var filtered []string
-		for _, m := range requestedMetrics {
-			m = strings.TrimSpace(m)
-			if !IsValidIdentifier(m) {
-				return nil, fmt.Errorf("invalid metric name %q", m)
-			}
-			if !available[m] {
-				return nil, fmt.Errorf("metric %q not found in probe %q", m, probeName)
-			}
-			filtered = append(filtered, m)
-		}
-		metricCols = filtered
+	// Split requested metrics into raw columns and derived metrics.
+	rawCols, derived, outputOrder, err := classifyMetrics(
+		requestedMetrics, metricCols, probeName)
+	if err != nil {
+		return nil, err
 	}
 
-	if len(metricCols) == 0 {
+	if len(outputOrder) == 0 {
 		return nil, fmt.Errorf("no numeric metrics found in probe %q", probeName)
 	}
 
@@ -484,81 +761,61 @@ func QueryTimeSeries(
 	}
 
 	// Collect data across all connections
-	type seriesKey struct {
-		metric       string
-		connectionID int
-	}
 	dataMap := make(map[seriesKey][]MetricDataPoint)
 
 	// Track last known value per metric column for LOCF
 	lastKnown := make(map[string]float64)
 
 	for _, connID := range connectionIDs {
-		query, queryArgs, err := BuildMetricsQuery(
-			probeName, metricCols, colTypes, connID, timeStart, timeEnd,
-			buckets, aggregation, filters)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build query: %w", err)
-		}
-
-		rows, err := pool.Query(ctx, query, queryArgs...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to query metrics for connection %d: %w", connID, err)
-		}
-
-		for rows.Next() {
-			values := make([]any, len(metricCols)+1)
-			valuePtrs := make([]any, len(metricCols)+1)
-			var bucketTime time.Time
-			valuePtrs[0] = &bucketTime
-			for i := range metricCols {
-				var v any
-				values[i+1] = &v
-				valuePtrs[i+1] = &values[i+1]
+		if len(rawCols) > 0 {
+			query, queryArgs, err := BuildMetricsQuery(
+				probeName, rawCols, colTypes, connID, timeStart, timeEnd,
+				buckets, aggregation, filters)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build query: %w", err)
 			}
-
-			if err := rows.Scan(valuePtrs...); err != nil {
-				rows.Close()
-				return nil, fmt.Errorf("failed to scan row: %w", err)
-			}
-
-			for i, col := range metricCols {
-				lkKey := fmt.Sprintf("%d:%s", connID, col)
-				val, ok := resolveMetricValue(values[i+1], lkKey, lastKnown)
-				if !ok {
-					continue
-				}
-				key := seriesKey{metric: col, connectionID: connID}
-				dataMap[key] = append(dataMap[key], MetricDataPoint{
-					Time:  bucketTime,
-					Value: val,
-				})
+			if err := scanSeriesRows(ctx, pool, query, queryArgs, rawCols,
+				connID, dataMap, lastKnown); err != nil {
+				return nil, err
 			}
 		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("error iterating results: %w", err)
+
+		if len(derived) > 0 {
+			query, queryArgs, err := BuildDerivedMetricsQuery(
+				probeName, derived, connID, timeStart, timeEnd,
+				buckets, aggregation, filters)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build derived query: %w", err)
+			}
+			names := make([]string, len(derived))
+			for i, d := range derived {
+				names[i] = d.OutputName
+			}
+			if err := scanSeriesRows(ctx, pool, query, queryArgs, names,
+				connID, dataMap, lastKnown); err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	// Build result series
+	// Build result series in the requested metric order.
 	var result []MetricSeries
-	for _, col := range metricCols {
+	for _, metric := range outputOrder {
 		for _, connID := range connectionIDs {
-			key := seriesKey{metric: col, connectionID: connID}
+			key := seriesKey{metric: metric, connectionID: connID}
 			data := dataMap[key]
 			if data == nil {
 				data = []MetricDataPoint{}
 			}
 
-			name := col
+			name := metric
 			if len(connectionIDs) > 1 {
-				name = fmt.Sprintf("%s (conn %d)", col, connID)
+				name = fmt.Sprintf("%s (conn %d)", metric, connID)
 			}
 
 			result = append(result, MetricSeries{
 				Name:   name,
-				Metric: col,
+				Metric: metric,
 				Data:   data,
 				Unit:   "",
 			})
@@ -566,6 +823,71 @@ func QueryTimeSeries(
 	}
 
 	return result, nil
+}
+
+// seriesKey identifies a metric series by name and connection.
+type seriesKey struct {
+	metric       string
+	connectionID int
+}
+
+// scanSeriesRows executes a bucketed metrics query whose first selected
+// column is the bucket time followed by one column per name in names, then
+// accumulates the values into dataMap. NULL buckets (LEFT JOIN gaps or
+// discarded derived samples) are filled with Last Observation Carried
+// Forward using lastKnown, keyed per connection and metric name.
+func scanSeriesRows(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	query string,
+	queryArgs []any,
+	names []string,
+	connID int,
+	dataMap map[seriesKey][]MetricDataPoint,
+	lastKnown map[string]float64,
+) error {
+	rows, err := pool.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to query metrics for connection %d: %w", connID, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		values := make([]any, len(names)+1)
+		valuePtrs := make([]any, len(names)+1)
+		var bucketTime time.Time
+		valuePtrs[0] = &bucketTime
+		for i := range names {
+			var v any
+			values[i+1] = &v
+			valuePtrs[i+1] = &values[i+1]
+		}
+
+		if err := rows.Scan(valuePtrs...); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		for i, name := range names {
+			lkKey := fmt.Sprintf("%d:%s", connID, name)
+			val, ok := toFloat64(values[i+1])
+			if !ok {
+				if prev, exists := lastKnown[lkKey]; exists {
+					val = prev
+				} else {
+					continue
+				}
+			} else {
+				lastKnown[lkKey] = val
+			}
+			key := seriesKey{metric: name, connectionID: connID}
+			dataMap[key] = append(dataMap[key], MetricDataPoint{
+				Time:  bucketTime,
+				Value: val,
+			})
+		}
+	}
+
+	return rows.Err()
 }
 
 // QueryBaselines retrieves aggregated baseline statistics for the given
@@ -691,31 +1013,6 @@ func QueryBaselines(
 	}
 
 	return result, nil
-}
-
-// resolveMetricValue converts a scanned bucket value into a plottable float,
-// applying last-observation-carried-forward (LOCF) for gaps. A gap is either a
-// NULL bucket produced by the LEFT JOIN or a non-finite sample (NaN/Inf).
-//
-// Non-finite samples must be treated as gaps rather than plotted: the
-// system_stats extension can emit NaN percentages from a 0/0 delta division,
-// and encoding/json cannot marshal NaN or Inf. Letting such a value through
-// would break the JSON response for every metric in the request, not just the
-// affected bucket. The second return value reports whether a point should be
-// appended; when false the caller skips the bucket.
-func resolveMetricValue(raw any, lkKey string, lastKnown map[string]float64) (float64, bool) {
-	val, ok := toFloat64(raw)
-	if ok && (math.IsNaN(val) || math.IsInf(val, 0)) {
-		ok = false
-	}
-	if !ok {
-		if prev, exists := lastKnown[lkKey]; exists {
-			return prev, true
-		}
-		return 0, false
-	}
-	lastKnown[lkKey] = val
-	return val, true
 }
 
 // ValidateOrder normalizes and validates a sort direction. It accepts
@@ -1077,8 +1374,19 @@ func normalizeLatestValue(v any) any {
 	}
 }
 
+// finiteFloat reports a float only when it is finite. NaN and +/-Inf are
+// rejected because encoding/json cannot marshal them; a non-finite value
+// would otherwise break the entire JSON response for every series in the
+// request. A rejected value is treated as a gap and handled by LOCF.
+func finiteFloat(f float64) (float64, bool) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, false
+	}
+	return f, true
+}
+
 // toFloat64 converts a scanned database value to float64. It returns
-// false when the value cannot be converted.
+// false when the value cannot be converted or is not finite.
 func toFloat64(v any) (float64, bool) {
 	if v == nil {
 		return 0, false
@@ -1094,9 +1402,9 @@ func toFloat64(v any) (float64, bool) {
 
 	switch val := v.(type) {
 	case float64:
-		return val, true
+		return finiteFloat(val)
 	case float32:
-		return float64(val), true
+		return finiteFloat(float64(val))
 	case int64:
 		return float64(val), true
 	case int32:
@@ -1123,7 +1431,7 @@ func toFloat64(v any) (float64, bool) {
 		if !f.Valid {
 			return 0, false
 		}
-		return f.Float64, true
+		return finiteFloat(f.Float64)
 	case *pgtype.Numeric:
 		if val == nil {
 			return 0, false
@@ -1135,7 +1443,7 @@ func toFloat64(v any) (float64, bool) {
 		if !f.Valid {
 			return 0, false
 		}
-		return f.Float64, true
+		return finiteFloat(f.Float64)
 	case pgtype.Interval:
 		if !val.Valid {
 			// NULL interval means no lag reported; treat as zero

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -307,6 +307,23 @@ func TestBuildMetricsQuery(t *testing.T) {
 			t.Error("last aggregation should use array_agg")
 		}
 	})
+
+	t.Run("sub-second bucket width clamped", func(t *testing.T) {
+		tinyEnd := start.Add(time.Second)
+		query, _, err := BuildMetricsQuery(
+			"pg_stat_database",
+			[]string{"xact_commit"},
+			map[string]string{"xact_commit": "bigint"},
+			1, start, tinyEnd, 60, "avg",
+			MetricFilters{},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(query, "date_bin($1::interval") {
+			t.Error("query should still build with clamped bucket width")
+		}
+	})
 }
 
 func TestGetAggSelectCols(t *testing.T) {
@@ -406,70 +423,6 @@ func TestGetCoalescedSelectCols(t *testing.T) {
 	})
 }
 
-func TestResolveMetricValue(t *testing.T) {
-	t.Run("finite value is recorded as last known", func(t *testing.T) {
-		lastKnown := map[string]float64{}
-		val, ok := resolveMetricValue(float64(3.5), "1:cpu", lastKnown)
-		if !ok || val != 3.5 {
-			t.Fatalf("got (%v, %v), want (3.5, true)", val, ok)
-		}
-		if lastKnown["1:cpu"] != 3.5 {
-			t.Errorf("lastKnown not updated: %v", lastKnown["1:cpu"])
-		}
-	})
-
-	t.Run("null bucket with no prior value is skipped", func(t *testing.T) {
-		lastKnown := map[string]float64{}
-		_, ok := resolveMetricValue(nil, "1:cpu", lastKnown)
-		if ok {
-			t.Fatalf("expected skip for null with no prior value")
-		}
-		if _, exists := lastKnown["1:cpu"]; exists {
-			t.Errorf("lastKnown should not be populated by a skipped bucket")
-		}
-	})
-
-	t.Run("null bucket carries forward prior value", func(t *testing.T) {
-		lastKnown := map[string]float64{"1:cpu": 7.25}
-		val, ok := resolveMetricValue(nil, "1:cpu", lastKnown)
-		if !ok || val != 7.25 {
-			t.Fatalf("got (%v, %v), want (7.25, true)", val, ok)
-		}
-	})
-
-	nonFinite := []struct {
-		name string
-		in   float64
-	}{
-		{"NaN", math.NaN()},
-		{"+Inf", math.Inf(1)},
-		{"-Inf", math.Inf(-1)},
-	}
-	for _, nf := range nonFinite {
-		t.Run(nf.name+" with no prior value is skipped", func(t *testing.T) {
-			lastKnown := map[string]float64{}
-			_, ok := resolveMetricValue(nf.in, "1:cpu", lastKnown)
-			if ok {
-				t.Fatalf("expected %s to be skipped when no prior value", nf.name)
-			}
-			if _, exists := lastKnown["1:cpu"]; exists {
-				t.Errorf("%s must not poison lastKnown", nf.name)
-			}
-		})
-
-		t.Run(nf.name+" carries forward prior value", func(t *testing.T) {
-			lastKnown := map[string]float64{"1:cpu": 42}
-			val, ok := resolveMetricValue(nf.in, "1:cpu", lastKnown)
-			if !ok || val != 42 {
-				t.Fatalf("got (%v, %v), want (42, true)", val, ok)
-			}
-			if lastKnown["1:cpu"] != 42 {
-				t.Errorf("%s overwrote the last known good value: %v", nf.name, lastKnown["1:cpu"])
-			}
-		})
-	}
-}
-
 func TestToFloat64(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -490,6 +443,10 @@ func TestToFloat64(t *testing.T) {
 		{"uint16", uint16(25), 25, true},
 		{"uint8", uint8(12), 12, true},
 		{"string", "abc", 0, false},
+		{"nan", math.NaN(), 0, false},
+		{"pos_inf", math.Inf(1), 0, false},
+		{"neg_inf", math.Inf(-1), 0, false},
+		{"float32_nan", float32(math.NaN()), 0, false},
 	}
 
 	for _, tt := range tests {
@@ -556,6 +513,36 @@ func TestToFloat64_PointerAndNumeric(t *testing.T) {
 			}
 			if result != tt.expected {
 				t.Errorf("toFloat64(%v) = %v, want %v",
+					tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFiniteFloat(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      float64
+		expected   float64
+		expectedOk bool
+	}{
+		{"zero", 0, 0, true},
+		{"positive", 3.14, 3.14, true},
+		{"negative", -2.5, -2.5, true},
+		{"nan", math.NaN(), 0, false},
+		{"pos_inf", math.Inf(1), 0, false},
+		{"neg_inf", math.Inf(-1), 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := finiteFloat(tt.input)
+			if ok != tt.expectedOk {
+				t.Errorf("finiteFloat(%v) ok = %v, want %v",
+					tt.input, ok, tt.expectedOk)
+			}
+			if result != tt.expected {
+				t.Errorf("finiteFloat(%v) = %v, want %v",
 					tt.input, result, tt.expected)
 			}
 		})
@@ -772,6 +759,190 @@ func TestResolveOrderByColumn(t *testing.T) {
 		_, err := ResolveOrderByColumn("1; DROP TABLE metrics.pg_stat_all_tables", metricCols)
 		if err == nil {
 			t.Fatal("expected error for injection attempt")
+		}
+	})
+}
+
+// tableCols mimics the numeric metric columns discovered for the
+// pg_stat_all_tables probe, which the table dashboards depend on.
+var tableCols = []string{
+	"seq_scan", "idx_scan", "n_tup_ins", "n_tup_upd", "n_tup_del",
+	"n_tup_hot_upd", "n_live_tup", "n_dead_tup",
+}
+
+func TestClassifyMetrics(t *testing.T) {
+	t.Run("empty request returns all columns as raw", func(t *testing.T) {
+		raw, derived, order, err := classifyMetrics(
+			nil, []string{"seq_scan", "idx_scan"}, "pg_stat_all_tables")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(derived) != 0 {
+			t.Errorf("expected no derived metrics, got %d", len(derived))
+		}
+		if len(raw) != 2 || len(order) != 2 {
+			t.Errorf("expected 2 raw/order entries, got %d/%d",
+				len(raw), len(order))
+		}
+		if order[0] != "seq_scan" || order[1] != "idx_scan" {
+			t.Errorf("unexpected order: %v", order)
+		}
+	})
+
+	t.Run("raw column accepted", func(t *testing.T) {
+		raw, derived, order, err := classifyMetrics(
+			[]string{"seq_scan"}, tableCols, "pg_stat_all_tables")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(raw) != 1 || raw[0] != "seq_scan" {
+			t.Errorf("expected raw [seq_scan], got %v", raw)
+		}
+		if len(derived) != 0 {
+			t.Errorf("expected no derived, got %v", derived)
+		}
+		if len(order) != 1 || order[0] != "seq_scan" {
+			t.Errorf("unexpected order: %v", order)
+		}
+	})
+
+	t.Run("valid per_sec base accepted", func(t *testing.T) {
+		raw, derived, order, err := classifyMetrics(
+			[]string{"seq_scan_per_sec"}, tableCols, "pg_stat_all_tables")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(raw) != 0 {
+			t.Errorf("expected no raw columns, got %v", raw)
+		}
+		if len(derived) != 1 {
+			t.Fatalf("expected 1 derived, got %d", len(derived))
+		}
+		if derived[0].Kind != DerivedPerSec {
+			t.Errorf("expected DerivedPerSec, got %v", derived[0].Kind)
+		}
+		if derived[0].BaseColumn != "seq_scan" {
+			t.Errorf("expected base seq_scan, got %q", derived[0].BaseColumn)
+		}
+		if derived[0].OutputName != "seq_scan_per_sec" {
+			t.Errorf("unexpected output name %q", derived[0].OutputName)
+		}
+		if len(order) != 1 || order[0] != "seq_scan_per_sec" {
+			t.Errorf("unexpected order: %v", order)
+		}
+	})
+
+	t.Run("per_sec suffix on non-column rejected", func(t *testing.T) {
+		_, _, _, err := classifyMetrics(
+			[]string{"bogus_per_sec"}, tableCols, "pg_stat_all_tables")
+		if err == nil {
+			t.Fatal("expected error for non-column per_sec base")
+		}
+		if !strings.Contains(err.Error(), "bogus_per_sec") {
+			t.Errorf("error should name the metric, got %q", err.Error())
+		}
+	})
+
+	t.Run("bare per_sec suffix rejected", func(t *testing.T) {
+		_, _, _, err := classifyMetrics(
+			[]string{"_per_sec"}, tableCols, "pg_stat_all_tables")
+		if err == nil {
+			t.Fatal("expected error for bare _per_sec")
+		}
+	})
+
+	t.Run("real column ending in per_sec wins over derived", func(t *testing.T) {
+		cols := []string{"seq_scan", "custom_per_sec"}
+		raw, derived, _, err := classifyMetrics(
+			[]string{"custom_per_sec"}, cols, "pg_stat_all_tables")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(derived) != 0 {
+			t.Errorf("expected raw treatment, got derived %v", derived)
+		}
+		if len(raw) != 1 || raw[0] != "custom_per_sec" {
+			t.Errorf("expected raw [custom_per_sec], got %v", raw)
+		}
+	})
+
+	t.Run("dead_tuple_ratio accepted when both columns present", func(t *testing.T) {
+		_, derived, order, err := classifyMetrics(
+			[]string{"dead_tuple_ratio"}, tableCols, "pg_stat_all_tables")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(derived) != 1 || derived[0].Kind != DerivedDeadTupleRatio {
+			t.Fatalf("expected 1 dead-tuple-ratio derived, got %v", derived)
+		}
+		if derived[0].OutputName != "dead_tuple_ratio" {
+			t.Errorf("unexpected output name %q", derived[0].OutputName)
+		}
+		if len(order) != 1 || order[0] != "dead_tuple_ratio" {
+			t.Errorf("unexpected order: %v", order)
+		}
+	})
+
+	t.Run("dead_tuple_ratio rejected when columns missing", func(t *testing.T) {
+		cols := []string{"seq_scan", "n_live_tup"} // no n_dead_tup
+		_, _, _, err := classifyMetrics(
+			[]string{"dead_tuple_ratio"}, cols, "pg_stat_all_tables")
+		if err == nil {
+			t.Fatal("expected error when n_dead_tup missing")
+		}
+		if !strings.Contains(err.Error(), "n_dead_tup") {
+			t.Errorf("error should mention required columns, got %q",
+				err.Error())
+		}
+	})
+
+	t.Run("unknown metric rejected", func(t *testing.T) {
+		_, _, _, err := classifyMetrics(
+			[]string{"nonexistent"}, tableCols, "pg_stat_all_tables")
+		if err == nil {
+			t.Fatal("expected error for unknown metric")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected not-found error, got %q", err.Error())
+		}
+	})
+
+	t.Run("invalid identifier rejected", func(t *testing.T) {
+		_, _, _, err := classifyMetrics(
+			[]string{"bad-name"}, tableCols, "pg_stat_all_tables")
+		if err == nil {
+			t.Fatal("expected error for invalid identifier")
+		}
+		if !strings.Contains(err.Error(), "invalid metric name") {
+			t.Errorf("expected invalid-identifier error, got %q", err.Error())
+		}
+	})
+
+	t.Run("mixed raw and derived preserves order", func(t *testing.T) {
+		raw, derived, order, err := classifyMetrics(
+			[]string{"seq_scan", "idx_scan_per_sec", "dead_tuple_ratio"},
+			tableCols, "pg_stat_all_tables")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(raw) != 1 || raw[0] != "seq_scan" {
+			t.Errorf("expected raw [seq_scan], got %v", raw)
+		}
+		if len(derived) != 2 {
+			t.Fatalf("expected 2 derived, got %d", len(derived))
+		}
+		if derived[0].Kind != DerivedPerSec ||
+			derived[0].BaseColumn != "idx_scan" {
+			t.Errorf("expected idx_scan per_sec first, got %v", derived[0])
+		}
+		if derived[1].Kind != DerivedDeadTupleRatio {
+			t.Errorf("expected dead_tuple_ratio second, got %v", derived[1])
+		}
+		want := []string{"seq_scan", "idx_scan_per_sec", "dead_tuple_ratio"}
+		for i := range want {
+			if order[i] != want[i] {
+				t.Errorf("order[%d] = %q, want %q", i, order[i], want[i])
+			}
 		}
 	})
 }
@@ -1081,6 +1252,249 @@ func TestSelectLatestOutputColumns(t *testing.T) {
 		got := selectLatestOutputColumns(allCols)
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty", got)
+		}
+	})
+}
+
+func TestRateAggExpr(t *testing.T) {
+	t.Run("standard aggregation", func(t *testing.T) {
+		expr := rateAggExpr("avg", 2, "seq_scan_per_sec")
+		if expr != `avg(rate_2) AS "seq_scan_per_sec"` {
+			t.Errorf("unexpected expr: %s", expr)
+		}
+	})
+
+	t.Run("last aggregation filters nulls", func(t *testing.T) {
+		expr := rateAggExpr("last", 0, "idx_scan_per_sec")
+		if !strings.Contains(expr, "array_agg(rate_0 ORDER BY collected_at DESC)") {
+			t.Errorf("last should use ordered array_agg, got %s", expr)
+		}
+		if !strings.Contains(expr, "FILTER (WHERE rate_0 IS NOT NULL)") {
+			t.Errorf("last should filter NULL rates, got %s", expr)
+		}
+		if !strings.Contains(expr, `AS "idx_scan_per_sec"`) {
+			t.Errorf("last should alias output, got %s", expr)
+		}
+	})
+}
+
+func TestBuildDerivedMetricsQuery(t *testing.T) {
+	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	t.Run("empty derived rejected", func(t *testing.T) {
+		_, _, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables", nil, 1, start, end, 60, "avg",
+			MetricFilters{})
+		if err == nil {
+			t.Fatal("expected error for empty derived slice")
+		}
+	})
+
+	t.Run("single per_sec rate", func(t *testing.T) {
+		query, args, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{{
+				OutputName: "seq_scan_per_sec",
+				BaseColumn: "seq_scan",
+				Kind:       DerivedPerSec,
+			}},
+			1, start, end, 60, "avg", MetricFilters{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		checks := []string{
+			`metrics."pg_stat_all_tables"`,
+			`SUM("seq_scan") AS total_0`,
+			`LAG(SUM("seq_scan")) OVER (ORDER BY collected_at) AS prev_0`,
+			`EXTRACT(EPOCH FROM collected_at`,
+			`CASE WHEN (total_0 - prev_0) >= 0 AND elapsed_sec > 0`,
+			`(total_0 - prev_0)::float / elapsed_sec`,
+			`avg(rate_0) AS "seq_scan_per_sec"`,
+			`generate_series($3::timestamptz, $4::timestamptz, $1::interval)`,
+			`LEFT JOIN rate_buckets ON all_buckets.bucket_time = rate_buckets.bucket_time`,
+			`rate_buckets."seq_scan_per_sec"`,
+			`connection_id = $2`,
+		}
+		for _, c := range checks {
+			if !strings.Contains(query, c) {
+				t.Errorf("query missing %q\n---\n%s", c, query)
+			}
+		}
+		if strings.Contains(query, "ratio_buckets") {
+			t.Error("query should not reference ratio_buckets")
+		}
+		if len(args) != 4 {
+			t.Errorf("expected 4 args, got %d", len(args))
+		}
+		if args[1] != 1 {
+			t.Errorf("expected connection_id=1, got %v", args[1])
+		}
+	})
+
+	t.Run("multiple per_sec rates", func(t *testing.T) {
+		query, _, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{
+				{OutputName: "n_tup_ins_per_sec", BaseColumn: "n_tup_ins", Kind: DerivedPerSec},
+				{OutputName: "n_tup_upd_per_sec", BaseColumn: "n_tup_upd", Kind: DerivedPerSec},
+			},
+			1, start, end, 60, "avg", MetricFilters{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, c := range []string{
+			`SUM("n_tup_ins") AS total_0`,
+			`SUM("n_tup_upd") AS total_1`,
+			"rate_0", "rate_1",
+			`avg(rate_0) AS "n_tup_ins_per_sec"`,
+			`avg(rate_1) AS "n_tup_upd_per_sec"`,
+		} {
+			if !strings.Contains(query, c) {
+				t.Errorf("query missing %q", c)
+			}
+		}
+	})
+
+	t.Run("dead_tuple_ratio uses 0-100 scale", func(t *testing.T) {
+		query, args, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{{
+				OutputName: "dead_tuple_ratio",
+				Kind:       DerivedDeadTupleRatio,
+			}},
+			1, start, end, 60, "avg", MetricFilters{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, c := range []string{
+			`SUM("n_live_tup")`,
+			`SUM("n_dead_tup")`,
+			`* 100.0`,
+			`END AS dead_tuple_ratio`,
+			`ratio_buckets.dead_tuple_ratio`,
+			`LEFT JOIN ratio_buckets ON all_buckets.bucket_time = ratio_buckets.bucket_time`,
+		} {
+			if !strings.Contains(query, c) {
+				t.Errorf("query missing %q\n---\n%s", c, query)
+			}
+		}
+		if strings.Contains(query, "rate_buckets") {
+			t.Error("ratio-only query should not reference rate_buckets")
+		}
+		if len(args) != 4 {
+			t.Errorf("expected 4 args, got %d", len(args))
+		}
+	})
+
+	t.Run("mixed per_sec and ratio", func(t *testing.T) {
+		query, _, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{
+				{OutputName: "seq_scan_per_sec", BaseColumn: "seq_scan", Kind: DerivedPerSec},
+				{OutputName: "dead_tuple_ratio", Kind: DerivedDeadTupleRatio},
+			},
+			1, start, end, 60, "avg", MetricFilters{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, c := range []string{
+			"rate_samples AS", "rate_buckets AS", "ratio_buckets AS",
+			`rate_buckets."seq_scan_per_sec"`,
+			"ratio_buckets.dead_tuple_ratio",
+			"LEFT JOIN rate_buckets", "LEFT JOIN ratio_buckets",
+		} {
+			if !strings.Contains(query, c) {
+				t.Errorf("query missing %q", c)
+			}
+		}
+		// The per_sec output must precede the ratio output.
+		iRate := strings.Index(query, `rate_buckets."seq_scan_per_sec"`)
+		iRatio := strings.Index(query, "ratio_buckets.dead_tuple_ratio")
+		if iRate < 0 || iRatio < 0 || iRate > iRatio {
+			t.Errorf("output columns out of order: rate=%d ratio=%d",
+				iRate, iRatio)
+		}
+	})
+
+	t.Run("filters add args and clauses", func(t *testing.T) {
+		query, args, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{{
+				OutputName: "seq_scan_per_sec",
+				BaseColumn: "seq_scan",
+				Kind:       DerivedPerSec,
+			}},
+			1, start, end, 60, "avg",
+			MetricFilters{
+				DatabaseName:   "mydb",
+				DatabaseColumn: "database_name",
+				SchemaName:     "public",
+				TableName:      "users",
+			})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, c := range []string{
+			`"database_name" = $5`,
+			"schemaname = $6",
+			"relname = $7",
+		} {
+			if !strings.Contains(query, c) {
+				t.Errorf("query missing filter %q", c)
+			}
+		}
+		if len(args) != 7 {
+			t.Errorf("expected 7 args, got %d", len(args))
+		}
+	})
+
+	t.Run("last aggregation on rate", func(t *testing.T) {
+		query, _, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{{
+				OutputName: "seq_scan_per_sec",
+				BaseColumn: "seq_scan",
+				Kind:       DerivedPerSec,
+			}},
+			1, start, end, 60, "last", MetricFilters{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(query, "array_agg(rate_0 ORDER BY collected_at DESC)") {
+			t.Errorf("last aggregation should use array_agg, got:\n%s", query)
+		}
+		if !strings.Contains(query, "FILTER (WHERE rate_0 IS NOT NULL)") {
+			t.Error("last aggregation should filter NULL rates")
+		}
+	})
+
+	t.Run("unknown derived kind rejected", func(t *testing.T) {
+		_, _, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{{OutputName: "weird", Kind: DerivedMetricKind(99)}},
+			1, start, end, 60, "avg", MetricFilters{})
+		if err == nil {
+			t.Fatal("expected error for unknown derived kind")
+		}
+	})
+
+	t.Run("sub-second bucket width clamped", func(t *testing.T) {
+		tinyEnd := start.Add(time.Second)
+		query, _, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{{
+				OutputName: "seq_scan_per_sec",
+				BaseColumn: "seq_scan",
+				Kind:       DerivedPerSec,
+			}},
+			1, start, tinyEnd, 60, "avg", MetricFilters{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(query, "rate_buckets") {
+			t.Error("query should still build with clamped bucket width")
 		}
 	})
 }

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -945,6 +945,38 @@ func TestClassifyMetrics(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("duplicate metric names deduplicated", func(t *testing.T) {
+		raw, derived, order, err := classifyMetrics(
+			[]string{
+				"seq_scan", "seq_scan",
+				"idx_scan_per_sec", "idx_scan_per_sec",
+				"dead_tuple_ratio", "dead_tuple_ratio",
+			},
+			tableCols, "pg_stat_all_tables")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(raw) != 1 || raw[0] != "seq_scan" {
+			t.Errorf("expected raw [seq_scan], got %v", raw)
+		}
+		if len(derived) != 2 {
+			t.Fatalf("expected 2 derived, got %d: %v", len(derived), derived)
+		}
+		if derived[0].OutputName != "idx_scan_per_sec" ||
+			derived[1].OutputName != "dead_tuple_ratio" {
+			t.Errorf("unexpected derived: %v", derived)
+		}
+		want := []string{"seq_scan", "idx_scan_per_sec", "dead_tuple_ratio"}
+		if len(order) != len(want) {
+			t.Fatalf("expected order %v, got %v", want, order)
+		}
+		for i := range want {
+			if order[i] != want[i] {
+				t.Errorf("order[%d] = %q, want %q", i, order[i], want[i])
+			}
+		}
+	})
 }
 
 func TestBuildLatestRowsQuery(t *testing.T) {
@@ -1482,7 +1514,7 @@ func TestBuildDerivedMetricsQuery(t *testing.T) {
 
 	t.Run("sub-second bucket width clamped", func(t *testing.T) {
 		tinyEnd := start.Add(time.Second)
-		query, _, err := BuildDerivedMetricsQuery(
+		query, args, err := BuildDerivedMetricsQuery(
 			"pg_stat_all_tables",
 			[]DerivedMetric{{
 				OutputName: "seq_scan_per_sec",
@@ -1495,6 +1527,81 @@ func TestBuildDerivedMetricsQuery(t *testing.T) {
 		}
 		if !strings.Contains(query, "rate_buckets") {
 			t.Error("query should still build with clamped bucket width")
+		}
+		if len(args) == 0 || args[0] != "1 seconds" {
+			t.Errorf("expected clamped bucket interval %q, got %v",
+				"1 seconds", args)
+		}
+	})
+
+	t.Run("dead_tuple_ratio last uses latest sample not SUM", func(t *testing.T) {
+		query, _, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_tables",
+			[]DerivedMetric{{
+				OutputName: "dead_tuple_ratio",
+				Kind:       DerivedDeadTupleRatio,
+			}},
+			1, start, end, 60, "last", MetricFilters{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, c := range []string{
+			`(array_agg("n_live_tup" ORDER BY collected_at DESC))[1]`,
+			`(array_agg("n_dead_tup" ORDER BY collected_at DESC))[1]`,
+			`END AS dead_tuple_ratio`,
+			`* 100.0`,
+		} {
+			if !strings.Contains(query, c) {
+				t.Errorf("query missing %q\n---\n%s", c, query)
+			}
+		}
+		if strings.Contains(query, `SUM("n_live_tup")`) ||
+			strings.Contains(query, `SUM("n_dead_tup")`) {
+			t.Errorf("last aggregation should not SUM tuple counts:\n%s", query)
+		}
+	})
+
+	for _, agg := range []string{"avg", "sum", "max"} {
+		t.Run("dead_tuple_ratio "+agg+" uses SUM", func(t *testing.T) {
+			query, _, err := BuildDerivedMetricsQuery(
+				"pg_stat_all_tables",
+				[]DerivedMetric{{
+					OutputName: "dead_tuple_ratio",
+					Kind:       DerivedDeadTupleRatio,
+				}},
+				1, start, end, 60, agg, MetricFilters{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, c := range []string{
+				`SUM("n_live_tup")`,
+				`SUM("n_dead_tup")`,
+			} {
+				if !strings.Contains(query, c) {
+					t.Errorf("query missing %q\n---\n%s", c, query)
+				}
+			}
+			if strings.Contains(query, `array_agg("n_dead_tup"`) {
+				t.Errorf("%s aggregation should not use array_agg:\n%s",
+					agg, query)
+			}
+		})
+	}
+}
+
+func TestRatioTupleExpr(t *testing.T) {
+	t.Run("standard aggregation uses SUM", func(t *testing.T) {
+		expr := ratioTupleExpr("avg", "n_dead_tup")
+		if expr != `SUM("n_dead_tup")` {
+			t.Errorf("unexpected expr: %s", expr)
+		}
+	})
+
+	t.Run("last aggregation uses ordered array_agg", func(t *testing.T) {
+		expr := ratioTupleExpr("last", "n_live_tup")
+		want := `(array_agg("n_live_tup" ORDER BY collected_at DESC))[1]`
+		if expr != want {
+			t.Errorf("expected %q, got %q", want, expr)
 		}
 	})
 }

--- a/server/src/internal/metrics/query_timeseries_db_test.go
+++ b/server/src/internal/metrics/query_timeseries_db_test.go
@@ -1,0 +1,475 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// These integration tests exercise the DB-executing time-series query path,
+// covering both the raw-column branch and the derived-metric branch
+// (per-second rates and the dead-tuple ratio) of QueryTimeSeries, together
+// with the shared scanSeriesRows helper. They follow the same gating
+// convention as query_db_test.go: they connect to TEST_AI_WORKBENCH_SERVER,
+// skip cleanly when it is unset or SKIP_DB_TESTS is set, and skip on any
+// connection or ping failure.
+
+const timeSeriesTestProbe = "pg_stat_all_tables_ts_test"
+
+// setupTimeSeriesFixture creates the metrics schema (if absent) and a probe
+// table carrying the counter and tuple columns the table dashboards depend
+// on. It inserts four connection-1 samples spaced one minute apart across the
+// last few minutes so they fall inside a "1h" query window. The cumulative
+// counters advance by a fixed amount per minute, giving a clean 1.0-per-second
+// rate, whilst n_live_tup and n_dead_tup stay constant at 90 and 10 so the
+// dead-tuple ratio is a steady 10 percent. It returns a cleanup that drops the
+// table.
+func setupTimeSeriesFixture(t *testing.T, pool *pgxpool.Pool) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS metrics"); err != nil {
+		t.Fatalf("failed to create metrics schema: %v", err)
+	}
+
+	dropTable(ctx, pool, timeSeriesTestProbe)
+
+	ddl := `CREATE TABLE metrics."` + timeSeriesTestProbe + `" (
+        connection_id integer NOT NULL,
+        collected_at  timestamp with time zone NOT NULL,
+        inserted_at   timestamp without time zone NOT NULL DEFAULT now(),
+        database_name text,
+        schemaname    name,
+        relname       name,
+        seq_scan      bigint,
+        idx_scan      bigint,
+        n_tup_ins     bigint,
+        n_live_tup    bigint,
+        n_dead_tup    bigint
+    )`
+	if _, err := pool.Exec(ctx, ddl); err != nil {
+		t.Fatalf("failed to create fixture table: %v", err)
+	}
+
+	// Bucket boundaries in QueryTimeSeries are anchored at the window start
+	// (now-1h) with a 60-second width, so minute-aligned samples fall cleanly
+	// into consecutive buckets. Each counter rises by 60 per minute, i.e. a
+	// rate of exactly 1.0 per second between adjacent samples.
+	now := time.Now().UTC().Truncate(time.Minute)
+	type sample struct {
+		offset  time.Duration
+		seqScan int64
+		idxScan int64
+		nTupIns int64
+	}
+	samples := []sample{
+		{-4 * time.Minute, 100, 1000, 50},
+		{-3 * time.Minute, 160, 1060, 110},
+		{-2 * time.Minute, 220, 1120, 170},
+		{-1 * time.Minute, 280, 1180, 230},
+	}
+
+	insert := `INSERT INTO metrics."` + timeSeriesTestProbe + `"
+        (connection_id, collected_at, database_name, schemaname, relname,
+         seq_scan, idx_scan, n_tup_ins, n_live_tup, n_dead_tup)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+	for i, s := range samples {
+		_, err := pool.Exec(ctx, insert,
+			1, now.Add(s.offset), "northwind", "public", "orders",
+			s.seqScan, s.idxScan, s.nTupIns, 90, 10)
+		if err != nil {
+			dropTable(ctx, pool, timeSeriesTestProbe)
+			t.Fatalf("failed to insert fixture sample %d: %v", i, err)
+		}
+	}
+
+	return func() { dropTable(context.Background(), pool, timeSeriesTestProbe) }
+}
+
+func TestScanSeriesRows_Integration(t *testing.T) {
+	pool, closePool := newLatestRowsTestPool(t)
+	defer closePool()
+
+	t.Run("query error surfaces", func(t *testing.T) {
+		// A canceled context fails when the pool tries to acquire a
+		// connection, so pool.Query returns an error before any rows scan.
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		dataMap := map[seriesKey][]MetricDataPoint{}
+		lastKnown := map[string]float64{}
+		err := scanSeriesRows(cctx, pool, "SELECT now(), 1", nil,
+			[]string{"m"}, 1, dataMap, lastKnown)
+		if err == nil {
+			t.Fatal("expected error from canceled context")
+		}
+	})
+
+	t.Run("scan error on destination mismatch", func(t *testing.T) {
+		// Three result columns but only two scan destinations (bucket time
+		// plus one metric) forces a scan destination mismatch.
+		dataMap := map[seriesKey][]MetricDataPoint{}
+		lastKnown := map[string]float64{}
+		err := scanSeriesRows(context.Background(), pool, "SELECT now(), 1, 2",
+			nil, []string{"only_one"}, 1, dataMap, lastKnown)
+		if err == nil {
+			t.Fatal("expected scan error for mismatched destination count")
+		}
+	})
+
+	t.Run("LOCF carries prior value across a NULL gap", func(t *testing.T) {
+		// The query yields a real value, then a NULL, then a real value;
+		// scanSeriesRows must carry the prior value forward across the gap
+		// rather than dropping the bucket.
+		dataMap := map[seriesKey][]MetricDataPoint{}
+		lastKnown := map[string]float64{}
+		query := `SELECT b, v FROM (VALUES
+            (now() - interval '2 min', 5::float8),
+            (now() - interval '1 min', NULL::float8),
+            (now(),                    9::float8)
+        ) AS t(b, v) ORDER BY b`
+		err := scanSeriesRows(context.Background(), pool, query, nil,
+			[]string{"m"}, 1, dataMap, lastKnown)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		data := dataMap[seriesKey{metric: "m", connectionID: 1}]
+		if len(data) != 3 {
+			t.Fatalf("expected 3 points (with LOCF fill), got %d", len(data))
+		}
+		if data[0].Value != 5 || data[1].Value != 5 || data[2].Value != 9 {
+			t.Errorf("unexpected LOCF sequence: %v %v %v",
+				data[0].Value, data[1].Value, data[2].Value)
+		}
+	})
+
+	t.Run("leading NULL with no prior value is skipped", func(t *testing.T) {
+		// A NULL in the very first bucket has no prior value to carry, so it
+		// is dropped; the following real value is retained.
+		dataMap := map[seriesKey][]MetricDataPoint{}
+		lastKnown := map[string]float64{}
+		query := `SELECT b, v FROM (VALUES
+            (now() - interval '1 min', NULL::float8),
+            (now(),                    7::float8)
+        ) AS t(b, v) ORDER BY b`
+		err := scanSeriesRows(context.Background(), pool, query, nil,
+			[]string{"m"}, 1, dataMap, lastKnown)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		data := dataMap[seriesKey{metric: "m", connectionID: 1}]
+		if len(data) != 1 {
+			t.Fatalf("expected 1 point (leading NULL skipped), got %d", len(data))
+		}
+		if data[0].Value != 7 {
+			t.Errorf("retained point = %v, want 7", data[0].Value)
+		}
+	})
+}
+
+// seriesByMetric returns the first series whose Metric matches name, failing
+// the test when no such series is present.
+func seriesByMetric(t *testing.T, series []MetricSeries, name string) MetricSeries {
+	t.Helper()
+	for _, s := range series {
+		if s.Metric == name {
+			return s
+		}
+	}
+	t.Fatalf("no series found for metric %q in %d series", name, len(series))
+	return MetricSeries{}
+}
+
+func TestQueryTimeSeries_Integration(t *testing.T) {
+	pool, closePool := newLatestRowsTestPool(t)
+	defer closePool()
+	cleanup := setupTimeSeriesFixture(t, pool)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("raw column request", func(t *testing.T) {
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "avg", []string{"n_live_tup"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(series) != 1 {
+			t.Fatalf("expected 1 series, got %d", len(series))
+		}
+		s := series[0]
+		if s.Metric != "n_live_tup" || s.Name != "n_live_tup" {
+			t.Errorf("unexpected series identity: metric=%q name=%q",
+				s.Metric, s.Name)
+		}
+		if len(s.Data) == 0 {
+			t.Fatal("expected at least one data point for the raw column")
+		}
+		// n_live_tup is a constant 90 across all samples; averaging or
+		// carrying forward must preserve that value.
+		for _, p := range s.Data {
+			if p.Value != 90 {
+				t.Errorf("raw n_live_tup point = %v, want 90", p.Value)
+			}
+		}
+	})
+
+	t.Run("per_sec rate request", func(t *testing.T) {
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "avg",
+			[]string{"seq_scan_per_sec"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(series) != 1 {
+			t.Fatalf("expected 1 series, got %d", len(series))
+		}
+		s := series[0]
+		if s.Metric != "seq_scan_per_sec" {
+			t.Errorf("unexpected metric %q", s.Metric)
+		}
+		if len(s.Data) == 0 {
+			t.Fatal("expected at least one rate data point")
+		}
+		// The counter rises 60 per 60 seconds, so every rate sample is 1.0.
+		// Rates must never be negative and at least one must reflect the
+		// observed 1.0-per-second delta.
+		sawExpected := false
+		for _, p := range s.Data {
+			if p.Value < 0 {
+				t.Errorf("rate point = %v, want non-negative", p.Value)
+			}
+			if p.Value >= 0.9 && p.Value <= 1.1 {
+				sawExpected = true
+			}
+		}
+		if !sawExpected {
+			t.Errorf("expected a rate near 1.0/sec, got %v", s.Data)
+		}
+	})
+
+	t.Run("per_sec rate with last aggregation", func(t *testing.T) {
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "last",
+			[]string{"idx_scan_per_sec"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := seriesByMetric(t, series, "idx_scan_per_sec")
+		if len(s.Data) == 0 {
+			t.Fatal("expected at least one rate data point")
+		}
+		sawExpected := false
+		for _, p := range s.Data {
+			if p.Value < 0 {
+				t.Errorf("rate point = %v, want non-negative", p.Value)
+			}
+			if p.Value >= 0.9 && p.Value <= 1.1 {
+				sawExpected = true
+			}
+		}
+		if !sawExpected {
+			t.Errorf("expected an idx_scan rate near 1.0/sec, got %v", s.Data)
+		}
+	})
+
+	t.Run("dead_tuple_ratio request", func(t *testing.T) {
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "avg",
+			[]string{"dead_tuple_ratio"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(series) != 1 {
+			t.Fatalf("expected 1 series, got %d", len(series))
+		}
+		s := series[0]
+		if s.Metric != "dead_tuple_ratio" {
+			t.Errorf("unexpected metric %q", s.Metric)
+		}
+		if len(s.Data) == 0 {
+			t.Fatal("expected at least one ratio data point")
+		}
+		// 10 dead / (90 live + 10 dead) * 100 = 10 percent, on a 0-100 scale.
+		sawExpected := false
+		for _, p := range s.Data {
+			if p.Value < 0 || p.Value > 100 {
+				t.Errorf("ratio point = %v, want within [0,100]", p.Value)
+			}
+			if p.Value >= 9.0 && p.Value <= 11.0 {
+				sawExpected = true
+			}
+		}
+		if !sawExpected {
+			t.Errorf("expected a dead-tuple ratio near 10, got %v", s.Data)
+		}
+	})
+
+	t.Run("mixed raw and derived preserves request order", func(t *testing.T) {
+		requested := []string{"n_live_tup", "seq_scan_per_sec", "dead_tuple_ratio"}
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "avg", requested)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(series) != len(requested) {
+			t.Fatalf("expected %d series, got %d", len(requested), len(series))
+		}
+		for i, want := range requested {
+			if series[i].Metric != want {
+				t.Errorf("series[%d].Metric = %q, want %q",
+					i, series[i].Metric, want)
+			}
+		}
+	})
+
+	t.Run("empty request returns all numeric columns", func(t *testing.T) {
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "avg", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// All five numeric counter columns are discovered as raw metrics.
+		for _, want := range []string{
+			"seq_scan", "idx_scan", "n_tup_ins", "n_live_tup", "n_dead_tup",
+		} {
+			seriesByMetric(t, series, want)
+		}
+	})
+
+	t.Run("unknown metric rejected", func(t *testing.T) {
+		_, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "avg",
+			[]string{"not_a_real_metric"})
+		if err == nil {
+			t.Fatal("expected error for unknown metric")
+		}
+	})
+
+	t.Run("invalid time range rejected", func(t *testing.T) {
+		_, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "bogus", MetricFilters{}, 60, "avg", []string{"seq_scan"})
+		if err == nil {
+			t.Fatal("expected error for invalid time range")
+		}
+	})
+
+	t.Run("missing probe rejected", func(t *testing.T) {
+		_, err := QueryTimeSeries(ctx, pool, "does_not_exist_probe",
+			[]int{1}, "1h", MetricFilters{}, 60, "avg", []string{"seq_scan"})
+		if err == nil {
+			t.Fatal("expected error for missing probe")
+		}
+	})
+
+	t.Run("invalid probe name rejected", func(t *testing.T) {
+		_, err := QueryTimeSeries(ctx, pool, "bad-name",
+			[]int{1}, "1h", MetricFilters{}, 60, "avg", []string{"seq_scan"})
+		if err == nil {
+			t.Fatal("expected error for invalid probe name")
+		}
+	})
+
+	t.Run("canceled context surfaces probe-verify error", func(t *testing.T) {
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := QueryTimeSeries(cctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "avg", []string{"seq_scan"})
+		if err == nil {
+			t.Fatal("expected error from canceled context")
+		}
+	})
+
+	t.Run("multiple connections tag series with connection id", func(t *testing.T) {
+		// Connection 2 has no fixture rows, but requesting more than one
+		// connection must still tag every series name with its connection
+		// and emit an empty series for the connection without data.
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1, 2}, "1h", MetricFilters{}, 60, "avg", []string{"n_live_tup"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(series) != 2 {
+			t.Fatalf("expected 2 series (one per connection), got %d",
+				len(series))
+		}
+		names := map[string]bool{}
+		for _, s := range series {
+			names[s.Name] = true
+			if s.Metric != "n_live_tup" {
+				t.Errorf("unexpected metric %q", s.Metric)
+			}
+		}
+		for _, want := range []string{"n_live_tup (conn 1)", "n_live_tup (conn 2)"} {
+			if !names[want] {
+				t.Errorf("expected series named %q, got %v", want, names)
+			}
+		}
+	})
+
+	t.Run("probe with no numeric columns rejected", func(t *testing.T) {
+		const internalOnly = "ts_internal_only_test"
+		dropTable(ctx, pool, internalOnly)
+		ddl := `CREATE TABLE metrics."` + internalOnly + `" (
+            connection_id integer NOT NULL,
+            collected_at  timestamp with time zone NOT NULL,
+            inserted_at   timestamp without time zone NOT NULL DEFAULT now(),
+            relname       name
+        )`
+		if _, err := pool.Exec(ctx, ddl); err != nil {
+			t.Fatalf("failed to create internal-only table: %v", err)
+		}
+		defer dropTable(ctx, pool, internalOnly)
+
+		_, err := QueryTimeSeries(ctx, pool, internalOnly,
+			[]int{1}, "1h", MetricFilters{}, 60, "avg", nil)
+		if err == nil {
+			t.Fatal("expected error for probe with no numeric metrics")
+		}
+	})
+
+	t.Run("raw query execution error propagates", func(t *testing.T) {
+		// An aggregation that names no real SQL function makes the built raw
+		// query fail at execution, exercising the raw-path error return.
+		_, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "no_such_agg",
+			[]string{"seq_scan"})
+		if err == nil {
+			t.Fatal("expected error from failing raw query")
+		}
+	})
+
+	t.Run("derived query execution error propagates", func(t *testing.T) {
+		// The same invalid aggregation makes the derived rate query fail at
+		// execution, exercising the derived-path error return.
+		_, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{}, 60, "no_such_agg",
+			[]string{"seq_scan_per_sec"})
+		if err == nil {
+			t.Fatal("expected error from failing derived query")
+		}
+	})
+
+	t.Run("database filter resolves and narrows", func(t *testing.T) {
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h", MetricFilters{DatabaseName: "northwind"}, 60,
+			"avg", []string{"n_live_tup"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := seriesByMetric(t, series, "n_live_tup")
+		if len(s.Data) == 0 {
+			t.Fatal("expected data for matching database filter")
+		}
+	})
+}


### PR DESCRIPTION
## Symptom

The "Activity Charts" section of the Table and Index object-detail dashboards ("No tuple operation data available", "No scan data available", "No dead tuple data available") were permanently blank, even against a monitored server with completely normal, healthy activity and confirmed-good underlying data.

## Root cause

Those charts call `GET /api/v1/metrics/query` requesting **computed** metric names that don't exist as literal columns in the underlying `metrics.*` tables:

- Table dashboard: `n_tup_ins_per_sec`, `n_tup_upd_per_sec`, `n_tup_del_per_sec`, `n_tup_hot_upd_per_sec`, `seq_scan_per_sec`, `idx_scan_per_sec`, `dead_tuple_ratio` (probe `pg_stat_all_tables`)
- Index dashboard: `idx_scan_per_sec` (probe `pg_stat_all_indexes`)

The generic time-series endpoint only recognizes literal columns discovered via `information_schema.columns`. Requesting a computed name like `seq_scan_per_sec` (the table only has the raw cumulative counter `seq_scan`) returned `400 metric "seq_scan_per_sec" not found in probe "pg_stat_all_tables"`, which the client's fetch hook rendered as a generic "no data" message.

This same class of computation (rate-per-second from a delta between samples, and a dead-tuple percentage) is already implemented correctly elsewhere in the codebase (`server/src/internal/api/perf_summary_handlers.go`), just never wired into the generic endpoint these two dashboards depend on.

Note: this investigation originally also flagged the Estate and Cluster dashboards as affected by the same pattern (same `_per_sec`/`_ratio` substrings showed up in a grep), but on closer inspection those two components call the existing, already-working `/api/v1/metrics/performance-summary` endpoint, not the generic query path — they were a false-positive match and are unaffected.

## Fix

- Added derived-metric support to the generic query path (`classifyMetrics`, `BuildDerivedMetricsQuery` in `server/src/internal/metrics/query.go`):
  - Any requested metric name ending in `_per_sec` is treated as a per-second rate request. The prefix is validated against the probe's real, discovered numeric columns before use — an unknown base column is rejected with a clear 400, not silently ignored. The rate itself uses the same delta/elapsed-time pattern (with counter-reset and non-positive-elapsed-time guards) already used for the equivalent calculation elsewhere in the codebase.
  - The literal name `dead_tuple_ratio` is accepted only for probes that expose both `n_live_tup` and `n_dead_tup`, computed on the same 0-100 percentage scale the client already expects, using the identical formula used elsewhere in the codebase for the same figure.
  - A single request can mix raw columns and either/both derived-metric kinds.
- Reused/extended the NaN/Infinity-safe float handling so these new computations can't reintroduce that class of bug (this branch predates the separate, still-open NaN-safety fix, so equivalent protection was added independently here).
- No client changes were needed — the client already sent the correct requests and expects exactly this data back.

## Test plan

- [x] `go build ./...` and `go test ./...` pass for the full `server` module
- [x] New unit tests for classification (raw column wins over a coincidental `_per_sec`-suffixed name, valid/invalid `_per_sec` base columns, `dead_tuple_ratio` accepted/rejected by column presence, mixed raw+derived requests preserve order) and for the derived SQL builder (single/multiple rates, ratio scale, filters, all supported aggregations)
- [x] New pure/validation/SQL-building logic at 100% function coverage; DB-orchestration functions mirror the pre-existing untested-without-a-live-pool scoping already accepted for two earlier, related fixes to this file
- [x] `gofmt` clean
- [x] Manually verified both new SQL patterns directly against a live datastore with real table activity (rate and ratio queries both returned correct, sane values)
- [x] Security review completed — traced the full `BaseColumn` validation path (including case/whitespace/cross-probe-column confusion attempts), confirmed `dead_tuple_ratio` only ever uses hardcoded column names, confirmed RBAC is inherited correctly, confirmed no new DoS surface beyond what the existing raw-column path already has — no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added derived Activity Chart metrics, including per-second rates for counter columns and dead-tuple ratio metrics for table dashboards.
* **Bug Fixes**
  * Fixed Activity Charts that could remain blank on Table and Index object-detail dashboards despite healthy servers.
  * Improved handling of missing/invalid/non-finite metric values to avoid chart rendering failures.
  * Maintained chart continuity across time gaps and sampling intervals.
* **Documentation**
  * Updated the changelog with the Activity Charts fix details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->