### PR TITLE
Fix Estate dashboard panels getting stuck on "No data" after a transient failure

### DIFF
--- a/client/src/components/Dashboard/EstateDashboard/KpiTilesSection.tsx
+++ b/client/src/components/Dashboard/EstateDashboard/KpiTilesSection.tsx
@@ -118,6 +118,11 @@ const KpiTilesSection: React.FC<KpiTilesSectionProps> = ({ selection, serverIds 
 
             const alertCount = (alertsData.alerts || []).length;
 
+            // A late resolution after unmount must not touch state; a
+            // superseded/unmounted attempt is not a failure, so report
+            // success to keep it out of the retry schedule.
+            if (!isMountedRef.current) { return true; }
+
             setAggregate({
                 totalServers,
                 totalConnections,

--- a/client/src/components/Dashboard/EstateDashboard/KpiTilesSection.tsx
+++ b/client/src/components/Dashboard/EstateDashboard/KpiTilesSection.tsx
@@ -21,6 +21,7 @@ import { formatNumber } from '../../../utils/formatters';
 import { KPI_GRID_SX } from '../styles';
 import { countEstateServers } from '../../../utils/clusterHelpers';
 import { logger } from '../../../utils/logger';
+import { useRetryingFetch } from '../../../hooks/useRetryingFetch';
 import type { EstateSelection } from '../../../types/selection';
 
 interface KpiTilesSectionProps {
@@ -62,12 +63,16 @@ const KpiTilesSection: React.FC<KpiTilesSectionProps> = ({ selection, serverIds 
     const [error, setError] = useState<string | null>(null);
     const isMountedRef = useRef<boolean>(true);
     const initialLoadDoneRef = useRef<boolean>(false);
+    const { run, retrying } = useRetryingFetch({
+        resetKey: lastRefresh,
+        enabled: !!user && serverIds.length > 0,
+    });
 
     const totalServers = useMemo(() => countEstateServers(selection), [selection]);
     const serverIdsKey = serverIds.join(',');
 
-    const fetchAggregateData = useCallback(async (): Promise<void> => {
-        if (!user || serverIds.length === 0) { return; }
+    const fetchAggregateData = useCallback(async (): Promise<boolean> => {
+        if (!user || serverIds.length === 0) { return true; }
 
         if (!initialLoadDoneRef.current) {
             setLoading(true);
@@ -84,7 +89,7 @@ const KpiTilesSection: React.FC<KpiTilesSectionProps> = ({ selection, serverIds 
                 ),
             ]);
 
-            if (!isMountedRef.current) { return; }
+            if (!isMountedRef.current) { return true; }
 
             let totalConnections = 0;
             let transactionRate = 0;
@@ -116,11 +121,13 @@ const KpiTilesSection: React.FC<KpiTilesSectionProps> = ({ selection, serverIds 
             });
 
             initialLoadDoneRef.current = true;
+            return true;
         } catch (err) {
             logger.error('Error fetching estate KPI data:', err);
             if (isMountedRef.current) {
                 setError((err as Error).message || 'Failed to fetch KPI data');
             }
+            return false;
         } finally {
             if (isMountedRef.current) {
                 setLoading(false);
@@ -136,13 +143,13 @@ const KpiTilesSection: React.FC<KpiTilesSectionProps> = ({ selection, serverIds 
         isMountedRef.current = true;
 
         if (user && serverIds.length > 0) {
-            void fetchAggregateData();
+            void run(fetchAggregateData);
         }
 
         return () => {
             isMountedRef.current = false;
         };
-    }, [user, serverIds.length, fetchAggregateData, lastRefresh]);
+    }, [user, serverIds.length, run, fetchAggregateData, lastRefresh]);
 
     if (loading && !initialLoadDoneRef.current) {
         return (
@@ -154,8 +161,8 @@ const KpiTilesSection: React.FC<KpiTilesSectionProps> = ({ selection, serverIds 
 
     if (error) {
         return (
-            <Typography sx={ERROR_SX}>
-                {error}
+            <Typography sx={ERROR_SX} role="status">
+                {retrying ? 'Reconnecting…' : error}
             </Typography>
         );
     }

--- a/client/src/components/Dashboard/EstateDashboard/KpiTilesSection.tsx
+++ b/client/src/components/Dashboard/EstateDashboard/KpiTilesSection.tsx
@@ -91,27 +91,32 @@ const KpiTilesSection: React.FC<KpiTilesSectionProps> = ({ selection, serverIds 
 
             if (!isMountedRef.current) { return true; }
 
+            // A non-OK response is a real failure. Surface it so the
+            // retry controller reschedules the fetch instead of silently
+            // rendering zero/partial KPI data as if the load succeeded.
+            if (!perfResponse.ok || !alertsResponse.ok) {
+                if (isMountedRef.current) {
+                    setError('Failed to fetch KPI data');
+                }
+                return false;
+            }
+
+            const perfData = await perfResponse.json();
+            const alertsData = await alertsResponse.json();
+
             let totalConnections = 0;
             let transactionRate = 0;
+            const connections = perfData.connections || [];
 
-            if (perfResponse.ok) {
-                const perfData = await perfResponse.json();
-                const connections = perfData.connections || [];
+            connections.forEach((conn: Record<string, unknown>) => {
+                totalConnections += 1;
+                const txns = conn.transactions as Record<string, unknown> | undefined;
+                if (txns && typeof txns.commits_per_sec === 'number') {
+                    transactionRate += txns.commits_per_sec;
+                }
+            });
 
-                connections.forEach((conn: Record<string, unknown>) => {
-                    totalConnections += 1;
-                    const txns = conn.transactions as Record<string, unknown> | undefined;
-                    if (txns && typeof txns.commits_per_sec === 'number') {
-                        transactionRate += txns.commits_per_sec;
-                    }
-                });
-            }
-
-            let alertCount = 0;
-            if (alertsResponse.ok) {
-                const alertsData = await alertsResponse.json();
-                alertCount = (alertsData.alerts || []).length;
-            }
+            const alertCount = (alertsData.alerts || []).length;
 
             setAggregate({
                 totalServers,

--- a/client/src/components/Dashboard/EstateDashboard/__tests__/KpiTilesSection.test.tsx
+++ b/client/src/components/Dashboard/EstateDashboard/__tests__/KpiTilesSection.test.tsx
@@ -1,0 +1,200 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import KpiTilesSection from '../KpiTilesSection';
+import { DEFAULT_RETRY_BASE_DELAY_MS } from '../../../../hooks/useRetryingFetch';
+import type { EstateSelection } from '../../../../types/selection';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApiFetch = vi.fn();
+
+vi.mock('../../../../utils/apiClient', () => ({
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+const mockUser = { id: 1, username: 'testuser' };
+
+vi.mock('../../../../contexts/useAuth', () => ({
+    useAuth: () => ({ user: mockUser }),
+}));
+
+let mockLastRefresh = 0;
+
+vi.mock('../../../../contexts/useClusterData', () => ({
+    useClusterData: () => ({ lastRefresh: mockLastRefresh }),
+}));
+
+// Stub KpiTile to a plain element so the test does not depend on the
+// AICapabilities provider or MUI theming details of the real tile.
+vi.mock('../../KpiTile', () => ({
+    default: ({ label, value, unit }: { label: string; value: string; unit?: string }) => (
+        <div data-testid="kpi-tile">
+            <span>{label}</span>
+            <span>{unit ? `${value} ${unit}` : value}</span>
+        </div>
+    ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function okResponse(body: unknown): Response {
+    return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+    } as unknown as Response;
+}
+
+function errorResponse(): Response {
+    return {
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({}),
+    } as unknown as Response;
+}
+
+const theme = createTheme();
+
+const renderSection = (serverIds: number[]) => {
+    const selection = {
+        type: 'estate',
+        name: 'Estate',
+        status: 'online',
+        groups: [
+            {
+                name: 'group-1',
+                clusters: [
+                    {
+                        name: 'c1',
+                        servers: serverIds.map(id => ({ id, name: `s${id}` })),
+                    },
+                ],
+            },
+        ],
+    } as unknown as EstateSelection;
+
+    return render(
+        <ThemeProvider theme={theme}>
+            <KpiTilesSection selection={selection} serverIds={serverIds} />
+        </ThemeProvider>,
+    );
+};
+
+const perfBody = {
+    connections: [
+        { transactions: { commits_per_sec: 3.5 } },
+        { transactions: { commits_per_sec: 1.25 } },
+    ],
+};
+
+const alertsBody = { alerts: [{ id: 1 }, { id: 2 }, { id: 3 }] };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('KpiTilesSection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLastRefresh = 0;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders aggregated KPI tiles after fetching', async () => {
+        mockApiFetch.mockImplementation((url: string) =>
+            url.includes('/alerts')
+                ? Promise.resolve(okResponse(alertsBody))
+                : Promise.resolve(okResponse(perfBody)),
+        );
+
+        renderSection([1, 2]);
+
+        // Two servers in the estate.
+        await screen.findByText('Total Servers');
+        await waitFor(() => {
+            // Transaction rate is the sum of commits_per_sec, rounded.
+            expect(screen.getByText('4.75 tx/s')).toBeInTheDocument();
+        });
+
+        // Total connections equals the number of connection entries.
+        expect(screen.getByText('Total Connections')).toBeInTheDocument();
+        // Active alerts reflects the alerts payload length.
+        expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('renders nothing to fetch when there are no server ids', async () => {
+        renderSection([]);
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockApiFetch).not.toHaveBeenCalled();
+        // Falls back to the zero-value tiles.
+        expect(screen.getByText('Total Servers')).toBeInTheDocument();
+    });
+
+    it('tolerates a non-ok performance response', async () => {
+        mockApiFetch.mockImplementation((url: string) =>
+            url.includes('/alerts')
+                ? Promise.resolve(okResponse(alertsBody))
+                : Promise.resolve(errorResponse()),
+        );
+
+        renderSection([1]);
+
+        await screen.findByText('Active Alerts');
+        // Alert count still renders from the successful alerts call.
+        await waitFor(() => {
+            expect(screen.getByText('3')).toBeInTheDocument();
+        });
+    });
+
+    it('shows a reconnecting indicator while retrying after a failure', async () => {
+        vi.useFakeTimers();
+        // First attempt rejects (both calls in the Promise.all fail).
+        mockApiFetch.mockRejectedValueOnce(new Error('down'));
+        mockApiFetch.mockRejectedValueOnce(new Error('down'));
+
+        renderSection([1]);
+
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(screen.getByText('Reconnecting…')).toBeInTheDocument();
+
+        // Recover on the scheduled retry.
+        mockApiFetch.mockImplementation((url: string) =>
+            url.includes('/alerts')
+                ? Promise.resolve(okResponse(alertsBody))
+                : Promise.resolve(okResponse(perfBody)),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+        });
+
+        expect(screen.queryByText('Reconnecting…')).not.toBeInTheDocument();
+        expect(screen.getByText('Active Alerts')).toBeInTheDocument();
+    });
+});

--- a/client/src/components/Dashboard/EstateDashboard/__tests__/KpiTilesSection.test.tsx
+++ b/client/src/components/Dashboard/EstateDashboard/__tests__/KpiTilesSection.test.tsx
@@ -152,7 +152,10 @@ describe('KpiTilesSection', () => {
         expect(screen.getByText('Total Servers')).toBeInTheDocument();
     });
 
-    it('tolerates a non-ok performance response', async () => {
+    it('treats a non-ok performance response as a failure and retries', async () => {
+        vi.useFakeTimers();
+        // First attempt: the performance call is non-OK, so the whole
+        // fetch must fail rather than rendering zero/partial data.
         mockApiFetch.mockImplementation((url: string) =>
             url.includes('/alerts')
                 ? Promise.resolve(okResponse(alertsBody))
@@ -161,11 +164,30 @@ describe('KpiTilesSection', () => {
 
         renderSection([1]);
 
-        await screen.findByText('Active Alerts');
-        // Alert count still renders from the successful alerts call.
-        await waitFor(() => {
-            expect(screen.getByText('3')).toBeInTheDocument();
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
         });
+
+        // The failure surfaces as the reconnecting indicator; no KPI
+        // tiles are shown from the partial data.
+        expect(screen.getByText('Reconnecting…')).toBeInTheDocument();
+        expect(screen.queryByText('Active Alerts')).not.toBeInTheDocument();
+
+        // The scheduled retry now sees both calls succeed and recovers.
+        mockApiFetch.mockImplementation((url: string) =>
+            url.includes('/alerts')
+                ? Promise.resolve(okResponse(alertsBody))
+                : Promise.resolve(okResponse(perfBody)),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+        });
+
+        expect(screen.queryByText('Reconnecting…')).not.toBeInTheDocument();
+        expect(screen.getByText('Active Alerts')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
     });
 
     it('shows a reconnecting indicator while retrying after a failure', async () => {

--- a/client/src/components/StatusPanel/PerformanceTiles/__tests__/PerformanceTiles.test.tsx
+++ b/client/src/components/StatusPanel/PerformanceTiles/__tests__/PerformanceTiles.test.tsx
@@ -111,6 +111,7 @@ describe('PerformanceTiles', () => {
             },
             loading: false,
             error: null,
+            retrying: false,
         });
         mockUseDatabaseCacheHit.mockReturnValue({
             databases: [],

--- a/client/src/components/StatusPanel/PerformanceTiles/__tests__/usePerformanceSummary.test.ts
+++ b/client/src/components/StatusPanel/PerformanceTiles/__tests__/usePerformanceSummary.test.ts
@@ -1,0 +1,259 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePerformanceSummary } from '../usePerformanceSummary';
+import { DEFAULT_RETRY_BASE_DELAY_MS } from '../../../../hooks/useRetryingFetch';
+import type {
+    ServerSelection,
+    ClusterSelection,
+    EstateSelection,
+} from '../../../../types/selection';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApiFetch = vi.fn();
+
+vi.mock('../../../../utils/apiClient', () => ({
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+const mockUser = { id: 1, username: 'testuser' };
+let mockAuthUser: typeof mockUser | null = mockUser;
+
+vi.mock('../../../../contexts/useAuth', () => ({
+    useAuth: () => ({ user: mockAuthUser }),
+}));
+
+let mockLastRefresh = 0;
+
+vi.mock('../../../../contexts/useClusterData', () => ({
+    useClusterData: () => ({ lastRefresh: mockLastRefresh }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function okResponse(body: unknown): Response {
+    return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+    } as unknown as Response;
+}
+
+function errorResponse(status = 500, body: unknown = {}): Response {
+    return {
+        ok: false,
+        status,
+        json: () => Promise.resolve(body),
+    } as unknown as Response;
+}
+
+const summaryBody = { time_range: '24h', connections: [] };
+
+const serverSelection: ServerSelection = {
+    type: 'server',
+    id: 7,
+    name: 'server-7',
+    status: 'online',
+    description: '',
+    host: 'localhost',
+    port: 5432,
+    role: 'primary',
+    version: '16',
+    database: 'postgres',
+    username: 'postgres',
+    os: 'linux',
+    platform: 'x86_64',
+};
+
+const clusterSelection: ClusterSelection = {
+    type: 'cluster',
+    id: 'cluster-1',
+    name: 'Cluster 1',
+    status: 'online',
+    description: '',
+    servers: [{ id: 1, name: 's1' }, { id: 2, name: 's2' }],
+    serverIds: [1, 2],
+};
+
+const estateSelection: EstateSelection = {
+    type: 'estate',
+    name: 'Estate',
+    status: 'online',
+    groups: [
+        {
+            name: 'group-1',
+            clusters: [
+                {
+                    name: 'c1',
+                    servers: [{ id: 10, name: 's10' }, { id: 11, name: 's11' }],
+                },
+            ],
+        },
+    ] as unknown as EstateSelection['groups'],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('usePerformanceSummary', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAuthUser = mockUser;
+        mockLastRefresh = 0;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns null data and does not fetch for a null selection', async () => {
+        const { result } = renderHook(() => usePerformanceSummary(null));
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockApiFetch).not.toHaveBeenCalled();
+        expect(result.current.data).toBeNull();
+        expect(result.current.retrying).toBe(false);
+    });
+
+    it('does not fetch when there is no user', async () => {
+        mockAuthUser = null;
+        const { result } = renderHook(() =>
+            usePerformanceSummary(serverSelection),
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockApiFetch).not.toHaveBeenCalled();
+        expect(result.current.data).toBeNull();
+    });
+
+    it('fetches performance data for a server selection', async () => {
+        mockApiFetch.mockResolvedValue(okResponse(summaryBody));
+
+        const { result } = renderHook(() =>
+            usePerformanceSummary(serverSelection),
+        );
+
+        await waitFor(() => {
+            expect(result.current.data).toEqual(summaryBody);
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledWith(
+            '/api/v1/metrics/performance-summary?connection_id=7&time_range=24h',
+        );
+        expect(result.current.error).toBeNull();
+        expect(result.current.retrying).toBe(false);
+    });
+
+    it('builds a multi-connection URL for a cluster selection', async () => {
+        mockApiFetch.mockResolvedValue(okResponse(summaryBody));
+
+        renderHook(() => usePerformanceSummary(clusterSelection));
+
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalled();
+        });
+        expect(mockApiFetch).toHaveBeenCalledWith(
+            '/api/v1/metrics/performance-summary?connection_ids=1,2&time_range=24h',
+        );
+    });
+
+    it('builds a multi-connection URL for an estate selection', async () => {
+        mockApiFetch.mockResolvedValue(okResponse(summaryBody));
+
+        renderHook(() => usePerformanceSummary(estateSelection));
+
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalled();
+        });
+        expect(mockApiFetch).toHaveBeenCalledWith(
+            '/api/v1/metrics/performance-summary?connection_ids=10,11&time_range=24h',
+        );
+    });
+
+    it('yields null data when a server selection has no id', async () => {
+        const noId = { ...serverSelection, id: undefined } as unknown as ServerSelection;
+        const { result } = renderHook(() => usePerformanceSummary(noId));
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockApiFetch).not.toHaveBeenCalled();
+        expect(result.current.data).toBeNull();
+    });
+
+    it('yields null data when a cluster selection has no server ids', async () => {
+        const empty = { ...clusterSelection, serverIds: [] };
+        const { result } = renderHook(() => usePerformanceSummary(empty));
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockApiFetch).not.toHaveBeenCalled();
+        expect(result.current.data).toBeNull();
+    });
+
+    it('surfaces the server error message on a non-ok response', async () => {
+        mockApiFetch.mockResolvedValue(
+            errorResponse(500, { error: 'boom from server' }),
+        );
+
+        const { result } = renderHook(() =>
+            usePerformanceSummary(serverSelection),
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).toBe('boom from server');
+        });
+        expect(result.current.data).toBeNull();
+    });
+
+    it('retries after a failed fetch and heals on recovery', async () => {
+        vi.useFakeTimers();
+        mockApiFetch
+            .mockRejectedValueOnce(new Error('network down'))
+            .mockResolvedValue(okResponse(summaryBody));
+
+        const { result } = renderHook(() =>
+            usePerformanceSummary(serverSelection),
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(result.current.error).toBe('network down');
+        expect(result.current.retrying).toBe(true);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledTimes(2);
+        expect(result.current.data).toEqual(summaryBody);
+        expect(result.current.retrying).toBe(false);
+    });
+});

--- a/client/src/components/StatusPanel/PerformanceTiles/usePerformanceSummary.ts
+++ b/client/src/components/StatusPanel/PerformanceTiles/usePerformanceSummary.ts
@@ -92,8 +92,10 @@ export const usePerformanceSummary = (
                 throw new Error(errorData.error || `Failed to fetch performance data: ${response.status}`);
             }
 
+            const result: PerformanceSummaryData = await response.json();
+            // Re-check mount state after the final await so a late
+            // resolution cannot call setState on an unmounted component.
             if (isMountedRef.current) {
-                const result: PerformanceSummaryData = await response.json();
                 setData(result);
                 initialLoadDoneRef.current = true;
             }

--- a/client/src/components/StatusPanel/PerformanceTiles/usePerformanceSummary.ts
+++ b/client/src/components/StatusPanel/PerformanceTiles/usePerformanceSummary.ts
@@ -15,12 +15,15 @@ import { useClusterData } from '../../../contexts/useClusterData';
 import type { PerformanceSummaryData } from './types';
 import { extractEstateServerIds } from '../../../utils/clusterHelpers';
 import { logger } from '../../../utils/logger';
+import { useRetryingFetch } from '../../../hooks/useRetryingFetch';
 import type { Selection } from '../../../types/selection';
 
 interface UsePerformanceSummaryReturn {
     data: PerformanceSummaryData | null;
     loading: boolean;
     error: string | null;
+    /** True while an automatic retry is pending after a failed fetch. */
+    retrying: boolean;
 }
 
 /**
@@ -38,6 +41,10 @@ export const usePerformanceSummary = (
     const [error, setError] = useState<string | null>(null);
     const isMountedRef = useRef<boolean>(true);
     const initialLoadDoneRef = useRef<boolean>(false);
+    const { run, retrying } = useRetryingFetch({
+        resetKey: lastRefresh,
+        enabled: !!user && !!selection,
+    });
 
     const buildUrl = useCallback((): string | null => {
         if (!selection) {return null;}
@@ -63,13 +70,13 @@ export const usePerformanceSummary = (
         return null;
     }, [selection]);
 
-    const fetchData = useCallback(async (): Promise<void> => {
-        if (!user) {return;}
+    const fetchData = useCallback(async (): Promise<boolean> => {
+        if (!user) {return true;}
 
         const url = buildUrl();
         if (!url) {
             setData(null);
-            return;
+            return true;
         }
 
         if (!initialLoadDoneRef.current) {
@@ -90,12 +97,14 @@ export const usePerformanceSummary = (
                 setData(result);
                 initialLoadDoneRef.current = true;
             }
+            return true;
         } catch (err) {
             logger.error('Error fetching performance summary:', err);
             if (isMountedRef.current) {
                 setError((err as Error).message || 'Failed to fetch performance data');
                 setData(null);
             }
+            return false;
         } finally {
             if (isMountedRef.current) {
                 setLoading(false);
@@ -114,15 +123,15 @@ export const usePerformanceSummary = (
         isMountedRef.current = true;
 
         if (user && selection) {
-            void fetchData();
+            void run(fetchData);
         }
 
         return () => {
             isMountedRef.current = false;
         };
-    }, [user, selection, fetchData, lastRefresh]);
+    }, [user, selection, run, fetchData, lastRefresh]);
 
-    return { data, loading, error };
+    return { data, loading, error, retrying };
 };
 
 export default usePerformanceSummary;

--- a/client/src/components/StatusPanel/__tests__/StatusPanel.acknowledge.test.tsx
+++ b/client/src/components/StatusPanel/__tests__/StatusPanel.acknowledge.test.tsx
@@ -5,24 +5,20 @@
  * Copyright (c) 2025 - 2026, pgEdge, Inc.
  * This software is released under The PostgreSQL License
  *
- * Tests for StatusPanel's alert-fetching resilience. These cover the
- * fetchAlertsData path routed through useRetryingFetch:
- *
- *   - Happy path: alerts render after a successful fetch.
- *   - Retry path: a transient failure leaves the panel empty, then a
- *     scheduled retry succeeds and the alert appears without any
- *     manual refresh.
- *   - Guard path: a server selection missing an id skips the fetch.
+ * Tests for StatusPanel's acknowledgement-refresh handlers. These
+ * confirm that both the single and group acknowledgement flows route
+ * their follow-up refresh through the retry-managed refetchAlerts path
+ * (which re-issues the alerts fetch) rather than an unmanaged direct
+ * call.
  *
  *-------------------------------------------------------------------------
  */
 
 import type React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createPgedgeTheme } from '../../../theme/pgedgeTheme';
-import { DEFAULT_RETRY_BASE_DELAY_MS } from '../../../hooks/useRetryingFetch';
 import type { Selection } from '../../../types/selection';
 
 // ---------------------------------------------------------------------------
@@ -30,10 +26,11 @@ import type { Selection } from '../../../types/selection';
 // ---------------------------------------------------------------------------
 
 const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
 
 vi.mock('../../../utils/apiClient', () => ({
     apiGet: (...args: unknown[]) => mockApiGet(...args),
-    apiPost: vi.fn(),
+    apiPost: (...args: unknown[]) => mockApiPost(...args),
     apiDelete: vi.fn(),
     apiFetch: vi.fn(),
     ApiError: class ApiError extends Error {
@@ -46,7 +43,6 @@ vi.mock('../../../utils/apiClient', () => ({
 }));
 
 const stableUser = { id: 1, username: 'testuser' };
-let mockAuthUser: typeof stableUser | null = stableUser;
 const stableHasPermission = () => false;
 const stableAIValue = { aiEnabled: false };
 const stableClusterValue = { lastRefresh: 0 };
@@ -58,7 +54,7 @@ const stableDashboardValue = {
 };
 
 vi.mock('../../../contexts/useAuth', () => ({
-    useAuth: () => ({ user: mockAuthUser, hasPermission: stableHasPermission }),
+    useAuth: () => ({ user: stableUser, hasPermission: stableHasPermission }),
 }));
 vi.mock('../../../contexts/useAICapabilities', () => ({ useAICapabilities: () => stableAIValue }));
 vi.mock('../../../contexts/useClusterData', () => ({ useClusterData: () => stableClusterValue }));
@@ -88,7 +84,36 @@ vi.mock('../../Dashboard/TimeRangeSelector', () => ({ default: () => null }));
 vi.mock('../SelectionHeader', () => ({ default: () => null }));
 vi.mock('../ServerInfoCard', () => ({ default: () => null }));
 vi.mock('../PerformanceTiles', () => ({ default: () => null }));
-vi.mock('../AcknowledgeDialog', () => ({ default: () => null }));
+
+// Expose the acknowledgement callbacks as buttons so the test can drive
+// the confirm handlers without the real dialog UI.
+vi.mock('../AcknowledgeDialog', () => ({
+    default: ({
+        onConfirm,
+        onConfirmMultiple,
+    }: {
+        onConfirm: (id: number, message: string, fp?: boolean) => void;
+        onConfirmMultiple: (ids: number[], message: string, fp?: boolean) => void;
+    }) => (
+        <div>
+            <button
+                type="button"
+                data-testid="confirm-ack"
+                onClick={() => onConfirm(99, 'ack message', false)}
+            >
+                confirm
+            </button>
+            <button
+                type="button"
+                data-testid="confirm-group-ack"
+                onClick={() => onConfirmMultiple([99, 100], 'group message', false)}
+            >
+                confirm group
+            </button>
+        </div>
+    ),
+}));
+
 vi.mock('../../../hooks/useServerAnalysis', () => ({ hasCachedServerAnalysis: () => false }));
 
 // ---------------------------------------------------------------------------
@@ -135,95 +160,59 @@ const serverSelection: Selection = {
     platform: 'x86_64',
 };
 
-const clusterSelection: Selection = {
-    type: 'cluster',
-    id: 'cluster-1',
-    name: 'Cluster 1',
-    status: 'online',
-    description: '',
-    servers: [{ id: 1, name: 's1' }, { id: 2, name: 's2' }],
-    serverIds: [1, 2],
-};
-
-describe('StatusPanel alert fetch resilience', () => {
+describe('StatusPanel acknowledgement refresh', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mockAuthUser = stableUser;
+        mockApiGet.mockResolvedValue({ alerts: [makeAlertRecord()] });
+        mockApiPost.mockResolvedValue({});
     });
 
     afterEach(() => {
         vi.useRealTimers();
     });
 
-    it('renders alerts after a successful fetch', async () => {
-        mockApiGet.mockResolvedValue({ alerts: [makeAlertRecord()] });
+    it('routes the single-ack refresh through the retry-managed path', async () => {
+        renderPanel(serverSelection);
 
+        // Wait for the initial fetch to settle.
+        expect(await screen.findByText('High CPU Usage')).toBeInTheDocument();
+        const initialGetCalls = mockApiGet.mock.calls.length;
+
+        await act(async () => {
+            screen.getByTestId('confirm-ack').click();
+        });
+
+        // The acknowledgement was posted and a managed refetch followed.
+        expect(mockApiPost).toHaveBeenCalledWith(
+            '/api/v1/alerts/acknowledge',
+            expect.objectContaining({ alert_id: 99, message: 'ack message' }),
+        );
+        await waitFor(() => {
+            expect(mockApiGet.mock.calls.length).toBeGreaterThan(initialGetCalls);
+        });
+    });
+
+    it('routes the group-ack refresh through the retry-managed path', async () => {
         renderPanel(serverSelection);
 
         expect(await screen.findByText('High CPU Usage')).toBeInTheDocument();
-        expect(mockApiGet).toHaveBeenCalledWith(
-            expect.stringContaining('/api/v1/alerts?exclude_cleared=true'),
+        const initialGetCalls = mockApiGet.mock.calls.length;
+
+        await act(async () => {
+            screen.getByTestId('confirm-group-ack').click();
+        });
+
+        // Each alert id is acknowledged, then a managed refetch follows.
+        expect(mockApiPost).toHaveBeenCalledWith(
+            '/api/v1/alerts/acknowledge',
+            expect.objectContaining({ alert_id: 99, message: 'group message' }),
         );
-    });
-
-    it('recovers via a scheduled retry after a transient failure', async () => {
-        vi.useFakeTimers();
-        mockApiGet
-            .mockRejectedValueOnce(new Error('backend restarting'))
-            .mockResolvedValue({ alerts: [makeAlertRecord()] });
-
-        renderPanel(serverSelection);
-
-        // Let the initial (failing) fetch settle.
-        await act(async () => {
-            await Promise.resolve();
-            await Promise.resolve();
-        });
-
-        expect(screen.queryByText('High CPU Usage')).not.toBeInTheDocument();
-
-        // The scheduled retry fires after the base backoff delay.
-        await act(async () => {
-            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
-            await Promise.resolve();
-        });
-
-        expect(mockApiGet).toHaveBeenCalledTimes(2);
-        expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
-    });
-
-    it('skips the fetch when a server selection has no id', async () => {
-        const noId = { ...serverSelection, id: undefined } as unknown as Selection;
-
-        renderPanel(noId);
-
-        await act(async () => {
-            await Promise.resolve();
-        });
-
-        expect(mockApiGet).not.toHaveBeenCalled();
-    });
-
-    it('builds a multi-connection alerts URL for a cluster selection', async () => {
-        mockApiGet.mockResolvedValue({ alerts: [makeAlertRecord()] });
-
-        renderPanel(clusterSelection);
-
-        expect(await screen.findByText('High CPU Usage')).toBeInTheDocument();
-        expect(mockApiGet).toHaveBeenCalledWith(
-            expect.stringContaining('connection_ids=1,2'),
+        expect(mockApiPost).toHaveBeenCalledWith(
+            '/api/v1/alerts/acknowledge',
+            expect.objectContaining({ alert_id: 100, message: 'group message' }),
         );
-    });
-
-    it('skips the fetch and clears alerts when there is no user', async () => {
-        mockAuthUser = null;
-
-        renderPanel(serverSelection);
-
-        await act(async () => {
-            await Promise.resolve();
+        await waitFor(() => {
+            expect(mockApiGet.mock.calls.length).toBeGreaterThan(initialGetCalls);
         });
-
-        expect(mockApiGet).not.toHaveBeenCalled();
     });
 });

--- a/client/src/components/StatusPanel/__tests__/StatusPanel.acknowledge.test.tsx
+++ b/client/src/components/StatusPanel/__tests__/StatusPanel.acknowledge.test.tsx
@@ -15,10 +15,11 @@
  */
 
 import type React from 'react';
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createPgedgeTheme } from '../../../theme/pgedgeTheme';
+import { DEFAULT_RETRY_BASE_DELAY_MS } from '../../../hooks/useRetryingFetch';
 import type { Selection } from '../../../types/selection';
 
 // ---------------------------------------------------------------------------
@@ -171,38 +172,84 @@ describe('StatusPanel acknowledgement refresh', () => {
         vi.useRealTimers();
     });
 
-    it('routes the single-ack refresh through the retry-managed path', async () => {
+    // Flush a handful of microtask turns so a chained
+    // post-then-refetch settles under fake timers without advancing the
+    // clock (the scheduled retry itself is driven separately).
+    const flushMicrotasks = async (turns = 8): Promise<void> => {
+        for (let i = 0; i < turns; i += 1) {
+            await Promise.resolve();
+        }
+    };
+
+    it('reschedules the single-ack refresh through the retry controller', async () => {
+        vi.useFakeTimers();
+        // Initial load succeeds and renders the active alert.
+        mockApiGet.mockResolvedValue({ alerts: [makeAlertRecord()] });
+
         renderPanel(serverSelection);
 
-        // Wait for the initial fetch to settle.
-        expect(await screen.findByText('High CPU Usage')).toBeInTheDocument();
-        const initialGetCalls = mockApiGet.mock.calls.length;
+        await act(async () => {
+            await flushMicrotasks();
+        });
+        expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+
+        // The post-acknowledgement alerts refresh fails on its first
+        // attempt, then recovers on the scheduled retry. A bare
+        // unmanaged fetchAlertsData() would clear the list and never
+        // bring the alert back, so this exercises the retry controller
+        // rather than merely a follow-up fetch.
+        mockApiGet.mockReset();
+        mockApiGet
+            .mockRejectedValueOnce(new Error('backend restarting'))
+            .mockResolvedValue({ alerts: [makeAlertRecord()] });
 
         await act(async () => {
             screen.getByTestId('confirm-ack').click();
+            await flushMicrotasks();
         });
 
-        // The acknowledgement was posted and a managed refetch followed.
+        // The acknowledgement was posted and the failed refresh cleared
+        // the list, so nothing renders while the retry is pending.
         expect(mockApiPost).toHaveBeenCalledWith(
             '/api/v1/alerts/acknowledge',
             expect.objectContaining({ alert_id: 99, message: 'ack message' }),
         );
-        await waitFor(() => {
-            expect(mockApiGet.mock.calls.length).toBeGreaterThan(initialGetCalls);
+        expect(screen.queryByText('High CPU Usage')).not.toBeInTheDocument();
+
+        // Only a retry scheduled by the controller can bring the alert
+        // back after the base backoff delay.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+            await flushMicrotasks();
         });
+
+        expect(mockApiGet).toHaveBeenCalledTimes(2);
+        expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
     });
 
-    it('routes the group-ack refresh through the retry-managed path', async () => {
+    it('reschedules the group-ack refresh through the retry controller', async () => {
+        vi.useFakeTimers();
+        mockApiGet.mockResolvedValue({ alerts: [makeAlertRecord()] });
+
         renderPanel(serverSelection);
 
-        expect(await screen.findByText('High CPU Usage')).toBeInTheDocument();
-        const initialGetCalls = mockApiGet.mock.calls.length;
+        await act(async () => {
+            await flushMicrotasks();
+        });
+        expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+
+        mockApiGet.mockReset();
+        mockApiGet
+            .mockRejectedValueOnce(new Error('backend restarting'))
+            .mockResolvedValue({ alerts: [makeAlertRecord()] });
 
         await act(async () => {
             screen.getByTestId('confirm-group-ack').click();
+            await flushMicrotasks();
         });
 
-        // Each alert id is acknowledged, then a managed refetch follows.
+        // Each alert id was acknowledged, and the failed refresh cleared
+        // the list while the retry is pending.
         expect(mockApiPost).toHaveBeenCalledWith(
             '/api/v1/alerts/acknowledge',
             expect.objectContaining({ alert_id: 99, message: 'group message' }),
@@ -211,8 +258,14 @@ describe('StatusPanel acknowledgement refresh', () => {
             '/api/v1/alerts/acknowledge',
             expect.objectContaining({ alert_id: 100, message: 'group message' }),
         );
-        await waitFor(() => {
-            expect(mockApiGet.mock.calls.length).toBeGreaterThan(initialGetCalls);
+        expect(screen.queryByText('High CPU Usage')).not.toBeInTheDocument();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+            await flushMicrotasks();
         });
+
+        expect(mockApiGet).toHaveBeenCalledTimes(2);
+        expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
     });
 });

--- a/client/src/components/StatusPanel/__tests__/StatusPanel.refetch.test.tsx
+++ b/client/src/components/StatusPanel/__tests__/StatusPanel.refetch.test.tsx
@@ -1,0 +1,228 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ *
+ * Tests for StatusPanel's alert-fetching resilience. These cover the
+ * fetchAlertsData path routed through useRetryingFetch:
+ *
+ *   - Happy path: alerts render after a successful fetch.
+ *   - Retry path: a transient failure leaves the panel empty, then a
+ *     scheduled retry succeeds and the alert appears without any
+ *     manual refresh.
+ *   - Guard path: a server selection missing an id skips the fetch.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import type React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createPgedgeTheme } from '../../../theme/pgedgeTheme';
+import { DEFAULT_RETRY_BASE_DELAY_MS } from '../../../hooks/useRetryingFetch';
+import type { Selection } from '../../../types/selection';
+
+// ---------------------------------------------------------------------------
+// Module mocks -- declared before importing the SUT so vi.mock is hoisted.
+// ---------------------------------------------------------------------------
+
+const mockApiGet = vi.fn();
+
+vi.mock('../../../utils/apiClient', () => ({
+    apiGet: (...args: unknown[]) => mockApiGet(...args),
+    apiPost: vi.fn(),
+    apiDelete: vi.fn(),
+    apiFetch: vi.fn(),
+    ApiError: class ApiError extends Error {
+        public readonly statusCode: number;
+        constructor(message: string, statusCode: number) {
+            super(message);
+            this.statusCode = statusCode;
+        }
+    },
+}));
+
+const stableUser = { id: 1, username: 'testuser' };
+let mockAuthUser: typeof stableUser | null = stableUser;
+const stableHasPermission = () => false;
+const stableAIValue = { aiEnabled: false };
+const stableClusterValue = { lastRefresh: 0 };
+const stableDashboardValue = {
+    currentOverlay: null,
+    clearOverlays: () => {},
+    pushOverlay: () => {},
+    refreshTrigger: 0,
+};
+
+vi.mock('../../../contexts/useAuth', () => ({
+    useAuth: () => ({ user: mockAuthUser, hasPermission: stableHasPermission }),
+}));
+vi.mock('../../../contexts/useAICapabilities', () => ({ useAICapabilities: () => stableAIValue }));
+vi.mock('../../../contexts/useClusterData', () => ({ useClusterData: () => stableClusterValue }));
+vi.mock('../../../contexts/useDashboard', () => ({ useDashboard: () => stableDashboardValue }));
+
+// Stub heavy siblings to keep the tree small.
+vi.mock('../../EventTimeline', () => ({ default: () => null }));
+vi.mock('../../BlackoutPanel', () => ({ default: () => null }));
+vi.mock('../../AlertAnalysisDialog', () => ({ default: () => null }));
+vi.mock('../../ServerAnalysisDialog', () => ({ default: () => null }));
+vi.mock('../../AlertOverrideEditDialog', () => ({ default: () => null }));
+vi.mock('../../BlackoutManagementDialog', () => ({ default: () => null }));
+vi.mock('../../AIOverview', () => ({ default: () => null }));
+vi.mock('../../Dashboard', () => ({
+    ServerDashboard: () => null,
+    EstateDashboard: () => null,
+    ClusterDashboard: () => null,
+    DatabaseDashboard: () => null,
+    ObjectDashboard: () => null,
+    MetricOverlay: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../Dashboard/ClusterDashboard/TopologySection', () => ({ default: () => null }));
+vi.mock('../../Dashboard/CollapsibleSection', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../Dashboard/TimeRangeSelector', () => ({ default: () => null }));
+vi.mock('../SelectionHeader', () => ({ default: () => null }));
+vi.mock('../ServerInfoCard', () => ({ default: () => null }));
+vi.mock('../PerformanceTiles', () => ({ default: () => null }));
+vi.mock('../AcknowledgeDialog', () => ({ default: () => null }));
+vi.mock('../../../hooks/useServerAnalysis', () => ({ hasCachedServerAnalysis: () => false }));
+
+// ---------------------------------------------------------------------------
+// Now import the SUT.
+// ---------------------------------------------------------------------------
+
+import StatusPanel from '../index';
+
+const testTheme = createPgedgeTheme('dark');
+
+const renderPanel = (selection: Selection) =>
+    render(
+        <ThemeProvider theme={testTheme}>
+            <StatusPanel selection={selection} />
+        </ThemeProvider>,
+    );
+
+const makeAlertRecord = (overrides: Record<string, unknown> = {}) => ({
+    id: 99,
+    title: 'High CPU Usage',
+    description: 'CPU usage exceeded threshold',
+    severity: 'warning',
+    alert_type: 'threshold',
+    triggered_at: '2026-04-20T12:00:00Z',
+    last_updated: '2026-04-20T12:00:00Z',
+    server_name: 'server-1',
+    connection_id: 1,
+    ...overrides,
+});
+
+const serverSelection: Selection = {
+    type: 'server',
+    id: 1,
+    name: 'server-1',
+    status: 'online',
+    description: 'Test server',
+    host: 'localhost',
+    port: 5432,
+    role: 'primary',
+    version: '14.0',
+    database: 'testdb',
+    username: 'testuser',
+    os: 'Linux',
+    platform: 'x86_64',
+};
+
+const clusterSelection: Selection = {
+    type: 'cluster',
+    id: 'cluster-1',
+    name: 'Cluster 1',
+    status: 'online',
+    description: '',
+    servers: [{ id: 1, name: 's1' }, { id: 2, name: 's2' }],
+    serverIds: [1, 2],
+};
+
+describe('StatusPanel alert fetch resilience', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAuthUser = stableUser;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders alerts after a successful fetch', async () => {
+        mockApiGet.mockResolvedValue({ alerts: [makeAlertRecord()] });
+
+        renderPanel(serverSelection);
+
+        expect(await screen.findByText('High CPU Usage')).toBeInTheDocument();
+        expect(mockApiGet).toHaveBeenCalledWith(
+            expect.stringContaining('/api/v1/alerts?exclude_cleared=true'),
+        );
+    });
+
+    it('recovers via a scheduled retry after a transient failure', async () => {
+        vi.useFakeTimers();
+        mockApiGet
+            .mockRejectedValueOnce(new Error('backend restarting'))
+            .mockResolvedValue({ alerts: [makeAlertRecord()] });
+
+        renderPanel(serverSelection);
+
+        // Let the initial (failing) fetch settle.
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(screen.queryByText('High CPU Usage')).not.toBeInTheDocument();
+
+        // The scheduled retry fires after the base backoff delay.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+            await Promise.resolve();
+        });
+
+        expect(mockApiGet).toHaveBeenCalledTimes(2);
+        expect(screen.getByText('High CPU Usage')).toBeInTheDocument();
+    });
+
+    it('skips the fetch when a server selection has no id', async () => {
+        const noId = { ...serverSelection, id: undefined } as unknown as Selection;
+
+        renderPanel(noId);
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockApiGet).not.toHaveBeenCalled();
+    });
+
+    it('builds a multi-connection alerts URL for a cluster selection', async () => {
+        mockApiGet.mockResolvedValue({ alerts: [makeAlertRecord()] });
+
+        renderPanel(clusterSelection);
+
+        expect(await screen.findByText('High CPU Usage')).toBeInTheDocument();
+        expect(mockApiGet).toHaveBeenCalledWith(
+            expect.stringContaining('connection_ids=1,2'),
+        );
+    });
+
+    it('skips the fetch and clears alerts when there is no user', async () => {
+        mockAuthUser = null;
+
+        renderPanel(serverSelection);
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockApiGet).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/components/StatusPanel/__tests__/StatusPanel.refetch.test.tsx
+++ b/client/src/components/StatusPanel/__tests__/StatusPanel.refetch.test.tsx
@@ -215,6 +215,37 @@ describe('StatusPanel alert fetch resilience', () => {
         );
     });
 
+    it('bails out of the terminal state update when unmounted mid-fetch', async () => {
+        // Hold the alerts fetch pending so the component can unmount
+        // while fetchAlertsData is still awaiting its response.
+        let resolveGet: (value: unknown) => void = () => {};
+        mockApiGet.mockImplementation(
+            () => new Promise(resolve => { resolveGet = resolve; }),
+        );
+
+        const { unmount } = renderPanel(serverSelection);
+
+        // Let the fetch start and reach the pending await.
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        // Unmount while the request is still in flight.
+        unmount();
+
+        // Resolving now drives fetchAlertsData past its await into the
+        // post-unmount guard, which returns without touching state.
+        await act(async () => {
+            resolveGet({ alerts: [makeAlertRecord()] });
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        // The guard prevented a setState on the unmounted component, so
+        // nothing was rendered.
+        expect(screen.queryByText('High CPU Usage')).not.toBeInTheDocument();
+    });
+
     it('skips the fetch and clears alerts when there is no user', async () => {
         mockAuthUser = null;
 

--- a/client/src/components/StatusPanel/index.tsx
+++ b/client/src/components/StatusPanel/index.tsx
@@ -123,6 +123,9 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
     const [alerts, setAlerts] = useState([]);
     const [loading, setLoading] = useState(false);
     const initialLoadDoneRef = React.useRef(false);
+    // Tracks mount state so a late fetch resolution never calls setState
+    // on an unmounted component. Set false in an unmount cleanup below.
+    const isMountedRef = useRef(true);
     const localAnalysisRef = React.useRef<Map<number, string>>(new Map());
     const [blackoutMgmtOpen, setBlackoutMgmtOpen] = useState(false);
     const [ackDialogOpen, setAckDialogOpen] = useState(false);
@@ -158,6 +161,15 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
     useEffect(() => {
         clearOverlays();
     }, [selection?.type, selection?.id, clearOverlays]);
+
+    // Track mount state so late fetch resolutions can bail out before
+    // calling setState on an unmounted component.
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, []);
 
     const statusColors = useMemo(() => getStatusColors(theme), [theme]);
 
@@ -439,15 +451,25 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
                     localAnalysisRef.current.delete(a.id);
                 }
             }
+            // A late resolution after unmount must not touch state; a
+            // superseded/unmounted attempt is not a failure, so report
+            // success to keep it out of the retry schedule.
+            if (!isMountedRef.current) {
+                return true;
+            }
             setAlerts(merged);
             initialLoadDoneRef.current = true;
             return true;
         } catch (err) {
             logger.error('Error fetching alerts:', err);
-            setAlerts([]);
+            if (isMountedRef.current) {
+                setAlerts([]);
+            }
             return false;
         } finally {
-            setLoading(false);
+            if (isMountedRef.current) {
+                setLoading(false);
+            }
         }
     }, [user, selection, transformAlerts]);
 

--- a/client/src/components/StatusPanel/index.tsx
+++ b/client/src/components/StatusPanel/index.tsx
@@ -357,7 +357,7 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
                 false_positive: falsePositive,
             });
             // Refresh alerts to show updated status
-            fetchAlertsData();
+            void refetchAlerts();
         } catch (err) {
             logger.error('Error acknowledging alert:', err);
         } finally {
@@ -379,7 +379,7 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
                     false_positive: falsePositive,
                 });
             }
-            fetchAlertsData();
+            void refetchAlerts();
         } catch (err) {
             logger.error('Error acknowledging alerts:', err);
         } finally {
@@ -451,6 +451,15 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
         }
     }, [user, selection, transformAlerts]);
 
+    // Retry-managed entry point for refreshing alerts. Every caller that
+    // wants fresh alert data should route through this wrapper rather
+    // than invoking fetchAlertsData directly, so a transient failure at
+    // any call site self-heals with capped exponential backoff instead
+    // of silently leaving stale or empty data behind.
+    const refetchAlerts = useCallback((): Promise<boolean> => {
+        return runAlertsFetch(fetchAlertsData);
+    }, [runAlertsFetch, fetchAlertsData]);
+
     // Handle unacknowledging an alert.
     //
     // Applies an optimistic update that immediately clears the
@@ -507,7 +516,7 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
             await apiDelete(`/api/v1/alerts/acknowledge?alert_id=${alertId}`);
             // Reconcile with server truth and beat the race with the
             // periodic cluster refresh.
-            await fetchAlertsData();
+            await refetchAlerts();
         } catch (err) {
             // Roll back the optimistic update.
             if (previousAlert) {
@@ -532,7 +541,7 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
                 return next;
             });
         }
-    }, [user, fetchAlertsData]);
+    }, [user, refetchAlerts]);
 
     const isUnacknowledging = useCallback(
         (id: number | string) => unacknowledgingIds.has(id),
@@ -549,8 +558,8 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
     // self-heals with capped exponential backoff instead of leaving
     // the panel stuck on stale or empty data.
     useEffect(() => {
-        void runAlertsFetch(fetchAlertsData);
-    }, [runAlertsFetch, fetchAlertsData, lastRefresh]);
+        void refetchAlerts();
+    }, [refetchAlerts, lastRefresh]);
 
     // Count only active (non-acknowledged) alerts for the header indicator
     const activeAlertCount = useMemo(() => {

--- a/client/src/components/StatusPanel/index.tsx
+++ b/client/src/components/StatusPanel/index.tsx
@@ -41,6 +41,7 @@ import BlackoutPanel from '../BlackoutPanel';
 import AlertAnalysisDialog from '../AlertAnalysisDialog';
 import ServerAnalysisDialog from '../ServerAnalysisDialog';
 import { hasCachedServerAnalysis } from '../../hooks/useServerAnalysis';
+import { useRetryingFetch } from '../../hooks/useRetryingFetch';
 import type { ServerSelection, ClusterSelection } from '../../types/selection';
 import AlertOverrideEditDialog from '../AlertOverrideEditDialog';
 import BlackoutManagementDialog from '../BlackoutManagementDialog';
@@ -145,6 +146,13 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
     // place, so a minimal MUI Snackbar+Alert is rendered here.
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const { clearOverlays } = useDashboard();
+    // fetchAlertsData guards on user/selection internally and reports
+    // success in those cases, so no separate enabled gate is needed
+    // here; passing lastRefresh as the reset key lets a manual refresh
+    // pre-empt any pending backoff.
+    const { run: runAlertsFetch } = useRetryingFetch({
+        resetKey: lastRefresh,
+    });
 
     // Clear dashboard overlay stack when the selection changes
     useEffect(() => {
@@ -382,11 +390,11 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
     };
 
     // Fetch alerts data function
-    const fetchAlertsData = useCallback(async () => {
+    const fetchAlertsData = useCallback(async (): Promise<boolean> => {
         if (!user || !selection) {
             setAlerts([]);
             setLoading(false);
-            return;
+            return true;
         }
 
         // For server selections, require a valid ID
@@ -394,7 +402,7 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
             logger.warn('Server selection missing ID, skipping alert fetch');
             setAlerts([]);
             setLoading(false);
-            return;
+            return true;
         }
 
         // Only show loading on initial fetch to prevent flashing (use ref to avoid re-renders)
@@ -433,9 +441,11 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
             }
             setAlerts(merged);
             initialLoadDoneRef.current = true;
+            return true;
         } catch (err) {
             logger.error('Error fetching alerts:', err);
             setAlerts([]);
+            return false;
         } finally {
             setLoading(false);
         }
@@ -534,10 +544,13 @@ const StatusPanel: React.FC<StatusPanelProps> = ({
         initialLoadDoneRef.current = false;
     }, [selection?.type, selection?.id]);
 
-    // Fetch alerts on selection change or cluster data refresh
+    // Fetch alerts on selection change or cluster data refresh.
+    // Routes through the retry controller so a transient failure
+    // self-heals with capped exponential backoff instead of leaving
+    // the panel stuck on stale or empty data.
     useEffect(() => {
-        fetchAlertsData();
-    }, [fetchAlertsData, lastRefresh]);
+        void runAlertsFetch(fetchAlertsData);
+    }, [runAlertsFetch, fetchAlertsData, lastRefresh]);
 
     // Count only active (non-acknowledged) alerts for the header indicator
     const activeAlertCount = useMemo(() => {

--- a/client/src/hooks/__tests__/useRetryingFetch.test.ts
+++ b/client/src/hooks/__tests__/useRetryingFetch.test.ts
@@ -1,0 +1,298 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+    useRetryingFetch,
+    DEFAULT_RETRY_BASE_DELAY_MS,
+    DEFAULT_RETRY_MAX_DELAY_MS,
+} from '../useRetryingFetch';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Flush pending microtasks so awaited promise chains inside the hook
+ * settle before assertions run.
+ */
+async function flushMicrotasks(): Promise<void> {
+    await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+describe('useRetryingFetch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
+
+    it('runs the fetch and does not retry on success', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(true);
+        const { result } = renderHook(() => useRetryingFetch());
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(result.current.retrying).toBe(false);
+
+        // Advance well beyond any backoff window; no further calls.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MAX_DELAY_MS * 4);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('schedules a retry after a failed fetch and heals on recovery', async () => {
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValueOnce(false)
+            .mockResolvedValue(true);
+        const { result } = renderHook(() => useRetryingFetch());
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(result.current.retrying).toBe(true);
+
+        // First retry fires after the base delay.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+        });
+
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+        expect(result.current.retrying).toBe(false);
+
+        // No further retries once healed.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MAX_DELAY_MS * 2);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry before the base delay elapses', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(false);
+        const { result } = renderHook(() => useRetryingFetch());
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS - 1);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('grows the delay exponentially and caps it', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(false);
+        const { result } = renderHook(() =>
+            useRetryingFetch({ baseDelayMs: 1000, maxDelayMs: 8000 }),
+        );
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        // Attempt 1 done; retry 1 scheduled at 1000ms.
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1000);
+        });
+        // Retry 1 fired; retry 2 scheduled at 2000ms.
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(2000);
+        });
+        // Retry 2 fired; retry 3 scheduled at 4000ms.
+        expect(fetchFn).toHaveBeenCalledTimes(3);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(4000);
+        });
+        // Retry 3 fired; retry 4 scheduled at 8000ms (would be 8000, capped).
+        expect(fetchFn).toHaveBeenCalledTimes(4);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(8000);
+        });
+        // Retry 4 fired; retry 5 scheduled, still capped at 8000ms.
+        expect(fetchFn).toHaveBeenCalledTimes(5);
+
+        // Confirm the cap: nothing fires at 8000ms - 1.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(7999);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(5);
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(6);
+    });
+
+    it('treats a rejected promise as a failure', async () => {
+        const fetchFn = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('boom'))
+            .mockResolvedValue(true);
+        const { result } = renderHook(() => useRetryingFetch());
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        expect(result.current.retrying).toBe(true);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+        expect(result.current.retrying).toBe(false);
+    });
+
+    it('resets the backoff when the reset key changes', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(false);
+        const { result, rerender } = renderHook(
+            ({ key }) => useRetryingFetch({ resetKey: key }),
+            { initialProps: { key: 1 } },
+        );
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        expect(result.current.retrying).toBe(true);
+
+        // Changing the reset key cancels the pending retry.
+        rerender({ key: 2 });
+        await flushMicrotasks();
+        expect(result.current.retrying).toBe(false);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MAX_DELAY_MS * 2);
+        });
+        // The cancelled retry never fires; only the original attempt ran.
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels pending retries when disabled', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(false);
+        const { result, rerender } = renderHook(
+            ({ enabled }) => useRetryingFetch({ enabled }),
+            { initialProps: { enabled: true } },
+        );
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        expect(result.current.retrying).toBe(true);
+
+        rerender({ enabled: false });
+        await flushMicrotasks();
+        expect(result.current.retrying).toBe(false);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MAX_DELAY_MS * 2);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not run the fetch while disabled', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(true);
+        const { result } = renderHook(() =>
+            useRetryingFetch({ enabled: false }),
+        );
+
+        let outcome: boolean | undefined;
+        await act(async () => {
+            outcome = await result.current.run(fetchFn);
+        });
+
+        expect(fetchFn).not.toHaveBeenCalled();
+        expect(outcome).toBe(false);
+    });
+
+    it('cancel() clears a pending retry and resets state', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(false);
+        const { result } = renderHook(() => useRetryingFetch());
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        expect(result.current.retrying).toBe(true);
+
+        act(() => {
+            result.current.cancel();
+        });
+        expect(result.current.retrying).toBe(false);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MAX_DELAY_MS * 2);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('a fresh run supersedes a pending retry and resets the delay', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(false);
+        const { result } = renderHook(() =>
+            useRetryingFetch({ baseDelayMs: 1000, maxDelayMs: 8000 }),
+        );
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        // Grow the backoff by letting one retry fire.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1000);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+
+        // A fresh run resets the failure count, so the next retry is
+        // scheduled at the base delay again rather than the grown value.
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(3);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1000);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(4);
+    });
+
+    it('clears the pending timer on unmount', async () => {
+        const fetchFn = vi.fn().mockResolvedValue(false);
+        const { result, unmount } = renderHook(() => useRetryingFetch());
+
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+
+        unmount();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MAX_DELAY_MS * 2);
+        });
+        // No retry runs after unmount.
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+});

--- a/client/src/hooks/__tests__/useRetryingFetch.test.ts
+++ b/client/src/hooks/__tests__/useRetryingFetch.test.ts
@@ -278,6 +278,87 @@ describe('useRetryingFetch', () => {
         expect(fetchFn).toHaveBeenCalledTimes(4);
     });
 
+    it('ignores a stale in-flight attempt superseded by a fresh run', async () => {
+        // The first attempt never resolves until we release it manually,
+        // modelling a slow request still in flight when a fresh run wins.
+        let resolveFirst: ((value: boolean) => void) | undefined;
+        const firstPromise = new Promise<boolean>((res) => {
+            resolveFirst = res;
+        });
+        const fetchFn = vi
+            .fn()
+            .mockReturnValueOnce(firstPromise)
+            .mockResolvedValueOnce(true);
+
+        const { result } = renderHook(() => useRetryingFetch());
+
+        // Kick off the first attempt; it stays pending.
+        let firstRun: Promise<boolean> | undefined;
+        act(() => {
+            firstRun = result.current.run(fetchFn);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+
+        // A fresh run supersedes the in-flight attempt and succeeds.
+        await act(async () => {
+            await result.current.run(fetchFn);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+        expect(result.current.retrying).toBe(false);
+
+        // Now the stale first attempt resolves with a FAILURE. Its result
+        // must be ignored: no retry scheduled, retrying stays false.
+        await act(async () => {
+            resolveFirst?.(false);
+            await firstRun;
+        });
+        expect(result.current.retrying).toBe(false);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MAX_DELAY_MS * 2);
+        });
+        // No extra fetch fired from a stale-scheduled retry.
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores a stale in-flight attempt superseded by a resetKey change', async () => {
+        let resolveFirst: ((value: boolean) => void) | undefined;
+        const firstPromise = new Promise<boolean>((res) => {
+            resolveFirst = res;
+        });
+        const fetchFn = vi.fn().mockReturnValueOnce(firstPromise);
+
+        const { result, rerender } = renderHook(
+            ({ key }) => useRetryingFetch({ resetKey: key }),
+            { initialProps: { key: 1 } },
+        );
+
+        let firstRun: Promise<boolean> | undefined;
+        act(() => {
+            firstRun = result.current.run(fetchFn);
+        });
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+
+        // A manual refresh (resetKey change) supersedes the in-flight
+        // attempt while its fetch promise is still pending.
+        rerender({ key: 2 });
+        await flushMicrotasks();
+        expect(result.current.retrying).toBe(false);
+
+        // The now-stale attempt resolves with a failure and is ignored.
+        await act(async () => {
+            resolveFirst?.(false);
+            await firstRun;
+        });
+        expect(result.current.retrying).toBe(false);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MAX_DELAY_MS * 2);
+        });
+        // Only the original attempt ran; the stale failure scheduled nothing.
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
     it('clears the pending timer on unmount', async () => {
         const fetchFn = vi.fn().mockResolvedValue(false);
         const { result, unmount } = renderHook(() => useRetryingFetch());

--- a/client/src/hooks/__tests__/useTimelineEvents.test.ts
+++ b/client/src/hooks/__tests__/useTimelineEvents.test.ts
@@ -8,9 +8,10 @@
  *-------------------------------------------------------------------------
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useTimelineEvents, type TimelineEvent, type TimeRangePreset } from '../useTimelineEvents';
+import { DEFAULT_RETRY_BASE_DELAY_MS } from '../useRetryingFetch';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -74,6 +75,10 @@ describe('useTimelineEvents', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockLastRefresh = 0;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     it('returns initial state with default options', () => {
@@ -396,6 +401,37 @@ describe('useTimelineEvents', () => {
         // Verify data is still present and loading is false
         expect(result.current.loading).toBe(false);
         expect(result.current.events).toHaveLength(2);
+    });
+
+    it('retries after a failed fetch and heals on recovery', async () => {
+        vi.useFakeTimers();
+        mockApiGet
+            .mockRejectedValueOnce(new Error('network down'))
+            .mockResolvedValue(makeApiResponse());
+
+        const { result } = renderHook(() =>
+            useTimelineEvents({ connectionId: 1 }),
+        );
+
+        // Let the initial (failing) fetch settle.
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(result.current.error).toBe('network down');
+        expect(result.current.retrying).toBe(true);
+        expect(result.current.events).toEqual([]);
+
+        // The scheduled retry fires after the base backoff delay.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_BASE_DELAY_MS);
+        });
+
+        expect(mockApiGet).toHaveBeenCalledTimes(2);
+        expect(result.current.events).toHaveLength(2);
+        expect(result.current.error).toBeNull();
+        expect(result.current.retrying).toBe(false);
     });
 
     it('includes limit parameter in query string', async () => {

--- a/client/src/hooks/useRetryingFetch.ts
+++ b/client/src/hooks/useRetryingFetch.ts
@@ -90,6 +90,13 @@ export function useRetryingFetch(
     const [retrying, setRetrying] = useState<boolean>(false);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const failureCountRef = useRef<number>(0);
+    // Monotonic attempt generation. Each execute() captures the value
+    // current at its start; run(), cancel(), and a resetKey change bump
+    // it. When an in-flight fetch resolves, its captured generation is
+    // compared against the current one so a stale attempt (superseded by
+    // a fresh run, a cancel, or a reset while its promise was pending)
+    // is ignored instead of mutating failure/retry state.
+    const generationRef = useRef<number>(0);
     const fetchFnRef = useRef<RetryableFetch | null>(null);
     const executeRef = useRef<() => Promise<boolean>>(() => Promise.resolve(false));
     const mountedRef = useRef<boolean>(true);
@@ -105,6 +112,9 @@ export function useRetryingFetch(
 
     const cancel = useCallback((): void => {
         clearTimer();
+        // Invalidate any in-flight attempt so a late failure cannot
+        // resurrect the retry loop after an explicit cancel.
+        generationRef.current += 1;
         failureCountRef.current = 0;
         if (mountedRef.current) {
             setRetrying(false);
@@ -126,6 +136,9 @@ export function useRetryingFetch(
             return false;
         }
 
+        // Capture the generation this attempt belongs to before awaiting.
+        const generation = generationRef.current;
+
         let success = false;
         try {
             success = await fetchFn();
@@ -137,6 +150,15 @@ export function useRetryingFetch(
         // we neither schedule an orphaned retry nor call setState on an
         // unmounted component.
         if (!mountedRef.current || !enabledRef.current) {
+            return success;
+        }
+
+        // Ignore a stale attempt whose generation was superseded while
+        // its fetch promise was still pending (a fresh run, a cancel, or
+        // a resetKey change). Acting on it would wrongly increment the
+        // failure count and schedule a retry for an already-resolved
+        // situation.
+        if (generation !== generationRef.current) {
             return success;
         }
 
@@ -164,7 +186,9 @@ export function useRetryingFetch(
         (fetchFn: RetryableFetch): Promise<boolean> => {
             fetchFnRef.current = fetchFn;
             // A fresh invocation supersedes any pending retry so a
-            // manual refresh always starts from a clean schedule.
+            // manual refresh always starts from a clean schedule. Bumping
+            // the generation also invalidates any older in-flight attempt.
+            generationRef.current += 1;
             failureCountRef.current = 0;
             clearTimer();
             setRetrying(false);
@@ -177,6 +201,9 @@ export function useRetryingFetch(
     // manual refresh). The consuming effect re-invokes run separately,
     // so this only needs to clear pending retries.
     useEffect(() => {
+        // Invalidate any in-flight attempt so a late failure from before
+        // the reset cannot restart the backoff after the manual refresh.
+        generationRef.current += 1;
         failureCountRef.current = 0;
         clearTimer();
         setRetrying(false);

--- a/client/src/hooks/useRetryingFetch.ts
+++ b/client/src/hooks/useRetryingFetch.ts
@@ -1,0 +1,204 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Default backoff parameters tuned for a monitoring dashboard.
+ *
+ * The first retry fires after roughly three seconds so a brief
+ * backend hiccup heals quickly, while the cap keeps a prolonged
+ * outage from hammering the server. With these values the delay
+ * schedule is 3s, 6s, 12s, 24s, then 45s for every subsequent
+ * attempt.
+ */
+export const DEFAULT_RETRY_BASE_DELAY_MS = 3000;
+export const DEFAULT_RETRY_MAX_DELAY_MS = 45000;
+
+/**
+ * A fetch function suitable for use with {@link useRetryingFetch}.
+ *
+ * The function performs its own request, handles its own success
+ * and error state, and returns a boolean describing the outcome:
+ * `true` when the fetch succeeded and `false` when it failed. A
+ * rejected promise is also treated as a failure.
+ */
+export type RetryableFetch = () => Promise<boolean>;
+
+export interface UseRetryingFetchOptions {
+    /**
+     * A value that, when it changes, cancels any pending retry and
+     * resets the backoff schedule. Pass the dashboard `lastRefresh`
+     * so a manual refresh always takes priority over the backoff.
+     */
+    resetKey?: unknown;
+    /**
+     * When false, any pending retry is cancelled and no new retries
+     * are scheduled. Defaults to true.
+     */
+    enabled?: boolean;
+    /** Delay before the first retry, in milliseconds. */
+    baseDelayMs?: number;
+    /** Maximum delay between retries, in milliseconds. */
+    maxDelayMs?: number;
+}
+
+export interface UseRetryingFetchResult {
+    /**
+     * Run the supplied fetch and manage retry scheduling from its
+     * outcome. Calling `run` supersedes any pending retry and resets
+     * the backoff, so it doubles as the "fetch now" entry point.
+     * Resolves with the boolean the fetch returned.
+     */
+    run: (fetchFn: RetryableFetch) => Promise<boolean>;
+    /** True while a retry is scheduled after a failed attempt. */
+    retrying: boolean;
+    /** Cancel any pending retry and reset the backoff schedule. */
+    cancel: () => void;
+}
+
+/**
+ * Provide capped exponential backoff retries for a data-fetching
+ * hook.
+ *
+ * The codebase has no React Query or SWR, so each dashboard panel
+ * fetches independently and previously had no way to recover from a
+ * transient backend failure on its own. This hook centralises the
+ * retry-with-backoff behaviour those panels share: on failure it
+ * reschedules the fetch with an exponentially growing, capped delay;
+ * on success it stops retrying; and it resets the schedule whenever
+ * `resetKey` changes so a manual refresh wins over any pending
+ * backoff.
+ */
+export function useRetryingFetch(
+    options: UseRetryingFetchOptions = {},
+): UseRetryingFetchResult {
+    const {
+        resetKey,
+        enabled = true,
+        baseDelayMs = DEFAULT_RETRY_BASE_DELAY_MS,
+        maxDelayMs = DEFAULT_RETRY_MAX_DELAY_MS,
+    } = options;
+
+    const [retrying, setRetrying] = useState<boolean>(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const failureCountRef = useRef<number>(0);
+    const fetchFnRef = useRef<RetryableFetch | null>(null);
+    const executeRef = useRef<() => Promise<boolean>>(() => Promise.resolve(false));
+    const mountedRef = useRef<boolean>(true);
+    const enabledRef = useRef<boolean>(enabled);
+    enabledRef.current = enabled;
+
+    const clearTimer = useCallback((): void => {
+        if (timerRef.current !== null) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
+        }
+    }, []);
+
+    const cancel = useCallback((): void => {
+        clearTimer();
+        failureCountRef.current = 0;
+        if (mountedRef.current) {
+            setRetrying(false);
+        }
+    }, [clearTimer]);
+
+    const computeDelay = useCallback(
+        (failureCount: number): number => {
+            // failureCount is a 1-based count of consecutive failures.
+            const exponential = baseDelayMs * 2 ** (failureCount - 1);
+            return Math.min(exponential, maxDelayMs);
+        },
+        [baseDelayMs, maxDelayMs],
+    );
+
+    const execute = useCallback(async (): Promise<boolean> => {
+        const fetchFn = fetchFnRef.current;
+        if (!fetchFn || !enabledRef.current) {
+            return false;
+        }
+
+        let success = false;
+        try {
+            success = await fetchFn();
+        } catch {
+            success = false;
+        }
+
+        // Bail out if the hook unmounted or was disabled mid-flight so
+        // we neither schedule an orphaned retry nor call setState on an
+        // unmounted component.
+        if (!mountedRef.current || !enabledRef.current) {
+            return success;
+        }
+
+        if (success) {
+            failureCountRef.current = 0;
+            clearTimer();
+            setRetrying(false);
+        } else {
+            failureCountRef.current += 1;
+            const delay = computeDelay(failureCountRef.current);
+            clearTimer();
+            setRetrying(true);
+            timerRef.current = setTimeout(() => {
+                timerRef.current = null;
+                void executeRef.current();
+            }, delay);
+        }
+
+        return success;
+    }, [clearTimer, computeDelay]);
+
+    executeRef.current = execute;
+
+    const run = useCallback(
+        (fetchFn: RetryableFetch): Promise<boolean> => {
+            fetchFnRef.current = fetchFn;
+            // A fresh invocation supersedes any pending retry so a
+            // manual refresh always starts from a clean schedule.
+            failureCountRef.current = 0;
+            clearTimer();
+            setRetrying(false);
+            return execute();
+        },
+        [clearTimer, execute],
+    );
+
+    // Reset the backoff whenever the reset key changes (for example a
+    // manual refresh). The consuming effect re-invokes run separately,
+    // so this only needs to clear pending retries.
+    useEffect(() => {
+        failureCountRef.current = 0;
+        clearTimer();
+        setRetrying(false);
+    }, [resetKey, clearTimer]);
+
+    // Cancel pending retries when disabled.
+    useEffect(() => {
+        if (!enabled) {
+            cancel();
+        }
+    }, [enabled, cancel]);
+
+    // Track mount state and clear any timer on unmount.
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+            clearTimer();
+        };
+    }, [clearTimer]);
+
+    return { run, retrying, cancel };
+}
+
+export default useRetryingFetch;

--- a/client/src/hooks/useTimelineEvents.ts
+++ b/client/src/hooks/useTimelineEvents.ts
@@ -13,6 +13,7 @@ import { useAuth } from '../contexts/useAuth';
 import { useClusterData } from '../contexts/useClusterData';
 import { apiGet } from '../utils/apiClient';
 import { logger } from '../utils/logger';
+import { useRetryingFetch } from './useRetryingFetch';
 
 export interface TimelineEvent {
     id: number;
@@ -47,6 +48,8 @@ export interface UseTimelineEventsReturn {
     error: string | null;
     refetch: () => Promise<void>;
     totalCount: number;
+    /** True while an automatic retry is pending after a failed fetch. */
+    retrying: boolean;
 }
 
 interface TimelineApiResponse {
@@ -114,6 +117,10 @@ export const useTimelineEvents = ({
     const [error, setError] = useState<string | null>(null);
     const isMountedRef = useRef<boolean>(true);
     const initialLoadDoneRef = useRef<boolean>(false);
+    const { run, retrying } = useRetryingFetch({
+        resetKey: lastRefresh,
+        enabled: enabled && !!user,
+    });
 
     // Create a stable string representation of eventTypes for dependency comparison
     // This ensures the callback is recreated when event types change, regardless of
@@ -151,8 +158,8 @@ export const useTimelineEvents = ({
     /**
      * Fetch timeline events from the API
      */
-    const fetchEvents = useCallback(async (): Promise<void> => {
-        if (!user || !enabled) {return;}
+    const fetchEvents = useCallback(async (): Promise<boolean> => {
+        if (!user || !enabled) {return true;}
 
         // Only show loading state on the very first fetch ever (use ref to avoid re-renders)
         if (!initialLoadDoneRef.current) {
@@ -169,6 +176,7 @@ export const useTimelineEvents = ({
                 setTotalCount(data.total_count ?? 0);
                 initialLoadDoneRef.current = true;
             }
+            return true;
         } catch (err) {
             logger.error('Error fetching timeline events:', err);
             if (isMountedRef.current) {
@@ -176,6 +184,7 @@ export const useTimelineEvents = ({
                 setEvents([]);
                 setTotalCount(0);
             }
+            return false;
         } finally {
             if (isMountedRef.current) {
                 setLoading(false);
@@ -184,11 +193,12 @@ export const useTimelineEvents = ({
     }, [user, enabled, buildQueryString]);
 
     /**
-     * Manual refetch function
+     * Manual refetch function. Routes through the retry controller so a
+     * manual refresh resets any pending backoff schedule.
      */
-    const refetch = useCallback((): Promise<void> => {
-        return fetchEvents();
-    }, [fetchEvents]);
+    const refetch = useCallback(async (): Promise<void> => {
+        await run(fetchEvents);
+    }, [run, fetchEvents]);
 
     // Reset initial load state when connection changes
     useEffect(() => {
@@ -202,13 +212,13 @@ export const useTimelineEvents = ({
         isMountedRef.current = true;
 
         if (enabled && user) {
-            void fetchEvents();
+            void run(fetchEvents);
         }
 
         return () => {
             isMountedRef.current = false;
         };
-    }, [enabled, user, fetchEvents, lastRefresh]);
+    }, [enabled, user, run, fetchEvents, lastRefresh]);
 
     return {
         events,
@@ -216,6 +226,7 @@ export const useTimelineEvents = ({
         error,
         refetch,
         totalCount,
+        retrying,
     };
 };
 

--- a/client/src/hooks/useTimelineEvents.ts
+++ b/client/src/hooks/useTimelineEvents.ts
@@ -127,6 +127,11 @@ export const useTimelineEvents = ({
     // array reference equality issues
     const eventTypesKey = eventTypes ? eventTypes.slice().sort().join(',') : '';
 
+    // Stable string representation of connectionIds for the same reason: a
+    // parent passing a new-but-equal array each render must not force a
+    // redundant refetch through buildQueryString's identity changing.
+    const connectionIdsKey = connectionIds ? connectionIds.slice().sort().join(',') : '';
+
     /**
      * Build the query string for the API request
      */
@@ -153,7 +158,7 @@ export const useTimelineEvents = ({
 
         return params.toString();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [connectionId, connectionIds, timeRange, eventTypesKey]);
+    }, [connectionId, connectionIdsKey, timeRange, eventTypesKey]);
 
     /**
      * Fetch timeline events from the API
@@ -203,7 +208,7 @@ export const useTimelineEvents = ({
     // Reset initial load state when connection changes
     useEffect(() => {
         initialLoadDoneRef.current = false;
-    }, [connectionId, connectionIds]);
+    }, [connectionId, connectionIdsKey]);
 
     // Fetch when dependencies change
     // Note: fetchEvents already captures connectionId, connectionIds, timeRange, eventTypes via buildQueryString

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -121,6 +121,25 @@ project adheres to
   The workbench rejects such a model with a clear error rather than
   truncating the vector. (#294)
 
+- Fix the Estate Overview dashboard's KPI tiles (XID Age, Cache Hit
+  Ratio, Transactions, and Checkpoints) and Event Timeline getting
+  stuck on "No data" indefinitely after a brief backend restart or
+  any transient API failure. Recovering required the user to click the
+  sidebar's Refresh button or reload the page, because nothing retried
+  on its own. The client uses no React Query or SWR; every panel hook
+  refetched only when a single shared `lastRefresh` timestamp changed,
+  and that timestamp advanced only when the sidebar's
+  `GET /api/v1/clusters` call succeeded. A transient failure in an
+  individual panel's fetch, or in the shared refresh call itself, left
+  the affected panels blank with no automatic recovery. A shared
+  `useRetryingFetch` hook now provides capped exponential backoff (3s,
+  6s, 12s, 24s, capped at 45s) for the Event Timeline, the
+  performance-summary tiles, the Estate KPI tiles, and the alerts
+  panel. A manual refresh always pre-empts any pending retry, and the
+  Estate KPI tiles show a subtle "Reconnecting..." indicator while a
+  retry is pending, distinguishing that state from genuinely empty
+  data.
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the


### PR DESCRIPTION
## Symptom

After a brief backend restart or any transient API failure, the
Estate Overview dashboard's KPI tiles (XID Age, Cache Hit Ratio,
Transactions, Checkpoints) and Event Timeline could get stuck
showing "No data" indefinitely. The only way to recover was to
manually click the sidebar's Refresh button or reload the page —
nothing retried on its own.

## Root cause

This client has no React Query or SWR. Every panel hook only
refetches when a single shared `lastRefresh` timestamp
(`ClusterDataContext`) changes, and that timestamp only advances
when the sidebar's `GET /api/v1/clusters` call succeeds. If an
individual panel's own fetch failed transiently, or if the shared
refresh call itself failed, nothing retried automatically and the
affected panel just sat blank.

## Fix

- New shared `useRetryingFetch` hook (`client/src/hooks/useRetryingFetch.ts`)
  providing capped exponential backoff: 3s, 6s, 12s, 24s, capped at
  45s. On success it stops retrying; a manual refresh (change in
  `resetKey`/`lastRefresh`) always pre-empts a pending retry.
- Wired into:
  - `useTimelineEvents` (Event Timeline)
  - `usePerformanceSummary` (XID Age / Cache Hit Ratio / Transactions
    / Checkpoints tiles)
  - `KpiTilesSection` (Estate KPI tiles) — also adds a subtle
    "Reconnecting..." indicator while a retry is pending, so a
    transient outage reads differently from genuinely empty data
  - `StatusPanel`'s `fetchAlertsData`

## Testing

- New unit tests for `useRetryingFetch` and the modified hooks;
  updated existing suites for the new return shapes.
- `npm run lint`: 0 errors (39 pre-existing warnings, none in
  touched files).
- Full suite: 164 test files / 3386 tests pass.
- Touched-file line coverage: `useRetryingFetch.ts` 98.46%,
  `useTimelineEvents.ts` 90.66%, `usePerformanceSummary.ts` 98.3%,
  `KpiTilesSection.tsx` 100%. `StatusPanel/index.tsx` is a large
  pre-existing file at ~71% overall coverage; every line touched by
  this change is covered, and the residual gap is pre-existing,
  untouched code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Dashboard KPI tiles, performance summaries, alerts, and timeline events now automatically retry after temporary API failures using capped exponential backoff.
  - The UI no longer gets stuck on “No data” after brief backend interruptions.
  - KPI tiles and related panels show **“Reconnecting…”** while a retry is pending, and resume normal rendering after recovery.
  - Manual refresh now pre-empts pending retries to immediately re-fetch fresh data.
- **Documentation**
  - Updated the changelog to reflect the improved dashboard recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->