### PR TITLE
fix(client): normalise tool schemas to the library's wire contract

### DIFF
--- a/client/src/hooks/chat/__tests__/chatAgenticLoop.test.ts
+++ b/client/src/hooks/chat/__tests__/chatAgenticLoop.test.ts
@@ -760,7 +760,35 @@ describe('chatAgenticLoop', () => {
                 ]);
                 expect(body.system_prompt).toBe('Be helpful');
                 expect(body.system).toBeUndefined();
-                expect(body.tools).toEqual(params.availableTools);
+                expect(body.tools).toEqual(
+                    params.availableTools.map(t => ({
+                        name: t.name,
+                        description: t.description,
+                        input_schema: t.inputSchema,
+                    })),
+                );
+            });
+
+            it('sends tools with a snake_case input_schema key, not the internal camelCase inputSchema (issue #370)', async () => {
+                // Regression guard: the library `llm/proxy` chat endpoint
+                // decodes tools into a struct tagged `json:"input_schema"`.
+                // Sending the app's internal camelCase `inputSchema` field
+                // verbatim causes the schema to silently unmarshal to nil,
+                // and Anthropic rejects the resulting empty schema. See
+                // issue #370.
+                const mockFetch = createMockFetch([createTextResponse('Hi')]);
+                const params = createLoopParams({ fetchFn: mockFetch });
+
+                await runAgenticLoop(params);
+
+                const call = mockFetch.mock.calls[0];
+                const body = JSON.parse(call[1]?.body as string);
+
+                expect(body.tools.length).toBeGreaterThan(0);
+                for (const tool of body.tools) {
+                    expect(tool.input_schema).toBeDefined();
+                    expect(tool.inputSchema).toBeUndefined();
+                }
             });
 
             it('sends correct request body to tool call endpoint', async () => {

--- a/client/src/hooks/chat/chatAgenticLoop.ts
+++ b/client/src/hooks/chat/chatAgenticLoop.ts
@@ -24,7 +24,7 @@ import type {
     ToolCallResponse,
     ToolResult,
 } from '../../types/llm';
-import { normaliseMessages } from '../../types/llm';
+import { normaliseMessages, normaliseTools } from '../../types/llm';
 import type { APIMessage, ToolDefinition } from './chatTypes';
 
 /**
@@ -191,7 +191,7 @@ export async function runAgenticLoop(
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 messages: normaliseMessages(currentMessages),
-                tools: availableTools,
+                tools: normaliseTools(availableTools),
                 system_prompt: systemPrompt,
             }),
             signal: abortSignal,

--- a/client/src/types/__tests__/llm.test.ts
+++ b/client/src/types/__tests__/llm.test.ts
@@ -1,0 +1,135 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normaliseTools } from '../llm';
+
+describe('normaliseTools', () => {
+    it('renames inputSchema to input_schema for each tool', () => {
+        const tools = [
+            {
+                name: 'list_connections',
+                description: 'List database connections',
+                inputSchema: { type: 'object', properties: {}, required: [] },
+            },
+        ];
+
+        const result = normaliseTools(tools);
+
+        expect(result).toEqual([
+            {
+                name: 'list_connections',
+                description: 'List database connections',
+                input_schema: {
+                    type: 'object',
+                    properties: {},
+                    required: [],
+                },
+            },
+        ]);
+    });
+
+    it('does not carry an inputSchema key on the returned objects', () => {
+        const tools = [
+            {
+                name: 'query_database',
+                description: 'Execute SQL query',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        query: { type: 'string', description: 'SQL query' },
+                    },
+                    required: ['query'],
+                },
+            },
+        ];
+
+        const result = normaliseTools(tools);
+
+        expect(result[0]).not.toHaveProperty('inputSchema');
+        expect(result[0]).toHaveProperty('input_schema');
+    });
+
+    it('preserves name and description unchanged', () => {
+        const tools = [
+            {
+                name: 'search_knowledgebase',
+                description: 'Search the knowledgebase',
+                inputSchema: { type: 'object', properties: {}, required: [] },
+            },
+        ];
+
+        const [result] = normaliseTools(tools);
+
+        expect(result.name).toBe('search_knowledgebase');
+        expect(result.description).toBe('Search the knowledgebase');
+    });
+
+    it('handles multiple tools, preserving order', () => {
+        const tools = [
+            {
+                name: 'tool_a',
+                description: 'First tool',
+                inputSchema: { type: 'object', properties: {}, required: [] },
+            },
+            {
+                name: 'tool_b',
+                description: 'Second tool',
+                inputSchema: { type: 'object', properties: {}, required: [] },
+            },
+        ];
+
+        const result = normaliseTools(tools);
+
+        expect(result.map(t => t.name)).toEqual(['tool_a', 'tool_b']);
+    });
+
+    it('returns an empty array when given an empty array', () => {
+        expect(normaliseTools([])).toEqual([]);
+    });
+
+    it('does not mutate the input array or its objects', () => {
+        const tools = [
+            {
+                name: 'list_connections',
+                description: 'List database connections',
+                inputSchema: { type: 'object', properties: {}, required: [] },
+            },
+        ];
+        const original = JSON.parse(JSON.stringify(tools));
+
+        const result = normaliseTools(tools);
+
+        expect(tools).toEqual(original);
+        expect(result).not.toBe(tools);
+        expect(result[0]).not.toBe(tools[0]);
+        expect(tools[0]).not.toHaveProperty('input_schema');
+    });
+
+    it('preserves an arbitrary inputSchema shape verbatim as input_schema', () => {
+        const arbitrarySchema = {
+            type: 'object',
+            properties: { foo: { type: 'string' } },
+            required: ['foo'],
+            additionalProperties: false,
+        };
+        const tools = [
+            {
+                name: 'custom_tool',
+                description: 'A custom tool',
+                inputSchema: arbitrarySchema,
+            },
+        ];
+
+        const [result] = normaliseTools(tools);
+
+        expect(result.input_schema).toEqual(arbitrarySchema);
+    });
+});

--- a/client/src/types/llm.ts
+++ b/client/src/types/llm.ts
@@ -128,3 +128,46 @@ export interface ToolInputSchema {
     properties: Record<string, { type: string; description: string }>;
     required: string[];
 }
+
+/**
+ * Wire shape of a tool definition sent to the library `llm/proxy` chat
+ * endpoint. The endpoint decodes the request body into the vendored
+ * `pgedge-go-llm-lib` package's `llm.Tool` struct, which tags its input
+ * schema field `json:"input_schema"` (snake_case); the app's own
+ * internal tool types use camelCase `inputSchema` instead, so this
+ * shape exists purely to describe the post-normalisation wire format.
+ */
+export interface LLMTool {
+    name: string;
+    description: string;
+    input_schema: unknown;
+}
+
+/**
+ * Normalise an array of app-internal tool definitions into the
+ * snake_case wire shape required by the library `llm/proxy` chat
+ * endpoint. See {@link LLMTool}.
+ *
+ * The app's internal tool types (`ToolDefinition`, `AnalysisTool`)
+ * carry a camelCase `inputSchema` field, but the vendored
+ * `pgedge-go-llm-lib` decodes `tools[].input_schema` (snake_case).
+ * Without this rename, `encoding/json` silently drops the schema for
+ * every tool, since an underscore is not a case-only difference and
+ * Go's JSON decoder has no fallback match. See issue #370.
+ *
+ * @param tools - The app-internal tool definitions to normalise.
+ * @returns Tool definitions with a snake_case `input_schema` field.
+ */
+export function normaliseTools(
+    tools: Array<{
+        name: string;
+        description: string;
+        inputSchema: unknown;
+    }>,
+): LLMTool[] {
+    return tools.map(t => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema,
+    }));
+}

--- a/client/src/utils/__tests__/agenticLoop.test.ts
+++ b/client/src/utils/__tests__/agenticLoop.test.ts
@@ -493,10 +493,55 @@ describe('runAgenticLoop', () => {
                             ],
                         },
                     ],
-                    tools,
+                    tools: [
+                        {
+                            name: 'test_tool',
+                            description: 'A test tool',
+                            input_schema: {
+                                type: 'object',
+                                properties: {},
+                                required: [],
+                            },
+                        },
+                    ],
                     system_prompt: baseOptions.systemPrompt,
                 }),
             });
+        });
+
+        it('sends tools with a snake_case input_schema key, not the internal camelCase inputSchema (issue #370)', async () => {
+            // Regression guard: the library `llm/proxy` chat endpoint
+            // decodes tools into a struct tagged `json:"input_schema"`.
+            // Sending the app's internal camelCase `inputSchema` field
+            // verbatim causes the schema to silently unmarshal to nil, and
+            // Anthropic rejects the resulting empty schema. This exercises
+            // the Server/Query/Alert analysis call site. See issue #370.
+            const tools = [
+                {
+                    name: 'test_tool',
+                    description: 'A test tool',
+                    inputSchema: { type: 'object', properties: {}, required: [] },
+                },
+            ];
+
+            mockApiFetch.mockResolvedValueOnce(
+                createMockResponse({
+                    content: [{ type: 'text', text: 'Response' }],
+                }),
+            );
+
+            await runAgenticLoop({
+                ...baseOptions,
+                messages: [{ role: 'user', content: 'Test query' }],
+                tools,
+            });
+
+            const call = mockApiFetch.mock.calls[0];
+            const body = JSON.parse(call[1].body as string);
+
+            expect(body.tools.length).toBe(1);
+            expect(body.tools[0].input_schema).toBeDefined();
+            expect(body.tools[0].inputSchema).toBeUndefined();
         });
 
         it('omits tools from request when tools array is empty', async () => {

--- a/client/src/utils/agenticLoop.ts
+++ b/client/src/utils/agenticLoop.ts
@@ -19,7 +19,7 @@ import type {
     ToolCallResponse,
     ToolResult,
 } from '../types/llm';
-import { normaliseMessages } from '../types/llm';
+import { normaliseMessages, normaliseTools } from '../types/llm';
 
 export interface AgenticLoopOptions {
     /** Initial messages (typically a single user message). */
@@ -66,7 +66,7 @@ export async function runAgenticLoop(
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 messages: normaliseMessages(messages),
-                tools: tools.length > 0 ? tools : undefined,
+                tools: tools.length > 0 ? normaliseTools(tools) : undefined,
                 system_prompt: systemPrompt,
             }),
         });

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,6 +51,20 @@ project adheres to
 
 ### Fixed
 
+- Fix every chat request that included a tool list failing with
+  `anthropic (400): tools.0.custom.input_schema: Input does not
+  match the expected shape`, which broke Ask Ellie and the Server,
+  Query, and Alert analysis panels for any interaction requiring a
+  tool call. The client built each tool with a camelCase
+  `inputSchema` field, but `POST /api/v1/llm/chat` decodes its
+  request body via the vendored `pgedge-go-llm-lib` package, whose
+  wire contract expects snake_case `input_schema`; the mismatched
+  key silently unmarshalled to an empty schema for every tool,
+  which Anthropic then rejected outright. The client now normalises
+  tool definitions to the library's wire shape before sending them,
+  mirroring the existing message normalisation added in the same
+  migration. (#370)
+
 - Connection-privilege chips in the Admin Groups and Users panels
   now show the connection name instead of the internal numeric
   connection id. (#309)


### PR DESCRIPTION
## Summary

- `POST /api/v1/llm/chat` and `/chat/stream` rejected every request that included a tool list with `anthropic (400): tools.0.custom.input_schema: Input does not match the expected shape`, breaking Ask Ellie and the Server, Query, and Alert analysis panels for any interaction requiring a tool call. This is 100% reproducible with any well-formed tool — it's systemic, not about a specific tool's schema.
- Root cause: `GET /api/v1/mcp/tools` correctly returns each tool's schema under the camelCase key `inputSchema`, matching the real MCP protocol's `mcp.Tool` struct — the same endpoint also serves genuine external MCP clients (e.g. Claude Desktop), so that field must stay camelCase there. The client took the tool list essentially verbatim and forwarded it as `tools` in the chat request, but that endpoint decodes its body via the vendored `github.com/pgEdge/pgedge-go-llm-lib` v0.1.1 package's `llm.Tool` struct, tagged `json:"input_schema"` (snake_case). Since `inputSchema` != `input_schema` for Go's `encoding/json` (an underscore is not a case-only difference, so there's no fallback match), every tool's `InputSchema` silently unmarshalled to `nil`, and Anthropic rejected the resulting empty schema.
- This is a **client-only** fix; nothing server-side changes, and `pkg/mcp/types.go` is untouched (renaming it would break the real MCP protocol surface for external clients).
- Adds a `normaliseTools` helper in `client/src/types/llm.ts`, mirroring the existing `normaliseMessages` helper added in the same historical wire-contract migration (the same migration that introduced this regression — the author normalised `messages` but missed `tools`). Applied at **both** independent places that build a `tools` list for `/api/v1/llm/chat`: `client/src/hooks/chat/chatAgenticLoop.ts` (the main Ask Ellie chat loop) and `client/src/utils/agenticLoop.ts` (the separate loop backing the Server/Query/Alert analysis panels) — both were broken, and both needed the same fix.

Closes #370

## Test plan

- [x] New unit tests for `normaliseTools` (`client/src/types/__tests__/llm.test.ts`): renames `inputSchema` → `input_schema`, preserves `name`/`description`, empty array, does not mutate input, preserves arbitrary schema shapes.
- [x] Regression-guard tests added at **both** call sites (`chatAgenticLoop.test.ts`, `agenticLoop.test.ts`) that assert on the actual outgoing request body's `tools` shape — no existing test did this (every mock fetch returned a scripted response regardless of the request body, and every Go-side test constructed already-correctly-shaped structs directly, bypassing JSON), which is why this shipped undetected.
- [x] Adversarially verified: reverted the `normaliseTools` call at both sites, confirmed the new regression-guard tests fail with the exact expected symptom, restored the fix, confirmed clean pass.
- [x] Full client suite passes (3484/3484), `npm run lint` clean (0 errors), `npm run build` clean.
- [x] 100% line coverage on all three touched source files.
- [x] Live-verified against the real Anthropic API (not mocked) through the actual running app: multi-turn tool-call round trips succeed end-to-end on **both** independent call sites (main chat invoking `list_connections`, and the analysis-loop path invoking `list_probes`), each confirmed both via direct API calls mirroring the real client request and by manually testing in the browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat requests that included tool definitions being rejected due to an invalid schema format.
  * Tool schemas are now sent using the expected `input_schema` format, improving reliability for Ask Ellie and analysis panels.

* **Documentation**
  * Added an unreleased changelog entry describing the chat request fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->