### PR TITLE
Fix cache hit ratio graph not rendering for flat time series

### DIFF
--- a/client/src/components/Chart/__tests__/common.test.ts
+++ b/client/src/components/Chart/__tests__/common.test.ts
@@ -234,6 +234,111 @@ describe('buildYAxis range padding', () => {
     });
 });
 
+describe('buildYAxis stacked range padding', () => {
+    interface YAxisOpts {
+        type: string;
+        axisLabel: { formatter: (value: number) => string };
+        min?: number;
+        max?: number;
+    }
+
+    it('pads around the cumulative total for flat stacked series', () => {
+        // Regression: a stacked checkpoint-write breakdown holds two
+        // series each flat at 100. The rendered stacked total is a
+        // flat 200, so the padded range must bound ~200 rather than
+        // the raw per-point value of 100 (which clipped the top off).
+        const yAxis = buildYAxis(
+            [
+                [100, 100, 100],
+                [100, 100, 100],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(180);
+        expect(yAxis.max).toBeCloseTo(220);
+    });
+
+    it('uses raw per-point values when stacking is disabled', () => {
+        // The same data unstacked stays degenerate at 100, proving the
+        // stacking flag is what shifts the range to the cumulative sum.
+        const yAxis = buildYAxis([
+            [100, 100, 100],
+            [100, 100, 100],
+        ]) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(90);
+        expect(yAxis.max).toBeCloseTo(110);
+    });
+
+    it('behaves identically to non-stacked for a single series', () => {
+        const stacked = buildYAxis(
+            [[100, 100, 100]],
+            true,
+        ) as unknown as YAxisOpts;
+        const flat = buildYAxis([
+            [100, 100, 100],
+        ]) as unknown as YAxisOpts;
+        expect(stacked.min).toBe(flat.min);
+        expect(stacked.max).toBe(flat.max);
+        expect(stacked.min).toBeCloseTo(90);
+        expect(stacked.max).toBeCloseTo(110);
+    });
+
+    it('leaves auto-scaling intact when stacked totals vary', () => {
+        // Per-point sums are 100 then 200, a non-degenerate range, so
+        // no synthetic min/max is emitted even though each raw series
+        // is individually flat.
+        const yAxis = buildYAxis(
+            [
+                [100, 100],
+                [0, 100],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis).not.toHaveProperty('min');
+        expect(yAxis).not.toHaveProperty('max');
+    });
+
+    it('sums only available indices for ragged stacked series', () => {
+        // The second series is shorter; the trailing index sums just
+        // the first series. Totals are 30, 30, 30 -> flat at 30.
+        const yAxis = buildYAxis(
+            [
+                [10, 10, 30],
+                [20, 20],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(27);
+        expect(yAxis.max).toBeCloseTo(33);
+    });
+
+    it('skips stacked points where every series is non-finite', () => {
+        // Index 1 is non-finite across both series and is ignored; the
+        // remaining totals are a flat 50, so the range pads around 50.
+        const yAxis = buildYAxis(
+            [
+                [30, NaN, 30],
+                [20, Infinity, 20],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(45);
+        expect(yAxis.max).toBeCloseTo(55);
+    });
+
+    it('omits min/max when all stacked points are non-finite', () => {
+        const yAxis = buildYAxis(
+            [
+                [NaN, Infinity],
+                [-Infinity, NaN],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis).not.toHaveProperty('min');
+        expect(yAxis).not.toHaveProperty('max');
+    });
+});
+
 describe('buildTooltip formatter', () => {
     interface TooltipOpts {
         show: boolean;

--- a/client/src/components/Chart/__tests__/common.test.ts
+++ b/client/src/components/Chart/__tests__/common.test.ts
@@ -337,6 +337,71 @@ describe('buildYAxis stacked range padding', () => {
         expect(yAxis).not.toHaveProperty('min');
         expect(yAxis).not.toHaveProperty('max');
     });
+
+    it('preserves the real span for a flat mixed-sign stacked chart', () => {
+        // Regression: ECharts stacks a positive series upward from zero
+        // and a negative series downward from the same baseline, so a
+        // series flat at +100 and another flat at -100 render a real
+        // ~200-unit span from -100 to +100. Summing them into one
+        // scalar netted the totals to a flat 0 and collapsed the axis to
+        // a tiny [-1, 1] window; the positive and negative totals must
+        // be tracked separately so the true span survives. The range is
+        // non-degenerate (-100 != 100), so no synthetic min/max is
+        // emitted and ECharts auto-scales across the full span.
+        const yAxis = buildYAxis(
+            [
+                [100, 100],
+                [-100, -100],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis).not.toHaveProperty('min');
+        expect(yAxis).not.toHaveProperty('max');
+    });
+
+    it('leaves auto-scaling intact for varying mixed-sign stacks', () => {
+        // Positive totals climb 50 -> 80 while the negative total holds
+        // at -30. The observed range spans -30 to 80, which is already
+        // non-degenerate, so no synthetic padding is applied.
+        const yAxis = buildYAxis(
+            [
+                [50, 80],
+                [-30, -30],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis).not.toHaveProperty('min');
+        expect(yAxis).not.toHaveProperty('max');
+    });
+
+    it('pads around the negative total for an all-negative stack', () => {
+        // No positive value appears, so the zero baseline is never
+        // observed; the flat negative total of -50 pads like the
+        // non-stacked flat-negative case rather than snapping to zero.
+        const yAxis = buildYAxis(
+            [
+                [-20, -20],
+                [-30, -30],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(-55);
+        expect(yAxis.max).toBeCloseTo(-45);
+    });
+
+    it('pads a fixed range around an all-zero stacked series', () => {
+        // Neither sign is present, so the flat zero baseline is observed
+        // and padded to the same fixed [-1, 1] window as the
+        // non-stacked flat-zero case.
+        const yAxis = buildYAxis(
+            [
+                [0, 0, 0],
+            ],
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBe(-1);
+        expect(yAxis.max).toBe(1);
+    });
 });
 
 describe('buildTooltip formatter', () => {

--- a/client/src/components/Chart/__tests__/common.test.ts
+++ b/client/src/components/Chart/__tests__/common.test.ts
@@ -127,6 +127,8 @@ describe('buildXAxis formatter', () => {
 describe('buildYAxis formatter', () => {
     interface YAxisOpts {
         axisLabel: { formatter: (value: number) => string };
+        min?: number;
+        max?: number;
     }
 
     it('formats billions with B suffix', () => {
@@ -154,6 +156,81 @@ describe('buildYAxis formatter', () => {
     it('rounds non-integer small numbers to 1 decimal', () => {
         const yAxis = buildYAxis() as unknown as YAxisOpts;
         expect(yAxis.axisLabel.formatter(3.14159)).toBe('3.1');
+    });
+});
+
+describe('buildYAxis range padding', () => {
+    interface YAxisOpts {
+        type: string;
+        axisLabel: { formatter: (value: number) => string };
+        min?: number;
+        max?: number;
+    }
+
+    it('omits min/max when no series data is supplied', () => {
+        const yAxis = buildYAxis() as unknown as YAxisOpts;
+        expect(yAxis).not.toHaveProperty('min');
+        expect(yAxis).not.toHaveProperty('max');
+    });
+
+    it('omits min/max when every point is non-finite', () => {
+        const yAxis = buildYAxis([
+            [NaN, Infinity, -Infinity],
+        ]) as unknown as YAxisOpts;
+        expect(yAxis).not.toHaveProperty('min');
+        expect(yAxis).not.toHaveProperty('max');
+    });
+
+    it('leaves auto-scaling intact for a varied series', () => {
+        const yAxis = buildYAxis([
+            [10, 20, 30],
+            [15, 25],
+        ]) as unknown as YAxisOpts;
+        expect(yAxis).not.toHaveProperty('min');
+        expect(yAxis).not.toHaveProperty('max');
+    });
+
+    it('pads a proportional range around a flat non-zero series', () => {
+        // Regression: a brand-new read-only database reports a
+        // cache-hit-ratio that is a flat 100.0 for its whole history.
+        const yAxis = buildYAxis([
+            [100, 100, 100, 100],
+        ]) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(90);
+        expect(yAxis.max).toBeCloseTo(110);
+        expect(Number(yAxis.max) - Number(yAxis.min)).toBeGreaterThan(0);
+    });
+
+    it('pads a fixed range around a flat zero series', () => {
+        const yAxis = buildYAxis([
+            [0, 0, 0],
+        ]) as unknown as YAxisOpts;
+        expect(yAxis.min).toBe(-1);
+        expect(yAxis.max).toBe(1);
+    });
+
+    it('pads proportionally for a flat large-scale series', () => {
+        const yAxis = buildYAxis([
+            [1e9, 1e9],
+        ]) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(9e8);
+        expect(yAxis.max).toBeCloseTo(1.1e9);
+    });
+
+    it('pads around a flat negative series without collapsing', () => {
+        const yAxis = buildYAxis([
+            [-50, -50],
+        ]) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(-55);
+        expect(yAxis.max).toBeCloseTo(-45);
+    });
+
+    it('ignores non-finite points when computing the range', () => {
+        const yAxis = buildYAxis([
+            [NaN, 100, Infinity, 100],
+        ]) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(90);
+        expect(yAxis.max).toBeCloseTo(110);
     });
 });
 

--- a/client/src/components/Chart/__tests__/common.test.ts
+++ b/client/src/components/Chart/__tests__/common.test.ts
@@ -242,19 +242,24 @@ describe('buildYAxis stacked range padding', () => {
         max?: number;
     }
 
-    it('pads around the cumulative total for flat stacked series', () => {
+    it('pads a baseline-inclusive range around the cumulative total for flat stacked series', () => {
         // Regression: a stacked checkpoint-write breakdown holds two
         // series each flat at 100. The rendered stacked total is a
         // flat 200, so the padded range must bound ~200 rather than
         // the raw per-point value of 100 (which clipped the top off).
+        // A stacked chart is zero-anchored (its fill grows from the
+        // zero baseline), so the padded range must also include zero:
+        // the window runs from 0 up to ~220 rather than excluding the
+        // baseline with a tight [180, 220].
         const yAxis = buildYAxis(
             [
                 [100, 100, 100],
                 [100, 100, 100],
             ],
             true,
+            true,
         ) as unknown as YAxisOpts;
-        expect(yAxis.min).toBeCloseTo(180);
+        expect(yAxis.min).toBe(0);
         expect(yAxis.max).toBeCloseTo(220);
     });
 
@@ -269,17 +274,17 @@ describe('buildYAxis stacked range padding', () => {
         expect(yAxis.max).toBeCloseTo(110);
     });
 
-    it('behaves identically to non-stacked for a single series', () => {
+    it('pads a baseline-inclusive range for a single-sign flat stacked series', () => {
+        // A single series flat at 100 stacks to a flat total of 100.
+        // Because the stacked area fills from the zero baseline, the
+        // degenerate range must include zero, giving [0, 110] rather
+        // than the tight [90, 110] a plain line would use.
         const stacked = buildYAxis(
             [[100, 100, 100]],
             true,
+            true,
         ) as unknown as YAxisOpts;
-        const flat = buildYAxis([
-            [100, 100, 100],
-        ]) as unknown as YAxisOpts;
-        expect(stacked.min).toBe(flat.min);
-        expect(stacked.max).toBe(flat.max);
-        expect(stacked.min).toBeCloseTo(90);
+        expect(stacked.min).toBe(0);
         expect(stacked.max).toBeCloseTo(110);
     });
 
@@ -374,33 +379,105 @@ describe('buildYAxis stacked range padding', () => {
         expect(yAxis).not.toHaveProperty('max');
     });
 
-    it('pads around the negative total for an all-negative stack', () => {
-        // No positive value appears, so the zero baseline is never
-        // observed; the flat negative total of -50 pads like the
-        // non-stacked flat-negative case rather than snapping to zero.
+    it('pads a baseline-inclusive range down to the negative total for an all-negative stack', () => {
+        // No positive value appears, so the observed flat total is the
+        // negative sum of -50. A stacked area is zero-anchored, so the
+        // padded range must run from the padded negative total up to
+        // the zero baseline: [-55, 0] rather than a tight [-55, -45].
         const yAxis = buildYAxis(
             [
                 [-20, -20],
                 [-30, -30],
             ],
             true,
+            true,
         ) as unknown as YAxisOpts;
         expect(yAxis.min).toBeCloseTo(-55);
-        expect(yAxis.max).toBeCloseTo(-45);
+        expect(yAxis.max).toBe(0);
     });
 
     it('pads a fixed range around an all-zero stacked series', () => {
         // Neither sign is present, so the flat zero baseline is observed
-        // and padded to the same fixed [-1, 1] window as the
-        // non-stacked flat-zero case.
+        // and padded to the fixed [-1, 1] window; the zero-anchored
+        // range already straddles the baseline so it is unchanged.
         const yAxis = buildYAxis(
             [
                 [0, 0, 0],
             ],
             true,
+            true,
         ) as unknown as YAxisOpts;
         expect(yAxis.min).toBe(-1);
         expect(yAxis.max).toBe(1);
+    });
+});
+
+describe('buildYAxis zero-anchored range padding', () => {
+    interface YAxisOpts {
+        type: string;
+        axisLabel: { formatter: (value: number) => string };
+        min?: number;
+        max?: number;
+    }
+
+    it('includes the zero baseline for a flat positive zero-anchored series', () => {
+        // A zero-anchored chart (bar, stacked line, or area fill) whose
+        // marks grow from y = 0 must keep the baseline in view, so a
+        // flat 100 pads to [0, 110] rather than the tight [90, 110].
+        const yAxis = buildYAxis(
+            [[100, 100, 100]],
+            false,
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBe(0);
+        expect(yAxis.max).toBeCloseTo(110);
+    });
+
+    it('includes the zero baseline for a flat negative zero-anchored series', () => {
+        // A flat -100 fill hangs from the baseline, so the padded range
+        // runs from the padded value up to zero: [-110, 0].
+        const yAxis = buildYAxis(
+            [[-100, -100]],
+            false,
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(-110);
+        expect(yAxis.max).toBe(0);
+    });
+
+    it('pads a fixed range straddling zero for a flat zero zero-anchored series', () => {
+        const yAxis = buildYAxis(
+            [[0, 0, 0]],
+            false,
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBe(-1);
+        expect(yAxis.max).toBe(1);
+    });
+
+    it('keeps a plain-line flat positive series in a tight window', () => {
+        // Regression guard for issue #336: a plain line (no stack, no
+        // area fill) is not zero-anchored, so it keeps the tight
+        // centred window and does not waste height down to zero.
+        const yAxis = buildYAxis(
+            [[100, 100, 100, 100]],
+            false,
+            false,
+        ) as unknown as YAxisOpts;
+        expect(yAxis.min).toBeCloseTo(90);
+        expect(yAxis.max).toBeCloseTo(110);
+    });
+
+    it('leaves auto-scaling intact for non-degenerate zero-anchored data', () => {
+        // The zero-anchored flag only reshapes the degenerate padded
+        // range; a varied series still emits no synthetic min/max.
+        const yAxis = buildYAxis(
+            [[10, 20, 30]],
+            false,
+            true,
+        ) as unknown as YAxisOpts;
+        expect(yAxis).not.toHaveProperty('min');
+        expect(yAxis).not.toHaveProperty('max');
     });
 });
 

--- a/client/src/components/Chart/__tests__/options.test.ts
+++ b/client/src/components/Chart/__tests__/options.test.ts
@@ -120,6 +120,43 @@ describe('buildLineOptions', () => {
         const result = buildLineOptions(sampleData, {}) as any;
         expect(result.xAxis.data).toEqual(['Jan', 'Feb', 'Mar']);
     });
+
+    it('keeps a flat plain line in a tight degenerate window', () => {
+        // A plain line (no stack, no area fill) is not zero-anchored,
+        // so a flat 100 keeps the tight [90, 110] window. This mirrors
+        // the CacheHitTile use case from issue #336.
+        const flat: ChartData = {
+            categories: ['a', 'b', 'c'],
+            series: [{ name: 'Cache Hit %', data: [100, 100, 100] }],
+        };
+        const result = buildLineOptions(flat, {}) as any;
+        expect(result.yAxis.min).toBeCloseTo(90);
+        expect(result.yAxis.max).toBeCloseTo(110);
+    });
+
+    it('anchors a flat area-fill line to the zero baseline', () => {
+        // An area fill makes the line zero-anchored even when it is not
+        // stacked, so a flat 100 pads to a baseline-inclusive [0, 110].
+        const flat: ChartData = {
+            categories: ['a', 'b', 'c'],
+            series: [{ name: 'v', data: [100, 100, 100] }],
+        };
+        const result = buildLineOptions(flat, { areaFill: true }) as any;
+        expect(result.yAxis.min).toBe(0);
+        expect(result.yAxis.max).toBeCloseTo(110);
+    });
+
+    it('anchors a flat stacked line to the zero baseline', () => {
+        // A stacked line fills from the baseline, so its flat total is
+        // padded to include zero.
+        const flat: ChartData = {
+            categories: ['a', 'b', 'c'],
+            series: [{ name: 'v', data: [100, 100, 100] }],
+        };
+        const result = buildLineOptions(flat, { stacked: true }) as any;
+        expect(result.yAxis.min).toBe(0);
+        expect(result.yAxis.max).toBeCloseTo(110);
+    });
 });
 
 describe('buildBarOptions', () => {
@@ -174,6 +211,19 @@ describe('buildBarOptions', () => {
         result.series.forEach((s: any) => {
             expect(s.barMaxWidth).toBe(50);
         });
+    });
+
+    it('anchors a flat unstacked bar chart to the zero baseline', () => {
+        // Bars always grow from zero, so a flat 100 pads to a
+        // baseline-inclusive [0, 110] even when the bars are not
+        // stacked.
+        const flat: ChartData = {
+            categories: ['a', 'b', 'c'],
+            series: [{ name: 'v', data: [100, 100, 100] }],
+        };
+        const result = buildBarOptions(flat, {}) as any;
+        expect(result.yAxis.min).toBe(0);
+        expect(result.yAxis.max).toBeCloseTo(110);
     });
 });
 

--- a/client/src/components/Chart/options/bar.ts
+++ b/client/src/components/Chart/options/bar.ts
@@ -37,7 +37,10 @@ export function buildBarOptions(
     }));
 
     const categoryAxis = buildXAxis(data.categories);
-    const valueAxis = buildYAxis(data.series.map((s) => s.data));
+    const valueAxis = buildYAxis(
+        data.series.map((s) => s.data),
+        options.stacked,
+    );
 
     return {
         tooltip: buildTooltip(options.showTooltip ?? true),

--- a/client/src/components/Chart/options/bar.ts
+++ b/client/src/components/Chart/options/bar.ts
@@ -37,9 +37,12 @@ export function buildBarOptions(
     }));
 
     const categoryAxis = buildXAxis(data.categories);
+    // Bars always grow from the zero baseline, so the value axis is
+    // zero-anchored regardless of whether the series are stacked.
     const valueAxis = buildYAxis(
         data.series.map((s) => s.data),
         options.stacked,
+        true,
     );
 
     return {

--- a/client/src/components/Chart/options/bar.ts
+++ b/client/src/components/Chart/options/bar.ts
@@ -37,7 +37,7 @@ export function buildBarOptions(
     }));
 
     const categoryAxis = buildXAxis(data.categories);
-    const valueAxis = buildYAxis();
+    const valueAxis = buildYAxis(data.series.map((s) => s.data));
 
     return {
         tooltip: buildTooltip(options.showTooltip ?? true),

--- a/client/src/components/Chart/options/common.ts
+++ b/client/src/components/Chart/options/common.ts
@@ -163,13 +163,49 @@ export function buildXAxis(categories?: string[]): object {
     };
 }
 
-export function buildYAxis(): object {
-    return {
+/**
+ * Builds the numeric value axis. When `seriesData` is supplied the
+ * range of the data is inspected; if every finite point shares the
+ * same value the axis would otherwise collapse to a zero-height range
+ * (`min === max`), leaving ECharts nothing to interpolate against so
+ * the line/area renders as blank. In that degenerate case a synthetic
+ * range is padded around the flat value so the series stays visible.
+ * For any non-degenerate range no `min`/`max` is emitted, so ECharts
+ * auto-scaling is preserved exactly as before.
+ */
+export function buildYAxis(seriesData?: number[][]): object {
+    const axis: {
+        type: string;
+        axisLabel: { formatter: (value: number) => string };
+        min?: number;
+        max?: number;
+    } = {
         type: 'value',
         axisLabel: {
             formatter: formatNumericValue,
         },
     };
+
+    let min = Infinity;
+    let max = -Infinity;
+    let hasValue = false;
+    for (const series of seriesData ?? []) {
+        for (const value of series) {
+            if (!Number.isFinite(value)) {continue;}
+            hasValue = true;
+            if (value < min) {min = value;}
+            if (value > max) {max = value;}
+        }
+    }
+
+    if (hasValue && min === max) {
+        const flat = min;
+        const padding = flat === 0 ? 1 : Math.abs(flat) * 0.1;
+        axis.min = flat - padding;
+        axis.max = flat + padding;
+    }
+
+    return axis;
 }
 
 export function buildDataZoom(enabled: boolean): object[] {

--- a/client/src/components/Chart/options/common.ts
+++ b/client/src/components/Chart/options/common.ts
@@ -174,12 +174,20 @@ export function buildXAxis(categories?: string[]): object {
  * auto-scaling is preserved exactly as before.
  *
  * When `stacked` is true the series are drawn on top of one another,
- * so the rendered height at each x-index is the cumulative sum across
- * all series at that index rather than any single raw value. The
- * degenerate-range check therefore inspects those per-index sums; a
- * stacked chart whose totals are flat (e.g. two series each holding
- * steady at 100, summing to a flat 200) is then padded around the
- * real stacked total instead of the smaller raw per-point value.
+ * so the rendered height at each x-index is the cumulative total across
+ * all series at that index rather than any single raw value. ECharts
+ * stacks positive values upward from the zero baseline and negative
+ * values downward from that same baseline, so the two signs do not net
+ * against one another. The per-index positive and negative totals are
+ * therefore accumulated separately: the positive total is the top of
+ * the rendered stack and the negative total is the bottom. A sign that
+ * never appears anywhere in the data is not folded into the observed
+ * range, so a single-sign stacked chart (e.g. one series flat at 100)
+ * still pads tightly around its real total rather than being anchored
+ * to a spurious zero baseline. A mixed-sign stacked chart (e.g. one
+ * series flat at +100 and another at -100) is bounded by both the
+ * positive and negative totals, preserving its true ~200-unit span
+ * instead of collapsing to a tiny window around a netted zero.
  */
 export function buildYAxis(
     seriesData?: number[][],
@@ -208,24 +216,46 @@ export function buildYAxis(
 
     const series = seriesData ?? [];
     if (stacked) {
-        // Stacked series render as a cumulative total at each x-index,
-        // so sum the finite values across all series at that index.
-        // Ragged series contribute only where they have a point; an
-        // index with no finite value across any series is skipped.
+        // Stacked series render as a cumulative total at each x-index.
+        // ECharts stacks positive values upward and negative values
+        // downward from a shared zero baseline, so the two signs are
+        // accumulated separately: the positive total is the top of the
+        // stack and the negative total is the bottom. A first pass
+        // records the longest series and whether either sign occurs
+        // anywhere; a sign that never appears is not folded into the
+        // observed range, keeping single-sign stacks padded tightly
+        // around their real total rather than anchored to a spurious
+        // zero baseline.
         let maxLen = 0;
+        let hasPositive = false;
+        let hasNegative = false;
         for (const s of series) {
             if (s.length > maxLen) {maxLen = s.length;}
+            for (const value of s) {
+                if (!Number.isFinite(value)) {continue;}
+                if (value > 0) {hasPositive = true;}
+                else if (value < 0) {hasNegative = true;}
+            }
         }
         for (let i = 0; i < maxLen; i++) {
-            let sum = 0;
+            let posSum = 0;
+            let negSum = 0;
             let finiteAtIndex = false;
             for (const s of series) {
                 const value = s[i];
                 if (!Number.isFinite(value)) {continue;}
-                sum += value;
                 finiteAtIndex = true;
+                if (value > 0) {posSum += value;}
+                else if (value < 0) {negSum += value;}
             }
-            if (finiteAtIndex) {observe(sum);}
+            if (!finiteAtIndex) {continue;}
+            // Observe each sign's total only when that sign is present
+            // somewhere in the data. When neither sign occurs the index
+            // holds only finite zeros, so observe the flat zero baseline
+            // so an all-zero stacked series still pads to a visible range.
+            if (hasPositive) {observe(posSum);}
+            if (hasNegative) {observe(negSum);}
+            if (!hasPositive && !hasNegative) {observe(0);}
         }
     } else {
         for (const s of series) {

--- a/client/src/components/Chart/options/common.ts
+++ b/client/src/components/Chart/options/common.ts
@@ -173,6 +173,18 @@ export function buildXAxis(categories?: string[]): object {
  * For any non-degenerate range no `min`/`max` is emitted, so ECharts
  * auto-scaling is preserved exactly as before.
  *
+ * The shape of that synthetic degenerate range depends on whether the
+ * chart is `zeroAnchored`. A chart is zero-anchored when its marks fill
+ * from the `y = 0` baseline: bars always grow from zero, and lines do so
+ * when they are stacked or carry an area fill. ECharts clips series to
+ * the axis extent, so for a zero-anchored chart the padded range must
+ * still include zero (a flat +100 pads to `[0, 110]`, a flat -100 to
+ * `[-110, 0]`, and a flat 0 to `[-1, 1]`); otherwise the fill or bar
+ * would be lopped off at the baseline. For a plain line (no fill, no
+ * stack) the range stays a tight window centred on the flat value
+ * (a flat 100 pads to `[90, 110]`), which keeps a bare line visible
+ * without wasting vertical space down to an irrelevant zero baseline.
+ *
  * When `stacked` is true the series are drawn on top of one another,
  * so the rendered height at each x-index is the cumulative total across
  * all series at that index rather than any single raw value. ECharts
@@ -192,6 +204,7 @@ export function buildXAxis(categories?: string[]): object {
 export function buildYAxis(
     seriesData?: number[][],
     stacked?: boolean,
+    zeroAnchored?: boolean,
 ): object {
     const axis: {
         type: string;
@@ -269,8 +282,18 @@ export function buildYAxis(
     if (hasValue && min === max) {
         const flat = min;
         const padding = flat === 0 ? 1 : Math.abs(flat) * 0.1;
-        axis.min = flat - padding;
-        axis.max = flat + padding;
+        if (zeroAnchored) {
+            // The chart's marks fill from the zero baseline, so the
+            // padded range must span zero to avoid clipping the fill or
+            // bar at that baseline.
+            axis.min = Math.min(0, flat - padding);
+            axis.max = Math.max(0, flat + padding);
+        } else {
+            // A plain line has no baseline fill, so a tight window
+            // centred on the flat value keeps it visible.
+            axis.min = flat - padding;
+            axis.max = flat + padding;
+        }
     }
 
     return axis;

--- a/client/src/components/Chart/options/common.ts
+++ b/client/src/components/Chart/options/common.ts
@@ -172,8 +172,19 @@ export function buildXAxis(categories?: string[]): object {
  * range is padded around the flat value so the series stays visible.
  * For any non-degenerate range no `min`/`max` is emitted, so ECharts
  * auto-scaling is preserved exactly as before.
+ *
+ * When `stacked` is true the series are drawn on top of one another,
+ * so the rendered height at each x-index is the cumulative sum across
+ * all series at that index rather than any single raw value. The
+ * degenerate-range check therefore inspects those per-index sums; a
+ * stacked chart whose totals are flat (e.g. two series each holding
+ * steady at 100, summing to a flat 200) is then padded around the
+ * real stacked total instead of the smaller raw per-point value.
  */
-export function buildYAxis(seriesData?: number[][]): object {
+export function buildYAxis(
+    seriesData?: number[][],
+    stacked?: boolean,
+): object {
     const axis: {
         type: string;
         axisLabel: { formatter: (value: number) => string };
@@ -189,12 +200,39 @@ export function buildYAxis(seriesData?: number[][]): object {
     let min = Infinity;
     let max = -Infinity;
     let hasValue = false;
-    for (const series of seriesData ?? []) {
-        for (const value of series) {
-            if (!Number.isFinite(value)) {continue;}
-            hasValue = true;
-            if (value < min) {min = value;}
-            if (value > max) {max = value;}
+    const observe = (value: number) => {
+        hasValue = true;
+        if (value < min) {min = value;}
+        if (value > max) {max = value;}
+    };
+
+    const series = seriesData ?? [];
+    if (stacked) {
+        // Stacked series render as a cumulative total at each x-index,
+        // so sum the finite values across all series at that index.
+        // Ragged series contribute only where they have a point; an
+        // index with no finite value across any series is skipped.
+        let maxLen = 0;
+        for (const s of series) {
+            if (s.length > maxLen) {maxLen = s.length;}
+        }
+        for (let i = 0; i < maxLen; i++) {
+            let sum = 0;
+            let finiteAtIndex = false;
+            for (const s of series) {
+                const value = s[i];
+                if (!Number.isFinite(value)) {continue;}
+                sum += value;
+                finiteAtIndex = true;
+            }
+            if (finiteAtIndex) {observe(sum);}
+        }
+    } else {
+        for (const s of series) {
+            for (const value of s) {
+                if (!Number.isFinite(value)) {continue;}
+                observe(value);
+            }
         }
     }
 

--- a/client/src/components/Chart/options/line.ts
+++ b/client/src/components/Chart/options/line.ts
@@ -49,7 +49,7 @@ export function buildLineOptions(
         legend: buildLegend(options.showLegend ?? true),
         grid: buildGrid(),
         xAxis: buildXAxis(data.categories),
-        yAxis: buildYAxis(),
+        yAxis: buildYAxis(data.series.map((s) => s.data)),
         dataZoom: buildDataZoom(options.enableZoom ?? false),
         series,
     };

--- a/client/src/components/Chart/options/line.ts
+++ b/client/src/components/Chart/options/line.ts
@@ -49,7 +49,10 @@ export function buildLineOptions(
         legend: buildLegend(options.showLegend ?? true),
         grid: buildGrid(),
         xAxis: buildXAxis(data.categories),
-        yAxis: buildYAxis(data.series.map((s) => s.data)),
+        yAxis: buildYAxis(
+            data.series.map((s) => s.data),
+            options.stacked,
+        ),
         dataZoom: buildDataZoom(options.enableZoom ?? false),
         series,
     };

--- a/client/src/components/Chart/options/line.ts
+++ b/client/src/components/Chart/options/line.ts
@@ -49,9 +49,13 @@ export function buildLineOptions(
         legend: buildLegend(options.showLegend ?? true),
         grid: buildGrid(),
         xAxis: buildXAxis(data.categories),
+        // A line fills from the zero baseline when it is stacked or
+        // carries an area fill, so the value axis is zero-anchored in
+        // either case; a plain line keeps its tight degenerate window.
         yAxis: buildYAxis(
             data.series.map((s) => s.data),
             options.stacked,
+            Boolean(options.stacked || options.areaFill),
         ),
         dataZoom: buildDataZoom(options.enableZoom ?? false),
         series,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -180,6 +180,17 @@ project adheres to
   and the Scan Activity chart sends it instead of misusing the
   table-name parameter.
 
+- Fix several dashboard charts rendering blank whenever their time
+  series was perfectly flat, most visibly the Cache Hit Ratio Over
+  Time chart for a new, essentially read-only sample database whose
+  ratio held steady at 100% for its whole history. A flat series gave
+  the value axis a zero-height range, with `min` equal to `max`, so
+  the line or area had nothing to draw against and the chart appeared
+  empty. The value axis now pads a small visible range around a flat
+  value so the series renders, and it does so in a baseline-aware way
+  for zero-anchored charts, such as bars and stacked or area fills, so
+  their fill still renders from zero. (#336)
+
 ## [1.0.0] - 2026-06-08
 
 This release is the first general-availability release of the


### PR DESCRIPTION
## Symptom

Reported in #336: the cache hit ratio graph does not render for the
Northwind sample database, even after a refresh/restart, though it
renders fine for other databases.

## Root cause

`buildYAxis()` in `client/src/components/Chart/options/common.ts` set
no `min`/`max`, so ECharts auto-computes the value-axis range from the
series data. When every point in a series shares the same value,
ECharts collapses the range to `min === max` — a zero-height axis
with nothing for the line/area to interpolate against, so it renders
blank.

Northwind is a brand-new, essentially read-only sample database, so
its cache-hit-ratio series has held a flat, unbroken `100.0` for its
entire history. Other databases have tiny natural sample-to-sample
fluctuation, so ECharts computes a real (if narrow) range and renders
normally.

## Fix

- `buildYAxis()` now accepts the series data (`seriesData?: number[][]`).
  It scans all finite values across all series for min/max; when the
  range is degenerate (`min === max`), it pads a synthetic range
  around the flat value (±10% of the value, or ±1 for a flat-zero
  series) so the axis has a non-zero visible range. Non-degenerate
  ranges are untouched — omitting data, or passing varied data,
  produces the same output as before.
- `bar.ts` and `line.ts` now pass their series data into `buildYAxis()`.
- Added regression tests in `common.test.ts` covering flat 100.0
  (the reported case), flat zero, flat 1e9, flat negative, no-data,
  non-finite-value filtering, and confirming varied series still
  auto-scale as before.

## Test plan

- [x] `npx vitest run src/components/Chart/__tests__/common.test.ts` — 29/29 passing
- [x] `npx eslint` clean on all touched files
- [x] `common.ts` at 100% line coverage (`make coverage`)
- [x] Manual check: verified live against the running dev instance's
      real Northwind data (proxying to the existing server) — the
      Cache Hit Ratio Over Time chart on northwind's Database
      Dashboard renders a flat 100% fill at both 1h and 7d ranges,
      where it previously rendered blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart y-axis scaling by deriving axis bounds from the actual series values, including stacked charts.
  * Added baseline-aware range padding for flat or all-zero datasets (including zero-anchored bars/areas/stacked) to keep charts from rendering blank.
  * Ignores non-finite values when calculating bounds, while preserving auto-scaling for non-degenerate ranges.
* **Tests**
  * Expanded coverage for flat, negative, large-scale, mixed-sign, ragged stacked, and non-finite inputs, plus zero-anchoring behaviors and window expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
