### PR TITLE
Fix blank Database Summaries chart for databases with no history yet

### DIFF
--- a/client/src/components/Dashboard/ServerDashboard/DatabaseSummariesSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/DatabaseSummariesSection.tsx
@@ -278,7 +278,8 @@ const DatabaseSummariesSection: React.FC<ServerSectionProps> = ({
                                 </Typography>
                             </Box>
 
-                            {db.cache_hit_ratio?.time_series && (
+                            {db.cache_hit_ratio?.time_series
+                                && db.cache_hit_ratio.time_series.length > 0 ? (
                                 <Box sx={{ height: 30, mt: 0.5, mb: 5 }}>
                                     <Sparkline
                                         data={toSparklineData(
@@ -289,6 +290,23 @@ const DatabaseSummariesSection: React.FC<ServerSectionProps> = ({
                                         )}
                                         height={30}
                                     />
+                                </Box>
+                            ) : (
+                                <Box sx={{
+                                    height: 30,
+                                    mt: 0.5,
+                                    mb: 5,
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                }}>
+                                    <Typography
+                                        variant="caption"
+                                        color="text.secondary"
+                                        sx={{ fontStyle: 'italic' }}
+                                    >
+                                        No history yet
+                                    </Typography>
                                 </Box>
                             )}
 

--- a/client/src/components/Dashboard/ServerDashboard/DatabaseSummariesSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/DatabaseSummariesSection.tsx
@@ -68,6 +68,15 @@ const DB_NAME_SX = {
     mb: 0.5,
 };
 
+/** Base dimensions for the cache hit ratio chart area; shared by the
+ *  sparkline and the "No history yet" placeholder so the layout stays
+ *  in lockstep between the two states. */
+const CHART_BOX_SX = {
+    height: 30,
+    mt: 0.5,
+    mb: 5,
+};
+
 /**
  * Determine color for cache hit ratio.
  */
@@ -280,7 +289,7 @@ const DatabaseSummariesSection: React.FC<ServerSectionProps> = ({
 
                             {db.cache_hit_ratio?.time_series
                                 && db.cache_hit_ratio.time_series.length > 0 ? (
-                                <Box sx={{ height: 30, mt: 0.5, mb: 5 }}>
+                                <Box sx={CHART_BOX_SX}>
                                     <Sparkline
                                         data={toSparklineData(
                                             db.cache_hit_ratio.time_series
@@ -293,9 +302,7 @@ const DatabaseSummariesSection: React.FC<ServerSectionProps> = ({
                                 </Box>
                             ) : (
                                 <Box sx={{
-                                    height: 30,
-                                    mt: 0.5,
-                                    mb: 5,
+                                    ...CHART_BOX_SX,
                                     display: 'flex',
                                     alignItems: 'center',
                                     justifyContent: 'center',

--- a/client/src/components/Dashboard/ServerDashboard/__tests__/DatabaseSummariesSection.test.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/__tests__/DatabaseSummariesSection.test.tsx
@@ -1,0 +1,328 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import DatabaseSummariesSection from '../DatabaseSummariesSection';
+import type { DatabaseSummary } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApiFetch = vi.fn();
+vi.mock('../../../../utils/apiClient', () => ({
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+const mockPushOverlay = vi.fn();
+vi.mock('../../../../contexts/useDashboard', () => ({
+    useDashboard: () => ({
+        refreshTrigger: 0,
+        pushOverlay: mockPushOverlay,
+    }),
+}));
+
+vi.mock('../../../../contexts/useAuth', () => ({
+    useAuth: () => ({
+        user: { id: 1, username: 'testuser' },
+    }),
+}));
+
+// Mock the Chart component (used by Sparkline) to avoid ECharts in tests.
+vi.mock('../../../Chart', () => ({
+    Chart: () => <div data-testid="sparkline-chart">chart</div>,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a mock DatabaseSummary with sensible defaults. */
+const makeDatabase = (
+    overrides: Partial<DatabaseSummary> = {},
+): DatabaseSummary => ({
+    database_name: 'mydb',
+    size_bytes: 1024,
+    size_pretty: '1 KB',
+    cache_hit_ratio: {
+        current: 98.5,
+        time_series: [
+            { time: '2024-01-01T00:00:00Z', value: 98.0 },
+            { time: '2024-01-01T00:01:00Z', value: 99.0 },
+        ],
+    },
+    transaction_rate: 12.3,
+    dead_tuple_ratio: 2.1,
+    active_connections: 5,
+    ...overrides,
+});
+
+/** Create a successful Response-like object. */
+const okResponse = (data: unknown): Partial<Response> => ({
+    ok: true,
+    json: () => Promise.resolve(data),
+});
+
+/** Create a failed Response-like object. */
+const errorResponse = (
+    status: number,
+    body: Record<string, string> = {},
+): Partial<Response> => ({
+    ok: false,
+    status,
+    json: () => Promise.resolve(body),
+});
+
+const theme = createTheme();
+
+const renderSection = () => render(
+    <ThemeProvider theme={theme}>
+        <DatabaseSummariesSection
+            connectionId={1}
+            connectionName="Test Server"
+        />
+    </ThemeProvider>,
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DatabaseSummariesSection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(localStorage.getItem).mockReturnValue(null);
+    });
+
+    it('renders the Sparkline when time_series is populated', async () => {
+        mockApiFetch.mockResolvedValue(
+            okResponse({ databases: [makeDatabase()] }),
+        );
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(
+                screen.getByTestId('sparkline-chart'),
+            ).toBeInTheDocument();
+        });
+
+        // The percentage still renders alongside the chart.
+        expect(screen.getByText('98.5%')).toBeInTheDocument();
+        // No placeholder is shown when history exists.
+        expect(
+            screen.queryByText('No history yet'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows a placeholder when current is valid but time_series is empty', async () => {
+        mockApiFetch.mockResolvedValue(
+            okResponse({
+                databases: [
+                    makeDatabase({
+                        cache_hit_ratio: {
+                            current: 97.2,
+                            time_series: [],
+                        },
+                    }),
+                ],
+            }),
+        );
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('No history yet'),
+            ).toBeInTheDocument();
+        });
+
+        // The current percentage still renders even without history.
+        expect(screen.getByText('97.2%')).toBeInTheDocument();
+        // The Sparkline chart is not rendered for an empty series.
+        expect(
+            screen.queryByTestId('sparkline-chart'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the placeholder when cache_hit_ratio is undefined', async () => {
+        mockApiFetch.mockResolvedValue(
+            okResponse({
+                databases: [
+                    makeDatabase({
+                        cache_hit_ratio: undefined as never,
+                    }),
+                ],
+            }),
+        );
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('No history yet'),
+            ).toBeInTheDocument();
+        });
+
+        // Current value falls back to the placeholder dash.
+        expect(screen.getByText('--')).toBeInTheDocument();
+    });
+
+    it('shows the loading spinner while fetching', () => {
+        mockApiFetch.mockReturnValue(new Promise(() => {}));
+
+        renderSection();
+
+        expect(
+            screen.getByLabelText('Loading databases'),
+        ).toBeInTheDocument();
+    });
+
+    it('shows an error message when the request fails', async () => {
+        mockApiFetch.mockResolvedValue(
+            errorResponse(500, { error: 'boom' }),
+        );
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(screen.getByText('boom')).toBeInTheDocument();
+        });
+    });
+
+    it('shows a fallback error message when the body has no error', async () => {
+        mockApiFetch.mockResolvedValue(errorResponse(503));
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/Failed to fetch database summaries: 503/),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('shows an error message when the fetch rejects', async () => {
+        mockApiFetch.mockRejectedValue(new Error('network down'));
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(screen.getByText('network down')).toBeInTheDocument();
+        });
+    });
+
+    it('shows the empty state when no databases are returned', async () => {
+        mockApiFetch.mockResolvedValue(okResponse({ databases: [] }));
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('No database summaries available'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('renders varied cache and dead-tuple color thresholds', async () => {
+        mockApiFetch.mockResolvedValue(
+            okResponse({
+                databases: [
+                    makeDatabase({
+                        database_name: 'warn_db',
+                        cache_hit_ratio: { current: 85, time_series: [] },
+                        dead_tuple_ratio: 15,
+                    }),
+                    makeDatabase({
+                        database_name: 'crit_db',
+                        cache_hit_ratio: { current: 50, time_series: [] },
+                        dead_tuple_ratio: 30,
+                    }),
+                ],
+            }),
+        );
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(screen.getByText('warn_db')).toBeInTheDocument();
+        });
+        expect(screen.getByText('crit_db')).toBeInTheDocument();
+        expect(screen.getByText('85.0%')).toBeInTheDocument();
+        expect(screen.getByText('50.0%')).toBeInTheDocument();
+    });
+
+    it('renders dashes when numeric fields are undefined', async () => {
+        mockApiFetch.mockResolvedValue(
+            okResponse({
+                databases: [
+                    makeDatabase({
+                        transaction_rate: undefined as never,
+                        dead_tuple_ratio: undefined as never,
+                        active_connections: undefined as never,
+                    }),
+                ],
+            }),
+        );
+
+        renderSection();
+
+        await waitFor(() => {
+            expect(screen.getByText('mydb')).toBeInTheDocument();
+        });
+        // Three undefined numeric fields each render a dash.
+        expect(screen.getAllByText('--').length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('opens the database overlay on click', async () => {
+        mockApiFetch.mockResolvedValue(
+            okResponse({ databases: [makeDatabase()] }),
+        );
+
+        renderSection();
+
+        const card = await screen.findByRole(
+            'button',
+            { name: /View details for database mydb/ },
+        );
+        fireEvent.click(card);
+
+        expect(mockPushOverlay).toHaveBeenCalledWith(
+            expect.objectContaining({
+                level: 'database',
+                databaseName: 'mydb',
+                connectionId: 1,
+            }),
+        );
+    });
+
+    it('opens the database overlay on Enter and Space keys', async () => {
+        mockApiFetch.mockResolvedValue(
+            okResponse({ databases: [makeDatabase()] }),
+        );
+
+        renderSection();
+
+        const card = await screen.findByRole(
+            'button',
+            { name: /View details for database mydb/ },
+        );
+
+        fireEvent.keyDown(card, { key: 'Enter' });
+        fireEvent.keyDown(card, { key: ' ' });
+        expect(mockPushOverlay).toHaveBeenCalledTimes(2);
+
+        // A non-activating key does not trigger the overlay.
+        fireEvent.keyDown(card, { key: 'a' });
+        expect(mockPushOverlay).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
## Symptom

Reported while investigating #336/#359: on a Server dashboard's
"Database Summaries" section, a database could show a correct
current Cache Hit Ratio percentage (e.g. 100.0%) right next to a
completely blank chart box, indistinguishable from a rendering
glitch.

## Root cause

`current` and `time_series` for each card come from two independent
server queries in `server/src/internal/api/perf_summary_handlers.go`:
`queryDatabaseStats` (latest single row) and
`queryDatabaseCacheHitTimeSeries` (24h bucketed history). A database
with only a few minutes of monitoring history can have a valid
`current` value while the bucketed query legitimately returns zero
rows, so the API returns `time_series: []` alongside a valid
`current`.

On the client, `DatabaseSummariesSection.tsx` guarded the chart with
`db.cache_hit_ratio?.time_series && (...)`. An empty array is truthy
in JavaScript, so the chart `Box` still rendered. Inside it,
`Sparkline` explicitly returns `null` for zero-length data, leaving an
empty box next to a populated percentage.

This is unrelated to #336/#359 (an ECharts axis-scaling min===max
collapse for flat-value series) — a different failure mode in a
different component. `Sparkline.tsx` and its existing null-for-empty
test are untouched.

## Fix

`DatabaseSummariesSection.tsx` now checks
`time_series.length > 0` before rendering the `Sparkline`, and shows a
small "No history yet" placeholder (matching the muted-secondary-text
empty-state convention used elsewhere in this file/directory) in the
same-sized chart area otherwise.

## Test plan

- [x] New `DatabaseSummariesSection.test.tsx`: populated time_series
      still renders the Sparkline; empty time_series with valid
      current shows the placeholder; undefined cache_hit_ratio shows
      the placeholder; plus existing loading/error/empty-state
      coverage.
- [x] `npx eslint` clean on both touched files
- [x] `npx vitest run` — 37/37 passing across ServerDashboard + the
      untouched Sparkline test
- [x] Coverage of the modified file: 98.5% lines, above the 90% floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Cache Hit Ratio card to display “No history yet” when cache-hit history is missing or empty, instead of showing a blank chart.
  * Kept the current Cache Hit Ratio percentage visible, with consistent placeholders when related metrics are unavailable.
* **Tests**
  * Added a comprehensive test suite for loading, error handling, empty states, chart visibility, metric formatting, and keyboard interactions for database card overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->