### PR TITLE
Fix latest-row metrics query returning stale historical data

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -148,6 +148,25 @@ project adheres to
   coexist, and the effective access for each connection is the
   higher of the two. (#302)
 
+- Fix the Table and Index object-detail dashboards showing stale,
+  pre-maintenance values in their overview tiles and Maintenance Info
+  panel indefinitely, even after the collector recorded fresh, correct
+  data. Running ANALYZE on a table corrected its live-tuple-count
+  estimate downward, yet the dashboard kept showing the old, larger
+  count and a stale or missing Last Analyze value. The latest-row mode
+  of the metrics API (`GET /api/v1/metrics/query` with `limit` and
+  `order_by`) ranked the table's entire history by the requested
+  `order_by` column and used `collected_at` only to break exact ties,
+  so it returned whichever historical sample had the highest column
+  value rather than the most recent sample. Any column that can
+  decrease over time, such as a tuple count after ANALYZE, VACUUM, or
+  DELETE, or a dead-tuple count after VACUUM, could therefore return a
+  permanently stale historical row. The query now reduces to each
+  monitored entity's newest sample by `collected_at` first, then ranks
+  those already-latest rows by the requested `order_by` column, so a
+  request filtered to one table or index always returns that entity's
+  true latest sample regardless of the sort column.
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/server/src/internal/api/latest_handlers.go
+++ b/server/src/internal/api/latest_handlers.go
@@ -390,23 +390,16 @@ func resolveDatabaseColumnCached(
 }
 
 // BuildDimensionColumns identifies entity key columns suitable for the
-// DISTINCT ON clause. These are text/name-type columns that are not
-// internal bookkeeping columns.
+// DISTINCT ON clause. It delegates to metrics.EntityKeyColumns so this
+// endpoint and the generic latest-row query path share one definition
+// of what counts as an identity column and can never drift apart. The
+// shared helper excludes text-typed value columns (e.g. the "_pretty"
+// size renderings) that would otherwise fragment a single entity.
 func BuildDimensionColumns(
 	allColumns []string,
 	colTypes map[string]string,
 ) []string {
-	var dims []string
-	for _, col := range allColumns {
-		if internalColumns[col] {
-			continue
-		}
-		dt := colTypes[col]
-		if dt == "text" || dt == "character varying" || dt == "name" {
-			dims = append(dims, col)
-		}
-	}
-	return dims
+	return metrics.EntityKeyColumns(allColumns, colTypes)
 }
 
 // queryLatestSnapshot builds and executes the DISTINCT ON query that

--- a/server/src/internal/api/latest_handlers_test.go
+++ b/server/src/internal/api/latest_handlers_test.go
@@ -151,6 +151,32 @@ func TestBuildDimensionColumns(t *testing.T) {
 			},
 			want: []string{"datname"},
 		},
+		{
+			// Simulates PR #343 adding table_size / table_size_pretty to
+			// the leaderboard table. The text-typed *_pretty rendering is
+			// a value, not identity; including it in DISTINCT ON would
+			// fragment one table across its changing rendered sizes and
+			// silently corrupt the leaderboard ranking. It must be
+			// excluded even though it is text.
+			name: "text _pretty value column excluded from dimensions",
+			allColumns: []string{
+				"connection_id", "collected_at", "inserted_at",
+				"database_name", "schemaname", "relname",
+				"table_size", "table_size_pretty", "n_live_tup",
+			},
+			colTypes: map[string]string{
+				"connection_id":     "integer",
+				"collected_at":      "timestamp with time zone",
+				"inserted_at":       "timestamp with time zone",
+				"database_name":     "text",
+				"schemaname":        "name",
+				"relname":           "name",
+				"table_size":        "bigint",
+				"table_size_pretty": "text",
+				"n_live_tup":        "bigint",
+			},
+			want: []string{"database_name", "schemaname", "relname"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -1160,17 +1160,22 @@ func GetProbeAllColumns(ctx context.Context, pool *pgxpool.Pool, probeName strin
 // connections and filters.
 //
 // "Most recent" always means the greatest collected_at, never the historical
-// maximum of orderCol. When the probe exposes entity-key columns (the
-// text/name dimension columns), an inner DISTINCT ON reduces the matching
-// rows to each entity's newest sample before the outer query ranks those
-// per-entity latest rows by orderCol and applies the limit. A filter that
-// pins a single entity therefore yields exactly that entity's newest row
-// regardless of orderCol, and a broad multi-entity request ranks each
-// entity by its own latest sample rather than by any stale historical peak.
+// maximum of orderCol. An inner DISTINCT ON reduces the matching rows to each
+// entity's newest sample (ordered by collected_at DESC) before the outer
+// query ranks those per-entity latest rows by orderCol and applies the limit.
+// A filter that pins a single entity therefore yields exactly that entity's
+// newest row regardless of orderCol, and a broad multi-entity request ranks
+// each entity by its own latest sample rather than by any stale historical
+// peak.
 //
-// When the probe has no entity-key columns the whole filtered set is a
-// single logical entity, so the query simply orders by collected_at DESC
-// and limits, which likewise keeps the newest sample first.
+// The entity key always includes connection_id, plus any text/name dimension
+// columns (schemaname, relname, indexrelname, ...) the probe exposes. Keying
+// on connection_id is essential: without it, two different monitored servers
+// that happen to have a table with the same schema+table name would collapse
+// into a single DISTINCT ON group, silently dropping one connection's latest
+// sample. connection_id is present on every probe table, so the entity key is
+// never empty and one query shape serves every probe, whether or not it has
+// text/name dimension columns.
 func buildLatestRowsQuery(
 	probeName string,
 	outputCols []string,
@@ -1227,44 +1232,25 @@ func buildLatestRowsQuery(
 
 	whereClause := strings.Join(whereClauses, " AND ")
 
-	entityKeys := EntityKeyColumns(outputCols, colTypes)
+	// connection_id is always part of the entity key so that two monitored
+	// servers sharing a schema+table name never collapse into one DISTINCT ON
+	// group. Any text/name dimension columns the probe exposes extend the key.
+	distinctParts := []string{"connection_id"}
+	for _, col := range EntityKeyColumns(outputCols, colTypes) {
+		distinctParts = append(distinctParts, QuoteIdentifier(col))
+	}
+	distinctClause := strings.Join(distinctParts, ", ")
 
-	var query string
-	if len(entityKeys) == 0 {
-		// No entity-key columns: the whole filtered set is a single logical
-		// entity, so the newest row is simply the one with the greatest
-		// collected_at. Ranking by orderCol only reorders the most recent
-		// samples; the #1 row is always the true latest.
-		query = fmt.Sprintf(`
-        SELECT %s
-        FROM metrics.%s
-        WHERE %s
-        ORDER BY %s %s, collected_at DESC
-        LIMIT $%d
-    `,
-			selectClause,
-			QuoteIdentifier(probeName),
-			whereClause,
-			QuoteIdentifier(orderCol),
-			order,
-			argNum,
-		)
-	} else {
-		// Reduce to each entity's newest sample first (DISTINCT ON ordered by
-		// collected_at DESC), then rank those per-entity latest rows by
-		// orderCol. collected_at is carried through the inner select so the
-		// default order_by (collected_at) and the DISTINCT ON tiebreak both
-		// resolve, while the outer select returns only the caller's columns.
-		var distinctParts []string
-		for _, col := range entityKeys {
-			distinctParts = append(distinctParts, QuoteIdentifier(col))
-		}
-		distinctClause := strings.Join(distinctParts, ", ")
-
-		query = fmt.Sprintf(`
+	// Reduce to each entity's newest sample first (DISTINCT ON ordered by
+	// collected_at DESC), then rank those per-entity latest rows by orderCol.
+	// connection_id and collected_at are carried through the inner select so
+	// the DISTINCT ON, its collected_at tiebreak, and the default order_by
+	// (collected_at) all resolve, while the outer select returns only the
+	// caller's columns.
+	query := fmt.Sprintf(`
         SELECT %s
         FROM (
-            SELECT DISTINCT ON (%s) %s, collected_at
+            SELECT DISTINCT ON (%s) %s, connection_id, collected_at
             FROM metrics.%s
             WHERE %s
             ORDER BY %s, collected_at DESC
@@ -1272,17 +1258,16 @@ func buildLatestRowsQuery(
         ORDER BY %s %s, collected_at DESC
         LIMIT $%d
     `,
-			selectClause,
-			distinctClause,
-			selectClause,
-			QuoteIdentifier(probeName),
-			whereClause,
-			distinctClause,
-			QuoteIdentifier(orderCol),
-			order,
-			argNum,
-		)
-	}
+		selectClause,
+		distinctClause,
+		selectClause,
+		QuoteIdentifier(probeName),
+		whereClause,
+		distinctClause,
+		QuoteIdentifier(orderCol),
+		order,
+		argNum,
+	)
 	args = append(args, limit)
 
 	return query, args

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -199,6 +199,53 @@ func IsMetricColumn(name, dataType string) bool {
 	return false
 }
 
+// IsEntityKeyColumn reports whether a probe output column is an
+// entity-key (identity/dimension) column that identifies a distinct
+// monitored entity, as opposed to a metric value or an internal
+// bookkeeping column. Entity keys are the text/name-typed dimension
+// columns such as schemaname, relname, indexrelname, database_name,
+// and datname.
+//
+// Text type alone is not sufficient: some value columns are text yet
+// vary over time for a fixed entity. This codebase renders a raw
+// numeric value column as a human-readable string in a companion
+// column whose name ends in "_pretty" (e.g. table_size_pretty for
+// table_size, index_size_pretty for index_size, via pg_size_pretty).
+// Such columns are values, not identity, so treating them as entity
+// keys would fragment one real entity into several by its changing
+// rendered size and defeat any DISTINCT ON reduction. They are
+// therefore excluded here even though they are text. No genuine
+// identity column in the schema ends in "_pretty", so the exclusion
+// is a pure bug fix that changes nothing for existing probes.
+func IsEntityKeyColumn(name, dataType string) bool {
+	if latestRowInternalColumns[name] {
+		return false
+	}
+	if strings.HasSuffix(name, "_pretty") {
+		return false
+	}
+	switch dataType {
+	case "text", "character varying", "name":
+		return true
+	default:
+		return false
+	}
+}
+
+// EntityKeyColumns returns the entity-key (identity/dimension) columns
+// among cols, preserving their input order. It is the single source of
+// truth shared by every latest-row path so that the DISTINCT ON entity
+// grouping never drifts between call sites.
+func EntityKeyColumns(cols []string, colTypes map[string]string) []string {
+	var keys []string
+	for _, col := range cols {
+		if IsEntityKeyColumn(col, colTypes[col]) {
+			keys = append(keys, col)
+		}
+	}
+	return keys
+}
+
 // IsValidIdentifier checks whether a string is a valid SQL identifier.
 func IsValidIdentifier(s string) bool {
 	if s == "" {
@@ -1108,23 +1155,6 @@ func GetProbeAllColumns(ctx context.Context, pool *pgxpool.Pool, probeName strin
 	return allCols, colTypes, rows.Err()
 }
 
-// latestEntityKeyColumns identifies the entity-key (dimension) columns of a
-// probe table from its output columns and their data types. These are the
-// text/name-typed columns that identify a distinct monitored entity, e.g.
-// schemaname + relname for a table probe or schemaname + indexrelname for an
-// index probe. They mirror the dimension columns used by the latest-snapshot
-// endpoint so both latest-row paths group by the same entity keys.
-func latestEntityKeyColumns(outputCols []string, colTypes map[string]string) []string {
-	var keys []string
-	for _, col := range outputCols {
-		switch colTypes[col] {
-		case "text", "character varying", "name":
-			keys = append(keys, col)
-		}
-	}
-	return keys
-}
-
 // buildLatestRowsQuery constructs a SQL statement that returns the most
 // recent row of a probe table per monitored entity for the given
 // connections and filters.
@@ -1197,7 +1227,7 @@ func buildLatestRowsQuery(
 
 	whereClause := strings.Join(whereClauses, " AND ")
 
-	entityKeys := latestEntityKeyColumns(outputCols, colTypes)
+	entityKeys := EntityKeyColumns(outputCols, colTypes)
 
 	var query string
 	if len(entityKeys) == 0 {

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -1108,13 +1108,43 @@ func GetProbeAllColumns(ctx context.Context, pool *pgxpool.Pool, probeName strin
 	return allCols, colTypes, rows.Err()
 }
 
+// latestEntityKeyColumns identifies the entity-key (dimension) columns of a
+// probe table from its output columns and their data types. These are the
+// text/name-typed columns that identify a distinct monitored entity, e.g.
+// schemaname + relname for a table probe or schemaname + indexrelname for an
+// index probe. They mirror the dimension columns used by the latest-snapshot
+// endpoint so both latest-row paths group by the same entity keys.
+func latestEntityKeyColumns(outputCols []string, colTypes map[string]string) []string {
+	var keys []string
+	for _, col := range outputCols {
+		switch colTypes[col] {
+		case "text", "character varying", "name":
+			keys = append(keys, col)
+		}
+	}
+	return keys
+}
+
 // buildLatestRowsQuery constructs a SQL statement that returns the most
-// recent rows of a probe table for the given connections and filters,
-// ordered by the validated orderCol and direction. collected_at DESC is
-// appended as a tiebreaker so equal-ranked rows favor the newest sample.
+// recent row of a probe table per monitored entity for the given
+// connections and filters.
+//
+// "Most recent" always means the greatest collected_at, never the historical
+// maximum of orderCol. When the probe exposes entity-key columns (the
+// text/name dimension columns), an inner DISTINCT ON reduces the matching
+// rows to each entity's newest sample before the outer query ranks those
+// per-entity latest rows by orderCol and applies the limit. A filter that
+// pins a single entity therefore yields exactly that entity's newest row
+// regardless of orderCol, and a broad multi-entity request ranks each
+// entity by its own latest sample rather than by any stale historical peak.
+//
+// When the probe has no entity-key columns the whole filtered set is a
+// single logical entity, so the query simply orders by collected_at DESC
+// and limits, which likewise keeps the newest sample first.
 func buildLatestRowsQuery(
 	probeName string,
 	outputCols []string,
+	colTypes map[string]string,
 	connectionIDs []int,
 	filters MetricFilters,
 	orderCol string,
@@ -1125,6 +1155,7 @@ func buildLatestRowsQuery(
 	for _, col := range outputCols {
 		selectParts = append(selectParts, QuoteIdentifier(col))
 	}
+	selectClause := strings.Join(selectParts, ", ")
 
 	var whereClauses []string
 	var args []any
@@ -1164,20 +1195,64 @@ func buildLatestRowsQuery(
 		argNum++
 	}
 
-	query := fmt.Sprintf(`
+	whereClause := strings.Join(whereClauses, " AND ")
+
+	entityKeys := latestEntityKeyColumns(outputCols, colTypes)
+
+	var query string
+	if len(entityKeys) == 0 {
+		// No entity-key columns: the whole filtered set is a single logical
+		// entity, so the newest row is simply the one with the greatest
+		// collected_at. Ranking by orderCol only reorders the most recent
+		// samples; the #1 row is always the true latest.
+		query = fmt.Sprintf(`
         SELECT %s
         FROM metrics.%s
         WHERE %s
         ORDER BY %s %s, collected_at DESC
         LIMIT $%d
     `,
-		strings.Join(selectParts, ", "),
-		QuoteIdentifier(probeName),
-		strings.Join(whereClauses, " AND "),
-		QuoteIdentifier(orderCol),
-		order,
-		argNum,
-	)
+			selectClause,
+			QuoteIdentifier(probeName),
+			whereClause,
+			QuoteIdentifier(orderCol),
+			order,
+			argNum,
+		)
+	} else {
+		// Reduce to each entity's newest sample first (DISTINCT ON ordered by
+		// collected_at DESC), then rank those per-entity latest rows by
+		// orderCol. collected_at is carried through the inner select so the
+		// default order_by (collected_at) and the DISTINCT ON tiebreak both
+		// resolve, while the outer select returns only the caller's columns.
+		var distinctParts []string
+		for _, col := range entityKeys {
+			distinctParts = append(distinctParts, QuoteIdentifier(col))
+		}
+		distinctClause := strings.Join(distinctParts, ", ")
+
+		query = fmt.Sprintf(`
+        SELECT %s
+        FROM (
+            SELECT DISTINCT ON (%s) %s, collected_at
+            FROM metrics.%s
+            WHERE %s
+            ORDER BY %s, collected_at DESC
+        ) latest
+        ORDER BY %s %s, collected_at DESC
+        LIMIT $%d
+    `,
+			selectClause,
+			distinctClause,
+			selectClause,
+			QuoteIdentifier(probeName),
+			whereClause,
+			distinctClause,
+			QuoteIdentifier(orderCol),
+			order,
+			argNum,
+		)
+	}
 	args = append(args, limit)
 
 	return query, args
@@ -1238,7 +1313,7 @@ func discoverLatestRowColumns(
 	probeName string,
 	orderBy string,
 	filters *MetricFilters,
-) ([]string, string, error) {
+) ([]string, map[string]string, string, error) {
 	var count int
 	existsQuery := `
         SELECT COUNT(*) FROM information_schema.tables
@@ -1247,20 +1322,20 @@ func discoverLatestRowColumns(
             AND table_type = 'BASE TABLE'
     `
 	if err := pool.QueryRow(ctx, existsQuery, probeName).Scan(&count); err != nil {
-		return nil, "", fmt.Errorf("failed to verify probe: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to verify probe: %w", err)
 	}
 	if count == 0 {
-		return nil, "", fmt.Errorf("probe %q not found", probeName)
+		return nil, nil, "", fmt.Errorf("probe %q not found", probeName)
 	}
 
-	allCols, _, err := GetProbeAllColumns(ctx, pool, probeName)
+	allCols, colTypes, err := GetProbeAllColumns(ctx, pool, probeName)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get probe columns: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to get probe columns: %w", err)
 	}
 
 	outputCols := selectLatestOutputColumns(allCols)
 	if len(outputCols) == 0 {
-		return nil, "", fmt.Errorf("no columns found in probe %q", probeName)
+		return nil, nil, "", fmt.Errorf("no columns found in probe %q", probeName)
 	}
 
 	// order_by is validated against the full set of returned columns, not
@@ -1268,18 +1343,18 @@ func discoverLatestRowColumns(
 	// timestamp columns (e.g. last_vacuum) that appear in the response.
 	orderCol, err := ResolveOrderByColumn(orderBy, outputCols)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 
 	if filters.DatabaseName != "" && filters.DatabaseColumn == "" {
 		dbCol, err := ResolveDatabaseColumn(ctx, pool, probeName)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to resolve database column: %w", err)
+			return nil, nil, "", fmt.Errorf("failed to resolve database column: %w", err)
 		}
 		filters.DatabaseColumn = dbCol
 	}
 
-	return outputCols, orderCol, nil
+	return outputCols, colTypes, orderCol, nil
 }
 
 // scanLatestRows reads every row from rows into flat maps keyed by the
@@ -1312,10 +1387,14 @@ func scanLatestRows(rows pgx.Rows, outputCols []string) ([]map[string]any, error
 	return result, nil
 }
 
-// QueryLatestRows returns the most recent rows of a probe table as flat
-// maps keyed by column name. Unlike QueryTimeSeries it produces raw row
-// objects rather than bucketed series, so dashboards can read individual
-// column values (including dimension and timestamp columns) directly.
+// QueryLatestRows returns the newest row per monitored entity of a probe
+// table as flat maps keyed by column name. Unlike QueryTimeSeries it
+// produces raw row objects rather than bucketed series, so dashboards can
+// read individual column values (including dimension and timestamp columns)
+// directly. "Newest" always means the greatest collected_at: a filter that
+// pins a single entity yields exactly that entity's latest sample, and
+// order_by only ranks the per-entity latest rows, never selecting a stale
+// historical peak.
 func QueryLatestRows(
 	ctx context.Context,
 	pool *pgxpool.Pool,
@@ -1331,23 +1410,24 @@ func QueryLatestRows(
 		return nil, err
 	}
 
-	outputCols, orderCol, err := discoverLatestRowColumns(
+	outputCols, colTypes, orderCol, err := discoverLatestRowColumns(
 		ctx, pool, probeName, orderBy, &filters)
 	if err != nil {
 		return nil, err
 	}
 
 	query, args := buildLatestRowsQuery(
-		probeName, outputCols, connectionIDs, filters, orderCol, order, limit)
+		probeName, outputCols, colTypes, connectionIDs, filters, orderCol, order, limit)
 
 	// This is not a SQL injection risk despite passing a non-literal query
 	// string: the only identifiers interpolated into the text are probeName,
-	// orderCol, and the output column names, each of which is validated
-	// against a live-discovered allow-list (the information_schema.tables
-	// existence check, ResolveOrderByColumn, and GetProbeAllColumns) and then
-	// QuoteIdentifier-wrapped before it reaches the query. Every runtime
-	// value (connection IDs, filter strings, and the limit) is bound through
-	// $N placeholders in args and is never concatenated into the SQL text.
+	// orderCol, the output column names, and the entity-key (DISTINCT ON)
+	// columns, each of which is validated against a live-discovered allow-list
+	// (the information_schema.tables existence check, ResolveOrderByColumn, and
+	// GetProbeAllColumns) and then QuoteIdentifier-wrapped before it reaches the
+	// query. Every runtime value (connection IDs, filter strings, and the
+	// limit) is bound through $N placeholders in args and is never concatenated
+	// into the SQL text.
 	// nosemgrep: go_sql_rule-concat-sqli
 	rows, err := pool.Query(ctx, query, args...)
 	if err != nil {

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -1176,6 +1176,13 @@ func GetProbeAllColumns(ctx context.Context, pool *pgxpool.Pool, probeName strin
 // sample. connection_id is present on every probe table, so the entity key is
 // never empty and one query shape serves every probe, whether or not it has
 // text/name dimension columns.
+//
+// Precondition: outputCols must already have the internal bookkeeping columns
+// (connection_id, collected_at, inserted_at) stripped by
+// selectLatestOutputColumns. The inner subquery appends connection_id and
+// collected_at itself, so if outputCols still contained them the subquery
+// would emit duplicate column labels and the outer references would be
+// ambiguous, breaking the query.
 func buildLatestRowsQuery(
 	probeName string,
 	outputCols []string,

--- a/server/src/internal/metrics/query_db_test.go
+++ b/server/src/internal/metrics/query_db_test.go
@@ -31,6 +31,7 @@ import (
 const (
 	latestRowsTestProbe    = "pg_stat_all_tables_latest_test"
 	latestRowsInternalOnly = "internal_only_latest_test"
+	latestRowsNoEntityKey  = "pg_sys_metric_latest_test"
 )
 
 // newLatestRowsTestPool connects to the test database named by
@@ -356,6 +357,103 @@ func TestQueryLatestRows_Integration(t *testing.T) {
 			[]int{1}, MetricFilters{}, "", "desc", 1)
 		if err == nil {
 			t.Fatal("expected error for missing probe")
+		}
+	})
+}
+
+// setupNoEntityKeyFixture creates a probe table with no text/name dimension
+// columns, only bookkeeping columns and numeric metrics. It models a
+// system-level probe such as pg_sys_cpu_info where the whole per-connection
+// series is a single logical entity keyed solely on connection_id.
+//
+// The three connection-1 samples are crafted so the newest sample (by
+// collected_at) is NOT the historical maximum of cpu_user: an older sample
+// peaks at 99 while the newest reads 50. A query that ranked the full history
+// by cpu_user DESC (the original staleness bug) would surface the stale 99;
+// the corrected query reduces to the newest sample first and must return 50.
+func setupNoEntityKeyFixture(t *testing.T, pool *pgxpool.Pool) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS metrics"); err != nil {
+		t.Fatalf("failed to create metrics schema: %v", err)
+	}
+
+	dropTable(ctx, pool, latestRowsNoEntityKey)
+
+	ddl := `CREATE TABLE metrics."` + latestRowsNoEntityKey + `" (
+        connection_id integer NOT NULL,
+        collected_at  timestamp with time zone NOT NULL,
+        inserted_at   timestamp without time zone NOT NULL DEFAULT now(),
+        cpu_user      double precision
+    )`
+	if _, err := pool.Exec(ctx, ddl); err != nil {
+		t.Fatalf("failed to create no-entity-key fixture table: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	samples := []struct {
+		collectedAt time.Time
+		cpuUser     float64
+	}{
+		{now.Add(-2 * time.Minute), 90.0},
+		{now.Add(-1 * time.Minute), 99.0}, // historical maximum
+		{now, 50.0},                       // newest sample, but not the max
+	}
+
+	insert := `INSERT INTO metrics."` + latestRowsNoEntityKey + `"
+        (connection_id, collected_at, cpu_user) VALUES ($1, $2, $3)`
+	for i, s := range samples {
+		if _, err := pool.Exec(ctx, insert, 1, s.collectedAt, s.cpuUser); err != nil {
+			dropTable(ctx, pool, latestRowsNoEntityKey)
+			t.Fatalf("failed to insert no-entity-key fixture row %d: %v", i, err)
+		}
+	}
+
+	return func() { dropTable(context.Background(), pool, latestRowsNoEntityKey) }
+}
+
+// TestQueryLatestRows_NoEntityKeyIntegration exercises the DISTINCT ON
+// (connection_id) path for a probe with no text/name entity-key columns. It
+// proves that ranking by a real metric column still returns the newest sample
+// by collected_at, not the historical maximum of that column.
+func TestQueryLatestRows_NoEntityKeyIntegration(t *testing.T) {
+	pool, closePool := newLatestRowsTestPool(t)
+	defer closePool()
+	cleanup := setupNoEntityKeyFixture(t, pool)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// order_by=cpu_user desc, limit=1. Under the old fallback the query
+	// ranked the whole history by cpu_user DESC and returned the stale 99;
+	// the corrected query reduces to the newest sample (50) first.
+	t.Run("metric order_by returns newest sample not historical max", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsNoEntityKey,
+			[]int{1}, MetricFilters{}, "cpu_user", "desc", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(result))
+		}
+		if got := toInt64(t, result[0]["cpu_user"]); got != 50 {
+			t.Errorf("cpu_user = %d, want 50 (newest sample), not 99 (historical max)", got)
+		}
+	})
+
+	// The default order_by (collected_at) must also return the newest sample.
+	t.Run("default order_by returns newest sample", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsNoEntityKey,
+			[]int{1}, MetricFilters{}, "", "desc", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(result))
+		}
+		if got := toInt64(t, result[0]["cpu_user"]); got != 50 {
+			t.Errorf("cpu_user = %d, want 50 (newest sample)", got)
 		}
 	})
 }

--- a/server/src/internal/metrics/query_db_test.go
+++ b/server/src/internal/metrics/query_db_test.go
@@ -80,12 +80,20 @@ type fixtureRow struct {
 // table with a representative column mix: bookkeeping columns, dimension
 // columns, numeric metrics, a timestamp column, an interval column, a
 // numeric column, and a double-precision column able to hold NaN. It
-// inserts three connection-1 rows and returns a cleanup that drops the
-// table. The three rows are:
+// inserts connection-1 rows for three distinct entities and returns a
+// cleanup that drops the table.
 //
-//	A: collected_at now-2m, n_live_tup 100, last_vacuum set, replay_lag 1s, nan 1.0
-//	B: collected_at now-1m, n_live_tup 300, last_vacuum set, replay_lag NULL, nan NaN
-//	C: collected_at now,    n_live_tup 200, last_vacuum NULL, replay_lag NULL, nan 2.0
+// The public.orders entity has three samples and models the stale-latest-row
+// regression: its most recent sample (200) is numerically smaller than an
+// older sample (300), so any query that ranks by the historical maximum of
+// n_live_tup would wrongly surface the older 300 row as "latest".
+//
+//	A: orders    now-2m, n_live_tup 100, last_vacuum set, replay_lag 1s, nan 1.0
+//	B: orders    now-1m, n_live_tup 300, last_vacuum set, replay_lag NULL, nan NaN
+//	C: orders    now,    n_live_tup 200, last_vacuum NULL, replay_lag NULL, nan 2.0
+//	D: customers now-90s, n_live_tup 400
+//	E: customers now-30s, n_live_tup 500 (customers' latest sample)
+//	F: products  now-45s, n_live_tup 50  (products' only sample)
 func setupLatestRowsFixture(t *testing.T, pool *pgxpool.Pool) func() {
 	t.Helper()
 	ctx := context.Background()
@@ -141,6 +149,24 @@ func setupLatestRowsFixture(t *testing.T, pool *pgxpool.Pool) func() {
 			replayLag:  nil,
 			nanMetric:  2.0,
 		},
+		{
+			collectedAt: now.Add(-90 * time.Second),
+			dbName:      "northwind", schema: "public", relname: "customers",
+			nLiveTup: 400, nDeadTup: 5, seqScan: 2, someRatio: 1.0,
+			lastVacuum: nil, replayLag: nil, nanMetric: 3.0,
+		},
+		{
+			collectedAt: now.Add(-30 * time.Second),
+			dbName:      "northwind", schema: "public", relname: "customers",
+			nLiveTup: 500, nDeadTup: 8, seqScan: 4, someRatio: 1.5,
+			lastVacuum: nil, replayLag: nil, nanMetric: 4.0,
+		},
+		{
+			collectedAt: now.Add(-45 * time.Second),
+			dbName:      "northwind", schema: "public", relname: "products",
+			nLiveTup: 50, nDeadTup: 1, seqScan: 1, someRatio: 0.5,
+			lastVacuum: nil, replayLag: nil, nanMetric: 5.0,
+		},
 	}
 
 	insert := `INSERT INTO metrics."` + latestRowsTestProbe + `"
@@ -179,7 +205,7 @@ func TestQueryLatestRows_Integration(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("happy path single newest row", func(t *testing.T) {
+	t.Run("happy path newest entity row", func(t *testing.T) {
 		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
 			[]int{1}, MetricFilters{}, "", "desc", 1)
 		if err != nil {
@@ -197,9 +223,10 @@ func TestQueryLatestRows_Integration(t *testing.T) {
 			}
 		}
 
-		// The newest row (collected_at now) has n_live_tup 200.
+		// Default order_by is collected_at; the entity with the newest
+		// sample is orders (collected_at now, n_live_tup 200).
 		if got := toInt64(t, row["n_live_tup"]); got != 200 {
-			t.Errorf("n_live_tup = %v, want 200 (newest row)", row["n_live_tup"])
+			t.Errorf("n_live_tup = %v, want 200 (orders' newest row)", row["n_live_tup"])
 		}
 		if row["relname"] != "orders" {
 			t.Errorf("relname = %v, want orders", row["relname"])
@@ -209,17 +236,70 @@ func TestQueryLatestRows_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("limit honored and order by collected_at desc", func(t *testing.T) {
+	// This is the exact regression the fix targets: a single entity whose
+	// most recent sample (200) is numerically smaller than an older sample
+	// (300). TableDetail.tsx requests limit=1 & order_by=n_live_tup desc, so
+	// the buggy "rank across all history by n_live_tup" query returned the
+	// stale 300 row (with its stale last_vacuum) forever. The corrected query
+	// must return the newest sample (200) regardless of order_by.
+	t.Run("single entity returns newest row not historical max", func(t *testing.T) {
+		filters := MetricFilters{SchemaName: "public", TableName: "orders"}
 		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
-			[]int{1}, MetricFilters{}, "", "desc", 3)
+			[]int{1}, filters, "n_live_tup", "desc", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("expected 1 row for orders, got %d", len(result))
+		}
+		row := result[0]
+		if got := toInt64(t, row["n_live_tup"]); got != 200 {
+			t.Errorf("n_live_tup = %d, want 200 (newest), not 300 (historical max)", got)
+		}
+		// Row C (the newest) has a NULL last_vacuum; the stale historical
+		// max row B had last_vacuum set, so a non-nil value here would prove
+		// the stale row leaked through.
+		if row["last_vacuum"] != nil {
+			t.Errorf("last_vacuum = %v, want nil (newest row's value)", row["last_vacuum"])
+		}
+	})
+
+	t.Run("multi-entity ranked by each entity latest sample", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{}, "n_live_tup", "desc", 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// One row per distinct entity (orders, customers, products), ranked
+		// by each entity's own latest n_live_tup DESC: customers 500,
+		// orders 200 (NOT its historical 300), products 50.
+		if len(result) != 3 {
+			t.Fatalf("expected 3 entity rows, got %d", len(result))
+		}
+		wantVal := []int64{500, 200, 50}
+		wantRel := []string{"customers", "orders", "products"}
+		for i := range wantVal {
+			if got := toInt64(t, result[i]["n_live_tup"]); got != wantVal[i] {
+				t.Errorf("row %d n_live_tup = %d, want %d", i, got, wantVal[i])
+			}
+			if result[i]["relname"] != wantRel[i] {
+				t.Errorf("row %d relname = %v, want %s", i, result[i]["relname"], wantRel[i])
+			}
+		}
+	})
+
+	t.Run("multi-entity default order by collected_at desc", func(t *testing.T) {
+		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
+			[]int{1}, MetricFilters{}, "", "desc", 10)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(result) != 3 {
-			t.Fatalf("expected 3 rows, got %d", len(result))
+			t.Fatalf("expected 3 entity rows, got %d", len(result))
 		}
-		// collected_at DESC => C(200), B(300), A(100)
-		want := []int64{200, 300, 100}
+		// Per-entity latest by collected_at DESC: orders (now, 200),
+		// customers (now-30s, 500), products (now-45s, 50).
+		want := []int64{200, 500, 50}
 		for i, w := range want {
 			if got := toInt64(t, result[i]["n_live_tup"]); got != w {
 				t.Errorf("row %d n_live_tup = %d, want %d", i, got, w)
@@ -227,36 +307,19 @@ func TestQueryLatestRows_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("order_by real column honored", func(t *testing.T) {
-		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
-			[]int{1}, MetricFilters{}, "n_live_tup", "desc", 3)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(result) != 3 {
-			t.Fatalf("expected 3 rows, got %d", len(result))
-		}
-		// n_live_tup DESC => 300, 200, 100
-		want := []int64{300, 200, 100}
-		for i, w := range want {
-			if got := toInt64(t, result[i]["n_live_tup"]); got != w {
-				t.Errorf("row %d n_live_tup = %d, want %d", i, got, w)
-			}
-		}
-	})
-
-	t.Run("limit clamped above max still returns all rows", func(t *testing.T) {
+	t.Run("limit clamped above max still returns one row per entity", func(t *testing.T) {
 		result, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
 			[]int{1}, MetricFilters{}, "", "asc", maxLatestRowLimit+10)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(result) != 3 {
-			t.Fatalf("expected 3 rows, got %d", len(result))
+			t.Fatalf("expected 3 entity rows, got %d", len(result))
 		}
-		// asc by collected_at => A(100), B(300), C(200)
-		if got := toInt64(t, result[0]["n_live_tup"]); got != 100 {
-			t.Errorf("first row n_live_tup = %d, want 100", got)
+		// Per-entity latest by collected_at ASC: products (now-45s, 50),
+		// customers (now-30s, 500), orders (now, 200).
+		if got := toInt64(t, result[0]["n_live_tup"]); got != 50 {
+			t.Errorf("first row n_live_tup = %d, want 50 (oldest latest sample)", got)
 		}
 	})
 
@@ -267,7 +330,7 @@ func TestQueryLatestRows_Integration(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(result) != 3 {
-			t.Fatalf("expected 3 rows for northwind, got %d", len(result))
+			t.Fatalf("expected 3 entity rows for northwind, got %d", len(result))
 		}
 
 		none, err := QueryLatestRows(ctx, pool, latestRowsTestProbe,
@@ -307,7 +370,7 @@ func TestDiscoverLatestRowColumns_Integration(t *testing.T) {
 
 	t.Run("resolves output and order_by columns", func(t *testing.T) {
 		filters := MetricFilters{}
-		outputCols, orderCol, err := discoverLatestRowColumns(
+		outputCols, colTypes, orderCol, err := discoverLatestRowColumns(
 			ctx, pool, latestRowsTestProbe, "n_live_tup", &filters)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -325,11 +388,19 @@ func TestDiscoverLatestRowColumns_Integration(t *testing.T) {
 				t.Errorf("output columns should include %q", col)
 			}
 		}
+		// colTypes must carry the data types the entity-key detection relies
+		// on so the caller can build the DISTINCT ON grouping.
+		if colTypes["relname"] != "name" {
+			t.Errorf("colTypes[relname] = %q, want name", colTypes["relname"])
+		}
+		if colTypes["n_live_tup"] != "bigint" {
+			t.Errorf("colTypes[n_live_tup] = %q, want bigint", colTypes["n_live_tup"])
+		}
 	})
 
 	t.Run("resolves database filter column", func(t *testing.T) {
 		filters := MetricFilters{DatabaseName: "northwind"}
-		_, _, err := discoverLatestRowColumns(
+		_, _, _, err := discoverLatestRowColumns(
 			ctx, pool, latestRowsTestProbe, "", &filters)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -341,7 +412,7 @@ func TestDiscoverLatestRowColumns_Integration(t *testing.T) {
 
 	t.Run("unknown order_by rejected", func(t *testing.T) {
 		filters := MetricFilters{}
-		_, _, err := discoverLatestRowColumns(
+		_, _, _, err := discoverLatestRowColumns(
 			ctx, pool, latestRowsTestProbe, "nope", &filters)
 		if err == nil {
 			t.Fatal("expected error for unknown order_by")
@@ -350,7 +421,7 @@ func TestDiscoverLatestRowColumns_Integration(t *testing.T) {
 
 	t.Run("missing probe rejected", func(t *testing.T) {
 		filters := MetricFilters{}
-		_, _, err := discoverLatestRowColumns(
+		_, _, _, err := discoverLatestRowColumns(
 			ctx, pool, "does_not_exist_probe", "", &filters)
 		if err == nil {
 			t.Fatal("expected error for missing probe")
@@ -370,7 +441,7 @@ func TestDiscoverLatestRowColumns_Integration(t *testing.T) {
 		defer dropTable(ctx, pool, latestRowsInternalOnly)
 
 		filters := MetricFilters{}
-		_, _, err := discoverLatestRowColumns(
+		_, _, _, err := discoverLatestRowColumns(
 			ctx, pool, latestRowsInternalOnly, "", &filters)
 		if err == nil {
 			t.Fatal("expected error for probe with no output columns")
@@ -381,7 +452,7 @@ func TestDiscoverLatestRowColumns_Integration(t *testing.T) {
 		cctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		filters := MetricFilters{}
-		_, _, err := discoverLatestRowColumns(
+		_, _, _, err := discoverLatestRowColumns(
 			cctx, pool, latestRowsTestProbe, "", &filters)
 		if err == nil {
 			t.Fatal("expected error from canceled context")
@@ -403,7 +474,7 @@ func TestScanLatestRows_Integration(t *testing.T) {
 		}
 		query := `SELECT relname, some_ratio, last_vacuum, replay_lag, nan_metric
             FROM metrics."` + latestRowsTestProbe + `"
-            WHERE connection_id = 1
+            WHERE connection_id = 1 AND relname = 'orders'
             ORDER BY collected_at ASC`
 		rows, err := pool.Query(ctx, query)
 		if err != nil {

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -1038,7 +1038,7 @@ func TestEntityKeyColumns(t *testing.T) {
 			want: []string{"database_name", "schemaname", "relname"},
 		},
 		{
-			// Index-probe analogue of the above (index_size_pretty).
+			// Index-probe analog of the above (index_size_pretty).
 			name: "index _pretty value column is excluded",
 			outputCols: []string{
 				"database_name", "schemaname", "relname", "indexrelname",
@@ -1131,12 +1131,12 @@ func TestBuildLatestRowsQuery(t *testing.T) {
 		if !strings.Contains(query, "connection_id IN ($1)") {
 			t.Error("query should filter by connection_id")
 		}
-		// The inner query reduces each entity (keyed by the text/name
-		// column relname) to its newest sample via DISTINCT ON.
-		if !strings.Contains(query, `DISTINCT ON ("relname")`) {
-			t.Errorf("query should use DISTINCT ON the entity key, got: %s", query)
+		// The inner query reduces each entity (keyed by connection_id plus
+		// the text/name column relname) to its newest sample via DISTINCT ON.
+		if !strings.Contains(query, `DISTINCT ON (connection_id, "relname")`) {
+			t.Errorf("query should use DISTINCT ON connection_id and the entity key, got: %s", query)
 		}
-		if !strings.Contains(query, `ORDER BY "relname", collected_at DESC`) {
+		if !strings.Contains(query, `ORDER BY connection_id, "relname", collected_at DESC`) {
 			t.Errorf("inner query should order by entity key then collected_at DESC, got: %s", query)
 		}
 		// The outer query ranks the per-entity latest rows by order_by.
@@ -1185,8 +1185,8 @@ func TestBuildLatestRowsQuery(t *testing.T) {
 		if !strings.Contains(query, "indexrelname = $6") {
 			t.Error("query should filter by indexrelname")
 		}
-		if !strings.Contains(query, `DISTINCT ON ("indexrelname")`) {
-			t.Errorf("query should use DISTINCT ON the index entity key, got: %s", query)
+		if !strings.Contains(query, `DISTINCT ON (connection_id, "indexrelname")`) {
+			t.Errorf("query should use DISTINCT ON connection_id and the index entity key, got: %s", query)
 		}
 		if !strings.Contains(query, `ORDER BY "idx_scan" asc, collected_at DESC`) {
 			t.Errorf("query should rank by idx_scan asc, got: %s", query)
@@ -1203,27 +1203,38 @@ func TestBuildLatestRowsQuery(t *testing.T) {
 		}
 	})
 
-	t.Run("no entity-key columns falls back to flat collected_at ordering", func(t *testing.T) {
+	t.Run("no text entity keys still keys DISTINCT ON connection_id", func(t *testing.T) {
+		// A probe with only numeric metric columns (e.g. pg_sys_cpu_info) has
+		// no text/name entity keys, yet connection_id alone must still key the
+		// DISTINCT ON so distinct connections never collapse into one row. The
+		// order_by is a real metric column, not collected_at, so the outer
+		// ranking is a genuine ORDER BY on that column rather than a no-op
+		// duplication of collected_at.
 		query, args := buildLatestRowsQuery(
 			"pg_sys_cpu_info",
 			[]string{"cpu_user"},
 			map[string]string{"cpu_user": "double precision"},
 			[]int{1},
 			MetricFilters{DatabaseName: "northwind", DatabaseColumn: ""},
-			"collected_at", "desc", 1,
+			"cpu_user", "desc", 1,
 		)
 
 		if strings.Contains(query, "database_name") || strings.Contains(query, "datname") {
 			t.Error("query should not filter by database when column unresolved")
 		}
-		// With no text/name entity keys, the query must not use DISTINCT ON;
-		// the whole filtered set is a single logical entity ordered by
-		// collected_at so the newest sample stays first.
-		if strings.Contains(query, "DISTINCT ON") {
-			t.Errorf("query should not use DISTINCT ON without entity keys, got: %s", query)
+		// Even without text/name entity keys, connection_id alone keys the
+		// DISTINCT ON so distinct connections stay separate entities.
+		if !strings.Contains(query, "DISTINCT ON (connection_id)") {
+			t.Errorf("query should use DISTINCT ON (connection_id), got: %s", query)
 		}
-		if !strings.Contains(query, `ORDER BY "collected_at" desc, collected_at DESC`) {
-			t.Errorf("query should order by collected_at, got: %s", query)
+		// The inner query reduces each connection to its newest sample.
+		if !strings.Contains(query, "ORDER BY connection_id, collected_at DESC") {
+			t.Errorf("inner query should order by connection_id then collected_at DESC, got: %s", query)
+		}
+		// The outer query ranks the per-connection latest rows by the
+		// requested metric column, proving it is not a collected_at no-op.
+		if !strings.Contains(query, `ORDER BY "cpu_user" desc, collected_at DESC`) {
+			t.Errorf("outer query should rank by cpu_user desc, got: %s", query)
 		}
 		// 1 connection + 1 limit only
 		if len(args) != 2 {

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -979,7 +979,7 @@ func TestClassifyMetrics(t *testing.T) {
 	})
 }
 
-func TestLatestEntityKeyColumns(t *testing.T) {
+func TestEntityKeyColumns(t *testing.T) {
 	tests := []struct {
 		name       string
 		outputCols []string
@@ -1016,11 +1016,63 @@ func TestLatestEntityKeyColumns(t *testing.T) {
 			colTypes:   map[string]string{"relname": "name", "schemaname": "name"},
 			want:       []string{"relname", "schemaname"},
 		},
+		{
+			// Simulates PR #343's additions (table_size /
+			// table_size_pretty). The text-typed *_pretty value column
+			// must NOT join the entity key, or different historical
+			// rendered sizes would fragment one table into many and
+			// reproduce the latest-row staleness bug.
+			name: "text-typed _pretty value column is excluded",
+			outputCols: []string{
+				"database_name", "schemaname", "relname",
+				"table_size", "table_size_pretty", "n_live_tup",
+			},
+			colTypes: map[string]string{
+				"database_name":     "text",
+				"schemaname":        "name",
+				"relname":           "name",
+				"table_size":        "bigint",
+				"table_size_pretty": "text",
+				"n_live_tup":        "bigint",
+			},
+			want: []string{"database_name", "schemaname", "relname"},
+		},
+		{
+			// Index-probe analogue of the above (index_size_pretty).
+			name: "index _pretty value column is excluded",
+			outputCols: []string{
+				"database_name", "schemaname", "relname", "indexrelname",
+				"index_size", "index_size_pretty", "idx_scan",
+			},
+			colTypes: map[string]string{
+				"database_name":     "character varying",
+				"schemaname":        "name",
+				"relname":           "name",
+				"indexrelname":      "name",
+				"index_size":        "bigint",
+				"index_size_pretty": "text",
+				"idx_scan":          "bigint",
+			},
+			want: []string{
+				"database_name", "schemaname", "relname", "indexrelname",
+			},
+		},
+		{
+			name:       "internal bookkeeping columns are excluded",
+			outputCols: []string{"connection_id", "collected_at", "inserted_at", "datname"},
+			colTypes: map[string]string{
+				"connection_id": "integer",
+				"collected_at":  "timestamp with time zone",
+				"inserted_at":   "timestamp with time zone",
+				"datname":       "name",
+			},
+			want: []string{"datname"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := latestEntityKeyColumns(tt.outputCols, tt.colTypes)
+			got := EntityKeyColumns(tt.outputCols, tt.colTypes)
 			if len(got) != len(tt.want) {
 				t.Fatalf("got %v, want %v", got, tt.want)
 			}
@@ -1028,6 +1080,35 @@ func TestLatestEntityKeyColumns(t *testing.T) {
 				if got[i] != tt.want[i] {
 					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
 				}
+			}
+		})
+	}
+}
+
+// TestIsEntityKeyColumn exercises the single-column predicate directly,
+// covering each type branch and both exclusion signals.
+func TestIsEntityKeyColumn(t *testing.T) {
+	tests := []struct {
+		name     string
+		colName  string
+		dataType string
+		want     bool
+	}{
+		{"text identity column", "schemaname", "name", true},
+		{"varchar identity column", "database_name", "character varying", true},
+		{"plain text column", "relname", "text", true},
+		{"numeric value column", "n_live_tup", "bigint", false},
+		{"timestamp column", "last_vacuum", "timestamp with time zone", false},
+		{"text _pretty value column", "table_size_pretty", "text", false},
+		{"internal bookkeeping column", "collected_at", "timestamp with time zone", false},
+		{"internal connection_id", "connection_id", "integer", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEntityKeyColumn(tt.colName, tt.dataType); got != tt.want {
+				t.Errorf("IsEntityKeyColumn(%q, %q) = %v, want %v",
+					tt.colName, tt.dataType, got, tt.want)
 			}
 		})
 	}

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -979,11 +979,66 @@ func TestClassifyMetrics(t *testing.T) {
 	})
 }
 
+func TestLatestEntityKeyColumns(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputCols []string
+		colTypes   map[string]string
+		want       []string
+	}{
+		{
+			name:       "table probe keys on text and name columns",
+			outputCols: []string{"database_name", "schemaname", "relname", "n_live_tup", "seq_scan"},
+			colTypes: map[string]string{
+				"database_name": "text",
+				"schemaname":    "name",
+				"relname":       "name",
+				"n_live_tup":    "bigint",
+				"seq_scan":      "bigint",
+			},
+			want: []string{"database_name", "schemaname", "relname"},
+		},
+		{
+			name:       "varchar columns count as entity keys",
+			outputCols: []string{"label", "value"},
+			colTypes:   map[string]string{"label": "character varying", "value": "numeric"},
+			want:       []string{"label"},
+		},
+		{
+			name:       "no text columns yields no keys",
+			outputCols: []string{"cpu_user", "cpu_system"},
+			colTypes:   map[string]string{"cpu_user": "double precision", "cpu_system": "double precision"},
+			want:       nil,
+		},
+		{
+			name:       "preserves output column order",
+			outputCols: []string{"relname", "schemaname"},
+			colTypes:   map[string]string{"relname": "name", "schemaname": "name"},
+			want:       []string{"relname", "schemaname"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := latestEntityKeyColumns(tt.outputCols, tt.colTypes)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestBuildLatestRowsQuery(t *testing.T) {
-	t.Run("connection filter and limit only", func(t *testing.T) {
+	t.Run("entity-key probe wraps in DISTINCT ON", func(t *testing.T) {
 		query, args := buildLatestRowsQuery(
 			"pg_stat_all_tables",
 			[]string{"relname", "n_live_tup"},
+			map[string]string{"relname": "name", "n_live_tup": "bigint"},
 			[]int{1},
 			MetricFilters{},
 			"n_live_tup", "desc", 1,
@@ -995,8 +1050,17 @@ func TestBuildLatestRowsQuery(t *testing.T) {
 		if !strings.Contains(query, "connection_id IN ($1)") {
 			t.Error("query should filter by connection_id")
 		}
+		// The inner query reduces each entity (keyed by the text/name
+		// column relname) to its newest sample via DISTINCT ON.
+		if !strings.Contains(query, `DISTINCT ON ("relname")`) {
+			t.Errorf("query should use DISTINCT ON the entity key, got: %s", query)
+		}
+		if !strings.Contains(query, `ORDER BY "relname", collected_at DESC`) {
+			t.Errorf("inner query should order by entity key then collected_at DESC, got: %s", query)
+		}
+		// The outer query ranks the per-entity latest rows by order_by.
 		if !strings.Contains(query, `ORDER BY "n_live_tup" desc, collected_at DESC`) {
-			t.Errorf("query should order by quoted column then collected_at, got: %s", query)
+			t.Errorf("outer query should rank by order_by column, got: %s", query)
 		}
 		if !strings.Contains(query, "LIMIT $2") {
 			t.Error("query should apply LIMIT placeholder")
@@ -1013,6 +1077,7 @@ func TestBuildLatestRowsQuery(t *testing.T) {
 		query, args := buildLatestRowsQuery(
 			"pg_stat_all_indexes",
 			[]string{"indexrelname", "idx_scan"},
+			map[string]string{"indexrelname": "name", "idx_scan": "bigint"},
 			[]int{2, 3},
 			MetricFilters{
 				DatabaseName:   "northwind",
@@ -1039,8 +1104,11 @@ func TestBuildLatestRowsQuery(t *testing.T) {
 		if !strings.Contains(query, "indexrelname = $6") {
 			t.Error("query should filter by indexrelname")
 		}
+		if !strings.Contains(query, `DISTINCT ON ("indexrelname")`) {
+			t.Errorf("query should use DISTINCT ON the index entity key, got: %s", query)
+		}
 		if !strings.Contains(query, `ORDER BY "idx_scan" asc, collected_at DESC`) {
-			t.Errorf("query should order by idx_scan asc, got: %s", query)
+			t.Errorf("query should rank by idx_scan asc, got: %s", query)
 		}
 		if !strings.Contains(query, "LIMIT $7") {
 			t.Error("query should apply LIMIT placeholder at $7")
@@ -1054,10 +1122,11 @@ func TestBuildLatestRowsQuery(t *testing.T) {
 		}
 	})
 
-	t.Run("database filter skipped without resolved column", func(t *testing.T) {
+	t.Run("no entity-key columns falls back to flat collected_at ordering", func(t *testing.T) {
 		query, args := buildLatestRowsQuery(
 			"pg_sys_cpu_info",
 			[]string{"cpu_user"},
+			map[string]string{"cpu_user": "double precision"},
 			[]int{1},
 			MetricFilters{DatabaseName: "northwind", DatabaseColumn: ""},
 			"collected_at", "desc", 1,
@@ -1065,6 +1134,15 @@ func TestBuildLatestRowsQuery(t *testing.T) {
 
 		if strings.Contains(query, "database_name") || strings.Contains(query, "datname") {
 			t.Error("query should not filter by database when column unresolved")
+		}
+		// With no text/name entity keys, the query must not use DISTINCT ON;
+		// the whole filtered set is a single logical entity ordered by
+		// collected_at so the newest sample stays first.
+		if strings.Contains(query, "DISTINCT ON") {
+			t.Errorf("query should not use DISTINCT ON without entity keys, got: %s", query)
+		}
+		if !strings.Contains(query, `ORDER BY "collected_at" desc, collected_at DESC`) {
+			t.Errorf("query should order by collected_at, got: %s", query)
 		}
 		// 1 connection + 1 limit only
 		if len(args) != 2 {


### PR DESCRIPTION
## Symptom

The Table and Index object-detail dashboards' overview tiles and
Maintenance Info panel could show stale, pre-maintenance values
indefinitely, even after the collector had already recorded fresh,
correct data.

Reproduced live: running `ANALYZE` on `northwind.public.orders`
corrected its live-tuple-count estimate downward (1933 → 1367), but
the dashboard kept showing the old, larger tuple count and a stale
(`Never`) Last Analyze value indefinitely afterward, despite the
datastore holding the correct fresh sample.

## Root cause

The latest-row mode of `GET /api/v1/metrics/query` (`limit` +
`order_by`, added by #340) built:

```sql
ORDER BY <order_by column> <asc|desc>, collected_at DESC
LIMIT <limit>
```

`order_by` was the *primary* sort key across the probe table's
**entire history** for the matching rows, with `collected_at DESC`
only breaking exact ties. So a request for "the latest row of table
X, sorted by `n_live_tup`" didn't return the most recent sample — it
returned whichever historical sample had the numerically highest
`n_live_tup`, which is exactly wrong for any column that can decrease
over time: tuple counts after `ANALYZE`/`VACUUM`/`DELETE`, dead-tuple
counts after `VACUUM`, and so on.

## Fix

`buildLatestRowsQuery` now always reduces to each monitored entity's
(table's or index's) newest sample by `collected_at` first, via an
inner `DISTINCT ON` over the entity-key (schema/table or
schema/index) columns, and only then ranks those already-latest rows
by the requested `order_by` column. Probes with no entity-key columns
keep a flat `ORDER BY ... collected_at DESC`.

A request filtered down to one specific table or index — which is
what `TableDetail.tsx`/`IndexDetail.tsx` always do — now always
returns that entity's true latest sample, regardless of which column
it asks to sort by. Confirmed no real caller today relies on
multi-entity ranking through this endpoint (the leaderboard widgets
use a separate, already-`DISTINCT ON`-correct `/api/v1/metrics/latest`
endpoint), but the fix keeps that case correct too, since it groups
by entity before ranking.

All identifiers remain validated against a live-discovered allow-list
and `QuoteIdentifier`-wrapped; all values stay `$N`-bound — no change
to the existing SQL-injection-safe pattern.

## Testing

- Rewrote the integration fixture with three distinct entities, one
  sampled so its newest value is smaller than an older historical
  peak — the exact regression.
- New/updated unit and integration tests confirm a single-entity
  query now returns the newest row (not the historical max) and a
  multi-entity query ranks by each entity's own latest sample.
- `gofmt -l .` clean, `go build ./...` clean.
- Full server suite passes; integration tests verified live against a
  real PostgreSQL instance.
- Touched-function line coverage: `buildLatestRowsQuery` 100%,
  `latestEntityKeyColumns` 100%, `discoverLatestRowColumns` 90.5%,
  `QueryLatestRows` 91.7%, `scanLatestRows` 93.3%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Table and Index object-detail dashboards showing stale overview tiles and Maintenance Info after fresh data.
  * Latest metrics now consistently return each entity’s newest `collected_at` sample (including correct behavior when ordering fields decrease over time), with proper single- and multi-entity ranking and `limit`.
  * Dimension columns no longer include `*_pretty` value columns, preventing entities from being split into multiple identity groups.
* **Documentation**
  * Updated the unreleased changelog entry describing the dashboard fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->