### PR TITLE
docs(config): document monitored-database user privileges

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -36,6 +36,11 @@ Before installing the Collector, ensure you have the following:
 - [PostgreSQL 14](https://www.postgresql.org/download/) or
   later for the datastore.
 - Network access to the PostgreSQL servers you want to monitor.
+- A PostgreSQL login role on each monitored server that holds the
+  `pg_monitor` predefined role and `CONNECT` on every database you want
+  to probe. The
+  [Monitored Database Privileges](https://github.com/pgEdge/ai-dba-workbench/blob/main/docs/getting-started/configuration/monitored-database-privileges.md)
+  document describes the least-privilege grants and their caveats.
 
 ## Installation
 

--- a/docs/admin-guide/connections.md
+++ b/docs/admin-guide/connections.md
@@ -39,6 +39,19 @@ the Collector for encrypting connection passwords. For
 full configuration details, see the
 [Server Configuration](../getting-started/configuration/server.md).
 
+## Monitored Server Privileges
+
+Each connection stores the credentials of a PostgreSQL
+role on the monitored server. Before creating a
+connection, grant that role the privileges the
+Workbench needs, which are the `pg_monitor` predefined
+role and `CONNECT` on every database you want to
+monitor. The
+[Monitored Database Privileges](../getting-started/configuration/monitored-database-privileges.md)
+document covers the least-privilege grants, the
+optional extensions, and the gaps that remain without
+superuser access.
+
 ## REST API Endpoints
 
 All endpoints require authentication via Bearer token.
@@ -227,3 +240,6 @@ standard JSON format:
   access control.
 - [API Reference](api/reference.md) provides
   interactive API documentation.
+- [Monitored Database Privileges](../getting-started/configuration/monitored-database-privileges.md)
+  describes the PostgreSQL grants a monitored role
+  needs.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,14 @@ project adheres to
   members of the group named with `-group`, including both member
   users and nested member groups. (#303)
 
+- Add a Monitored Database Privileges page to the configuration
+  documentation, describing the PostgreSQL grants a monitoring role
+  needs on a monitored instance. The page recommends a
+  least-privilege role based on `pg_monitor` plus per-database
+  `CONNECT`, covers the optional `pg_stat_statements`, `system_stats`,
+  and Spock grants, and documents the coverage gaps that remain
+  without superuser access. (#351)
+
 ### Changed
 
 - Extend the `-show-group-privileges` CLI command to also display a

--- a/docs/developer-guide/collector/probe-reference.md
+++ b/docs/developer-guide/collector/probe-reference.md
@@ -3,6 +3,13 @@
 This document provides a complete reference for all
 built-in probes in the Collector.
 
+Each probe reads its source views with the credentials
+stored against the monitored connection. The
+[Monitored Database Privileges](../../getting-started/configuration/monitored-database-privileges.md)
+document describes the PostgreSQL grants those probes
+require, and lists the probes that return no data when
+the monitoring role lacks them.
+
 ## Probe Categories
 
 The Collector organizes probes into two categories:

--- a/docs/getting-started/configuration/collector.md
+++ b/docs/getting-started/configuration/collector.md
@@ -303,6 +303,13 @@ file requires re-entering all monitored connection passwords. Do not
 manually encrypt passwords; use the MCP server API to create and
 manage connections with passwords.
 
+The credentials stored against a monitored connection belong to a
+PostgreSQL role on the monitored server, which is separate from the
+datastore role configured above. The
+[Monitored Database Privileges](monitored-database-privileges.md)
+document describes the grants that role needs, including the
+`pg_monitor` predefined role and the per-database `CONNECT` privilege.
+
 ## Command-Line Flags
 
 The following table lists all available command-line flags.

--- a/docs/getting-started/configuration/monitored-database-privileges.md
+++ b/docs/getting-started/configuration/monitored-database-privileges.md
@@ -1,0 +1,296 @@
+# Monitored Database Privileges
+
+Every monitored connection stores the credentials of a PostgreSQL role
+that the Workbench uses to log in to the monitored instance. This page
+describes the privileges that role needs, recommends a least-privilege
+configuration, and explains the gaps that remain when the role is not a
+superuser.
+
+The collector is strictly read-only on monitored instances. The probes
+read system catalogues, statistics views, and a small number of
+information functions; the collector never resets statistics, never
+terminates or cancels backends, and never reloads the server
+configuration. All collected metrics are written to the datastore
+instead, which uses its own separate credentials described in
+[Collector Configuration](collector.md).
+
+## Recommended Configuration
+
+The recommended monitoring role is a dedicated login role that holds the
+`pg_monitor` predefined role plus `CONNECT` on each database you want to
+monitor. Perform the following steps on every monitored instance,
+connected as a superuser.
+
+1. Create the login role with a strong password:
+
+    ```sql
+    CREATE ROLE workbench_monitor LOGIN PASSWORD 'use-a-strong-password';
+    ```
+
+2. Grant the `pg_monitor` predefined role, which confers
+   `pg_read_all_settings`, `pg_read_all_stats`, and
+   `pg_stat_scan_tables`:
+
+    ```sql
+    GRANT pg_monitor TO workbench_monitor;
+    ```
+
+3. Grant `CONNECT` on each database that the collector should probe,
+   repeating the statement for every database:
+
+    ```sql
+    GRANT CONNECT ON DATABASE myapp TO workbench_monitor;
+    ```
+
+4. Create the optional extensions described in
+   [Optional Extensions](#optional-extensions) if you want the metrics
+   they provide.
+
+5. Add a `pg_hba.conf` entry that permits the new role to connect from
+   the host running the collector, then reload the server
+   configuration.
+
+Store the resulting credentials against the monitored connection as
+described in [Connection Management](../../admin-guide/connections.md).
+The alerter needs no privileges at all on monitored instances, because
+the alerter only ever reads the datastore.
+
+## Per-Database CONNECT Requirement
+
+Ten of the collector's probes are database-scoped and therefore run in
+every database on the monitored instance. The probes concerned are
+`pg_stat_database`, `pg_stat_database_conflicts`, `pg_stat_all_tables`,
+`pg_stat_all_indexes`, `pg_statio_all_sequences`,
+`pg_stat_user_functions`, `pg_extension`, `pg_stat_statements`,
+`spock_exception_log`, and `spock_resolutions`.
+
+The collector enumerates the databases to probe with a query equivalent
+to the following statement:
+
+```sql
+SELECT datname
+FROM pg_database
+WHERE datallowconn = TRUE
+  AND NOT datistemplate;
+```
+
+The collector then opens a separate connection to each database in that
+list, reusing the same stored credentials. This has three practical
+consequences:
+
+- The monitoring role needs `CONNECT` on every non-template database
+  where `datallowconn` is true.
+- Each optional extension must be created separately in every database
+  from which you want the extension's metrics.
+- The instance needs enough connection headroom for one collector
+  connection per database, bounded by the `datconnlimit` of each
+  database, the server's `max_connections` setting, and the collector's
+  own `pool.max_connections_per_server` option.
+
+A database that the role cannot connect to is skipped with a logged
+error rather than a fatal one, so a missing `CONNECT` grant degrades
+coverage silently. This is the most common misconfiguration; check the
+collector log after adding a monitored connection, and confirm that
+metrics arrive for every database you expect.
+
+## Optional Extensions
+
+Two extensions supply metrics that PostgreSQL does not expose on its
+own. Create each extension in every database you want to probe, because
+extensions are per-database objects.
+
+The following table describes the optional extensions and the probes
+that depend on them:
+
+| Extension | Probes | Additional requirement |
+|-----------|--------|------------------------|
+| pg_stat_statements | pg_stat_statements | In shared_preload_libraries |
+| system_stats | The ten pg_sys_* probes | None beyond the extension |
+
+In the following example, the statements create both extensions in the
+current database:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS system_stats;
+```
+
+The probes that rely on these extensions check for the relevant objects
+before running, and return no data rather than raising an error when an
+extension is absent. You can therefore leave both extensions out
+without disturbing the rest of the collection.
+
+## Spock Clusters
+
+Monitored instances that participate in a Spock cluster expose
+replication metadata in the `spock` schema. The collector reads five
+tables in that schema and calls no Spock functions at all.
+
+In the following example, the statements grant the access the collector
+needs for Spock metrics:
+
+```sql
+GRANT USAGE ON SCHEMA spock TO workbench_monitor;
+GRANT SELECT ON spock.exception_log TO workbench_monitor;
+GRANT SELECT ON spock.resolutions TO workbench_monitor;
+GRANT SELECT ON spock.local_node TO workbench_monitor;
+GRANT SELECT ON spock.node TO workbench_monitor;
+GRANT SELECT ON spock.subscription TO workbench_monitor;
+```
+
+The `spock.exception_log` and `spock.resolutions` tables are
+database-scoped, so grant access in every database that hosts Spock
+replication. Instances with no Spock installation need none of these
+grants.
+
+## Privileges by Probe
+
+The `pg_monitor` role covers the great majority of the collection, but
+a handful of probes need more, and a few need nothing at all. The
+following table shows the privilege each group of probes requires:
+
+| Probe or feature | Required privilege |
+|------------------|--------------------|
+| pg_server_info | pg_read_all_settings, for data_directory |
+| pg_settings | pg_read_all_settings, or restricted values are NULL |
+| pg_stat_activity | pg_read_all_stats, or other sessions are masked |
+| pg_stat_replication | pg_read_all_stats, for sender and receiver rows |
+| pg_node_role | pg_read_all_stats, plus superuser for subconninfo |
+| pg_stat_connection_security | pg_read_all_stats, for backend detail |
+| pg_stat_statements | pg_read_all_stats, or query text is hidden |
+| pg_database | pg_read_all_stats, or CONNECT on all databases |
+| pg_hba_file_rules | Grants on the view and function, or superuser |
+| pg_ident_file_mappings | Grants on the view and function, or superuser |
+| The ten database-scoped probes | CONNECT on each database probed |
+| spock_exception_log, spock_resolutions | USAGE and SELECT in spock |
+| The ten pg_sys_* probes | The system_stats extension, no grants |
+| Remaining server-scoped probes | No privilege beyond login |
+
+## Why pg_monitor Is Required
+
+Several probes fail or silently lose data without `pg_monitor`, so
+treat the role as a requirement rather than a refinement. The most
+important dependencies are as follows:
+
+- The `pg_server_info` probe calls
+  `current_setting('data_directory')`, which raises a hard error
+  without `pg_read_all_settings` and so fails the whole probe.
+- Superuser-restricted values in `pg_settings` read as NULL without
+  `pg_read_all_settings`, even though the view itself is readable by
+  PUBLIC.
+- The `query` column and other cross-session columns of
+  `pg_stat_activity` are masked without `pg_read_all_stats`.
+- The `pg_stat_wal_receiver` view is defined with a `WHERE pid IS NOT
+  NULL` clause over a privileged function, so an unprivileged role sees
+  zero rows rather than nulls; this affects both the
+  `pg_stat_replication` probe and standby detection in the
+  `pg_node_role` probe.
+- The wal sender columns of `pg_stat_replication` are masked without
+  `pg_read_all_stats`.
+- Per-backend detail in `pg_stat_ssl` and `pg_stat_gssapi` is masked
+  without `pg_read_all_stats`.
+- The `query` text of other users' entries in `pg_stat_statements`
+  reads as `<insufficient privilege>` without `pg_read_all_stats`.
+- The `pg_database_size()` function requires either `CONNECT` on the
+  target database or `pg_read_all_stats`, and the `pg_database` probe
+  sizes every row including templates, so `pg_read_all_stats` is the
+  reliable answer.
+
+The third role that `pg_monitor` confers, `pg_stat_scan_tables`, is not
+currently exercised by any probe, because the collector uses neither
+`pgstattuple` nor `pg_buffercache`. The role simply comes along with
+`pg_monitor`, so do not go looking for the feature that needs it.
+
+## Privileges Not Required
+
+Two functions that look privileged need no grant at all. The
+`pg_server_info` probe calls `pg_control_system()` and the
+`pg_node_role` probe calls `pg_control_checkpoint()`; PostgreSQL leaves
+execution of both available to PUBLIC. Adding explicit grants for
+either function achieves nothing.
+
+The collector also needs no access to the data in your tables. Table
+and index statistics come from catalogue views combined with
+`pg_table_size()` and `pg_relation_size()`, which report on relation
+storage rather than reading rows.
+
+## Known Gaps Under a Non-Superuser Role
+
+A `pg_monitor` role leaves a small number of gaps, each of which
+degrades quietly rather than raising an error. Review the following
+list and decide whether the affected data matters in your environment.
+
+- The `pg_hba_file_rules` and `pg_ident_file_mappings` views are
+  revoked from PUBLIC and granted to no predefined role, so both
+  probes return no data. The `pg_monitor` role does not cover them.
+- The `subconninfo` column of `pg_subscription` is superuser-only,
+  although SELECT on every other column is granted to PUBLIC. The
+  `pg_node_role` probe reads that column to derive the publisher host
+  and port, and degrades silently without access.
+- A database that the role cannot connect to is skipped, as described
+  in [Per-Database CONNECT Requirement](#per-database-connect-requirement).
+- The `system_stats` and Spock probes return empty results when the
+  corresponding extension or schema is absent from the monitored
+  server.
+
+To close the authentication file gaps without granting superuser, grant
+both the view and the underlying function of the same name. The
+function grant is easy to overlook, and the view alone is not enough.
+
+In the following example, the statements grant access to both
+authentication file views and their functions:
+
+```sql
+GRANT SELECT ON pg_hba_file_rules TO workbench_monitor;
+GRANT EXECUTE ON FUNCTION pg_hba_file_rules() TO workbench_monitor;
+GRANT SELECT ON pg_ident_file_mappings TO workbench_monitor;
+GRANT EXECUTE ON FUNCTION pg_ident_file_mappings()
+    TO workbench_monitor;
+```
+
+A superuser monitoring role covers every probe with no gaps at all, and
+that is the trade-off to weigh: complete coverage against least
+privilege. The shipped demonstration configuration at
+[ai-dba-server.yaml](https://github.com/pgEdge/ai-dba-workbench/blob/main/examples/walkthrough/config/ai-dba-server.yaml)
+monitors as the `postgres` superuser for the sake of simplicity, which
+suits a walkthrough rather than a production estate.
+
+## Privileges for AI and MCP Features
+
+The MCP server connects to monitored instances with the same stored
+credentials that the collector uses, and several of its tools do read
+user data. The following table describes the tools that touch table
+data:
+
+| Tool | Access to user data |
+|------|---------------------|
+| query_database | Executes arbitrary SQL supplied by the user |
+| execute_explain | Runs EXPLAIN ANALYZE, which executes the query |
+| test_query | Runs EXPLAIN only, without executing the query |
+| count_rows | Runs SELECT COUNT(*) against a table |
+| get_schema_info | Reads schema metadata for a database |
+| similarity_search | Reads vector data from a table |
+
+If you want these features to work, the monitoring role additionally
+needs `USAGE` on the relevant user schemas and `SELECT` on the tables
+you are willing to expose. The collector alone needs neither.
+
+Grant this access deliberately, because the read_write setting on a
+Workbench connection is an application-level gate rather than a
+database one. The privileges of the PostgreSQL role are the real
+backstop: a read_write grant in the Workbench achieves nothing unless
+the underlying role also holds write privileges, and granting the role
+write privileges widens what the AI features can do regardless of the
+Workbench setting. Treat the two as one security decision.
+
+## Next Steps
+
+The following documents cover related configuration.
+
+- The [Collector Configuration](collector.md) document describes the
+  datastore credentials, connection pooling, and probe settings.
+- The [Connection Management](../../admin-guide/connections.md)
+  document explains how to create and select monitored connections.
+- The
+  [Probe Reference](../../developer-guide/collector/probe-reference.md)
+  document lists the source views and columns that each probe reads.

--- a/docs/getting-started/configuration/monitored-database-privileges.md
+++ b/docs/getting-started/configuration/monitored-database-privileges.md
@@ -152,7 +152,7 @@ following table shows the privilege each group of probes requires:
 | Probe or feature | Required privilege |
 |------------------|--------------------|
 | pg_server_info | pg_read_all_settings, for data_directory |
-| pg_settings | pg_read_all_settings, or restricted values are NULL |
+| pg_settings | pg_read_all_settings, or restricted rows are omitted |
 | pg_stat_activity | pg_read_all_stats, or other sessions are masked |
 | pg_stat_replication | pg_read_all_stats, for sender and receiver rows |
 | pg_node_role | pg_read_all_stats, plus superuser for subconninfo |
@@ -175,9 +175,15 @@ important dependencies are as follows:
 - The `pg_server_info` probe calls
   `current_setting('data_directory')`, which raises a hard error
   without `pg_read_all_settings` and so fails the whole probe.
-- Superuser-restricted values in `pg_settings` read as NULL without
-  `pg_read_all_settings`, even though the view itself is readable by
-  PUBLIC.
+- Superuser-restricted settings are omitted from `pg_settings`
+  entirely without `pg_read_all_settings`, rather than appearing with a
+  NULL `setting`; the view itself is readable by PUBLIC, so the rows
+  simply are not returned. The `pg_settings` probe runs a plain
+  `SELECT * FROM pg_settings`, so an unprivileged monitoring role
+  silently collects a smaller set of settings with nothing to indicate
+  the shortfall. Measured on PostgreSQL 18: 380 rows without the
+  privilege against 403 with it, and no NULL `setting` values in
+  either case.
 - The `query` column and other cross-session columns of
   `pg_stat_activity` are masked without `pg_read_all_stats`.
 - The `pg_stat_wal_receiver` view is defined with a `WHERE pid IS NOT

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
     - Configuration Details:
       - Server: getting-started/configuration/server.md
       - Collector: getting-started/configuration/collector.md
+      - Monitored Database Privileges: getting-started/configuration/monitored-database-privileges.md
       - Alerter: getting-started/configuration/alerter.md
       - Web Client: getting-started/configuration/client.md
       - Configuring systemd Services: getting-started/configuration/configure_systemd.md


### PR DESCRIPTION
## Summary

- Adds `docs/getting-started/configuration/monitored-database-privileges.md`,
  documenting the PostgreSQL privileges a monitoring role needs on a
  **monitored** instance. The docs previously covered only the datastore
  role, so a prospect asking what grants a monitoring user needs had no
  answer in the repository.
- Recommends a least-privilege role built on `pg_monitor` plus per-database
  `CONNECT`, and documents the optional `pg_stat_statements` and
  `system_stats` extensions, the Spock grants, and the gaps that remain
  without superuser access.
- Links the page from `collector/README.md`, the collector and connection
  configuration pages, and the probe reference, so it is discoverable from
  the getting-started section as the issue asked.

## Notes on the grants

I derived the grants by auditing the probes against the collector source
and the PostgreSQL catalogue ACLs rather than taking the issue's suggested
SQL at face value, which turned up several corrections worth flagging for
review:

- `pg_monitor` is *mandatory*, not merely advisable: the `pg_server_info`
  probe calls `current_setting('data_directory')`, which raises a hard
  error without `pg_read_all_settings` and fails the whole probe.
- The Spock probes read **five** tables, not the two the issue listed;
  `pg_node_role` also reads `spock.local_node`, `spock.node`, and
  `spock.subscription`.
- `pg_stat_wal_receiver` is defined `WHERE pid IS NOT NULL`, so an
  unprivileged role sees **zero rows** rather than nulls, which breaks
  standby detection outright rather than blanking a column.
- Closing the `pg_hba_file_rules` and `pg_ident_file_mappings` gaps without
  granting superuser requires a grant on **both** the view and its
  underlying function; the function grant is easy to miss.
- `pg_subscription.subconninfo` is superuser-only and degrades publisher
  host and port detection silently.
- A missing `CONNECT` grant is skipped with a logged error rather than a
  fatal one, so it degrades coverage silently. This is the likeliest
  misconfiguration, so the page calls it out explicitly.

The page also covers something the issue did not anticipate: the MCP server
reuses the same stored credentials and several of its tools do read user
data, so the AI features need `USAGE` on schemas and `SELECT` on tables that
the collector itself never requires. Since the Workbench's `read_write`
setting is only an application-level gate, the role's own privileges are the
real backstop, which is framed as a deliberate security decision.

## Test plan

- [x] `mkdocs build --strict` passes with no warnings or errors, so the nav
      entry and every cross-link resolve.
- [x] Verified the internal anchor target resolves in the built HTML.
- [x] Confirmed all added lines wrap at 79 characters, bar unsplittable
      hyperlinks and the mkdocs nav path.
- [x] Confirmed no test asserts on `mkdocs.yml` or docs paths; this diff
      touches no code, so `lint` and the Go/client suites are unaffected.
- [x] All example values are synthetic (`workbench_monitor`, `myapp`, a
      placeholder password).

Closes #351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the PostgreSQL privileges required for monitored connections, including `pg_monitor` and per-database `CONNECT` access.
  * Added a dedicated Monitored Database Privileges guide with least-privilege recommendations, probe-specific requirements, optional extensions, and known limitations.
  * Updated collector setup, administration, probe reference, and security documentation with links and clarifications.
  * Added the new guide to the documentation navigation and unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->