### PR TITLE
Fix "Hide monitoring queries" missing Workbench-internal traffic

### DIFF
--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -148,6 +148,110 @@ var validTopQueryOrderColumns = map[string]bool{
 	"shared_blks_read": true,
 }
 
+// workbenchInternalExclusionClause filters pg_stat_statements rows that
+// represent AI DBA Workbench's own internal traffic rather than genuine
+// activity on the monitored database. Because the ai_workbench metadata
+// database shares its PostgreSQL instance with monitored databases,
+// instance-wide pg_stat_statements captures Workbench's own overhead. The
+// clause removes three categories of that internal traffic:
+//
+//  1. Collector probe SELECTs, which the collector wraps in a marker
+//     column literal (ai_dba_wb_probe) before running them against the
+//     monitored database (see collector/src/probes/base.go).
+//  2. The collector's own batched writes into the internal metrics schema,
+//     emitted as INSERT INTO "metrics"."<table>" ... via pgx.Identifier,
+//     which quotes both the schema and table identifiers.
+//  3. The alerter's and server's own reads of the internal metrics schema,
+//     hand-authored as unquoted metrics.<table> references (for example
+//     the alerter's slow_query_count and age_percent CTEs in
+//     alerter/src/internal/database/metric_registry.go).
+//
+// Categories 2 and 3 match the "metrics" schema qualifier combined with
+// the pg_ / spock_ table-name prefixes that every internal metrics table
+// uses by convention, in both the unquoted (hand-written SQL) and quoted
+// (pgx.Identifier) forms. Matching the table-name prefix rather than the
+// bare "metrics" schema avoids hiding a genuinely monitored database that
+// happens to expose its own application schema named "metrics": the pg_
+// prefix is reserved by PostgreSQL and spock_ is the Spock extension's
+// namespace, so a collision with real user tables is effectively
+// impossible. The trailing underscore is escaped so LIKE treats it as a
+// literal rather than a single-character wildcard.
+//
+// This fragment contains only hardcoded literals and never interpolates
+// user input, so it is safe to splice into the query with fmt.Sprintf.
+const workbenchInternalExclusionClause = `AND pss.query NOT LIKE '%ai_dba_wb_probe%'
+              AND pss.query NOT LIKE '%metrics.pg\_%' ESCAPE '\'
+              AND pss.query NOT LIKE '%metrics.spock\_%' ESCAPE '\'
+              AND pss.query NOT LIKE '%"metrics"."pg\_%' ESCAPE '\'
+              AND pss.query NOT LIKE '%"metrics"."spock\_%' ESCAPE '\'`
+
+// buildTopQueriesQuery assembles the SQL and positional arguments for the
+// top-queries lookup. orderBy and order must already be validated against
+// their whitelists by the caller, since they are interpolated directly into
+// the ORDER BY clause. queryID, when non-empty, is bound as a positional
+// parameter rather than interpolated. When excludeCollector is true, the
+// hardcoded workbenchInternalExclusionClause is appended to hide Workbench's
+// own internal traffic. No user-supplied string is ever spliced into the
+// query text; only whitelisted literals and positional placeholders are.
+func buildTopQueriesQuery(
+	connID, limit int,
+	queryID, orderBy, order string,
+	excludeCollector bool,
+) (string, []any) {
+	// Build optional queryid filter clause.
+	queryIDClause := ""
+	args := []any{connID, limit}
+	if queryID != "" {
+		queryIDClause = fmt.Sprintf(
+			"AND pss.queryid::text = $%d", len(args)+1)
+		args = append(args, queryID)
+	}
+
+	// Build optional clause to exclude Workbench-internal traffic (collector
+	// probe SELECTs, collector metrics-store writes, and alerter/server
+	// metrics-store reads). See workbenchInternalExclusionClause.
+	excludeCollectorClause := ""
+	if excludeCollector {
+		excludeCollectorClause = workbenchInternalExclusionClause
+	}
+
+	// Safe to use string formatting for ORDER BY because orderBy and order
+	// are validated against whitelists by the caller.
+	query := fmt.Sprintf(`
+        WITH db_names AS (
+            SELECT DISTINCT datid, datname
+            FROM metrics.pg_stat_activity
+            WHERE connection_id = $1
+              AND datid IS NOT NULL
+              AND datname IS NOT NULL
+        ),
+        deduped AS (
+            SELECT DISTINCT ON (pss.queryid)
+                pss.queryid::text,
+                COALESCE(dn.datname, pss.database_name) AS database_name,
+                pss.query, pss.calls, pss.total_exec_time,
+                pss.mean_exec_time, pss.rows,
+                pss.shared_blks_hit, pss.shared_blks_read
+            FROM metrics.pg_stat_statements pss
+            LEFT JOIN db_names dn ON pss.dbid = dn.datid
+            WHERE pss.connection_id = $1
+              AND pss.collected_at = (
+                  SELECT MAX(collected_at)
+                  FROM metrics.pg_stat_statements
+                  WHERE connection_id = $1
+              )
+              %s
+              %s
+            ORDER BY pss.queryid
+        )
+        SELECT * FROM deduped
+        ORDER BY %s %s
+        LIMIT $2
+    `, queryIDClause, excludeCollectorClause, orderBy, order)
+
+	return query, args
+}
+
 // NewPerfSummaryHandler creates a new performance summary handler.
 func NewPerfSummaryHandler(
 	datastore *database.Datastore,
@@ -1117,54 +1221,8 @@ func (h *PerfSummaryHandler) handleTopQueries(
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // Rollback after commit is a no-op
 
-	// Safe to use string formatting for ORDER BY because orderBy and order
-	// are validated against whitelists above.
-	// Build optional queryid filter clause.
-	queryIDClause := ""
-	args := []any{connID, limit}
-	if queryID != "" {
-		queryIDClause = fmt.Sprintf(
-			"AND pss.queryid::text = $%d", len(args)+1)
-		args = append(args, queryID)
-	}
-
-	// Build optional clause to exclude collector probe queries.
-	excludeCollectorClause := ""
-	if excludeCollector {
-		excludeCollectorClause = "AND pss.query NOT LIKE '%ai_dba_wb_probe%'"
-	}
-
-	query := fmt.Sprintf(`
-        WITH db_names AS (
-            SELECT DISTINCT datid, datname
-            FROM metrics.pg_stat_activity
-            WHERE connection_id = $1
-              AND datid IS NOT NULL
-              AND datname IS NOT NULL
-        ),
-        deduped AS (
-            SELECT DISTINCT ON (pss.queryid)
-                pss.queryid::text,
-                COALESCE(dn.datname, pss.database_name) AS database_name,
-                pss.query, pss.calls, pss.total_exec_time,
-                pss.mean_exec_time, pss.rows,
-                pss.shared_blks_hit, pss.shared_blks_read
-            FROM metrics.pg_stat_statements pss
-            LEFT JOIN db_names dn ON pss.dbid = dn.datid
-            WHERE pss.connection_id = $1
-              AND pss.collected_at = (
-                  SELECT MAX(collected_at)
-                  FROM metrics.pg_stat_statements
-                  WHERE connection_id = $1
-              )
-              %s
-              %s
-            ORDER BY pss.queryid
-        )
-        SELECT * FROM deduped
-        ORDER BY %s %s
-        LIMIT $2
-    `, queryIDClause, excludeCollectorClause, orderBy, order)
+	query, args := buildTopQueriesQuery(
+		connID, limit, queryID, orderBy, order, excludeCollector)
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {

--- a/server/src/internal/api/perf_summary_top_queries_test.go
+++ b/server/src/internal/api/perf_summary_top_queries_test.go
@@ -1,0 +1,584 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+)
+
+// topQueriesTestSchema mirrors the minimum columns handleTopQueries reads
+// from the metrics schema. The tables live in the metrics schema because the
+// query fully qualifies its table names with metrics.*.
+const topQueriesTestSchema = `
+CREATE SCHEMA IF NOT EXISTS metrics;
+DROP TABLE IF EXISTS metrics.pg_stat_statements CASCADE;
+DROP TABLE IF EXISTS metrics.pg_stat_activity CASCADE;
+
+CREATE TABLE metrics.pg_stat_statements (
+    connection_id     integer     NOT NULL,
+    database_name     text        NOT NULL,
+    dbid              oid         NOT NULL DEFAULT 0,
+    queryid           bigint      NOT NULL,
+    query             text,
+    calls             bigint,
+    rows              bigint,
+    total_exec_time   double precision,
+    mean_exec_time    double precision,
+    shared_blks_hit   bigint,
+    shared_blks_read  bigint,
+    collected_at      timestamptz NOT NULL
+);
+
+CREATE TABLE metrics.pg_stat_activity (
+    connection_id  integer     NOT NULL,
+    collected_at   timestamptz NOT NULL,
+    datid          oid,
+    datname        text
+);
+`
+
+const topQueriesTestSchemaTeardown = `
+DROP TABLE IF EXISTS metrics.pg_stat_statements CASCADE;
+DROP TABLE IF EXISTS metrics.pg_stat_activity CASCADE;
+`
+
+// newTopQueriesTestPool connects to the TEST_AI_WORKBENCH_SERVER Postgres
+// instance and installs the trimmed metrics schema above. The test is
+// skipped when the environment is not configured for database-backed tests.
+func newTopQueriesTestPool(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping issue #364 test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, topQueriesTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create top-queries test schema: %v", err)
+	}
+
+	cleanup := func() {
+		_, _ = pool.Exec(context.Background(), topQueriesTestSchemaTeardown)
+		pool.Close()
+	}
+	return pool, cleanup
+}
+
+// topQueryFixture describes one seeded pg_stat_statements row and whether the
+// exclude_collector filter is expected to hide it.
+type topQueryFixture struct {
+	queryid          int64
+	query            string
+	excludedByToggle bool
+}
+
+// topQueriesFixtures is the seed set covering every branch of the exclusion
+// clause plus genuine user traffic that must never be filtered.
+var topQueriesFixtures = []topQueryFixture{
+	{
+		// Collector probe SELECT: wrapped in the ai_dba_wb_probe marker.
+		queryid: 1,
+		query: "SELECT 'ai_dba_wb_probe' AS ai_dba_wb_probe, subq.* " +
+			"FROM (SELECT * FROM pg_stat_activity) AS subq",
+		excludedByToggle: true,
+	},
+	{
+		// Collector metrics-store write: pgx.Identifier quotes both the
+		// schema and table (metrics.pg_stat_statements).
+		queryid: 2,
+		query: `INSERT INTO "metrics"."pg_stat_statements" ` +
+			`("connection_id", "query") VALUES ($1, $2)`,
+		excludedByToggle: true,
+	},
+	{
+		// Collector metrics-store write into a spock_* table.
+		queryid: 3,
+		query: `INSERT INTO "metrics"."spock_exception_log" ` +
+			`("connection_id") VALUES ($1)`,
+		excludedByToggle: true,
+	},
+	{
+		// Alerter slow_query_count read: unquoted metrics.pg_stat_statements.
+		queryid: 4,
+		query: "WITH recent_statements AS (SELECT connection_id, queryid " +
+			"FROM metrics.pg_stat_statements WHERE collected_at > NOW()) " +
+			"SELECT count(*) FROM recent_statements",
+		excludedByToggle: true,
+	},
+	{
+		// Alerter age_percent read: unquoted metrics.pg_settings.
+		queryid: 5,
+		query: "WITH freeze_settings AS (SELECT connection_id " +
+			"FROM metrics.pg_settings WHERE name = $1) " +
+			"SELECT * FROM freeze_settings",
+		excludedByToggle: true,
+	},
+	{
+		// Genuine user query on a monitored database: no relation to the
+		// metrics schema and no probe marker. Must never be filtered.
+		queryid:          6,
+		query:            "SELECT * FROM orders WHERE customer_id = $1",
+		excludedByToggle: false,
+	},
+	{
+		// Genuine user query against an external application schema that
+		// happens to be named "metrics" but whose table is not a pg_/spock_
+		// internal table. Must never be filtered (false-positive guard).
+		queryid:          7,
+		query:            "SELECT count(*) FROM metrics.events WHERE ts > $1",
+		excludedByToggle: false,
+	},
+	{
+		// External table whose name starts with "pgx"; the escaped
+		// underscore in the LIKE pattern means metrics.pg_ does not match
+		// metrics.pgx_data, so this genuine query is not filtered.
+		queryid:          8,
+		query:            "SELECT * FROM metrics.pgx_data WHERE id = $1",
+		excludedByToggle: false,
+	},
+}
+
+// seedTopQueriesFixtures inserts every fixture row at the same latest
+// collected_at so the handler's MAX(collected_at) filter keeps all of them.
+func seedTopQueriesFixtures(
+	t *testing.T, pool *pgxpool.Pool, connID int, collectedAt time.Time,
+) {
+	t.Helper()
+	ctx := context.Background()
+	for _, f := range topQueriesFixtures {
+		if _, err := pool.Exec(ctx, `
+            INSERT INTO metrics.pg_stat_statements
+                (connection_id, database_name, dbid, queryid, query, calls,
+                 rows, total_exec_time, mean_exec_time, shared_blks_hit,
+                 shared_blks_read, collected_at)
+            VALUES ($1, 'ai_workbench', 0, $2, $3, 10, 5, 100.0, 10.0, 1, 1,
+                    $4)`,
+			connID, f.queryid, f.query, collectedAt); err != nil {
+			t.Fatalf("seed statement %d failed: %v", f.queryid, err)
+		}
+	}
+}
+
+// runTopQueries executes the exact SQL that handleTopQueries builds for the
+// given exclude_collector setting and returns the set of queries returned.
+func runTopQueries(
+	t *testing.T, pool *pgxpool.Pool, connID int, excludeCollector bool,
+) map[string]bool {
+	t.Helper()
+	ctx := context.Background()
+
+	query, args := buildTopQueriesQuery(
+		connID, 100, "", "total_exec_time", "desc", excludeCollector)
+
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		t.Fatalf("BeginTx failed: %v", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback after read is a no-op
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		t.Fatalf("top queries query failed: %v", err)
+	}
+	defer rows.Close()
+
+	got := make(map[string]bool)
+	for rows.Next() {
+		var r TopQueryRow
+		if err := rows.Scan(
+			&r.QueryID, &r.DatabaseName, &r.Query, &r.Calls,
+			&r.TotalExecTime, &r.MeanExecTime, &r.Rows,
+			&r.SharedBlksHit, &r.SharedBlksRead,
+		); err != nil {
+			t.Fatalf("scan failed: %v", err)
+		}
+		got[r.Query] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration failed: %v", err)
+	}
+	return got
+}
+
+// TestTopQueries_Issue364_ExcludeCollector verifies that with the
+// exclude_collector toggle on, all three categories of Workbench-internal
+// traffic (collector probe SELECTs, collector metrics-store writes, and
+// alerter/server metrics-store reads) are filtered, while genuine user
+// queries -- including those against an unrelated external schema named
+// "metrics" -- are preserved.
+func TestTopQueries_Issue364_ExcludeCollector(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	const connID = 91
+	collectedAt := time.Now().UTC().Add(-time.Minute)
+	seedTopQueriesFixtures(t, pool, connID, collectedAt)
+
+	got := runTopQueries(t, pool, connID, true)
+
+	for _, f := range topQueriesFixtures {
+		present := got[f.query]
+		if f.excludedByToggle && present {
+			t.Errorf("query %d should be excluded but was returned: %q",
+				f.queryid, f.query)
+		}
+		if !f.excludedByToggle && !present {
+			t.Errorf("query %d should be returned but was excluded: %q",
+				f.queryid, f.query)
+		}
+	}
+}
+
+// TestTopQueries_Issue364_NoExcludeReturnsAll verifies that without the
+// toggle every seeded row is returned, so the filter never fires unless
+// explicitly requested.
+func TestTopQueries_Issue364_NoExcludeReturnsAll(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	const connID = 92
+	collectedAt := time.Now().UTC().Add(-time.Minute)
+	seedTopQueriesFixtures(t, pool, connID, collectedAt)
+
+	got := runTopQueries(t, pool, connID, false)
+
+	if len(got) != len(topQueriesFixtures) {
+		t.Fatalf("expected all %d rows without toggle, got %d: %#v",
+			len(topQueriesFixtures), len(got), got)
+	}
+	for _, f := range topQueriesFixtures {
+		if !got[f.query] {
+			t.Errorf("query %d missing when filter disabled: %q",
+				f.queryid, f.query)
+		}
+	}
+}
+
+// TestTopQueries_Issue364_HandlerHTTP drives handleTopQueries end-to-end
+// over HTTP with a nil authStore (which makes the RBAC checker treat the
+// caller as fully authorized) to prove the exclude_collector query parameter
+// filters Workbench-internal traffic through the real handler, not just the
+// extracted query builder.
+func TestTopQueries_Issue364_HandlerHTTP(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	const connID = 93
+	collectedAt := time.Now().UTC().Add(-time.Minute)
+	seedTopQueriesFixtures(t, pool, connID, collectedAt)
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+
+	do := func(exclude string) []TopQueryRow {
+		url := "/api/v1/metrics/top-queries?connection_id=" +
+			strconv.Itoa(connID) + "&limit=100"
+		if exclude != "" {
+			url += "&exclude_collector=" + exclude
+		}
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rec := httptest.NewRecorder()
+		h.handleTopQueries(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var out []TopQueryRow
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode response: %v (body %s)", err, rec.Body.String())
+		}
+		return out
+	}
+
+	// With the toggle on, internal traffic must be gone but user queries
+	// must survive.
+	filtered := do("true")
+	seen := make(map[string]bool)
+	for _, r := range filtered {
+		seen[r.Query] = true
+	}
+	for _, f := range topQueriesFixtures {
+		if f.excludedByToggle && seen[f.query] {
+			t.Errorf("HTTP: query %d should be excluded: %q",
+				f.queryid, f.query)
+		}
+		if !f.excludedByToggle && !seen[f.query] {
+			t.Errorf("HTTP: query %d should be present: %q",
+				f.queryid, f.query)
+		}
+	}
+
+	// With the toggle absent, every seeded row must be returned.
+	all := do("")
+	if len(all) != len(topQueriesFixtures) {
+		t.Fatalf("HTTP without toggle: expected %d rows, got %d",
+			len(topQueriesFixtures), len(all))
+	}
+
+	// Exercise the limit-clamp branches: 0 clamps up to 1, and an
+	// over-large value clamps down to 100.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id="+strconv.Itoa(connID)+
+			"&limit=0", nil)
+	rec := httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("limit=0 status = %d", rec.Code)
+	}
+	req = httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id="+strconv.Itoa(connID)+
+			"&limit=500", nil)
+	rec = httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("limit=500 status = %d", rec.Code)
+	}
+}
+
+// TestTopQueries_HandlerQueryError verifies that when the underlying query
+// fails (metrics tables missing) the handler responds 200 with an empty list
+// rather than an error, matching its defensive "no data" contract.
+func TestTopQueries_HandlerQueryError(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	// Drop the metrics tables so the top-queries query fails.
+	if _, err := pool.Exec(context.Background(),
+		topQueriesTestSchemaTeardown); err != nil {
+		t.Fatalf("teardown failed: %v", err)
+	}
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id=1", nil)
+	rec := httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	var out []TopQueryRow
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty result on query error, got %d", len(out))
+	}
+}
+
+// TestTopQueries_HandlerScanError verifies that a row which fails to scan (a
+// NULL in a NOT NULL destination column) is skipped rather than aborting the
+// response.
+func TestTopQueries_HandlerScanError(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	const connID = 94
+	collectedAt := time.Now().UTC().Add(-time.Minute)
+	// calls is NULL, so scanning into the int64 Calls field fails.
+	if _, err := pool.Exec(context.Background(), `
+        INSERT INTO metrics.pg_stat_statements
+            (connection_id, database_name, dbid, queryid, query, calls,
+             rows, total_exec_time, mean_exec_time, shared_blks_hit,
+             shared_blks_read, collected_at)
+        VALUES ($1, 'ai_workbench', 0, 1, 'SELECT 1', NULL, 5, 1.0, 1.0, 1,
+                1, $2)`, connID, collectedAt); err != nil {
+		t.Fatalf("seed bad row: %v", err)
+	}
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id="+strconv.Itoa(connID), nil)
+	rec := httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var out []TopQueryRow
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("row that fails to scan must be skipped, got %d", len(out))
+	}
+}
+
+// TestTopQueries_HandlerBeginTxError verifies the handler returns 500 when a
+// read-only transaction cannot be started (here, a closed pool).
+func TestTopQueries_HandlerBeginTxError(t *testing.T) {
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping issue #364 test")
+	}
+	pool, err := pgxpool.New(context.Background(), connStr)
+	if err != nil {
+		t.Skipf("connect: %v", err)
+	}
+	pool.Close() // BeginTx on a closed pool fails.
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id=1", nil)
+	rec := httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (body %s)",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestTopQueries_HandlerValidationErrors covers the request-validation
+// branches of handleTopQueries that reject the request before any database
+// access, so they need no datastore.
+func TestTopQueries_HandlerValidationErrors(t *testing.T) {
+	h := &PerfSummaryHandler{}
+	cases := []struct {
+		name   string
+		method string
+		url    string
+		want   int
+	}{
+		{
+			name:   "non-GET rejected",
+			method: http.MethodPost,
+			url:    "/api/v1/metrics/top-queries?connection_id=1",
+			want:   http.StatusMethodNotAllowed,
+		},
+		{
+			name:   "missing connection id",
+			method: http.MethodGet,
+			url:    "/api/v1/metrics/top-queries",
+			want:   http.StatusBadRequest,
+		},
+		{
+			name:   "multiple connection ids rejected",
+			method: http.MethodGet,
+			url:    "/api/v1/metrics/top-queries?connection_ids=1,2",
+			want:   http.StatusBadRequest,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.handleTopQueries(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body %s)",
+					rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestTopQueries_HandlerParamValidationDB covers the parameter-validation
+// branches that run after the RBAC check and therefore need a datastore; a
+// nil authStore authorizes the caller so validation is reached.
+func TestTopQueries_HandlerParamValidationDB(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	cases := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{
+			name: "invalid limit",
+			url:  "/api/v1/metrics/top-queries?connection_id=1&limit=abc",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "invalid order_by",
+			url:  "/api/v1/metrics/top-queries?connection_id=1&order_by=drop",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "invalid order",
+			url:  "/api/v1/metrics/top-queries?connection_id=1&order=sideways",
+			want: http.StatusBadRequest,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.handleTopQueries(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body %s)",
+					rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestBuildTopQueriesQuery_ClauseSelection asserts, without touching a
+// database, that the exclusion fragment is present only when requested and
+// that the optional queryid filter is bound as a positional parameter rather
+// than interpolated.
+func TestBuildTopQueriesQuery_ClauseSelection(t *testing.T) {
+	// Without exclusion the internal clause must be absent.
+	q, args := buildTopQueriesQuery(1, 10, "", "calls", "asc", false)
+	if strings.Contains(q, "ai_dba_wb_probe") {
+		t.Errorf("exclusion clause present when not requested")
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(args))
+	}
+
+	// With exclusion the full internal clause must be spliced in.
+	q, _ = buildTopQueriesQuery(1, 10, "", "calls", "asc", true)
+	for _, frag := range []string{
+		"ai_dba_wb_probe",
+		`metrics.pg\_`,
+		`metrics.spock\_`,
+		`"metrics"."pg\_`,
+		`"metrics"."spock\_`,
+	} {
+		if !strings.Contains(q, frag) {
+			t.Errorf("exclusion clause missing fragment %q", frag)
+		}
+	}
+
+	// A queryid filter must be added as a positional parameter.
+	q, args = buildTopQueriesQuery(1, 10, "42", "calls", "asc", false)
+	if !strings.Contains(q, "pss.queryid::text = $3") {
+		t.Errorf("queryid filter not bound positionally: %q", q)
+	}
+	if len(args) != 3 || args[2] != "42" {
+		t.Errorf("queryid not appended to args: %#v", args)
+	}
+}


### PR DESCRIPTION
## Symptom

The Server dashboard's "Top Queries" section has a "Hide monitoring
queries" toggle. With it on, Workbench-internal overhead queries
against the app's own `ai_workbench` metadata database still showed
up, e.g. `INSERT INTO "metrics"."pg_stat_s...`, `WITH
recent_statements AS (...`, `WITH freeze_settings AS (...`.

## Root cause

`handleTopQueries`'s `exclude_collector` filter only excluded queries
containing the collector's `ai_dba_wb_probe` marker literal, which
`collector/src/probes/base.go` wraps only around the collector's
read-only probe SELECTs against monitored databases. Since
`ai_workbench` shares its Postgres instance with monitored databases,
`pg_stat_statements` captures instance-wide activity, including two
unmarked categories of Workbench's own traffic:

1. The collector's own batched `INSERT INTO metrics.*` writes that
   persist collected metrics — storage writes, never wrapped in the
   probe marker.
2. The alerter's (and server's) own internal reads of that same
   metrics schema for alert evaluation — e.g. the `recent_statements`
   and `freeze_settings` CTEs in
   `alerter/src/internal/database/metric_registry.go`, an entirely
   separate binary the collector's marker has no bearing on.

## Fix

The exclusion clause now also matches the `metrics` schema qualifier
combined with the `pg_`/`spock_` table-name prefixes every internal
metrics table uses by convention, in both quoted (`pgx.Identifier`,
the collector's writes) and unquoted (hand-written SQL, the
alerter's/server's reads) forms.

Matching on the table-name prefix rather than the bare `metrics`
schema name is a deliberate choice: it avoids hiding a genuinely
monitored external database that happens to expose its own
application schema also named `metrics`. `pg_` is reserved by
PostgreSQL and `spock_` is the Spock extension's namespace, so a
collision with real user tables is effectively impossible, and any
future internal metrics table following the same convention is
covered automatically.

Query construction is extracted into a `buildTopQueriesQuery` helper
so the SQL is directly testable in isolation from the HTTP/RBAC
plumbing, matching the pattern already used by sibling handlers in
this file.

## Test plan

- [x] `TestTopQueries_Issue364_ExcludeCollector` — probe-marked,
      quoted collector metrics writes, and unquoted alerter/server
      metrics reads are all excluded; a normal user query and external
      queries against a database-level `metrics` schema (including one
      shaped like `metrics.pgx_data`, guarding the underscore-escape)
      are preserved.
- [x] `TestTopQueries_Issue364_NoExcludeReturnsAll` — toggle off
      returns everything, unchanged.
- [x] `TestTopQueries_Issue364_HandlerHTTP` — full handler over HTTP
      confirms the same filtering end-to-end.
- [x] `TestBuildTopQueriesQuery_ClauseSelection` plus handler
      validation/error-path tests (query error, scan error, begin-tx
      error, param validation).
- [x] `gofmt`/`go vet`/`golangci-lint` clean
- [x] Coverage: `buildTopQueriesQuery` 100%, `handleTopQueries` 95.4%
      (previously untested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the top-queries performance summary filter to reliably exclude Workbench’s internal monitoring activity.
  * Preserved legitimate queries, including those involving similarly named schemas and tables.
  * Improved handling of invalid requests and database errors with safer, predictable responses.

* **Tests**
  * Added comprehensive coverage for filtering, validation, query limits, ordering, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->