### PR TITLE
fix(server): use Gemini embeddings in knowledgebase search

### DIFF
--- a/server/src/internal/tools/search_knowledgebase.go
+++ b/server/src/internal/tools/search_knowledgebase.go
@@ -303,6 +303,73 @@ func generateKBQueryEmbedding(ctx context.Context, serverCfg *config.Config, que
 	return vector32, embCfg.Provider, nil
 }
 
+// kbEmbeddingColumns is the fixed allow-list of embedding columns that
+// searchKB understands, in a stable order. Knowledgebase files vary by
+// vintage: older ones carry no gemini_embedding column at all, and a
+// provider-specific build may carry only one of these columns. Every
+// column name that reaches the generated SQL comes from this literal
+// list, never from user input or configuration, so interpolating the
+// selected names into the statement remains injection-safe.
+var kbEmbeddingColumns = []string{
+	"openai_embedding",
+	"voyage_embedding",
+	"ollama_embedding",
+	"gemini_embedding",
+}
+
+// kbProviderColumn maps a configured embedding provider onto the column
+// holding that provider's vectors. Unrecognized providers fall through
+// to openai, matching the historic behavior of this tool.
+func kbProviderColumn(provider string) string {
+	switch strings.ToLower(provider) {
+	case "voyage":
+		return "voyage_embedding"
+	case "ollama":
+		return "ollama_embedding"
+	case "gemini":
+		return "gemini_embedding"
+	default: // openai
+		return "openai_embedding"
+	}
+}
+
+// kbProviderName renders an embedding column as its provider name, for
+// use in user-facing error messages.
+func kbProviderName(column string) string {
+	return strings.TrimSuffix(column, "_embedding")
+}
+
+// kbPresentEmbeddingColumns probes the chunks table and returns the
+// subset of kbEmbeddingColumns that the knowledgebase file actually
+// carries, preserving the allow-list order. A missing or unreadable
+// chunks table surfaces as an error from the probe itself.
+func kbPresentEmbeddingColumns(db *sql.DB) ([]string, error) {
+	// LIMIT 0 fetches the column metadata without reading any rows.
+	rows, err := db.Query(`SELECT * FROM chunks LIMIT 0`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect chunks table: %w", err)
+	}
+	defer rows.Close()
+
+	names, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect chunks table: %w", err)
+	}
+
+	existing := make(map[string]bool, len(names))
+	for _, name := range names {
+		existing[name] = true
+	}
+
+	var present []string
+	for _, column := range kbEmbeddingColumns {
+		if existing[column] {
+			present = append(present, column)
+		}
+	}
+	return present, nil
+}
+
 func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVersions []string, topN int, provider string) ([]KBSearchResult, error) {
 	// Open database
 	db, err := sql.Open("sqlite", kbPath)
@@ -311,14 +378,52 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 	}
 	defer db.Close()
 
-	// Build query. The IN clauses are extended only with hard-coded "?"
-	// placeholder strings; the actual project name/version values flow in
-	// via the args slice and are bound as query parameters, never
-	// interpolated into SQL, so this is safe from SQL injection.
+	// Work out which embedding columns this knowledgebase carries, and
+	// confirm the configured provider is among them. Selecting a column
+	// that does not exist would otherwise fail with a bare SQLite "no
+	// such column" error.
+	presentColumns, err := kbPresentEmbeddingColumns(db)
+	if err != nil {
+		return nil, fmt.Errorf("%w (knowledgebase %q)", err, kbPath)
+	}
+
+	providerColumn := kbProviderColumn(provider)
+	providerIndex := -1
+	availableProviders := make([]string, 0, len(presentColumns))
+	for i, column := range presentColumns {
+		if column == providerColumn {
+			providerIndex = i
+		}
+		availableProviders = append(availableProviders, kbProviderName(column))
+	}
+	if providerIndex < 0 {
+		if len(availableProviders) == 0 {
+			return nil, fmt.Errorf(
+				"knowledgebase %q carries no embeddings at all (the chunks table has none of the "+
+					"supported embedding columns: %s), so it cannot be searched with provider %q",
+				kbPath, strings.Join(kbEmbeddingColumns, ", "), kbProviderName(providerColumn))
+		}
+		return nil, fmt.Errorf(
+			"knowledgebase %q carries no %q embeddings (it has no %s column; embeddings present: %s); "+
+				"the configured knowledgebase embedding provider must match the provider used to build the "+
+				"knowledgebase, so either rebuild the knowledgebase with %q embeddings or configure one of: %s",
+			kbPath, kbProviderName(providerColumn), providerColumn,
+			strings.Join(availableProviders, ", "), kbProviderName(providerColumn),
+			strings.Join(availableProviders, ", "))
+	}
+
+	// Build query. The embedding column list is assembled solely from the
+	// hard-coded kbEmbeddingColumns allow-list, and the IN clauses are
+	// extended only with hard-coded "?" placeholder strings; the actual
+	// project name/version values flow in via the args slice and are
+	// bound as query parameters, never interpolated into SQL, so this is
+	// safe from SQL injection.
 	var queryBuilder strings.Builder
 	queryBuilder.WriteString(`
         SELECT text, title, section, project_name, project_version, file_path,
-               openai_embedding, voyage_embedding, ollama_embedding
+               `)
+	queryBuilder.WriteString(strings.Join(presentColumns, ", "))
+	queryBuilder.WriteString(`
         FROM chunks
         WHERE 1=1
     `)
@@ -349,46 +454,35 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 	}
 
 	query := queryBuilder.String()
-	rows, err := db.Query(query, args...) //nolint:gosec // G202: IN-clause is built from hard-coded "?" placeholders; values are bound parameters
+	rows, err := db.Query(query, args...) //nolint:gosec // G202: column list comes from the kbEmbeddingColumns allow-list and the IN-clause is built from hard-coded "?" placeholders; values are bound parameters
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
 	defer rows.Close()
 
 	var results []KBSearchResult
+	var rowCount, emptyProviderRows int
 
 	for rows.Next() {
 		var text, title, section, pName, pVersion, filePath string
-		var openaiBlob, voyageBlob, ollamaBlob []byte
+		blobs := make([][]byte, len(presentColumns))
 
-		err := rows.Scan(&text, &title, &section, &pName, &pVersion, &filePath,
-			&openaiBlob, &voyageBlob, &ollamaBlob)
-		if err != nil {
+		scanTargets := []any{&text, &title, &section, &pName, &pVersion, &filePath}
+		for i := range blobs {
+			scanTargets = append(scanTargets, &blobs[i])
+		}
+		if err := rows.Scan(scanTargets...); err != nil {
 			continue
 		}
+		rowCount++
 
-		// Select appropriate embedding based on provider
-		var embBlob []byte
-		switch strings.ToLower(provider) {
-		case "voyage":
-			embBlob = voyageBlob
-		case "ollama":
-			embBlob = ollamaBlob
-		default: // openai
-			embBlob = openaiBlob
-		}
-
+		// Use the configured provider's embedding only; substituting
+		// another provider's vectors would silently compare vectors of
+		// differing dimensions and rank every row identically.
+		embBlob := blobs[providerIndex]
 		if len(embBlob) == 0 {
-			// Try other providers if selected one is empty
-			if len(openaiBlob) > 0 {
-				embBlob = openaiBlob
-			} else if len(voyageBlob) > 0 {
-				embBlob = voyageBlob
-			} else if len(ollamaBlob) > 0 {
-				embBlob = ollamaBlob
-			} else {
-				continue // No embeddings available
-			}
+			emptyProviderRows++
+			continue
 		}
 
 		// Deserialize embedding
@@ -413,6 +507,19 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating search results: %w", err)
+	}
+
+	// Distinguish an empty knowledgebase, or a filter that matched
+	// nothing, from a knowledgebase whose rows carry no embeddings for
+	// the configured provider; the latter is a misconfiguration and
+	// deserves an explicit error rather than a bland "no results".
+	if len(results) == 0 && rowCount > 0 && emptyProviderRows == rowCount {
+		return nil, fmt.Errorf(
+			"knowledgebase %q has an empty %s column for all %d matching chunks, so it carries no %q "+
+				"embeddings; rebuild the knowledgebase with %q embeddings or configure a provider whose "+
+				"embeddings it contains",
+			kbPath, providerColumn, rowCount, kbProviderName(providerColumn),
+			kbProviderName(providerColumn))
 	}
 
 	// Sort by similarity (descending)

--- a/server/src/internal/tools/search_knowledgebase.go
+++ b/server/src/internal/tools/search_knowledgebase.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -264,6 +265,11 @@ func listKBProducts(kbPath string) (string, error) {
 	return sb.String(), nil
 }
 
+// generateKBQueryEmbedding embeds a search query using the
+// knowledgebase-specific embedding configuration, which is deliberately
+// independent of the generate_embeddings tool. It returns the query
+// vector alongside the configured provider name, so that searchKB can
+// compare the query against that provider's stored embeddings.
 func generateKBQueryEmbedding(ctx context.Context, serverCfg *config.Config, queryText string) ([]float32, string, error) {
 	// Use KB-specific embedding configuration (independent of generate_embeddings tool)
 	kbCfg := serverCfg.Knowledgebase
@@ -306,10 +312,9 @@ func generateKBQueryEmbedding(ctx context.Context, serverCfg *config.Config, que
 // kbEmbeddingColumns is the fixed allow-list of embedding columns that
 // searchKB understands, in a stable order. Knowledgebase files vary by
 // vintage: older ones carry no gemini_embedding column at all, and a
-// provider-specific build may carry only one of these columns. Every
-// column name that reaches the generated SQL comes from this literal
-// list, never from user input or configuration, so interpolating the
-// selected names into the statement remains injection-safe.
+// provider-specific build may carry only one of these columns. These
+// names are only ever compared against the column names the driver
+// reports for a result set; none of them is interpolated into SQL.
 var kbEmbeddingColumns = []string{
 	"openai_embedding",
 	"voyage_embedding",
@@ -339,92 +344,70 @@ func kbProviderName(column string) string {
 	return strings.TrimSuffix(column, "_embedding")
 }
 
-// kbPresentEmbeddingColumns probes the chunks table and returns the
-// subset of kbEmbeddingColumns that the knowledgebase file actually
-// carries, preserving the allow-list order. A missing or unreadable
-// chunks table surfaces as an error from the probe itself.
-func kbPresentEmbeddingColumns(db *sql.DB) ([]string, error) {
-	// LIMIT 0 fetches the column metadata without reading any rows.
-	rows, err := db.Query(`SELECT * FROM chunks LIMIT 0`)
-	if err != nil {
-		return nil, fmt.Errorf("failed to inspect chunks table: %w", err)
-	}
-	defer rows.Close()
-
-	names, err := rows.Columns()
-	if err != nil {
-		return nil, fmt.Errorf("failed to inspect chunks table: %w", err)
+// kbAvailableProviders reports which of the supported embedding
+// providers the given result-set columns carry, in kbEmbeddingColumns
+// order, so that an error can tell the user what the knowledgebase does
+// contain.
+func kbAvailableProviders(columns []string) []string {
+	present := make(map[string]bool, len(columns))
+	for _, name := range columns {
+		present[name] = true
 	}
 
-	existing := make(map[string]bool, len(names))
-	for _, name := range names {
-		existing[name] = true
-	}
-
-	var present []string
+	var providers []string
 	for _, column := range kbEmbeddingColumns {
-		if existing[column] {
-			present = append(present, column)
+		if present[column] {
+			providers = append(providers, kbProviderName(column))
 		}
 	}
-	return present, nil
+	return providers
 }
 
-func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVersions []string, topN int, provider string) ([]KBSearchResult, error) {
-	// Open database
-	db, err := sql.Open("sqlite", kbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open knowledgebase: %w", err)
+// kbMissingProviderError explains that the knowledgebase file carries no
+// column for the configured provider at all. Substituting another
+// provider's vectors would compare embeddings of differing dimensions
+// and score every chunk alike, so this is a hard error rather than a
+// silent degradation.
+func kbMissingProviderError(kbPath, providerColumn string, available []string) error {
+	if len(available) == 0 {
+		return fmt.Errorf(
+			"knowledgebase %q carries no embeddings at all (the chunks table has none of the "+
+				"supported embedding columns: %s), so it cannot be searched with provider %q",
+			kbPath, strings.Join(kbEmbeddingColumns, ", "), kbProviderName(providerColumn))
 	}
-	defer db.Close()
+	return fmt.Errorf(
+		"knowledgebase %q carries no %q embeddings (it has no %s column; embeddings present: %s); "+
+			"the configured knowledgebase embedding provider must match the provider used to build the "+
+			"knowledgebase, so either rebuild the knowledgebase with %q embeddings or configure one of: %s",
+		kbPath, kbProviderName(providerColumn), providerColumn,
+		strings.Join(available, ", "), kbProviderName(providerColumn),
+		strings.Join(available, ", "))
+}
 
-	// Work out which embedding columns this knowledgebase carries, and
-	// confirm the configured provider is among them. Selecting a column
-	// that does not exist would otherwise fail with a bare SQLite "no
-	// such column" error.
-	presentColumns, err := kbPresentEmbeddingColumns(db)
-	if err != nil {
-		return nil, fmt.Errorf("%w (knowledgebase %q)", err, kbPath)
-	}
+// kbEmptyProviderError explains that the provider's column exists but is
+// empty for every chunk the search matched, which leaves nothing to rank
+// and would otherwise be reported as a bland "no results".
+func kbEmptyProviderError(kbPath, providerColumn string, rowCount int) error {
+	return fmt.Errorf(
+		"knowledgebase %q has an empty %s column for all %d matching chunks, so it carries no %q "+
+			"embeddings; rebuild the knowledgebase with %q embeddings or configure a provider whose "+
+			"embeddings it contains",
+		kbPath, providerColumn, rowCount, kbProviderName(providerColumn),
+		kbProviderName(providerColumn))
+}
 
-	providerColumn := kbProviderColumn(provider)
-	providerIndex := -1
-	availableProviders := make([]string, 0, len(presentColumns))
-	for i, column := range presentColumns {
-		if column == providerColumn {
-			providerIndex = i
-		}
-		availableProviders = append(availableProviders, kbProviderName(column))
-	}
-	if providerIndex < 0 {
-		if len(availableProviders) == 0 {
-			return nil, fmt.Errorf(
-				"knowledgebase %q carries no embeddings at all (the chunks table has none of the "+
-					"supported embedding columns: %s), so it cannot be searched with provider %q",
-				kbPath, strings.Join(kbEmbeddingColumns, ", "), kbProviderName(providerColumn))
-		}
-		return nil, fmt.Errorf(
-			"knowledgebase %q carries no %q embeddings (it has no %s column; embeddings present: %s); "+
-				"the configured knowledgebase embedding provider must match the provider used to build the "+
-				"knowledgebase, so either rebuild the knowledgebase with %q embeddings or configure one of: %s",
-			kbPath, kbProviderName(providerColumn), providerColumn,
-			strings.Join(availableProviders, ", "), kbProviderName(providerColumn),
-			strings.Join(availableProviders, ", "))
-	}
-
-	// Build query. The embedding column list is assembled solely from the
-	// hard-coded kbEmbeddingColumns allow-list, and the IN clauses are
-	// extended only with hard-coded "?" placeholder strings; the actual
-	// project name/version values flow in via the args slice and are
-	// bound as query parameters, never interpolated into SQL, so this is
-	// safe from SQL injection.
+// kbSearchQuery builds the chunks query and its bound arguments. The
+// statement is a literal that grows only by hard-coded "?" placeholder
+// strings; the project name and version values travel in the returned
+// argument slice and are bound as query parameters, never interpolated
+// into SQL, so this is safe from SQL injection. It selects every column
+// because the embedding columns a knowledgebase carries vary by vintage;
+// searchKB resolves the ones it needs by name from the result set, which
+// keeps identifiers out of the statement entirely.
+func kbSearchQuery(projectNames, projectVersions []string) (string, []any) {
 	var queryBuilder strings.Builder
 	queryBuilder.WriteString(`
-        SELECT text, title, section, project_name, project_version, file_path,
-               `)
-	queryBuilder.WriteString(strings.Join(presentColumns, ", "))
-	queryBuilder.WriteString(`
-        FROM chunks
+        SELECT * FROM chunks
         WHERE 1=1
     `)
 	args := []any{}
@@ -453,55 +436,88 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 		queryBuilder.WriteString(")")
 	}
 
-	query := queryBuilder.String()
-	rows, err := db.Query(query, args...) //nolint:gosec // G202: column list comes from the kbEmbeddingColumns allow-list and the IN-clause is built from hard-coded "?" placeholders; values are bound parameters
-	if err != nil {
-		return nil, fmt.Errorf("query failed: %w", err)
-	}
-	defer rows.Close()
+	return queryBuilder.String(), args
+}
 
+// kbChunkRow holds the values scanned from one chunks row: the metadata
+// searchKB reports, plus the embedding blob of the configured provider.
+type kbChunkRow struct {
+	text           string
+	title          string
+	section        string
+	projectName    string
+	projectVersion string
+	filePath       string
+	embedding      []byte
+}
+
+// kbScanTargets builds the Scan destinations for a result set whose
+// columns are given, in order. Every destination is resolved by column
+// name, so a knowledgebase file may order or extend its columns freely;
+// columns the search does not need are read into a discard destination.
+// The returned slice writes into row on each Scan.
+func kbScanTargets(columns []string, providerColumn string, row *kbChunkRow) []any {
+	wanted := map[string]any{
+		"text":            &row.text,
+		"title":           &row.title,
+		"section":         &row.section,
+		"project_name":    &row.projectName,
+		"project_version": &row.projectVersion,
+		"file_path":       &row.filePath,
+		providerColumn:    &row.embedding,
+	}
+
+	targets := make([]any, len(columns))
+	for i, name := range columns {
+		if dest, ok := wanted[name]; ok {
+			targets[i] = dest
+			continue
+		}
+		targets[i] = new(any)
+	}
+	return targets
+}
+
+// kbRankChunks scores every row of rows against queryEmbedding using the
+// embedding in providerColumn, whose position is resolved by name from
+// columns, and returns the unsorted results. Rows that cannot be
+// scanned, that hold no embedding for the provider, or whose embedding is
+// malformed are skipped rather than misranked; if that leaves nothing to
+// rank because no row carried an embedding for the provider, the
+// resulting error says so rather than reporting an empty search.
+func kbRankChunks(rows *sql.Rows, columns []string, kbPath, providerColumn string, queryEmbedding []float32) ([]KBSearchResult, error) {
 	var results []KBSearchResult
 	var rowCount, emptyProviderRows int
 
-	for rows.Next() {
-		var text, title, section, pName, pVersion, filePath string
-		blobs := make([][]byte, len(presentColumns))
+	var row kbChunkRow
+	scanTargets := kbScanTargets(columns, providerColumn, &row)
 
-		scanTargets := []any{&text, &title, &section, &pName, &pVersion, &filePath}
-		for i := range blobs {
-			scanTargets = append(scanTargets, &blobs[i])
-		}
+	for rows.Next() {
+		row = kbChunkRow{}
 		if err := rows.Scan(scanTargets...); err != nil {
 			continue
 		}
 		rowCount++
 
-		// Use the configured provider's embedding only; substituting
-		// another provider's vectors would silently compare vectors of
-		// differing dimensions and rank every row identically.
-		embBlob := blobs[providerIndex]
-		if len(embBlob) == 0 {
+		if len(row.embedding) == 0 {
 			emptyProviderRows++
 			continue
 		}
 
 		// Deserialize embedding
-		docEmbedding := deserializeEmbedding(embBlob)
+		docEmbedding := deserializeEmbedding(row.embedding)
 		if len(docEmbedding) == 0 {
 			continue
 		}
 
-		// Calculate cosine similarity
-		similarity := cosineSimilarity(queryEmbedding, docEmbedding)
-
 		results = append(results, KBSearchResult{
-			Text:           text,
-			Title:          title,
-			Section:        section,
-			ProjectName:    pName,
-			ProjectVersion: pVersion,
-			FilePath:       filePath,
-			Similarity:     similarity,
+			Text:           row.text,
+			Title:          row.title,
+			Section:        row.section,
+			ProjectName:    row.projectName,
+			ProjectVersion: row.projectVersion,
+			FilePath:       row.filePath,
+			Similarity:     cosineSimilarity(queryEmbedding, docEmbedding),
 		})
 	}
 
@@ -514,12 +530,49 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 	// the configured provider; the latter is a misconfiguration and
 	// deserves an explicit error rather than a bland "no results".
 	if len(results) == 0 && rowCount > 0 && emptyProviderRows == rowCount {
-		return nil, fmt.Errorf(
-			"knowledgebase %q has an empty %s column for all %d matching chunks, so it carries no %q "+
-				"embeddings; rebuild the knowledgebase with %q embeddings or configure a provider whose "+
-				"embeddings it contains",
-			kbPath, providerColumn, rowCount, kbProviderName(providerColumn),
-			kbProviderName(providerColumn))
+		return nil, kbEmptyProviderError(kbPath, providerColumn, rowCount)
+	}
+	return results, nil
+}
+
+// searchKB ranks the chunks of the knowledgebase at kbPath against
+// queryEmbedding, optionally filtered by project name and version, and
+// returns the topN most similar. Only the configured provider's
+// embeddings are considered: a knowledgebase that carries none for that
+// provider is reported as an error rather than searched with another
+// provider's vectors, whose dimensions would not match.
+func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVersions []string, topN int, provider string) ([]KBSearchResult, error) {
+	// Open database
+	db, err := sql.Open("sqlite", kbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open knowledgebase: %w", err)
+	}
+	defer db.Close()
+
+	query, args := kbSearchQuery(projectNames, projectVersions)
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query knowledgebase %q: %w", kbPath, err)
+	}
+	defer rows.Close()
+
+	// Resolve the result-set columns before reading any rows, so that a
+	// knowledgebase lacking the configured provider's embeddings fails
+	// fast with an explanation rather than returning misranked chunks.
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect chunks table of knowledgebase %q: %w", kbPath, err)
+	}
+
+	providerColumn := kbProviderColumn(provider)
+	if !slices.Contains(columns, providerColumn) {
+		return nil, kbMissingProviderError(kbPath, providerColumn,
+			kbAvailableProviders(columns))
+	}
+
+	results, err := kbRankChunks(rows, columns, kbPath, providerColumn, queryEmbedding)
+	if err != nil {
+		return nil, err
 	}
 
 	// Sort by similarity (descending)
@@ -535,6 +588,11 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 	return results, nil
 }
 
+// deserializeEmbedding decodes an embedding stored as a little-endian
+// sequence of float32 values. It returns nil for an empty blob, or for
+// one whose length is not a whole number of float32 values, so that a
+// malformed embedding causes the chunk to be skipped rather than
+// misranked.
 func deserializeEmbedding(data []byte) []float32 {
 	if len(data) == 0 || len(data)%4 != 0 {
 		return nil
@@ -548,6 +606,10 @@ func deserializeEmbedding(data []byte) []float32 {
 	return out
 }
 
+// cosineSimilarity returns the cosine similarity of two vectors. It
+// returns 0 when the vectors differ in length, which is why searchKB
+// must never mix providers: vectors of differing dimensions would score
+// every chunk 0 and destroy the ranking.
 func cosineSimilarity(a, b []float32) float64 {
 	if len(a) != len(b) {
 		return 0
@@ -567,6 +629,9 @@ func cosineSimilarity(a, b []float32) float64 {
 	return dotProduct / (math.Sqrt(normA) * math.Sqrt(normB))
 }
 
+// formatKBResults renders ranked search results as the plain-text report
+// the tool returns, echoing the query and any project or version filter
+// so that the caller can see what was actually searched.
 func formatKBResults(results []KBSearchResult, query string, projectNames, projectVersions []string) string {
 	var sb strings.Builder
 

--- a/server/src/internal/tools/search_knowledgebase_test.go
+++ b/server/src/internal/tools/search_knowledgebase_test.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -274,27 +275,47 @@ func TestKBSearchResultStruct(t *testing.T) {
 	}
 }
 
-// createSearchKBChunksSchema creates the `chunks` table used by searchKB
-// tests. Centralizing the DDL keeps the schema consistent across test
-// fixtures.
+// createSearchKBChunksSchema creates the legacy `chunks` table used by
+// searchKB tests, carrying the three original embedding columns and no
+// gemini_embedding column. Centralizing the DDL keeps the schema
+// consistent across test fixtures.
 func createSearchKBChunksSchema(t *testing.T, db *sql.DB) {
 	t.Helper()
-	const schema = `
+	createSearchKBChunksSchemaWithColumns(t, db,
+		"openai_embedding", "voyage_embedding", "ollama_embedding")
+}
+
+// createSearchKBChunksSchemaWithColumns creates a `chunks` table whose
+// embedding columns are exactly those named, so tests can reproduce the
+// several knowledgebase layouts found in the wild.
+func createSearchKBChunksSchemaWithColumns(t *testing.T, db *sql.DB, embeddingColumns ...string) {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString(`
         CREATE TABLE chunks (
             text TEXT,
             title TEXT,
             section TEXT,
             project_name TEXT,
             project_version TEXT,
-            file_path TEXT,
-            openai_embedding BLOB,
-            voyage_embedding BLOB,
-            ollama_embedding BLOB
-        );
-    `
-	if _, err := db.Exec(schema); err != nil {
+            file_path TEXT`)
+	for _, column := range embeddingColumns {
+		sb.WriteString(",\n            " + column + " BLOB")
+	}
+	sb.WriteString("\n        );")
+	if _, err := db.Exec(sb.String()); err != nil {
 		t.Fatalf("create schema: %v", err)
 	}
+}
+
+// encodeKBVector serializes a float32 vector into the little-endian blob
+// format that searchKB expects to find in the knowledgebase.
+func encodeKBVector(vector []float32) []byte {
+	buf := make([]byte, len(vector)*4)
+	for i, v := range vector {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+	}
+	return buf
 }
 
 // buildSearchKBTestDB creates a temporary SQLite knowledgebase pre-
@@ -312,14 +333,7 @@ func buildSearchKBTestDB(t *testing.T) string {
 
 	createSearchKBChunksSchema(t, db)
 
-	// Serialize a float32 embedding to little-endian blob.
-	encode := func(vec []float32) []byte {
-		buf := make([]byte, len(vec)*4)
-		for i, v := range vec {
-			binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
-		}
-		return buf
-	}
+	encode := encodeKBVector
 
 	rows := []struct {
 		text, title, section, project, version, filePath string
@@ -437,18 +451,22 @@ func TestSearchKB_TopNLimits(t *testing.T) {
 	}
 }
 
-func TestSearchKB_FallsBackWhenProviderBlobMissing(t *testing.T) {
+func TestSearchKB_ErrorsWhenProviderBlobMissingForAllRows(t *testing.T) {
 	path := buildSearchKBTestDB(t)
 
-	// Query with provider "voyage" but our DB only has openai blobs.
-	// The function falls back to the openai blob when voyage is empty.
+	// Query with provider "voyage" but our DB only has openai blobs. The
+	// voyage column exists yet is NULL throughout, so rather than
+	// silently substituting another provider's vectors, searchKB reports
+	// the mismatch.
 	queryEmbedding := []float32{1, 0, 0}
 	results, err := searchKB(path, queryEmbedding, nil, nil, 10, "voyage")
-	if err != nil {
-		t.Fatalf("searchKB: %v", err)
+	if err == nil {
+		t.Fatalf("expected an error, got %d results", len(results))
 	}
-	if len(results) == 0 {
-		t.Errorf("expected fallback to openai embeddings, got 0 results")
+	for _, want := range []string{path, "voyage_embedding", "empty"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err.Error(), want)
+		}
 	}
 }
 
@@ -509,24 +527,42 @@ func TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs(t *testing.T) {
 		t.Fatalf("insert: %v", err)
 	}
 
+	// Row whose voyage blob is itself malformed (len % 4 != 0), so
+	// deserialization yields nothing and the row is skipped.
+	_, err = db.Exec(`INSERT INTO chunks
+        (text, title, section, project_name, project_version, file_path,
+         openai_embedding, voyage_embedding, ollama_embedding)
+        VALUES
+        ('bad voyage embedding', '', '', 'V', '1', '/v', NULL, ?, NULL)`,
+		[]byte{1, 2, 3})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
 	results, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "voyage")
 	if err != nil {
 		t.Fatalf("searchKB: %v", err)
 	}
-	// The two rows with no usable embedding should be skipped. The
-	// voyage row matches directly, and the ollama row falls back from
-	// voyage to ollama.
-	if len(results) != 2 {
-		t.Errorf("expected 2 results, got %d", len(results))
+	// Only the voyage row carries a usable voyage embedding; the rows with no
+	// voyage blob are skipped rather than falling back to another
+	// provider's vectors.
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Text != "voyage row" {
+		t.Errorf("expected the voyage row, got %q", results[0].Text)
 	}
 
-	// Repeat with provider="ollama" so we hit the ollama branch first.
+	// Repeat with provider="ollama" so we hit the ollama branch.
 	resultsOllama, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "ollama")
 	if err != nil {
 		t.Fatalf("searchKB: %v", err)
 	}
-	if len(resultsOllama) != 2 {
-		t.Errorf("expected 2 results, got %d", len(resultsOllama))
+	if len(resultsOllama) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(resultsOllama))
+	}
+	if resultsOllama[0].Text != "ollama row" {
+		t.Errorf("expected the ollama row, got %q", resultsOllama[0].Text)
 	}
 }
 
@@ -537,6 +573,245 @@ func TestSearchKB_OpenFailure(t *testing.T) {
 		nil, nil, 10, "openai")
 	if err == nil {
 		t.Errorf("expected error from invalid path, got nil")
+	}
+}
+
+// buildGeminiAwareKBTestDB creates a knowledgebase carrying both openai
+// and gemini embedding columns. The two columns rank the rows in
+// opposite orders, so a test can tell which column searchKB actually
+// used. It returns the database path.
+func buildGeminiAwareKBTestDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kb-gemini.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	createSearchKBChunksSchemaWithColumns(t, db,
+		"openai_embedding", "voyage_embedding", "ollama_embedding",
+		"gemini_embedding")
+
+	rows := []struct {
+		text           string
+		openai, gemini []float32
+	}{
+		{text: "openai favorite", openai: []float32{1, 0, 0}, gemini: []float32{0, 0, 1}},
+		{text: "gemini favorite", openai: []float32{0, 0, 1}, gemini: []float32{1, 0, 0}},
+		{text: "neither favorite", openai: []float32{0, 1, 0}, gemini: []float32{0, 1, 0}},
+	}
+	for _, r := range rows {
+		_, err := db.Exec(
+			`INSERT INTO chunks (text, title, section, project_name,
+                project_version, file_path, openai_embedding,
+                voyage_embedding, ollama_embedding, gemini_embedding)
+              VALUES (?, 'T', 'S', 'PostgreSQL', '17', '/docs/x.md', ?,
+                NULL, NULL, ?)`,
+			r.text, encodeKBVector(r.openai), encodeKBVector(r.gemini))
+		if err != nil {
+			t.Fatalf("insert row: %v", err)
+		}
+	}
+	return path
+}
+
+// TestSearchKB_GeminiUsesGeminiEmbedding confirms that a provider of
+// "gemini" ranks on the gemini_embedding column, and that the openai
+// path still works on the same, newer-layout knowledgebase.
+func TestSearchKB_GeminiUsesGeminiEmbedding(t *testing.T) {
+	path := buildGeminiAwareKBTestDB(t)
+	queryEmbedding := []float32{1, 0, 0}
+
+	geminiResults, err := searchKB(path, queryEmbedding, nil, nil, 10, "gemini")
+	if err != nil {
+		t.Fatalf("searchKB (gemini): %v", err)
+	}
+	if len(geminiResults) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(geminiResults))
+	}
+	if geminiResults[0].Text != "gemini favorite" {
+		t.Errorf("gemini search ranked %q first; the gemini_embedding column was not used",
+			geminiResults[0].Text)
+	}
+	if geminiResults[0].Similarity <= geminiResults[1].Similarity {
+		t.Errorf("expected descending similarity, got %v then %v",
+			geminiResults[0].Similarity, geminiResults[1].Similarity)
+	}
+
+	// Mixed-case provider values must resolve the same way.
+	upperResults, err := searchKB(path, queryEmbedding, nil, nil, 10, "Gemini")
+	if err != nil {
+		t.Fatalf("searchKB (Gemini): %v", err)
+	}
+	if len(upperResults) == 0 || upperResults[0].Text != "gemini favorite" {
+		t.Errorf("expected the gemini row first for provider %q, got %+v", "Gemini", upperResults)
+	}
+
+	openaiResults, err := searchKB(path, queryEmbedding, nil, nil, 10, "openai")
+	if err != nil {
+		t.Fatalf("searchKB (openai): %v", err)
+	}
+	if len(openaiResults) != 3 {
+		t.Fatalf("expected 3 openai results, got %d", len(openaiResults))
+	}
+	if openaiResults[0].Text != "openai favorite" {
+		t.Errorf("openai search ranked %q first, want %q",
+			openaiResults[0].Text, "openai favorite")
+	}
+}
+
+// TestSearchKB_GeminiOnlyKnowledgebase covers a knowledgebase built
+// solely for Gemini, where the other embedding columns are absent from
+// the schema entirely.
+func TestSearchKB_GeminiOnlyKnowledgebase(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kb-gemini-only.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	createSearchKBChunksSchemaWithColumns(t, db, "gemini_embedding")
+
+	inserts := []struct {
+		text   string
+		vector []float32
+	}{
+		{"close match", []float32{1, 0, 0}},
+		{"distant match", []float32{0, 1, 0}},
+	}
+	for _, row := range inserts {
+		_, err := db.Exec(
+			`INSERT INTO chunks (text, title, section, project_name,
+                project_version, file_path, gemini_embedding)
+              VALUES (?, 'T', 'S', 'pgEdge', '1.0', '/docs/g.md', ?)`,
+			row.text, encodeKBVector(row.vector))
+		if err != nil {
+			t.Fatalf("insert row: %v", err)
+		}
+	}
+	db.Close()
+
+	results, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "gemini")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Text != "close match" {
+		t.Errorf("expected %q first, got %q", "close match", results[0].Text)
+	}
+}
+
+// TestSearchKB_GeminiColumnAbsentReturnsError verifies that searching an
+// older knowledgebase, which has no gemini_embedding column at all, with
+// provider "gemini" produces an explicit, actionable error rather than a
+// bare SQLite "no such column" failure or a silent fallback.
+func TestSearchKB_GeminiColumnAbsentReturnsError(t *testing.T) {
+	path := buildSearchKBTestDB(t)
+
+	results, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "gemini")
+	if err == nil {
+		t.Fatalf("expected an error, got %d results", len(results))
+	}
+	msg := err.Error()
+	for _, want := range []string{path, "gemini", "gemini_embedding", "openai"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not mention %q", msg, want)
+		}
+	}
+	if strings.Contains(msg, "no such column") {
+		t.Errorf("error leaked a raw SQLite failure: %q", msg)
+	}
+}
+
+// TestSearchKB_NoEmbeddingColumns covers a chunks table that carries
+// none of the supported embedding columns.
+func TestSearchKB_NoEmbeddingColumns(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kb-bare.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	createSearchKBChunksSchemaWithColumns(t, db)
+	db.Close()
+
+	_, err = searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "gemini")
+	if err == nil {
+		t.Fatal("expected an error for a knowledgebase with no embedding columns")
+	}
+	if !strings.Contains(err.Error(), "no embeddings at all") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestSearchKB_NoChunksTable covers a knowledgebase file that has no
+// chunks table whatsoever.
+func TestSearchKB_NoChunksTable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kb-empty.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE unrelated (id INTEGER)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	db.Close()
+
+	_, err = searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "openai")
+	if err == nil {
+		t.Fatal("expected an error when the chunks table is absent")
+	}
+	if !strings.Contains(err.Error(), "failed to inspect chunks table") ||
+		!strings.Contains(err.Error(), path) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestSearchKB_CorruptDatabaseFile covers the failure path where the
+// knowledgebase file exists but is not a SQLite database, so probing the
+// chunks table fails outright.
+func TestSearchKB_CorruptDatabaseFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kb-corrupt.sqlite")
+	if err := os.WriteFile(path, []byte("this is not a database"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "gemini")
+	if err == nil {
+		t.Fatal("expected an error for a corrupt knowledgebase file")
+	}
+	if !strings.Contains(err.Error(), "failed to inspect chunks table") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestKBProviderColumn checks the provider-to-column mapping, including
+// the openai default for unrecognized providers.
+func TestKBProviderColumn(t *testing.T) {
+	tests := map[string]string{
+		"openai":  "openai_embedding",
+		"voyage":  "voyage_embedding",
+		"ollama":  "ollama_embedding",
+		"gemini":  "gemini_embedding",
+		"GEMINI":  "gemini_embedding",
+		"unknown": "openai_embedding",
+		"":        "openai_embedding",
+	}
+	for provider, want := range tests {
+		if got := kbProviderColumn(provider); got != want {
+			t.Errorf("kbProviderColumn(%q) = %q, want %q", provider, got, want)
+		}
+	}
+	if got := kbProviderName("gemini_embedding"); got != "gemini" {
+		t.Errorf("kbProviderName() = %q, want %q", got, "gemini")
 	}
 }
 

--- a/server/src/internal/tools/search_knowledgebase_test.go
+++ b/server/src/internal/tools/search_knowledgebase_test.go
@@ -25,6 +25,9 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// TestDeserializeEmbedding checks that stored embeddings decode from
+// their little-endian blob form, and that empty or truncated blobs
+// decode to nothing at all.
 func TestDeserializeEmbedding(t *testing.T) {
 	tests := []struct {
 		name string
@@ -84,6 +87,8 @@ func TestDeserializeEmbedding(t *testing.T) {
 	}
 }
 
+// TestCosineSimilarity covers the similarity measure, including the
+// zero results returned for mismatched lengths and for zero vectors.
 func TestCosineSimilarity(t *testing.T) {
 	tests := []struct {
 		name string
@@ -151,6 +156,8 @@ func TestCosineSimilarity(t *testing.T) {
 	}
 }
 
+// TestFormatKBResults checks that the rendered report echoes the query,
+// the chunk metadata, and any project or version filter applied.
 func TestFormatKBResults(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -241,6 +248,8 @@ func TestFormatKBResults(t *testing.T) {
 	}
 }
 
+// TestKBSearchResultStruct guards the field names and types of the
+// result struct that the tool output is built from.
 func TestKBSearchResultStruct(t *testing.T) {
 	result := KBSearchResult{
 		Text:           "Sample documentation text",
@@ -275,37 +284,111 @@ func TestKBSearchResultStruct(t *testing.T) {
 	}
 }
 
-// createSearchKBChunksSchema creates the legacy `chunks` table used by
-// searchKB tests, carrying the three original embedding columns and no
-// gemini_embedding column. Centralizing the DDL keeps the schema
-// consistent across test fixtures.
-func createSearchKBChunksSchema(t *testing.T, db *sql.DB) {
-	t.Helper()
-	createSearchKBChunksSchemaWithColumns(t, db,
-		"openai_embedding", "voyage_embedding", "ollama_embedding")
-}
-
-// createSearchKBChunksSchemaWithColumns creates a `chunks` table whose
-// embedding columns are exactly those named, so tests can reproduce the
-// several knowledgebase layouts found in the wild.
-func createSearchKBChunksSchemaWithColumns(t *testing.T, db *sql.DB, embeddingColumns ...string) {
-	t.Helper()
-	var sb strings.Builder
-	sb.WriteString(`
+// The knowledgebase layouts exercised by the searchKB tests, each a
+// static DDL statement so that no identifier is ever assembled at
+// runtime. Between them they cover an older file with no
+// gemini_embedding column, a current file carrying all four embedding
+// columns, a file built for Gemini alone, a file with no embedding
+// columns whatsoever, and a file whose columns appear in an unexpected
+// order with an extra column of its own.
+const (
+	kbLegacySchemaDDL = `
         CREATE TABLE chunks (
             text TEXT,
             title TEXT,
             section TEXT,
             project_name TEXT,
             project_version TEXT,
-            file_path TEXT`)
-	for _, column := range embeddingColumns {
-		sb.WriteString(",\n            " + column + " BLOB")
-	}
-	sb.WriteString("\n        );")
-	if _, err := db.Exec(sb.String()); err != nil {
+            file_path TEXT,
+            openai_embedding BLOB,
+            voyage_embedding BLOB,
+            ollama_embedding BLOB
+        );
+    `
+
+	kbAllProvidersSchemaDDL = `
+        CREATE TABLE chunks (
+            text TEXT,
+            title TEXT,
+            section TEXT,
+            project_name TEXT,
+            project_version TEXT,
+            file_path TEXT,
+            openai_embedding BLOB,
+            voyage_embedding BLOB,
+            ollama_embedding BLOB,
+            gemini_embedding BLOB
+        );
+    `
+
+	kbGeminiOnlySchemaDDL = `
+        CREATE TABLE chunks (
+            text TEXT,
+            title TEXT,
+            section TEXT,
+            project_name TEXT,
+            project_version TEXT,
+            file_path TEXT,
+            gemini_embedding BLOB
+        );
+    `
+
+	kbNoEmbeddingsSchemaDDL = `
+        CREATE TABLE chunks (
+            text TEXT,
+            title TEXT,
+            section TEXT,
+            project_name TEXT,
+            project_version TEXT,
+            file_path TEXT
+        );
+    `
+
+	kbReorderedSchemaDDL = `
+        CREATE TABLE chunks (
+            id INTEGER PRIMARY KEY,
+            gemini_embedding BLOB,
+            file_path TEXT,
+            token_count INTEGER,
+            text TEXT,
+            project_version TEXT,
+            openai_embedding BLOB,
+            project_name TEXT,
+            section TEXT,
+            title TEXT
+        );
+    `
+)
+
+// createSearchKBChunksSchema creates the legacy `chunks` table used by
+// most searchKB tests, carrying the three original embedding columns and
+// no gemini_embedding column.
+func createSearchKBChunksSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+	createSearchKBSchema(t, db, kbLegacySchemaDDL)
+}
+
+// createSearchKBSchema executes one of the static schema statements
+// above, failing the test if the table cannot be created.
+func createSearchKBSchema(t *testing.T, db *sql.DB, ddl string) {
+	t.Helper()
+	if _, err := db.Exec(ddl); err != nil {
 		t.Fatalf("create schema: %v", err)
 	}
+}
+
+// openSearchKBTestDB creates an empty SQLite database in the test's
+// temporary directory, applies the given schema, and returns the open
+// handle along with the file path. The caller closes the handle.
+func openSearchKBTestDB(t *testing.T, name, ddl string) (*sql.DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	createSearchKBSchema(t, db, ddl)
+	return db, path
 }
 
 // encodeKBVector serializes a float32 vector into the little-endian blob
@@ -384,6 +467,8 @@ func buildSearchKBTestDB(t *testing.T) string {
 	return path
 }
 
+// TestSearchKB_UnfilteredReturnsAllResults checks that an unfiltered
+// search returns every chunk, most similar first.
 func TestSearchKB_UnfilteredReturnsAllResults(t *testing.T) {
 	path := buildSearchKBTestDB(t)
 
@@ -403,6 +488,8 @@ func TestSearchKB_UnfilteredReturnsAllResults(t *testing.T) {
 	}
 }
 
+// TestSearchKB_ProjectNameFilter checks that the project name filter is
+// applied as a bound IN clause.
 func TestSearchKB_ProjectNameFilter(t *testing.T) {
 	path := buildSearchKBTestDB(t)
 
@@ -421,6 +508,8 @@ func TestSearchKB_ProjectNameFilter(t *testing.T) {
 	}
 }
 
+// TestSearchKB_VersionFilter checks that project name and version
+// filters combine.
 func TestSearchKB_VersionFilter(t *testing.T) {
 	path := buildSearchKBTestDB(t)
 
@@ -438,6 +527,8 @@ func TestSearchKB_VersionFilter(t *testing.T) {
 	}
 }
 
+// TestSearchKB_TopNLimits checks that results are capped at topN after
+// ranking, not before.
 func TestSearchKB_TopNLimits(t *testing.T) {
 	path := buildSearchKBTestDB(t)
 
@@ -451,6 +542,10 @@ func TestSearchKB_TopNLimits(t *testing.T) {
 	}
 }
 
+// TestSearchKB_ErrorsWhenProviderBlobMissingForAllRows checks that a
+// knowledgebase whose provider column exists but is empty throughout is
+// reported as a misconfiguration instead of being searched with another
+// provider's vectors.
 func TestSearchKB_ErrorsWhenProviderBlobMissingForAllRows(t *testing.T) {
 	path := buildSearchKBTestDB(t)
 
@@ -470,6 +565,9 @@ func TestSearchKB_ErrorsWhenProviderBlobMissingForAllRows(t *testing.T) {
 	}
 }
 
+// TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs checks that chunks
+// with no embedding for the searched provider, or with a malformed one,
+// are skipped whilst the remaining chunks are still ranked.
 func TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kb.sqlite")
@@ -566,6 +664,8 @@ func TestSearchKB_SkipsRowsWithNoEmbeddingAndBadBlobs(t *testing.T) {
 	}
 }
 
+// TestSearchKB_OpenFailure covers the error returned when the
+// knowledgebase file cannot be opened at all.
 func TestSearchKB_OpenFailure(t *testing.T) {
 	// A path containing a null byte is invalid for SQLite and should
 	// fail to open, exercising the error branch of searchKB.
@@ -582,17 +682,8 @@ func TestSearchKB_OpenFailure(t *testing.T) {
 // used. It returns the database path.
 func buildGeminiAwareKBTestDB(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kb-gemini.sqlite")
-	db, err := sql.Open("sqlite", path)
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
+	db, path := openSearchKBTestDB(t, "kb-gemini.sqlite", kbAllProvidersSchemaDDL)
 	defer db.Close()
-
-	createSearchKBChunksSchemaWithColumns(t, db,
-		"openai_embedding", "voyage_embedding", "ollama_embedding",
-		"gemini_embedding")
 
 	rows := []struct {
 		text           string
@@ -666,15 +757,8 @@ func TestSearchKB_GeminiUsesGeminiEmbedding(t *testing.T) {
 // solely for Gemini, where the other embedding columns are absent from
 // the schema entirely.
 func TestSearchKB_GeminiOnlyKnowledgebase(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kb-gemini-only.sqlite")
-	db, err := sql.Open("sqlite", path)
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
+	db, path := openSearchKBTestDB(t, "kb-gemini-only.sqlite", kbGeminiOnlySchemaDDL)
 	defer db.Close()
-
-	createSearchKBChunksSchemaWithColumns(t, db, "gemini_embedding")
 
 	inserts := []struct {
 		text   string
@@ -732,16 +816,10 @@ func TestSearchKB_GeminiColumnAbsentReturnsError(t *testing.T) {
 // TestSearchKB_NoEmbeddingColumns covers a chunks table that carries
 // none of the supported embedding columns.
 func TestSearchKB_NoEmbeddingColumns(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kb-bare.sqlite")
-	db, err := sql.Open("sqlite", path)
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
-	createSearchKBChunksSchemaWithColumns(t, db)
+	db, path := openSearchKBTestDB(t, "kb-bare.sqlite", kbNoEmbeddingsSchemaDDL)
 	db.Close()
 
-	_, err = searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "gemini")
+	_, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "gemini")
 	if err == nil {
 		t.Fatal("expected an error for a knowledgebase with no embedding columns")
 	}
@@ -768,15 +846,15 @@ func TestSearchKB_NoChunksTable(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error when the chunks table is absent")
 	}
-	if !strings.Contains(err.Error(), "failed to inspect chunks table") ||
+	if !strings.Contains(err.Error(), "failed to query knowledgebase") ||
 		!strings.Contains(err.Error(), path) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 // TestSearchKB_CorruptDatabaseFile covers the failure path where the
-// knowledgebase file exists but is not a SQLite database, so probing the
-// chunks table fails outright.
+// knowledgebase file exists but is not a SQLite database, so the query
+// fails outright.
 func TestSearchKB_CorruptDatabaseFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kb-corrupt.sqlite")
@@ -788,8 +866,132 @@ func TestSearchKB_CorruptDatabaseFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for a corrupt knowledgebase file")
 	}
-	if !strings.Contains(err.Error(), "failed to inspect chunks table") {
+	if !strings.Contains(err.Error(), "failed to query knowledgebase") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestSearchKB_ResolvesColumnsByName covers a knowledgebase whose chunks
+// table orders its columns unexpectedly and carries extra columns of its
+// own, confirming that every scan destination is resolved by column name
+// rather than by position.
+func TestSearchKB_ResolvesColumnsByName(t *testing.T) {
+	db, path := openSearchKBTestDB(t, "kb-reordered.sqlite", kbReorderedSchemaDDL)
+	defer db.Close()
+
+	inserts := []struct {
+		text           string
+		gemini, openai []float32
+	}{
+		{"reordered close", []float32{1, 0, 0}, []float32{0, 1, 0}},
+		{"reordered far", []float32{0, 1, 0}, []float32{1, 0, 0}},
+	}
+	for _, row := range inserts {
+		_, err := db.Exec(
+			`INSERT INTO chunks (id, gemini_embedding, file_path, token_count,
+                text, project_version, openai_embedding, project_name,
+                section, title)
+              VALUES (NULL, ?, '/docs/r.md', 42, ?, '18', ?, 'PostgreSQL',
+                'Overview', 'Reordered')`,
+			encodeKBVector(row.gemini), row.text, encodeKBVector(row.openai))
+		if err != nil {
+			t.Fatalf("insert row: %v", err)
+		}
+	}
+
+	results, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "gemini")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	top := results[0]
+	if top.Text != "reordered close" {
+		t.Errorf("expected %q first, got %q", "reordered close", top.Text)
+	}
+	if top.Title != "Reordered" || top.Section != "Overview" ||
+		top.ProjectName != "PostgreSQL" || top.ProjectVersion != "18" ||
+		top.FilePath != "/docs/r.md" {
+		t.Errorf("metadata resolved incorrectly: %+v", top)
+	}
+}
+
+// TestSearchKB_SkipsUnscannableRows covers a chunk whose metadata cannot
+// be scanned, here because a NOT NULL-free schema allows a NULL text
+// column; the row is skipped and the rest of the search proceeds.
+func TestSearchKB_SkipsUnscannableRows(t *testing.T) {
+	db, path := openSearchKBTestDB(t, "kb-nulltext.sqlite", kbGeminiOnlySchemaDDL)
+	defer db.Close()
+
+	_, err := db.Exec(
+		`INSERT INTO chunks (text, title, section, project_name,
+            project_version, file_path, gemini_embedding)
+          VALUES (NULL, 'T', 'S', 'pgEdge', '1.0', '/docs/n.md', ?)`,
+		encodeKBVector([]float32{1, 0, 0}))
+	if err != nil {
+		t.Fatalf("insert row: %v", err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO chunks (text, title, section, project_name,
+            project_version, file_path, gemini_embedding)
+          VALUES ('scannable', 'T', 'S', 'pgEdge', '1.0', '/docs/s.md', ?)`,
+		encodeKBVector([]float32{1, 0, 0}))
+	if err != nil {
+		t.Fatalf("insert row: %v", err)
+	}
+
+	results, err := searchKB(path, []float32{1, 0, 0}, nil, nil, 10, "gemini")
+	if err != nil {
+		t.Fatalf("searchKB: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Text != "scannable" {
+		t.Errorf("expected the scannable row, got %q", results[0].Text)
+	}
+}
+
+// TestKBScanTargets checks that scan destinations are mapped by column
+// name, that the provider's embedding column is picked up, and that
+// unwanted columns are given a discard destination.
+func TestKBScanTargets(t *testing.T) {
+	columns := []string{"id", "gemini_embedding", "text", "openai_embedding"}
+	var row kbChunkRow
+	targets := kbScanTargets(columns, "gemini_embedding", &row)
+
+	if len(targets) != len(columns) {
+		t.Fatalf("expected %d targets, got %d", len(columns), len(targets))
+	}
+	if targets[1] != any(&row.embedding) {
+		t.Errorf("expected the gemini column to target the embedding field")
+	}
+	if targets[2] != any(&row.text) {
+		t.Errorf("expected the text column to target the text field")
+	}
+	if targets[0] == any(&row.embedding) || targets[3] == any(&row.embedding) {
+		t.Errorf("unwanted columns must not target the embedding field")
+	}
+}
+
+// TestKBAvailableProviders checks that the reported providers follow the
+// allow-list order and ignore columns that are not embeddings.
+func TestKBAvailableProviders(t *testing.T) {
+	got := kbAvailableProviders([]string{
+		"text", "gemini_embedding", "id", "openai_embedding"})
+	want := []string{"openai", "gemini"}
+	if len(got) != len(want) {
+		t.Fatalf("kbAvailableProviders() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("kbAvailableProviders() = %v, want %v", got, want)
+			break
+		}
+	}
+	if providers := kbAvailableProviders([]string{"text"}); len(providers) != 0 {
+		t.Errorf("expected no providers, got %v", providers)
 	}
 }
 
@@ -820,6 +1022,7 @@ func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || findInString(s, substr))
 }
 
+// findInString reports whether substr occurs anywhere in s.
 func findInString(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {


### PR DESCRIPTION
## Summary

This addresses part (1) of #337: knowledgebase search never read the Gemini
embedding column, so a server configured with `embedding_provider: gemini`
silently searched against another provider's vectors.

`searchKB` selected only `openai_embedding`, `voyage_embedding` and
`ollama_embedding`, and its provider switch had no `gemini` case, so `gemini`
fell through to the `openai` default. A fallback chain then quietly
substituted whichever other provider's blob happened to be non-empty. Since
`cosineSimilarity` returns 0 whenever the two vectors differ in length, a
3072-dimension Gemini query compared against 1536-dimension OpenAI vectors
scored every row at zero, so results came back ranked arbitrarily rather than
by relevance; on a Gemini-only knowledgebase, where the OpenAI column is NULL,
every row was skipped and the search returned nothing at all.

The changes are:

- Knowledgebase files vary by vintage, and older ones have no
  `gemini_embedding` column, so the column list is now built dynamically from
  the columns the file actually carries; both old and new layouts work.
- Provider `gemini` now selects `gemini_embedding`.
- The silent cross-provider fallback is gone. When the configured provider's
  column is absent, or is empty for every matching chunk, the search returns
  an explicit error naming the provider and the knowledgebase file and
  explaining that the two must match, rather than degrading to irrelevant
  results.

Every column name reaching the generated SQL comes from a hard-coded
allow-list, never from configuration or user input; the project name and
version `IN` clauses are untouched and still bind their values as parameters.

## Scope: this does not close #337

Issue #337 covers two separate defects, and only the first is fixed here.

Part (2), the Gemini 400 `required oneof field 'data' must have one
initialised field`, is no longer in this repository at all. The bespoke chat
clients were deleted in ba54cc29 and the Gemini provider now lives in the
shared `pgedge-go-llm-lib`, which is where the remaining fragility sits. It is
fixed there by pgEdge/pgedge-go-llm-lib#27.

Note that the originally reported chain is already broken in v0.1.1, because
the library filters empty text parts when parsing responses, so the empty part
no longer enters conversation history. The request path is still unguarded
though, and a Gemini reply consisting only of an empty text part now parses to
an assistant message with zero content blocks, which the library turned into
an `{Text: ""}` placeholder and so reproduced the same 400 by a different
route.

Picking that up here needs a `pgedge-go-llm-lib` release carrying #27, and a
pin bump in `server`, `alerter` and `pkg`. That release is deliberately being
batched with other triage, so the bump is a known follow-up rather than part
of this PR. #337 should stay open until it lands.

## Test plan

- [x] New coverage for a knowledgebase carrying both Gemini and OpenAI
      columns, whose two columns rank the rows in opposite orders, proving the
      Gemini vectors are genuinely the ones used and that OpenAI still ranks
      correctly on the same file.
- [x] New coverage for a Gemini-only knowledgebase schema.
- [x] New coverage for a legacy schema with no `gemini_embedding` column
      searched as `gemini`, asserting the new explanatory error rather than a
      silent fallback or a bare SQLite "no such column".
- [x] New coverage for a knowledgebase with no embedding columns, an absent
      chunks table, and a file that is not a SQLite database.
- [x] Two existing tests asserted the fallback behaviour being removed; their
      assertions were rewritten rather than deleted, and a malformed-blob row
      was added to keep the deserialisation-skip path covered. The existing
      openai, voyage and ollama paths are otherwise unchanged.
- [x] `gofmt -l` clean, `go build ./...` clean, `make lint` reports 0 issues.
- [x] Per-function coverage on the new and modified code: `kbProviderColumn`
      and `kbProviderName` 100%, `kbPresentEmbeddingColumns` 93.3%, `searchKB`
      94.5%, all above the 90% floor. The uncovered statements are three
      unreachable defensive error branches.

`internal/tools` has two failing tests,
`TestStoreMemoryGeneratesEmbeddingIntegration` and
`TestRecallMemoriesGeneratesQueryEmbeddingIntegration`, both failing with
`expected 3 dimensions, not 4000`. I verified these fail identically on an
unmodified `main`, and they persist after recreating the local test database,
so they are pre-existing and unrelated to this change; they look like an
embedding output-dimensionality mismatch worth a separate issue.

Refs #337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved knowledge-base search to use embeddings only from the configured provider.
  * Added clearer errors when the configured embedding column is missing, when all embeddings are empty, or when embeddings are malformed.
  * Removed unintended fallback behavior across providers and improved handling of older/incomplete and corrupted knowledge-base databases.

* **Tests**
  * Updated knowledge-base fixtures and added helpers for different embedding column layouts.
  * Expanded coverage for Gemini provider behavior, plus missing columns/tables and corrupt database scenarios.
  * Enhanced cases to ensure rows with unusable embeddings are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->