### PR TITLE
Fix "Hide monitoring queries" showing Workbench-internal traffic

### DIFF
--- a/server/src/cmd/mcp-server/handlers.go
+++ b/server/src/cmd/mcp-server/handlers.go
@@ -195,8 +195,16 @@ func SetupHandlers(deps *HandlerDependencies) func(*http.ServeMux) error {
 		timelineHandler := api.NewTimelineHandler(deps.Datastore, deps.AuthStore, rbacChecker)
 		registerDatastoreHandler(mux, timelineHandler, authWrapper, "Timeline events", deps.Datastore)
 
-		// Performance summary endpoint (for performance dashboard)
-		perfHandler := api.NewPerfSummaryHandler(deps.Datastore, deps.AuthStore)
+		// Performance summary endpoint (for performance dashboard).
+		// Pass the configured maintenance (datastore) database name so the
+		// top-queries endpoint can filter the Workbench's own traffic when
+		// exclude_collector is set (issue #366).
+		maintenanceDBName := ""
+		if deps.Config != nil && deps.Config.Database != nil {
+			maintenanceDBName = deps.Config.Database.Database
+		}
+		perfHandler := api.NewPerfSummaryHandler(
+			deps.Datastore, deps.AuthStore, maintenanceDBName)
 		registerDatastoreHandler(mux, perfHandler, authWrapper, "Performance summary", deps.Datastore)
 
 		// Metrics query endpoints (for monitoring dashboards)

--- a/server/src/internal/api/perf_summary_database_summaries_test.go
+++ b/server/src/internal/api/perf_summary_database_summaries_test.go
@@ -96,7 +96,7 @@ func newDatabaseSummariesTestHandler(
 	}
 
 	ds := database.NewTestDatastore(pool)
-	handler := NewPerfSummaryHandler(ds, nil)
+	handler := NewPerfSummaryHandler(ds, nil, "")
 	cleanup := func() {
 		_, _ = pool.Exec(context.Background(),
 			databaseSummariesTestSchemaTeardown)

--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -148,6 +148,110 @@ var validTopQueryOrderColumns = map[string]bool{
 	"shared_blks_read": true,
 }
 
+// workbenchInternalExclusionClause filters pg_stat_statements rows that
+// represent AI DBA Workbench's own internal traffic rather than genuine
+// activity on the monitored database. Because the ai_workbench metadata
+// database shares its PostgreSQL instance with monitored databases,
+// instance-wide pg_stat_statements captures Workbench's own overhead. The
+// clause removes three categories of that internal traffic:
+//
+//  1. Collector probe SELECTs, which the collector wraps in a marker
+//     column literal (ai_dba_wb_probe) before running them against the
+//     monitored database (see collector/src/probes/base.go).
+//  2. The collector's own batched writes into the internal metrics schema,
+//     emitted as INSERT INTO "metrics"."<table>" ... via pgx.Identifier,
+//     which quotes both the schema and table identifiers.
+//  3. The alerter's and server's own reads of the internal metrics schema,
+//     hand-authored as unquoted metrics.<table> references (for example
+//     the alerter's slow_query_count and age_percent CTEs in
+//     alerter/src/internal/database/metric_registry.go).
+//
+// Categories 2 and 3 match the "metrics" schema qualifier combined with
+// the pg_ / spock_ table-name prefixes that every internal metrics table
+// uses by convention, in both the unquoted (hand-written SQL) and quoted
+// (pgx.Identifier) forms. Matching the table-name prefix rather than the
+// bare "metrics" schema avoids hiding a genuinely monitored database that
+// happens to expose its own application schema named "metrics": the pg_
+// prefix is reserved by PostgreSQL and spock_ is the Spock extension's
+// namespace, so a collision with real user tables is effectively
+// impossible. The trailing underscore is escaped so LIKE treats it as a
+// literal rather than a single-character wildcard.
+//
+// This fragment contains only hardcoded literals and never interpolates
+// user input, so it is safe to splice into the query with fmt.Sprintf.
+const workbenchInternalExclusionClause = `AND pss.query NOT LIKE '%ai_dba_wb_probe%'
+              AND pss.query NOT LIKE '%metrics.pg\_%' ESCAPE '\'
+              AND pss.query NOT LIKE '%metrics.spock\_%' ESCAPE '\'
+              AND pss.query NOT LIKE '%"metrics"."pg\_%' ESCAPE '\'
+              AND pss.query NOT LIKE '%"metrics"."spock\_%' ESCAPE '\'`
+
+// buildTopQueriesQuery assembles the SQL and positional arguments for the
+// top-queries lookup. orderBy and order must already be validated against
+// their whitelists by the caller, since they are interpolated directly into
+// the ORDER BY clause. queryID, when non-empty, is bound as a positional
+// parameter rather than interpolated. When excludeCollector is true, the
+// hardcoded workbenchInternalExclusionClause is appended to hide Workbench's
+// own internal traffic. No user-supplied string is ever spliced into the
+// query text; only whitelisted literals and positional placeholders are.
+func buildTopQueriesQuery(
+	connID, limit int,
+	queryID, orderBy, order string,
+	excludeCollector bool,
+) (string, []any) {
+	// Build optional queryid filter clause.
+	queryIDClause := ""
+	args := []any{connID, limit}
+	if queryID != "" {
+		queryIDClause = fmt.Sprintf(
+			"AND pss.queryid::text = $%d", len(args)+1)
+		args = append(args, queryID)
+	}
+
+	// Build optional clause to exclude Workbench-internal traffic (collector
+	// probe SELECTs, collector metrics-store writes, and alerter/server
+	// metrics-store reads). See workbenchInternalExclusionClause.
+	excludeCollectorClause := ""
+	if excludeCollector {
+		excludeCollectorClause = workbenchInternalExclusionClause
+	}
+
+	// Safe to use string formatting for ORDER BY because orderBy and order
+	// are validated against whitelists by the caller.
+	query := fmt.Sprintf(`
+        WITH db_names AS (
+            SELECT DISTINCT datid, datname
+            FROM metrics.pg_stat_activity
+            WHERE connection_id = $1
+              AND datid IS NOT NULL
+              AND datname IS NOT NULL
+        ),
+        deduped AS (
+            SELECT DISTINCT ON (pss.queryid)
+                pss.queryid::text,
+                COALESCE(dn.datname, pss.database_name) AS database_name,
+                pss.query, pss.calls, pss.total_exec_time,
+                pss.mean_exec_time, pss.rows,
+                pss.shared_blks_hit, pss.shared_blks_read
+            FROM metrics.pg_stat_statements pss
+            LEFT JOIN db_names dn ON pss.dbid = dn.datid
+            WHERE pss.connection_id = $1
+              AND pss.collected_at = (
+                  SELECT MAX(collected_at)
+                  FROM metrics.pg_stat_statements
+                  WHERE connection_id = $1
+              )
+              %s
+              %s
+            ORDER BY pss.queryid
+        )
+        SELECT * FROM deduped
+        ORDER BY %s %s
+        LIMIT $2
+    `, queryIDClause, excludeCollectorClause, orderBy, order)
+
+	return query, args
+}
+
 // NewPerfSummaryHandler creates a new performance summary handler.
 func NewPerfSummaryHandler(
 	datastore *database.Datastore,
@@ -1117,54 +1221,8 @@ func (h *PerfSummaryHandler) handleTopQueries(
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // Rollback after commit is a no-op
 
-	// Safe to use string formatting for ORDER BY because orderBy and order
-	// are validated against whitelists above.
-	// Build optional queryid filter clause.
-	queryIDClause := ""
-	args := []any{connID, limit}
-	if queryID != "" {
-		queryIDClause = fmt.Sprintf(
-			"AND pss.queryid::text = $%d", len(args)+1)
-		args = append(args, queryID)
-	}
-
-	// Build optional clause to exclude collector probe queries.
-	excludeCollectorClause := ""
-	if excludeCollector {
-		excludeCollectorClause = "AND pss.query NOT LIKE '%ai_dba_wb_probe%'"
-	}
-
-	query := fmt.Sprintf(`
-        WITH db_names AS (
-            SELECT DISTINCT datid, datname
-            FROM metrics.pg_stat_activity
-            WHERE connection_id = $1
-              AND datid IS NOT NULL
-              AND datname IS NOT NULL
-        ),
-        deduped AS (
-            SELECT DISTINCT ON (pss.queryid)
-                pss.queryid::text,
-                COALESCE(dn.datname, pss.database_name) AS database_name,
-                pss.query, pss.calls, pss.total_exec_time,
-                pss.mean_exec_time, pss.rows,
-                pss.shared_blks_hit, pss.shared_blks_read
-            FROM metrics.pg_stat_statements pss
-            LEFT JOIN db_names dn ON pss.dbid = dn.datid
-            WHERE pss.connection_id = $1
-              AND pss.collected_at = (
-                  SELECT MAX(collected_at)
-                  FROM metrics.pg_stat_statements
-                  WHERE connection_id = $1
-              )
-              %s
-              %s
-            ORDER BY pss.queryid
-        )
-        SELECT * FROM deduped
-        ORDER BY %s %s
-        LIMIT $2
-    `, queryIDClause, excludeCollectorClause, orderBy, order)
+	query, args := buildTopQueriesQuery(
+		connID, limit, queryID, orderBy, order, excludeCollector)
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {

--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -38,6 +38,14 @@ var validTimeRanges = map[string]time.Duration{
 type PerfSummaryHandler struct {
 	datastore *database.Datastore
 	authStore *auth.AuthStore
+
+	// maintenanceDBName is the server's configured maintenance (datastore)
+	// database name (config database.database, e.g. "ai_workbench"). Rows
+	// attributed to this database are the Workbench's own traffic and are
+	// filtered from top-queries results when exclude_collector is set. It
+	// is captured at construction time; the value is fixed once the server
+	// starts. An empty value disables the database-identity filter.
+	maintenanceDBName string
 }
 
 // PerfSummaryResponse is the top-level JSON response.
@@ -148,54 +156,55 @@ var validTopQueryOrderColumns = map[string]bool{
 	"shared_blks_read": true,
 }
 
-// workbenchInternalExclusionClause filters pg_stat_statements rows that
-// represent AI DBA Workbench's own internal traffic rather than genuine
-// activity on the monitored database. Because the ai_workbench metadata
-// database shares its PostgreSQL instance with monitored databases,
-// instance-wide pg_stat_statements captures Workbench's own overhead. The
-// clause removes three categories of that internal traffic:
+// workbenchProbeExclusionClause filters pg_stat_statements rows that the
+// collector generates while probing OTHER monitored databases. Because
+// pg_stat_statements is instance-wide, a collector probe that runs against
+// a genuinely-monitored database is attributed to that database, so a
+// database-identity check against the Workbench maintenance database alone
+// cannot catch it. The collector wraps every probe SELECT in a marker
+// column literal (ai_dba_wb_probe) before executing it (see
+// collector/src/probes/base.go), which this clause matches.
 //
-//  1. Collector probe SELECTs, which the collector wraps in a marker
-//     column literal (ai_dba_wb_probe) before running them against the
-//     monitored database (see collector/src/probes/base.go).
-//  2. The collector's own batched writes into the internal metrics schema,
-//     emitted as INSERT INTO "metrics"."<table>" ... via pgx.Identifier,
-//     which quotes both the schema and table identifiers.
-//  3. The alerter's and server's own reads of the internal metrics schema,
-//     hand-authored as unquoted metrics.<table> references (for example
-//     the alerter's slow_query_count and age_percent CTEs in
-//     alerter/src/internal/database/metric_registry.go).
+// This clause complements the database-identity exclusion applied in
+// buildTopQueriesQuery. The identity check removes ALL traffic attributed
+// to the maintenance database itself -- the collector's metrics-store
+// writes (INSERT INTO "metrics"."<table>" ...), the alerter's and server's
+// metrics-store reads (metrics.<table> ...), and schema-introspection
+// queries whose table names arrive as bound parameters -- categorically,
+// regardless of query-text shape, quoting style, or parameterization. That
+// makes the earlier query-text patterns for metrics.pg_/metrics.spock_
+// redundant: none of the maintenance database's own traffic is ever
+// genuine end-user activity, and the only Workbench traffic that lands in
+// a different (monitored) database is the marker-tagged probe SELECT this
+// clause handles. See issue #366.
 //
-// Categories 2 and 3 match the "metrics" schema qualifier combined with
-// the pg_ / spock_ table-name prefixes that every internal metrics table
-// uses by convention, in both the unquoted (hand-written SQL) and quoted
-// (pgx.Identifier) forms. Matching the table-name prefix rather than the
-// bare "metrics" schema avoids hiding a genuinely monitored database that
-// happens to expose its own application schema named "metrics": the pg_
-// prefix is reserved by PostgreSQL and spock_ is the Spock extension's
-// namespace, so a collision with real user tables is effectively
-// impossible. The trailing underscore is escaped so LIKE treats it as a
-// literal rather than a single-character wildcard.
-//
-// This fragment contains only hardcoded literals and never interpolates
+// This fragment contains only a hardcoded literal and never interpolates
 // user input, so it is safe to splice into the query with fmt.Sprintf.
-const workbenchInternalExclusionClause = `AND pss.query NOT LIKE '%ai_dba_wb_probe%'
-              AND pss.query NOT LIKE '%metrics.pg\_%' ESCAPE '\'
-              AND pss.query NOT LIKE '%metrics.spock\_%' ESCAPE '\'
-              AND pss.query NOT LIKE '%"metrics"."pg\_%' ESCAPE '\'
-              AND pss.query NOT LIKE '%"metrics"."spock\_%' ESCAPE '\'`
+const workbenchProbeExclusionClause = `AND pss.query NOT LIKE '%ai_dba_wb_probe%'`
 
 // buildTopQueriesQuery assembles the SQL and positional arguments for the
 // top-queries lookup. orderBy and order must already be validated against
 // their whitelists by the caller, since they are interpolated directly into
 // the ORDER BY clause. queryID, when non-empty, is bound as a positional
-// parameter rather than interpolated. When excludeCollector is true, the
-// hardcoded workbenchInternalExclusionClause is appended to hide Workbench's
-// own internal traffic. No user-supplied string is ever spliced into the
-// query text; only whitelisted literals and positional placeholders are.
+// parameter rather than interpolated.
+//
+// When excludeCollector is true, two complementary filters hide the
+// Workbench's own traffic. First, every row whose resolved database_name
+// matches maintenanceDBName -- the server's configured maintenance
+// (datastore) database -- is removed via a bound-parameter comparison;
+// none of that database's own traffic is ever genuine end-user activity,
+// so this catches the collector's metrics-store writes, the
+// alerter/server metrics-store reads, and schema-introspection queries
+// regardless of query-text shape or quoting. Second, the hardcoded
+// workbenchProbeExclusionClause removes marker-tagged collector probe
+// SELECTs that run against OTHER monitored databases, which the
+// database-identity check cannot catch. maintenanceDBName is bound as a
+// positional parameter; when it is empty only the probe-marker clause is
+// applied. No user-supplied string is ever spliced into the query text;
+// only whitelisted literals and positional placeholders are.
 func buildTopQueriesQuery(
 	connID, limit int,
-	queryID, orderBy, order string,
+	queryID, orderBy, order, maintenanceDBName string,
 	excludeCollector bool,
 ) (string, []any) {
 	// Build optional queryid filter clause.
@@ -207,12 +216,22 @@ func buildTopQueriesQuery(
 		args = append(args, queryID)
 	}
 
-	// Build optional clause to exclude Workbench-internal traffic (collector
-	// probe SELECTs, collector metrics-store writes, and alerter/server
-	// metrics-store reads). See workbenchInternalExclusionClause.
+	// Build optional clause to exclude Workbench-internal traffic. The
+	// database-identity check (COALESCE(dn.datname, pss.database_name)
+	// against the configured maintenance database) removes all traffic on
+	// the maintenance database itself; the probe-marker clause removes the
+	// collector's marker-tagged probes against other monitored databases.
 	excludeCollectorClause := ""
 	if excludeCollector {
-		excludeCollectorClause = workbenchInternalExclusionClause
+		clauses := []string{workbenchProbeExclusionClause}
+		if maintenanceDBName != "" {
+			clauses = append(clauses, fmt.Sprintf(
+				"AND COALESCE(dn.datname, pss.database_name) <> $%d",
+				len(args)+1))
+			args = append(args, maintenanceDBName)
+		}
+		excludeCollectorClause = strings.Join(clauses,
+			"\n              ")
 	}
 
 	// Safe to use string formatting for ORDER BY because orderBy and order
@@ -253,13 +272,18 @@ func buildTopQueriesQuery(
 }
 
 // NewPerfSummaryHandler creates a new performance summary handler.
+// maintenanceDBName is the configured maintenance (datastore) database
+// name used to filter the Workbench's own traffic from top-queries
+// results; pass an empty string to disable that database-identity filter.
 func NewPerfSummaryHandler(
 	datastore *database.Datastore,
 	authStore *auth.AuthStore,
+	maintenanceDBName string,
 ) *PerfSummaryHandler {
 	return &PerfSummaryHandler{
-		datastore: datastore,
-		authStore: authStore,
+		datastore:         datastore,
+		authStore:         authStore,
+		maintenanceDBName: maintenanceDBName,
 	}
 }
 
@@ -1222,7 +1246,8 @@ func (h *PerfSummaryHandler) handleTopQueries(
 	defer tx.Rollback(ctx) //nolint:errcheck // Rollback after commit is a no-op
 
 	query, args := buildTopQueriesQuery(
-		connID, limit, queryID, orderBy, order, excludeCollector)
+		connID, limit, queryID, orderBy, order,
+		h.maintenanceDBName, excludeCollector)
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {

--- a/server/src/internal/api/perf_summary_top_queries_test.go
+++ b/server/src/internal/api/perf_summary_top_queries_test.go
@@ -97,82 +97,122 @@ func newTopQueriesTestPool(t *testing.T) (*pgxpool.Pool, func()) {
 	return pool, cleanup
 }
 
-// topQueryFixture describes one seeded pg_stat_statements row and whether the
-// exclude_collector filter is expected to hide it.
+// testMaintenanceDBName is the configured maintenance (datastore) database
+// name the tests thread into the handler. Rows attributed to this database
+// represent the Workbench's own traffic and must be excluded when
+// exclude_collector is set, regardless of query-text shape (issue #366).
+const testMaintenanceDBName = "ai_workbench"
+
+// testMonitoredDBName is a genuinely-monitored database whose rows must
+// survive the exclude_collector filter unless individually marked as a
+// collector probe.
+const testMonitoredDBName = "northwind"
+
+// topQueryFixture describes one seeded pg_stat_statements row, the database
+// it is attributed to, and whether the exclude_collector filter is expected
+// to hide it.
 type topQueryFixture struct {
 	queryid          int64
+	databaseName     string
 	query            string
 	excludedByToggle bool
 }
 
-// topQueriesFixtures is the seed set covering every branch of the exclusion
-// clause plus genuine user traffic that must never be filtered.
+// topQueriesFixtures is the seed set covering the database-identity
+// exclusion (all maintenance-database traffic, regardless of query text),
+// the surviving probe-marker exclusion (marker-tagged probes against a
+// different monitored database), and genuine user traffic that must never
+// be filtered -- including monitored-database queries whose text
+// superficially resembles internal metrics access.
 var topQueriesFixtures = []topQueryFixture{
 	{
-		// Collector probe SELECT: wrapped in the ai_dba_wb_probe marker.
-		queryid: 1,
-		query: "SELECT 'ai_dba_wb_probe' AS ai_dba_wb_probe, subq.* " +
-			"FROM (SELECT * FROM pg_stat_activity) AS subq",
+		// New unfilterable case #1 from issue #366: a schema-introspection
+		// query whose schema/table names arrive as bound parameters, so no
+		// query-text pattern could ever match it. Caught only by the
+		// database-identity check because it runs on the maintenance DB.
+		queryid:      1,
+		databaseName: testMaintenanceDBName,
+		query: "SELECT column_name, data_type FROM " +
+			"information_schema.columns WHERE table_schema = $2 " +
+			"AND table_name = $1 ORDER BY ordinal_position",
+		excludedByToggle: true,
+	},
+	{
+		// New unfilterable case #2 from issue #366: a third quoting style
+		// (unquoted schema, quoted table) that #365's patterns did not
+		// anticipate. Caught by the database-identity check.
+		queryid:      2,
+		databaseName: testMaintenanceDBName,
+		query: `WITH data_buckets AS (SELECT date_bin('1 hour', ` +
+			`collected_at, now()) AS bucket FROM ` +
+			`metrics."pg_stat_statements") SELECT * FROM data_buckets`,
 		excludedByToggle: true,
 	},
 	{
 		// Collector metrics-store write: pgx.Identifier quotes both the
-		// schema and table (metrics.pg_stat_statements).
-		queryid: 2,
+		// schema and table. Now caught by the database-identity check.
+		queryid:      3,
+		databaseName: testMaintenanceDBName,
 		query: `INSERT INTO "metrics"."pg_stat_statements" ` +
 			`("connection_id", "query") VALUES ($1, $2)`,
 		excludedByToggle: true,
 	},
 	{
-		// Collector metrics-store write into a spock_* table.
-		queryid: 3,
-		query: `INSERT INTO "metrics"."spock_exception_log" ` +
-			`("connection_id") VALUES ($1)`,
-		excludedByToggle: true,
-	},
-	{
 		// Alerter slow_query_count read: unquoted metrics.pg_stat_statements.
-		queryid: 4,
+		// Now caught by the database-identity check.
+		queryid:      4,
+		databaseName: testMaintenanceDBName,
 		query: "WITH recent_statements AS (SELECT connection_id, queryid " +
 			"FROM metrics.pg_stat_statements WHERE collected_at > NOW()) " +
 			"SELECT count(*) FROM recent_statements",
 		excludedByToggle: true,
 	},
 	{
-		// Alerter age_percent read: unquoted metrics.pg_settings.
-		queryid: 5,
-		query: "WITH freeze_settings AS (SELECT connection_id " +
-			"FROM metrics.pg_settings WHERE name = $1) " +
-			"SELECT * FROM freeze_settings",
+		// Collector probe SELECT wrapped in the ai_dba_wb_probe marker,
+		// running against a DIFFERENT monitored database. The
+		// database-identity check cannot catch it (its database_name is not
+		// the maintenance DB), so the surviving probe-marker clause must.
+		queryid:      5,
+		databaseName: testMonitoredDBName,
+		query: "SELECT 'ai_dba_wb_probe' AS ai_dba_wb_probe, subq.* " +
+			"FROM (SELECT * FROM pg_stat_activity) AS subq",
 		excludedByToggle: true,
 	},
 	{
 		// Genuine user query on a monitored database: no relation to the
 		// metrics schema and no probe marker. Must never be filtered.
 		queryid:          6,
+		databaseName:     testMonitoredDBName,
 		query:            "SELECT * FROM orders WHERE customer_id = $1",
 		excludedByToggle: false,
 	},
 	{
-		// Genuine user query against an external application schema that
-		// happens to be named "metrics" but whose table is not a pg_/spock_
-		// internal table. Must never be filtered (false-positive guard).
+		// Genuine user query on a monitored database against an application
+		// schema that happens to be named "metrics". Must never be filtered.
 		queryid:          7,
+		databaseName:     testMonitoredDBName,
 		query:            "SELECT count(*) FROM metrics.events WHERE ts > $1",
 		excludedByToggle: false,
 	},
 	{
-		// External table whose name starts with "pgx"; the escaped
-		// underscore in the LIKE pattern means metrics.pg_ does not match
-		// metrics.pgx_data, so this genuine query is not filtered.
-		queryid:          8,
-		query:            "SELECT * FROM metrics.pgx_data WHERE id = $1",
+		// Genuine user query on a monitored database whose text is
+		// indistinguishable from internal metrics access
+		// (metrics."pg_stat_statements"). Under the old text-pattern
+		// approach this would have been wrongly filtered; the
+		// database-identity approach correctly preserves it because it is
+		// attributed to a monitored database, not the maintenance DB.
+		queryid:      8,
+		databaseName: testMonitoredDBName,
+		query: `SELECT * FROM metrics."pg_stat_statements" ` +
+			`WHERE queryid = $1`,
 		excludedByToggle: false,
 	},
 }
 
 // seedTopQueriesFixtures inserts every fixture row at the same latest
 // collected_at so the handler's MAX(collected_at) filter keeps all of them.
+// Each row is attributed to its fixture's database so the database-identity
+// exclusion can be exercised.
 func seedTopQueriesFixtures(
 	t *testing.T, pool *pgxpool.Pool, connID int, collectedAt time.Time,
 ) {
@@ -184,9 +224,10 @@ func seedTopQueriesFixtures(
                 (connection_id, database_name, dbid, queryid, query, calls,
                  rows, total_exec_time, mean_exec_time, shared_blks_hit,
                  shared_blks_read, collected_at)
-            VALUES ($1, 'ai_workbench', 0, $2, $3, 10, 5, 100.0, 10.0, 1, 1,
-                    $4)`,
-			connID, f.queryid, f.query, collectedAt); err != nil {
+            VALUES ($1, $2, 0, $3, $4, 10, 5, 100.0, 10.0, 1, 1,
+                    $5)`,
+			connID, f.databaseName, f.queryid, f.query,
+			collectedAt); err != nil {
 			t.Fatalf("seed statement %d failed: %v", f.queryid, err)
 		}
 	}
@@ -201,7 +242,8 @@ func runTopQueries(
 	ctx := context.Background()
 
 	query, args := buildTopQueriesQuery(
-		connID, 100, "", "total_exec_time", "desc", excludeCollector)
+		connID, 100, "", "total_exec_time", "desc",
+		testMaintenanceDBName, excludeCollector)
 
 	tx, err := pool.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
 	if err != nil {
@@ -234,11 +276,15 @@ func runTopQueries(
 }
 
 // TestTopQueries_Issue364_ExcludeCollector verifies that with the
-// exclude_collector toggle on, all three categories of Workbench-internal
-// traffic (collector probe SELECTs, collector metrics-store writes, and
-// alerter/server metrics-store reads) are filtered, while genuine user
-// queries -- including those against an unrelated external schema named
-// "metrics" -- are preserved.
+// exclude_collector toggle on, every category of Workbench-internal
+// traffic is filtered: all traffic attributed to the maintenance database
+// (collector metrics-store writes, alerter/server metrics-store reads, and
+// -- per issue #366 -- parameterized schema-introspection queries and
+// mixed-quoting metrics access that no text pattern could catch), plus
+// marker-tagged collector probes running against a different monitored
+// database. Genuine user queries on a monitored database are preserved,
+// including one whose text is indistinguishable from internal metrics
+// access, proving the filter keys on database identity rather than text.
 func TestTopQueries_Issue364_ExcludeCollector(t *testing.T) {
 	pool, cleanup := newTopQueriesTestPool(t)
 	defer cleanup()
@@ -300,7 +346,8 @@ func TestTopQueries_Issue364_HandlerHTTP(t *testing.T) {
 	collectedAt := time.Now().UTC().Add(-time.Minute)
 	seedTopQueriesFixtures(t, pool, connID, collectedAt)
 
-	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	h := NewPerfSummaryHandler(
+		database.NewTestDatastore(pool), nil, testMaintenanceDBName)
 
 	do := func(exclude string) []TopQueryRow {
 		url := "/api/v1/metrics/top-queries?connection_id=" +
@@ -379,7 +426,8 @@ func TestTopQueries_HandlerQueryError(t *testing.T) {
 		t.Fatalf("teardown failed: %v", err)
 	}
 
-	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	h := NewPerfSummaryHandler(
+		database.NewTestDatastore(pool), nil, testMaintenanceDBName)
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/metrics/top-queries?connection_id=1", nil)
 	rec := httptest.NewRecorder()
@@ -416,7 +464,8 @@ func TestTopQueries_HandlerScanError(t *testing.T) {
 		t.Fatalf("seed bad row: %v", err)
 	}
 
-	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	h := NewPerfSummaryHandler(
+		database.NewTestDatastore(pool), nil, testMaintenanceDBName)
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/metrics/top-queries?connection_id="+strconv.Itoa(connID), nil)
 	rec := httptest.NewRecorder()
@@ -449,7 +498,8 @@ func TestTopQueries_HandlerBeginTxError(t *testing.T) {
 	}
 	pool.Close() // BeginTx on a closed pool fails.
 
-	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	h := NewPerfSummaryHandler(
+		database.NewTestDatastore(pool), nil, testMaintenanceDBName)
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/metrics/top-queries?connection_id=1", nil)
 	rec := httptest.NewRecorder()
@@ -510,7 +560,8 @@ func TestTopQueries_HandlerParamValidationDB(t *testing.T) {
 	pool, cleanup := newTopQueriesTestPool(t)
 	defer cleanup()
 
-	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	h := NewPerfSummaryHandler(
+		database.NewTestDatastore(pool), nil, testMaintenanceDBName)
 	cases := []struct {
 		name string
 		url  string
@@ -546,39 +597,83 @@ func TestTopQueries_HandlerParamValidationDB(t *testing.T) {
 }
 
 // TestBuildTopQueriesQuery_ClauseSelection asserts, without touching a
-// database, that the exclusion fragment is present only when requested and
-// that the optional queryid filter is bound as a positional parameter rather
-// than interpolated.
+// database, that the probe-marker and database-identity exclusions are
+// present only when requested, that the maintenance database name is bound
+// as a positional parameter (never interpolated), and that the optional
+// queryid filter is likewise bound positionally.
 func TestBuildTopQueriesQuery_ClauseSelection(t *testing.T) {
-	// Without exclusion the internal clause must be absent.
-	q, args := buildTopQueriesQuery(1, 10, "", "calls", "asc", false)
+	const identityFrag = "COALESCE(dn.datname, pss.database_name) <>"
+
+	// Without exclusion neither clause must be present.
+	q, args := buildTopQueriesQuery(
+		1, 10, "", "calls", "asc", testMaintenanceDBName, false)
 	if strings.Contains(q, "ai_dba_wb_probe") {
-		t.Errorf("exclusion clause present when not requested")
+		t.Errorf("probe-marker clause present when not requested")
+	}
+	if strings.Contains(q, identityFrag) {
+		t.Errorf("database-identity clause present when not requested")
 	}
 	if len(args) != 2 {
 		t.Errorf("expected 2 args, got %d", len(args))
 	}
 
-	// With exclusion the full internal clause must be spliced in.
-	q, _ = buildTopQueriesQuery(1, 10, "", "calls", "asc", true)
+	// With exclusion and a maintenance DB name, both the probe-marker
+	// clause and the database-identity clause must be spliced in, and the
+	// maintenance name must be bound as $3 rather than interpolated.
+	q, args = buildTopQueriesQuery(
+		1, 10, "", "calls", "asc", testMaintenanceDBName, true)
+	if !strings.Contains(q, "ai_dba_wb_probe") {
+		t.Errorf("probe-marker clause missing when requested")
+	}
+	if !strings.Contains(q, identityFrag+" $3") {
+		t.Errorf("database-identity clause not bound at $3: %q", q)
+	}
+	if strings.Contains(q, testMaintenanceDBName) {
+		t.Errorf("maintenance DB name interpolated into query text: %q", q)
+	}
+	if len(args) != 3 || args[2] != testMaintenanceDBName {
+		t.Errorf("maintenance DB name not bound positionally: %#v", args)
+	}
+
+	// The removed text-pattern fragments must no longer appear.
 	for _, frag := range []string{
-		"ai_dba_wb_probe",
 		`metrics.pg\_`,
 		`metrics.spock\_`,
 		`"metrics"."pg\_`,
 		`"metrics"."spock\_`,
 	} {
-		if !strings.Contains(q, frag) {
-			t.Errorf("exclusion clause missing fragment %q", frag)
+		if strings.Contains(q, frag) {
+			t.Errorf("obsolete text-pattern fragment still present: %q",
+				frag)
 		}
 	}
 
-	// A queryid filter must be added as a positional parameter.
-	q, args = buildTopQueriesQuery(1, 10, "42", "calls", "asc", false)
+	// With exclusion but an empty maintenance DB name, only the
+	// probe-marker clause applies and no extra argument is bound.
+	q, args = buildTopQueriesQuery(1, 10, "", "calls", "asc", "", true)
+	if !strings.Contains(q, "ai_dba_wb_probe") {
+		t.Errorf("probe-marker clause missing with empty maintenance name")
+	}
+	if strings.Contains(q, identityFrag) {
+		t.Errorf("database-identity clause present with empty name")
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args with empty maintenance name, got %d",
+			len(args))
+	}
+
+	// A queryid filter must be added as a positional parameter, and with
+	// exclusion enabled the maintenance name must follow it at $4.
+	q, args = buildTopQueriesQuery(
+		1, 10, "42", "calls", "asc", testMaintenanceDBName, true)
 	if !strings.Contains(q, "pss.queryid::text = $3") {
 		t.Errorf("queryid filter not bound positionally: %q", q)
 	}
-	if len(args) != 3 || args[2] != "42" {
-		t.Errorf("queryid not appended to args: %#v", args)
+	if !strings.Contains(q, identityFrag+" $4") {
+		t.Errorf("maintenance name not bound at $4 after queryid: %q", q)
+	}
+	if len(args) != 4 || args[2] != "42" ||
+		args[3] != testMaintenanceDBName {
+		t.Errorf("args not appended in order: %#v", args)
 	}
 }

--- a/server/src/internal/api/perf_summary_top_queries_test.go
+++ b/server/src/internal/api/perf_summary_top_queries_test.go
@@ -1,0 +1,584 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+)
+
+// topQueriesTestSchema mirrors the minimum columns handleTopQueries reads
+// from the metrics schema. The tables live in the metrics schema because the
+// query fully qualifies its table names with metrics.*.
+const topQueriesTestSchema = `
+CREATE SCHEMA IF NOT EXISTS metrics;
+DROP TABLE IF EXISTS metrics.pg_stat_statements CASCADE;
+DROP TABLE IF EXISTS metrics.pg_stat_activity CASCADE;
+
+CREATE TABLE metrics.pg_stat_statements (
+    connection_id     integer     NOT NULL,
+    database_name     text        NOT NULL,
+    dbid              oid         NOT NULL DEFAULT 0,
+    queryid           bigint      NOT NULL,
+    query             text,
+    calls             bigint,
+    rows              bigint,
+    total_exec_time   double precision,
+    mean_exec_time    double precision,
+    shared_blks_hit   bigint,
+    shared_blks_read  bigint,
+    collected_at      timestamptz NOT NULL
+);
+
+CREATE TABLE metrics.pg_stat_activity (
+    connection_id  integer     NOT NULL,
+    collected_at   timestamptz NOT NULL,
+    datid          oid,
+    datname        text
+);
+`
+
+const topQueriesTestSchemaTeardown = `
+DROP TABLE IF EXISTS metrics.pg_stat_statements CASCADE;
+DROP TABLE IF EXISTS metrics.pg_stat_activity CASCADE;
+`
+
+// newTopQueriesTestPool connects to the TEST_AI_WORKBENCH_SERVER Postgres
+// instance and installs the trimmed metrics schema above. The test is
+// skipped when the environment is not configured for database-backed tests.
+func newTopQueriesTestPool(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping issue #364 test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, topQueriesTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create top-queries test schema: %v", err)
+	}
+
+	cleanup := func() {
+		_, _ = pool.Exec(context.Background(), topQueriesTestSchemaTeardown)
+		pool.Close()
+	}
+	return pool, cleanup
+}
+
+// topQueryFixture describes one seeded pg_stat_statements row and whether the
+// exclude_collector filter is expected to hide it.
+type topQueryFixture struct {
+	queryid          int64
+	query            string
+	excludedByToggle bool
+}
+
+// topQueriesFixtures is the seed set covering every branch of the exclusion
+// clause plus genuine user traffic that must never be filtered.
+var topQueriesFixtures = []topQueryFixture{
+	{
+		// Collector probe SELECT: wrapped in the ai_dba_wb_probe marker.
+		queryid: 1,
+		query: "SELECT 'ai_dba_wb_probe' AS ai_dba_wb_probe, subq.* " +
+			"FROM (SELECT * FROM pg_stat_activity) AS subq",
+		excludedByToggle: true,
+	},
+	{
+		// Collector metrics-store write: pgx.Identifier quotes both the
+		// schema and table (metrics.pg_stat_statements).
+		queryid: 2,
+		query: `INSERT INTO "metrics"."pg_stat_statements" ` +
+			`("connection_id", "query") VALUES ($1, $2)`,
+		excludedByToggle: true,
+	},
+	{
+		// Collector metrics-store write into a spock_* table.
+		queryid: 3,
+		query: `INSERT INTO "metrics"."spock_exception_log" ` +
+			`("connection_id") VALUES ($1)`,
+		excludedByToggle: true,
+	},
+	{
+		// Alerter slow_query_count read: unquoted metrics.pg_stat_statements.
+		queryid: 4,
+		query: "WITH recent_statements AS (SELECT connection_id, queryid " +
+			"FROM metrics.pg_stat_statements WHERE collected_at > NOW()) " +
+			"SELECT count(*) FROM recent_statements",
+		excludedByToggle: true,
+	},
+	{
+		// Alerter age_percent read: unquoted metrics.pg_settings.
+		queryid: 5,
+		query: "WITH freeze_settings AS (SELECT connection_id " +
+			"FROM metrics.pg_settings WHERE name = $1) " +
+			"SELECT * FROM freeze_settings",
+		excludedByToggle: true,
+	},
+	{
+		// Genuine user query on a monitored database: no relation to the
+		// metrics schema and no probe marker. Must never be filtered.
+		queryid:          6,
+		query:            "SELECT * FROM orders WHERE customer_id = $1",
+		excludedByToggle: false,
+	},
+	{
+		// Genuine user query against an external application schema that
+		// happens to be named "metrics" but whose table is not a pg_/spock_
+		// internal table. Must never be filtered (false-positive guard).
+		queryid:          7,
+		query:            "SELECT count(*) FROM metrics.events WHERE ts > $1",
+		excludedByToggle: false,
+	},
+	{
+		// External table whose name starts with "pgx"; the escaped
+		// underscore in the LIKE pattern means metrics.pg_ does not match
+		// metrics.pgx_data, so this genuine query is not filtered.
+		queryid:          8,
+		query:            "SELECT * FROM metrics.pgx_data WHERE id = $1",
+		excludedByToggle: false,
+	},
+}
+
+// seedTopQueriesFixtures inserts every fixture row at the same latest
+// collected_at so the handler's MAX(collected_at) filter keeps all of them.
+func seedTopQueriesFixtures(
+	t *testing.T, pool *pgxpool.Pool, connID int, collectedAt time.Time,
+) {
+	t.Helper()
+	ctx := context.Background()
+	for _, f := range topQueriesFixtures {
+		if _, err := pool.Exec(ctx, `
+            INSERT INTO metrics.pg_stat_statements
+                (connection_id, database_name, dbid, queryid, query, calls,
+                 rows, total_exec_time, mean_exec_time, shared_blks_hit,
+                 shared_blks_read, collected_at)
+            VALUES ($1, 'ai_workbench', 0, $2, $3, 10, 5, 100.0, 10.0, 1, 1,
+                    $4)`,
+			connID, f.queryid, f.query, collectedAt); err != nil {
+			t.Fatalf("seed statement %d failed: %v", f.queryid, err)
+		}
+	}
+}
+
+// runTopQueries executes the exact SQL that handleTopQueries builds for the
+// given exclude_collector setting and returns the set of queries returned.
+func runTopQueries(
+	t *testing.T, pool *pgxpool.Pool, connID int, excludeCollector bool,
+) map[string]bool {
+	t.Helper()
+	ctx := context.Background()
+
+	query, args := buildTopQueriesQuery(
+		connID, 100, "", "total_exec_time", "desc", excludeCollector)
+
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		t.Fatalf("BeginTx failed: %v", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback after read is a no-op
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		t.Fatalf("top queries query failed: %v", err)
+	}
+	defer rows.Close()
+
+	got := make(map[string]bool)
+	for rows.Next() {
+		var r TopQueryRow
+		if err := rows.Scan(
+			&r.QueryID, &r.DatabaseName, &r.Query, &r.Calls,
+			&r.TotalExecTime, &r.MeanExecTime, &r.Rows,
+			&r.SharedBlksHit, &r.SharedBlksRead,
+		); err != nil {
+			t.Fatalf("scan failed: %v", err)
+		}
+		got[r.Query] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration failed: %v", err)
+	}
+	return got
+}
+
+// TestTopQueries_Issue364_ExcludeCollector verifies that with the
+// exclude_collector toggle on, all three categories of Workbench-internal
+// traffic (collector probe SELECTs, collector metrics-store writes, and
+// alerter/server metrics-store reads) are filtered, while genuine user
+// queries -- including those against an unrelated external schema named
+// "metrics" -- are preserved.
+func TestTopQueries_Issue364_ExcludeCollector(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	const connID = 91
+	collectedAt := time.Now().UTC().Add(-time.Minute)
+	seedTopQueriesFixtures(t, pool, connID, collectedAt)
+
+	got := runTopQueries(t, pool, connID, true)
+
+	for _, f := range topQueriesFixtures {
+		present := got[f.query]
+		if f.excludedByToggle && present {
+			t.Errorf("query %d should be excluded but was returned: %q",
+				f.queryid, f.query)
+		}
+		if !f.excludedByToggle && !present {
+			t.Errorf("query %d should be returned but was excluded: %q",
+				f.queryid, f.query)
+		}
+	}
+}
+
+// TestTopQueries_Issue364_NoExcludeReturnsAll verifies that without the
+// toggle every seeded row is returned, so the filter never fires unless
+// explicitly requested.
+func TestTopQueries_Issue364_NoExcludeReturnsAll(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	const connID = 92
+	collectedAt := time.Now().UTC().Add(-time.Minute)
+	seedTopQueriesFixtures(t, pool, connID, collectedAt)
+
+	got := runTopQueries(t, pool, connID, false)
+
+	if len(got) != len(topQueriesFixtures) {
+		t.Fatalf("expected all %d rows without toggle, got %d: %#v",
+			len(topQueriesFixtures), len(got), got)
+	}
+	for _, f := range topQueriesFixtures {
+		if !got[f.query] {
+			t.Errorf("query %d missing when filter disabled: %q",
+				f.queryid, f.query)
+		}
+	}
+}
+
+// TestTopQueries_Issue364_HandlerHTTP drives handleTopQueries end-to-end
+// over HTTP with a nil authStore (which makes the RBAC checker treat the
+// caller as fully authorized) to prove the exclude_collector query parameter
+// filters Workbench-internal traffic through the real handler, not just the
+// extracted query builder.
+func TestTopQueries_Issue364_HandlerHTTP(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	const connID = 93
+	collectedAt := time.Now().UTC().Add(-time.Minute)
+	seedTopQueriesFixtures(t, pool, connID, collectedAt)
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+
+	do := func(exclude string) []TopQueryRow {
+		url := "/api/v1/metrics/top-queries?connection_id=" +
+			strconv.Itoa(connID) + "&limit=100"
+		if exclude != "" {
+			url += "&exclude_collector=" + exclude
+		}
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rec := httptest.NewRecorder()
+		h.handleTopQueries(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var out []TopQueryRow
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode response: %v (body %s)", err, rec.Body.String())
+		}
+		return out
+	}
+
+	// With the toggle on, internal traffic must be gone but user queries
+	// must survive.
+	filtered := do("true")
+	seen := make(map[string]bool)
+	for _, r := range filtered {
+		seen[r.Query] = true
+	}
+	for _, f := range topQueriesFixtures {
+		if f.excludedByToggle && seen[f.query] {
+			t.Errorf("HTTP: query %d should be excluded: %q",
+				f.queryid, f.query)
+		}
+		if !f.excludedByToggle && !seen[f.query] {
+			t.Errorf("HTTP: query %d should be present: %q",
+				f.queryid, f.query)
+		}
+	}
+
+	// With the toggle absent, every seeded row must be returned.
+	all := do("")
+	if len(all) != len(topQueriesFixtures) {
+		t.Fatalf("HTTP without toggle: expected %d rows, got %d",
+			len(topQueriesFixtures), len(all))
+	}
+
+	// Exercise the limit-clamp branches: 0 clamps up to 1, and an
+	// over-large value clamps down to 100.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id="+strconv.Itoa(connID)+
+			"&limit=0", nil)
+	rec := httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("limit=0 status = %d", rec.Code)
+	}
+	req = httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id="+strconv.Itoa(connID)+
+			"&limit=500", nil)
+	rec = httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("limit=500 status = %d", rec.Code)
+	}
+}
+
+// TestTopQueries_HandlerQueryError verifies that when the underlying query
+// fails (metrics tables missing) the handler responds 200 with an empty list
+// rather than an error, matching its defensive "no data" contract.
+func TestTopQueries_HandlerQueryError(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	// Drop the metrics tables so the top-queries query fails.
+	if _, err := pool.Exec(context.Background(),
+		topQueriesTestSchemaTeardown); err != nil {
+		t.Fatalf("teardown failed: %v", err)
+	}
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id=1", nil)
+	rec := httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	var out []TopQueryRow
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty result on query error, got %d", len(out))
+	}
+}
+
+// TestTopQueries_HandlerScanError verifies that a row which fails to scan (a
+// NULL in a NOT NULL destination column) is skipped rather than aborting the
+// response.
+func TestTopQueries_HandlerScanError(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	const connID = 94
+	collectedAt := time.Now().UTC().Add(-time.Minute)
+	// calls is NULL, so scanning into the int64 Calls field fails.
+	if _, err := pool.Exec(context.Background(), `
+        INSERT INTO metrics.pg_stat_statements
+            (connection_id, database_name, dbid, queryid, query, calls,
+             rows, total_exec_time, mean_exec_time, shared_blks_hit,
+             shared_blks_read, collected_at)
+        VALUES ($1, 'ai_workbench', 0, 1, 'SELECT 1', NULL, 5, 1.0, 1.0, 1,
+                1, $2)`, connID, collectedAt); err != nil {
+		t.Fatalf("seed bad row: %v", err)
+	}
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id="+strconv.Itoa(connID), nil)
+	rec := httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var out []TopQueryRow
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("row that fails to scan must be skipped, got %d", len(out))
+	}
+}
+
+// TestTopQueries_HandlerBeginTxError verifies the handler returns 500 when a
+// read-only transaction cannot be started (here, a closed pool).
+func TestTopQueries_HandlerBeginTxError(t *testing.T) {
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping issue #364 test")
+	}
+	pool, err := pgxpool.New(context.Background(), connStr)
+	if err != nil {
+		t.Skipf("connect: %v", err)
+	}
+	pool.Close() // BeginTx on a closed pool fails.
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/top-queries?connection_id=1", nil)
+	rec := httptest.NewRecorder()
+	h.handleTopQueries(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (body %s)",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestTopQueries_HandlerValidationErrors covers the request-validation
+// branches of handleTopQueries that reject the request before any database
+// access, so they need no datastore.
+func TestTopQueries_HandlerValidationErrors(t *testing.T) {
+	h := &PerfSummaryHandler{}
+	cases := []struct {
+		name   string
+		method string
+		url    string
+		want   int
+	}{
+		{
+			name:   "non-GET rejected",
+			method: http.MethodPost,
+			url:    "/api/v1/metrics/top-queries?connection_id=1",
+			want:   http.StatusMethodNotAllowed,
+		},
+		{
+			name:   "missing connection id",
+			method: http.MethodGet,
+			url:    "/api/v1/metrics/top-queries",
+			want:   http.StatusBadRequest,
+		},
+		{
+			name:   "multiple connection ids rejected",
+			method: http.MethodGet,
+			url:    "/api/v1/metrics/top-queries?connection_ids=1,2",
+			want:   http.StatusBadRequest,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.handleTopQueries(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body %s)",
+					rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestTopQueries_HandlerParamValidationDB covers the parameter-validation
+// branches that run after the RBAC check and therefore need a datastore; a
+// nil authStore authorizes the caller so validation is reached.
+func TestTopQueries_HandlerParamValidationDB(t *testing.T) {
+	pool, cleanup := newTopQueriesTestPool(t)
+	defer cleanup()
+
+	h := NewPerfSummaryHandler(database.NewTestDatastore(pool), nil)
+	cases := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{
+			name: "invalid limit",
+			url:  "/api/v1/metrics/top-queries?connection_id=1&limit=abc",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "invalid order_by",
+			url:  "/api/v1/metrics/top-queries?connection_id=1&order_by=drop",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "invalid order",
+			url:  "/api/v1/metrics/top-queries?connection_id=1&order=sideways",
+			want: http.StatusBadRequest,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.handleTopQueries(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body %s)",
+					rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestBuildTopQueriesQuery_ClauseSelection asserts, without touching a
+// database, that the exclusion fragment is present only when requested and
+// that the optional queryid filter is bound as a positional parameter rather
+// than interpolated.
+func TestBuildTopQueriesQuery_ClauseSelection(t *testing.T) {
+	// Without exclusion the internal clause must be absent.
+	q, args := buildTopQueriesQuery(1, 10, "", "calls", "asc", false)
+	if strings.Contains(q, "ai_dba_wb_probe") {
+		t.Errorf("exclusion clause present when not requested")
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(args))
+	}
+
+	// With exclusion the full internal clause must be spliced in.
+	q, _ = buildTopQueriesQuery(1, 10, "", "calls", "asc", true)
+	for _, frag := range []string{
+		"ai_dba_wb_probe",
+		`metrics.pg\_`,
+		`metrics.spock\_`,
+		`"metrics"."pg\_`,
+		`"metrics"."spock\_`,
+	} {
+		if !strings.Contains(q, frag) {
+			t.Errorf("exclusion clause missing fragment %q", frag)
+		}
+	}
+
+	// A queryid filter must be added as a positional parameter.
+	q, args = buildTopQueriesQuery(1, 10, "42", "calls", "asc", false)
+	if !strings.Contains(q, "pss.queryid::text = $3") {
+		t.Errorf("queryid filter not bound positionally: %q", q)
+	}
+	if len(args) != 3 || args[2] != "42" {
+		t.Errorf("queryid not appended to args: %#v", args)
+	}
+}


### PR DESCRIPTION
## Symptom

Follow-up to #364/#365. With "Hide monitoring queries" on, Top Queries
still showed only `ai_workbench` (the app's own maintenance database)
rows — confirmed live after exercising a real monitored `northwind`
database with a genuine workload, none of its activity ever surfaced.

## Root cause

#365's `exclude_collector` filter matched query *text* against known
schema/table patterns. That approach is fundamentally incomplete —
found two more categories live by querying the raw metrics store:

1. `SELECT column_name, data_type FROM information_schema.columns
   WHERE table_schema = $2 AND table_name = $1` — a schema-
   introspection query where the schema/table names are bound
   parameters, not literal text. No text pattern can ever match this.
2. `WITH data_buckets AS (SELECT ... FROM metrics."pg_stat_statements"
   ...)` — a third quoting style (schema unquoted, table quoted)
   #365's patterns didn't anticipate.

Because the maintenance database's own collector-driven traffic
accumulates far more total execution time than a freshly exercised
monitored database, these unfiltered rows dominated a
`total_exec_time`-sorted top-10 list and crowded out genuine
monitored-database activity entirely.

## Fix

Replace text-pattern matching with a database-identity check:
`buildTopQueriesQuery` now excludes every row whose resolved
`database_name` matches the server's configured maintenance database
(`database.database` in the YAML config, e.g. `ai_workbench` — read
via a new `maintenanceDBName` parameter threaded through
`NewPerfSummaryHandler`, not hardcoded). This catches all of the
maintenance database's own traffic categorically, regardless of
query-text shape, quoting, or parameterization.

The `ai_dba_wb_probe` marker clause is kept — it still matters for
collector probe SELECTs that run against *other* monitored databases,
which the database-identity check can't catch since those rows are
attributed to the monitored database, not the maintenance one. The
now-redundant `metrics.pg_*`/`metrics.spock_*` text patterns are
removed, since the database-identity check supersedes them entirely.

## Test plan

- [x] Fixtures cover both previously-unfilterable cases (parameterized
      `information_schema` query, mixed-quoting `metrics."pg_stat_statements"`
      CTE) — both now excluded by identity, not text.
- [x] A marker-tagged probe attributed to a monitored (`northwind`)
      database is still excluded via the surviving marker clause.
- [x] A genuine `northwind` row whose text happens to superficially
      resemble `metrics."pg_stat_statements"` is preserved — proving
      the filter now goes by identity, not text (would have been
      wrongly dropped under #365's approach).
- [x] `TestBuildTopQueriesQuery_ClauseSelection` rewritten to assert
      clause presence/absence, parameter binding order, and that
      obsolete text fragments are gone.
- [x] `gofmt`/`go vet`/`golangci-lint` clean; full `internal/api` and
      `cmd/mcp-server` suites pass
- [x] Coverage: `buildTopQueriesQuery` 100%, `NewPerfSummaryHandler`
      100%, `handleTopQueries` 95.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the Top Queries performance summary to optionally exclude internal maintenance and collector-generated activity.
  * Added more accurate filtering while preserving genuine monitored-database queries.
  * Enhanced handling of query limits, filtering, and validation.

* **Bug Fixes**
  * Improved resilience when performance data cannot be queried or processed, returning safer results instead of failing unexpectedly.

* **Tests**
  * Added comprehensive coverage for filtering, validation, error handling, and HTTP behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->