### PR TITLE
Fix Index Scan Activity chart always showing no data

### DIFF
--- a/client/src/components/Dashboard/ObjectDashboard/IndexDetail.tsx
+++ b/client/src/components/Dashboard/ObjectDashboard/IndexDetail.tsx
@@ -145,7 +145,7 @@ const IndexDetail: React.FC<ObjectDetailProps> = ({
         connectionId,
         databaseName,
         schemaName,
-        tableName: objectName,
+        indexName: objectName,
         timeRange: timeRange.range,
         buckets: CHART_BUCKETS,
         aggregation: 'avg',

--- a/client/src/components/Dashboard/ObjectDashboard/__tests__/IndexDetail.test.tsx
+++ b/client/src/components/Dashboard/ObjectDashboard/__tests__/IndexDetail.test.tsx
@@ -15,7 +15,7 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import IndexDetail from '../IndexDetail';
 import type { IndexDetailData } from '../types';
 import type { UseMetricsReturn } from '../../../../hooks/useMetrics';
-import type { MetricSeries } from '../../types';
+import type { MetricSeries, MetricQueryParams } from '../../types';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -47,8 +47,15 @@ let mockMetricsReturn: UseMetricsReturn = {
     error: null,
     refetch: vi.fn(),
 };
+// Spy that captures the params IndexDetail hands to useMetrics for the
+// Scan Activity chart, so the routing tests can assert the query is scoped
+// to the index (indexName) rather than misrouted into tableName.
+const mockUseMetrics = vi.fn();
 vi.mock('../../../../hooks/useMetrics', () => ({
-    useMetrics: () => mockMetricsReturn,
+    useMetrics: (params: MetricQueryParams | null) => {
+        mockUseMetrics(params);
+        return mockMetricsReturn;
+    },
 }));
 
 vi.mock('../../../../contexts/useAICapabilities', () => ({
@@ -293,5 +300,37 @@ describe('IndexDetail', () => {
         renderIndexDetail();
 
         expect(mockApiFetch).not.toHaveBeenCalled();
+    });
+
+    // -----------------------------------------------------------------------
+    // Scan Activity chart query routing (guards PR #353's fix)
+    //
+    // The regression these guard: the index name was previously sent to the
+    // chart query as tableName, which filtered relname = the index name and
+    // returned no rows. The fix scopes the query via indexName instead.
+    // -----------------------------------------------------------------------
+
+    it('scopes the chart query to the index via indexName', () => {
+        // A never-resolving latest-row fetch keeps the component in its
+        // pending state so no async updates fire; useMetrics is still
+        // invoked with the chart params during the initial render.
+        mockApiFetch.mockReturnValue(new Promise(() => {}));
+
+        renderIndexDetail();
+
+        const params = mockUseMetrics.mock.calls[0][0] as MetricQueryParams;
+        expect(params.probeName).toBe('pg_stat_all_indexes');
+        expect(params.indexName).toBe('users_pkey');
+        expect(params.metrics).toEqual(['idx_scan_per_sec']);
+        expect(params.schemaName).toBe('public');
+    });
+
+    it('does not misroute the index name into tableName', () => {
+        mockApiFetch.mockReturnValue(new Promise(() => {}));
+
+        renderIndexDetail();
+
+        const params = mockUseMetrics.mock.calls[0][0] as MetricQueryParams;
+        expect(params.tableName).toBeUndefined();
     });
 });

--- a/client/src/components/Dashboard/types.ts
+++ b/client/src/components/Dashboard/types.ts
@@ -128,6 +128,7 @@ export interface MetricQueryParams {
     databaseName?: string;
     schemaName?: string;
     tableName?: string;
+    indexName?: string;
     timeRange: TimeRange;
     buckets?: number;
     aggregation?: 'avg' | 'sum' | 'min' | 'max' | 'last';

--- a/client/src/hooks/__tests__/useMetrics.test.ts
+++ b/client/src/hooks/__tests__/useMetrics.test.ts
@@ -157,6 +157,52 @@ describe('useMetrics', () => {
         expect(url).toContain('connection_ids=1%2C2%2C3');
     });
 
+    it('builds URL with index_name when indexName is set', async () => {
+        mockApiGet.mockResolvedValueOnce(makeMetricSeries());
+
+        const params = {
+            probeName: 'pg_stat_all_indexes',
+            timeRange: '24h',
+            connectionId: 5,
+            databaseName: 'mydb',
+            schemaName: 'public',
+            indexName: 'pk_orders',
+            metrics: ['idx_scan_per_sec'],
+        };
+
+        renderHook(() => useMetrics(params));
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).toContain('index_name=pk_orders');
+        // The index name must not leak into table_name.
+        expect(url).not.toContain('table_name');
+    });
+
+    it('omits index_name when indexName is not set', async () => {
+        mockApiGet.mockResolvedValueOnce(makeMetricSeries());
+
+        const params = {
+            probeName: 'pg_stat_user_tables',
+            timeRange: '24h',
+            connectionId: 5,
+            tableName: 'orders',
+        };
+
+        renderHook(() => useMetrics(params));
+
+        await waitFor(() => {
+            expect(mockApiGet).toHaveBeenCalled();
+        });
+
+        const url = mockApiGet.mock.calls[0][0];
+        expect(url).not.toContain('index_name');
+        expect(url).toContain('table_name=orders');
+    });
+
     it('sets loading to true during initial fetch', async () => {
         let resolvePromise: (value: unknown) => void;
         mockApiGet.mockImplementationOnce(() =>

--- a/client/src/hooks/__tests__/useMetrics.test.ts
+++ b/client/src/hooks/__tests__/useMetrics.test.ts
@@ -301,6 +301,64 @@ describe('useMetrics', () => {
         });
     });
 
+    it('resets initial load state when indexName changes so loading flashes again', async () => {
+        // Initial index resolves immediately.
+        mockApiGet.mockResolvedValueOnce(makeMetricSeries());
+
+        const { result, rerender } = renderHook(
+            ({ params }) => useMetrics(params),
+            {
+                initialProps: {
+                    params: {
+                        probeName: 'pg_stat_all_indexes',
+                        timeRange: '24h',
+                        connectionId: 5,
+                        indexName: 'pk_orders',
+                    },
+                },
+            },
+        );
+
+        // Wait for initial load to complete.
+        await waitFor(() => {
+            expect(result.current.data).not.toBeNull();
+        });
+        expect(result.current.loading).toBe(false);
+
+        // Switching to a different index should reset initialLoadDoneRef,
+        // so the next fetch flashes loading to true (no stale data shown).
+        let resolvePromise: (value: unknown) => void;
+        mockApiGet.mockImplementationOnce(() =>
+            new Promise(resolve => {
+                resolvePromise = resolve;
+            }),
+        );
+
+        rerender({
+            params: {
+                probeName: 'pg_stat_all_indexes',
+                timeRange: '24h',
+                connectionId: 5,
+                indexName: 'idx_customers_email',
+            },
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(true);
+        });
+
+        await act(async () => {
+            resolvePromise!(makeMetricSeries());
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        const url = mockApiGet.mock.calls[1][0];
+        expect(url).toContain('index_name=idx_customers_email');
+    });
+
     it('does not flash loading on auto-refresh after initial load', async () => {
         mockApiGet.mockResolvedValue(makeMetricSeries());
 

--- a/client/src/hooks/useMetrics.ts
+++ b/client/src/hooks/useMetrics.ts
@@ -127,7 +127,14 @@ export const useMetrics = (params: MetricQueryParams | null): UseMetricsReturn =
     // Reset initial load state when params change
     useEffect(() => {
         initialLoadDoneRef.current = false;
-    }, [params?.probeName, params?.connectionId, params?.timeRange, params?.indexName]);
+    }, [
+        params?.probeName,
+        params?.connectionId,
+        params?.timeRange,
+        params?.indexName,
+        params?.tableName,
+        params?.schemaName,
+    ]);
 
     // Fetch when dependencies change or refresh is triggered
     useEffect(() => {

--- a/client/src/hooks/useMetrics.ts
+++ b/client/src/hooks/useMetrics.ts
@@ -127,7 +127,7 @@ export const useMetrics = (params: MetricQueryParams | null): UseMetricsReturn =
     // Reset initial load state when params change
     useEffect(() => {
         initialLoadDoneRef.current = false;
-    }, [params?.probeName, params?.connectionId, params?.timeRange]);
+    }, [params?.probeName, params?.connectionId, params?.timeRange, params?.indexName]);
 
     // Fetch when dependencies change or refresh is triggered
     useEffect(() => {

--- a/client/src/hooks/useMetrics.ts
+++ b/client/src/hooks/useMetrics.ts
@@ -57,6 +57,10 @@ const buildMetricsUrl = (params: MetricQueryParams): string => {
         searchParams.append('table_name', params.tableName);
     }
 
+    if (params.indexName) {
+        searchParams.append('index_name', params.indexName);
+    }
+
     if (params.buckets !== undefined) {
         searchParams.append('buckets', params.buckets.toString());
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -167,6 +167,19 @@ project adheres to
   request filtered to one table or index always returns that entity's
   true latest sample regardless of the sort column.
 
+- Fix the Index object-detail dashboard's Scan Activity chart always
+  showing "No index scan data available" for every index. The web
+  client sent the index's own name as the `table_name` query
+  parameter, but the metrics time-series query filtered on `relname`,
+  so no table ever matched an index name and the request returned no
+  rows. The time-series query path also had no way to filter by index
+  name, so a table with several indexes would have blended all of
+  their scan activity together. The metrics API
+  (`GET /api/v1/metrics/query`) now filters on `indexrelname`, the
+  client's metrics-fetching hook accepts a new `indexName` parameter,
+  and the Scan Activity chart sends it instead of misusing the
+  table-name parameter.
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the

--- a/server/src/internal/api/metrics_handlers.go
+++ b/server/src/internal/api/metrics_handlers.go
@@ -17,16 +17,38 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/database"
 	"github.com/pgedge/ai-workbench/server/internal/metrics"
 )
+
+// timeSeriesQueryFunc matches the signature of metrics.QueryTimeSeries.
+// Tests inject a fake to assert the parsed MetricFilters (notably the
+// IndexName the Index detail dashboard's Scan Activity chart depends on)
+// actually reach the query layer, without requiring a live pool.
+type timeSeriesQueryFunc func(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	probeName string,
+	connectionIDs []int,
+	timeRange string,
+	filters metrics.MetricFilters,
+	buckets int,
+	aggregation string,
+	requestedMetrics []string,
+) ([]metrics.MetricSeries, error)
 
 // MetricsHandler handles REST API endpoints for monitoring dashboard
 // metric queries and baselines.
 type MetricsHandler struct {
 	datastore *database.Datastore
 	authStore *auth.AuthStore
+
+	// queryTimeSeriesFn performs the time-series query. When nil the
+	// handler falls back to metrics.QueryTimeSeries; tests substitute a
+	// fake to capture the MetricFilters reaching the query layer.
+	queryTimeSeriesFn timeSeriesQueryFunc
 }
 
 // NewMetricsHandler creates a new MetricsHandler.
@@ -171,7 +193,11 @@ func (h *MetricsHandler) handleMetricsQuery(
 	defer cancel()
 
 	pool := h.datastore.GetPool()
-	result, err := metrics.QueryTimeSeries(
+	queryFn := h.queryTimeSeriesFn
+	if queryFn == nil {
+		queryFn = metrics.QueryTimeSeries
+	}
+	result, err := queryFn(
 		ctx, pool, probeName, connectionIDs, timeRange,
 		filters, buckets, aggregation, requestedMetrics)
 	if err != nil {

--- a/server/src/internal/api/metrics_handlers.go
+++ b/server/src/internal/api/metrics_handlers.go
@@ -125,6 +125,7 @@ func (h *MetricsHandler) handleMetricsQuery(
 		DatabaseName: ParseQueryString(r, "database_name"),
 		SchemaName:   ParseQueryString(r, "schema_name"),
 		TableName:    ParseQueryString(r, "table_name"),
+		IndexName:    ParseQueryString(r, "index_name"),
 	}
 
 	// Parse buckets (default 150)

--- a/server/src/internal/api/metrics_handlers_test.go
+++ b/server/src/internal/api/metrics_handlers_test.go
@@ -10,10 +10,16 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+	"github.com/pgedge/ai-workbench/server/internal/metrics"
 )
 
 func TestNewMetricsHandler(t *testing.T) {
@@ -193,27 +199,90 @@ func TestHandleMetricsQuery_TimeSeriesMode_InvalidTimeRange(t *testing.T) {
 }
 
 func TestHandleMetricsQuery_TimeSeriesMode_ParsesIndexNameFilter(t *testing.T) {
-	// A valid time_range keeps the handler on the time-series path long
-	// enough to build the MetricFilters (including the index_name parse the
-	// Index detail dashboard's Scan Activity chart relies on); an invalid
-	// buckets value then bails before any datastore access. This proves the
-	// index_name filter is parsed on the time-series path, not just the
-	// latest-row path.
+	// The Index detail dashboard's Scan Activity chart relies on the
+	// time-series path forwarding index_name into MetricFilters.IndexName.
+	// Inject a fake query function to capture the filters the handler
+	// actually passes downstream; the request uses only valid parameters
+	// so the handler reaches the query layer instead of short-circuiting
+	// on a validation error. This test fails if index_name parsing on the
+	// time-series path is removed or broken.
+	var gotFilters metrics.MetricFilters
+	called := false
+	handler := &MetricsHandler{
+		datastore: &database.Datastore{},
+		queryTimeSeriesFn: func(
+			_ context.Context,
+			_ *pgxpool.Pool,
+			_ string,
+			_ []int,
+			_ string,
+			filters metrics.MetricFilters,
+			_ int,
+			_ string,
+			_ []string,
+		) ([]metrics.MetricSeries, error) {
+			called = true
+			gotFilters = filters
+			return []metrics.MetricSeries{}, nil
+		},
+	}
+
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/metrics/query?connection_id=1"+
 			"&probe_name=pg_stat_all_indexes&time_range=1h"+
-			"&index_name=pk_orders&buckets=9999", nil)
+			"&index_name=pk_orders", nil)
 	rec := httptest.NewRecorder()
 
-	handler := &MetricsHandler{}
+	handler.handleMetricsQuery(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d (body %q)",
+			http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if !called {
+		t.Fatal("expected time-series query function to be called")
+	}
+	if gotFilters.IndexName != "pk_orders" {
+		t.Errorf("expected IndexName %q reaching the query layer, got %q",
+			"pk_orders", gotFilters.IndexName)
+	}
+}
+
+func TestHandleMetricsQuery_TimeSeriesMode_DefaultQueryFn(t *testing.T) {
+	// Exercises the nil-queryTimeSeriesFn fallback: a handler built without
+	// an injected query function must resolve to metrics.QueryTimeSeries. A
+	// real pool lets that default run; an unknown probe makes the query
+	// return an error the handler maps to 400, proving the default wiring
+	// reaches the query layer instead of relying on the injected seam.
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping datastore integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	handler := &MetricsHandler{datastore: database.NewTestDatastore(pool)}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/query?connection_id=1"+
+			"&probe_name=zzz_no_such_probe&time_range=1h", nil)
+	rec := httptest.NewRecorder()
+
 	handler.handleMetricsQuery(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected status %d, got %d",
-			http.StatusBadRequest, rec.Code)
-	}
-	if resp := decodeError(t, rec); resp.Error !=
-		"Invalid buckets: must be between 1 and 500" {
-		t.Errorf("unexpected error: %q", resp.Error)
+		t.Fatalf("expected status %d, got %d (body %q)",
+			http.StatusBadRequest, rec.Code, rec.Body.String())
 	}
 }

--- a/server/src/internal/api/metrics_handlers_test.go
+++ b/server/src/internal/api/metrics_handlers_test.go
@@ -191,3 +191,29 @@ func TestHandleMetricsQuery_TimeSeriesMode_InvalidTimeRange(t *testing.T) {
 		t.Errorf("unexpected error: %q", resp.Error)
 	}
 }
+
+func TestHandleMetricsQuery_TimeSeriesMode_ParsesIndexNameFilter(t *testing.T) {
+	// A valid time_range keeps the handler on the time-series path long
+	// enough to build the MetricFilters (including the index_name parse the
+	// Index detail dashboard's Scan Activity chart relies on); an invalid
+	// buckets value then bails before any datastore access. This proves the
+	// index_name filter is parsed on the time-series path, not just the
+	// latest-row path.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/query?connection_id=1"+
+			"&probe_name=pg_stat_all_indexes&time_range=1h"+
+			"&index_name=pk_orders&buckets=9999", nil)
+	rec := httptest.NewRecorder()
+
+	handler := &MetricsHandler{}
+	handler.handleMetricsQuery(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d",
+			http.StatusBadRequest, rec.Code)
+	}
+	if resp := decodeError(t, rec); resp.Error !=
+		"Invalid buckets: must be between 1 and 500" {
+		t.Errorf("unexpected error: %q", resp.Error)
+	}
+}

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -500,6 +500,8 @@ func metricQueryBase(
 		whereClauses = append(whereClauses,
 			fmt.Sprintf("indexrelname = $%d", argNum))
 		queryArgs = append(queryArgs, filters.IndexName)
+		// No argNum++ here: IndexName is the last filter. A new filter
+		// added below must add argNum++ above first.
 	}
 
 	return strings.Join(whereClauses, " AND "), queryArgs

--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -488,6 +488,18 @@ func metricQueryBase(
 		whereClauses = append(whereClauses,
 			fmt.Sprintf("relname = $%d", argNum))
 		queryArgs = append(queryArgs, filters.TableName)
+		argNum++
+	}
+
+	// IndexName filters on indexrelname, mirroring the SchemaName/TableName
+	// filters above. Like those, it applies no probe-column-existence check:
+	// if the probe table has no indexrelname column the query simply fails at
+	// execution time, exactly as an unsupported schemaname/relname filter
+	// would. This keeps the validation semantics identical across dimensions.
+	if filters.IndexName != "" {
+		whereClauses = append(whereClauses,
+			fmt.Sprintf("indexrelname = $%d", argNum))
+		queryArgs = append(queryArgs, filters.IndexName)
 	}
 
 	return strings.Join(whereClauses, " AND "), queryArgs

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -268,6 +268,78 @@ func TestBuildMetricsQuery(t *testing.T) {
 		}
 	})
 
+	t.Run("with index_name filter", func(t *testing.T) {
+		query, args, err := BuildMetricsQuery(
+			"pg_stat_all_indexes",
+			[]string{"idx_scan"},
+			map[string]string{"idx_scan": "bigint"},
+			1, start, end, 60, "avg",
+			MetricFilters{
+				SchemaName: "public",
+				TableName:  "orders",
+				IndexName:  "pk_orders",
+			},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Filters bind after the four fixed args ($1-$4): schemaname $5,
+		// relname $6, then indexrelname $7.
+		if !strings.Contains(query, "schemaname = $5") {
+			t.Error("query should filter by schemaname")
+		}
+		if !strings.Contains(query, "relname = $6") {
+			t.Error("query should filter by relname")
+		}
+		if !strings.Contains(query, "indexrelname = $7") {
+			t.Errorf("query should filter by indexrelname, got:\n%s", query)
+		}
+		if len(args) != 7 {
+			t.Fatalf("expected 7 args, got %d", len(args))
+		}
+		if args[6] != "pk_orders" {
+			t.Errorf("expected indexrelname arg 'pk_orders', got %v", args[6])
+		}
+	})
+
+	t.Run("index_name filter omitted leaves SQL unchanged", func(t *testing.T) {
+		// The Table Detail dashboard never sends index_name; verify that an
+		// empty IndexName produces byte-identical SQL and args to a query
+		// built with a zero-value filter set that also omits it.
+		withoutField, argsA, err := BuildMetricsQuery(
+			"pg_stat_all_tables",
+			[]string{"seq_scan"},
+			map[string]string{"seq_scan": "bigint"},
+			1, start, end, 60, "avg",
+			MetricFilters{SchemaName: "public", TableName: "orders"},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		withEmptyField, argsB, err := BuildMetricsQuery(
+			"pg_stat_all_tables",
+			[]string{"seq_scan"},
+			map[string]string{"seq_scan": "bigint"},
+			1, start, end, 60, "avg",
+			MetricFilters{SchemaName: "public", TableName: "orders", IndexName: ""},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if withoutField != withEmptyField {
+			t.Errorf("empty IndexName changed SQL:\n%s\n---\n%s",
+				withoutField, withEmptyField)
+		}
+		if strings.Contains(withEmptyField, "indexrelname") {
+			t.Error("empty IndexName must not add an indexrelname clause")
+		}
+		if len(argsA) != len(argsB) {
+			t.Errorf("empty IndexName changed arg count: %d vs %d",
+				len(argsA), len(argsB))
+		}
+	})
+
 	t.Run("database filter skipped when column empty", func(t *testing.T) {
 		query, args, err := BuildMetricsQuery(
 			"pg_sys_cpu_info",
@@ -1649,6 +1721,47 @@ func TestBuildDerivedMetricsQuery(t *testing.T) {
 		}
 		if len(args) != 7 {
 			t.Errorf("expected 7 args, got %d", len(args))
+		}
+	})
+
+	t.Run("index_name filter binds indexrelname", func(t *testing.T) {
+		// This is the derived per-second path that powers the Index detail
+		// dashboard's Scan Activity chart (idx_scan_per_sec over time).
+		query, args, err := BuildDerivedMetricsQuery(
+			"pg_stat_all_indexes",
+			[]DerivedMetric{{
+				OutputName: "idx_scan_per_sec",
+				BaseColumn: "idx_scan",
+				Kind:       DerivedPerSec,
+			}},
+			1, start, end, 60, "avg",
+			MetricFilters{
+				SchemaName: "public",
+				TableName:  "orders",
+				IndexName:  "pk_orders",
+			})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, c := range []string{
+			"schemaname = $5",
+			"relname = $6",
+			"indexrelname = $7",
+		} {
+			if !strings.Contains(query, c) {
+				t.Errorf("query missing filter %q, got:\n%s", c, query)
+			}
+		}
+		// The shared WHERE clause is emitted in every rate CTE; confirm both
+		// occurrences bind the same placeholder so the scoping is consistent.
+		if strings.Count(query, "indexrelname = $7") < 1 {
+			t.Error("query should filter by indexrelname")
+		}
+		if len(args) != 7 {
+			t.Fatalf("expected 7 args, got %d", len(args))
+		}
+		if args[6] != "pk_orders" {
+			t.Errorf("expected indexrelname arg 'pk_orders', got %v", args[6])
 		}
 	})
 

--- a/server/src/internal/metrics/query_timeseries_db_test.go
+++ b/server/src/internal/metrics/query_timeseries_db_test.go
@@ -45,6 +45,8 @@ func setupTimeSeriesFixture(t *testing.T, pool *pgxpool.Pool) func() {
 
 	dropTable(ctx, pool, timeSeriesTestProbe)
 
+	// indexrelname carries the index dimension so the IndexName filter can be
+	// exercised end-to-end, mirroring the pg_stat_all_indexes probe shape.
 	ddl := `CREATE TABLE metrics."` + timeSeriesTestProbe + `" (
         connection_id integer NOT NULL,
         collected_at  timestamp with time zone NOT NULL,
@@ -52,6 +54,7 @@ func setupTimeSeriesFixture(t *testing.T, pool *pgxpool.Pool) func() {
         database_name text,
         schemaname    name,
         relname       name,
+        indexrelname  name,
         seq_scan      bigint,
         idx_scan      bigint,
         n_tup_ins     bigint,
@@ -82,12 +85,12 @@ func setupTimeSeriesFixture(t *testing.T, pool *pgxpool.Pool) func() {
 
 	insert := `INSERT INTO metrics."` + timeSeriesTestProbe + `"
         (connection_id, collected_at, database_name, schemaname, relname,
-         seq_scan, idx_scan, n_tup_ins, n_live_tup, n_dead_tup)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+         indexrelname, seq_scan, idx_scan, n_tup_ins, n_live_tup, n_dead_tup)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
 	for i, s := range samples {
 		_, err := pool.Exec(ctx, insert,
 			1, now.Add(s.offset), "northwind", "public", "orders",
-			s.seqScan, s.idxScan, s.nTupIns, 90, 10)
+			"pk_orders", s.seqScan, s.idxScan, s.nTupIns, 90, 10)
 		if err != nil {
 			dropTable(ctx, pool, timeSeriesTestProbe)
 			t.Fatalf("failed to insert fixture sample %d: %v", i, err)
@@ -470,6 +473,70 @@ func TestQueryTimeSeries_Integration(t *testing.T) {
 		s := seriesByMetric(t, series, "n_live_tup")
 		if len(s.Data) == 0 {
 			t.Fatal("expected data for matching database filter")
+		}
+	})
+
+	t.Run("index_name filter yields per-sec data for the Scan Activity chart", func(t *testing.T) {
+		// This reproduces the fixed bug: the Index detail dashboard requests
+		// idx_scan_per_sec scoped to a single index. With IndexName plumbed
+		// through metricQueryBase, the matching index returns real rate data.
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h",
+			MetricFilters{SchemaName: "public", TableName: "orders", IndexName: "pk_orders"},
+			60, "avg", []string{"idx_scan_per_sec"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := seriesByMetric(t, series, "idx_scan_per_sec")
+		if len(s.Data) == 0 {
+			t.Fatal("expected rate data for the matching index name")
+		}
+		sawExpected := false
+		for _, p := range s.Data {
+			if p.Value < 0 {
+				t.Errorf("rate point = %v, want non-negative", p.Value)
+			}
+			if p.Value >= 0.9 && p.Value <= 1.1 {
+				sawExpected = true
+			}
+		}
+		if !sawExpected {
+			t.Errorf("expected an idx_scan rate near 1.0/sec, got %v", s.Data)
+		}
+	})
+
+	t.Run("index_name filter narrows out non-matching indexes", func(t *testing.T) {
+		// A different index name matches no rows, so the series is present but
+		// empty; this is what previously happened for every index because the
+		// filter was silently dropped and the wrong dimension was queried.
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h",
+			MetricFilters{IndexName: "some_other_index"},
+			60, "avg", []string{"idx_scan_per_sec"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := seriesByMetric(t, series, "idx_scan_per_sec")
+		if len(s.Data) != 0 {
+			t.Errorf("expected no data for a non-matching index, got %d points",
+				len(s.Data))
+		}
+	})
+
+	t.Run("raw column request honors index_name filter", func(t *testing.T) {
+		// The raw-column path shares metricQueryBase, so IndexName must scope
+		// it too; a non-matching index yields an empty raw series.
+		series, err := QueryTimeSeries(ctx, pool, timeSeriesTestProbe,
+			[]int{1}, "1h",
+			MetricFilters{IndexName: "no_such_index"},
+			60, "avg", []string{"idx_scan"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := seriesByMetric(t, series, "idx_scan")
+		if len(s.Data) != 0 {
+			t.Errorf("expected no raw data for a non-matching index, got %d points",
+				len(s.Data))
 		}
 	})
 }


### PR DESCRIPTION
## Symptom

The Index object-detail dashboard's Scan Activity chart always
showed "No index scan data available" — for every index, with no
exceptions.

## Root cause

Two compounding gaps, confirmed live via `curl`:

1. **Client:** `IndexDetail.tsx`'s Scan Activity chart query sent the
   index's own name (e.g. `pk_orders`) as the `table_name` parameter:
   ```js
   tableName: objectName,  // objectName = "pk_orders"
   ```
   The server filters `table_name` on `relname` (the table name), so
   `table_name=pk_orders` matched zero rows — no table is ever named
   after an index. Confirmed: `table_name=pk_orders` → `"data":[]`;
   `table_name=orders` (the real table) → real data, but that would
   wrongly blend every index on the table together.

2. **Server:** even a corrected client request would have needed a
   server-side fix. `metricQueryBase` in
   `server/src/internal/metrics/query.go` — shared by the raw-column
   and derived-metric time-series query builders that back Activity
   Charts — only filtered on `DatabaseName`/`SchemaName`/`TableName`.
   It had no `IndexName` handling at all, unlike the separate
   latest-row query path (added by #340), which already supports
   `index_name`. The client also had no `indexName` field anywhere to
   send one with (`useMetrics.ts`/`MetricQueryParams` only knew about
   `schemaName`/`tableName`).

## Fix

- `metricQueryBase` now filters on `indexrelname` when `IndexName` is
  set, mirroring the existing `SchemaName`/`TableName` pattern
  exactly (`$N`-bound, no probe-column-existence check — consistent
  with how those two already behave). Purely additive: omitting
  `index_name` produces byte-identical SQL to before, so the Table
  Detail dashboard's existing Activity Charts are unaffected.
- `handleMetricsQuery` (time-series mode) now parses `index_name`,
  mirroring the latest-row handler's existing parsing.
- Client: added `indexName` to `MetricQueryParams`, wired it into
  `useMetrics.ts`'s query-string builder, and `IndexDetail.tsx`'s
  Scan Activity chart now sends `indexName: objectName` instead of
  the incorrect `tableName: objectName` (and sends no `tableName`, so
  it scopes to the specific index rather than the whole table).

## Testing

- Server: new unit tests proving `index_name` binds to
  `indexrelname = $N` for both the raw-column and derived-metric
  paths, and that omitting it leaves the generated SQL/args
  unchanged. New live-DB integration tests confirm a matching index
  returns real rate data and a non-matching one returns empty, for
  both query paths. Handler test added for the new parsing.
- Client: new/updated tests confirm the Scan Activity chart request
  now carries `index_name=<index name>` and no `table_name`; existing
  `TableDetail.tsx` Activity Charts are confirmed unaffected (they
  never set `indexName`, so `index_name` is never appended).
- `gofmt`/`go vet`/`golangci-lint`: clean. Full Go suite (unit + live
  integration) passes. `npm run lint`: 0 errors. Full client suite:
  3364 tests pass.
- Touched-function coverage: server `metricQueryBase`,
  `BuildMetricsQuery`, `BuildDerivedMetricsQuery` all 100%; client
  `useMetrics.ts` 100% lines, `IndexDetail.tsx` 98.14% lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Index dashboard’s **Scan Activity** chart to correctly scope metrics to the selected index.
  * Prevented scan activity data from mixing across different indexes by ensuring metrics requests use the correct index-scoping filter.
  * Improved handling of index-scoped metric queries so the chart returns data reliably (and not “No index scan data available” incorrectly).
* **Documentation**
  * Updated the changelog with details about the **Scan Activity** chart fix and index filtering improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->