### PR TITLE
fix(server): widen memory embedding test fixture to halfvec(4000)

### DIFF
--- a/server/src/internal/tools/memory_tools_embedding_db_test.go
+++ b/server/src/internal/tools/memory_tools_embedding_db_test.go
@@ -27,11 +27,13 @@ import (
 )
 
 // memoryEmbeddingTableDDL mirrors the chat_memories table that the memory
-// store reads from and writes to. The vector dimension is 3 so the mocked
-// Gemini endpoint can return a three-element vector and the store can
-// persist it without dimension mismatch. The table is created inside a
-// per-test private schema (see newMemoryEmbeddingStore) so it never
-// clobbers the canonical public.chat_memories shared with other tests.
+// store reads from and writes to. The column is halfvec(4000) because the
+// store pads every embedding to embedding.MaxDimensions before insert and
+// before querying, so a shorter vector column would reject the padded
+// value; halfvec rather than vector is required because pgvector caps the
+// vector type at 2000 dimensions. The table is created inside a per-test
+// private schema (see newMemoryEmbeddingStore) so it never clobbers the
+// canonical public.chat_memories shared with other tests.
 const memoryEmbeddingTableDDL = `
 CREATE TABLE chat_memories (
     id BIGSERIAL PRIMARY KEY,
@@ -40,7 +42,7 @@ CREATE TABLE chat_memories (
     category TEXT NOT NULL,
     content TEXT NOT NULL,
     pinned BOOLEAN NOT NULL DEFAULT FALSE,
-    embedding vector(3),
+    embedding halfvec(4000),
     model_name TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -51,7 +53,7 @@ CREATE TABLE chat_memories (
 // TEST_AI_WORKBENCH_SERVER Postgres instance. To avoid clobbering the
 // shared public.chat_memories table (which other tools and memory-package
 // integration tests rely on), it creates a uniquely-named private schema
-// and a chat_memories table with a vector(3) embedding column inside it.
+// and a chat_memories table with a halfvec(4000) embedding column inside it.
 // The pool's search_path is set so the memory store's unqualified
 // chat_memories references resolve to this private table. Teardown drops
 // the whole schema, leaving the shared table untouched. The test skips
@@ -148,8 +150,9 @@ func uniqueSchemaName(testName string) string {
 // endpoint. The wire contract mirrors the pgedge-go-llm-lib Gemini provider:
 // the request path is /v1beta/models/<model>:embedContent, the API key is
 // carried in the x-goog-api-key header, and the response is
-// {"embedding":{"values":[...]}}. A three-element vector matches the
-// vector(3) column used by the test schema.
+// {"embedding":{"values":[...]}}. The response carries a three-element
+// vector; the memory store pads it to the fixed 4000-dimension width before
+// insert, which is why the test schema declares a halfvec(4000) column.
 func newMockGeminiEmbeddingServer(t *testing.T, apiKey string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/src/internal/tools/memory_tools_embedding_db_test.go
+++ b/server/src/internal/tools/memory_tools_embedding_db_test.go
@@ -29,11 +29,14 @@ import (
 // memoryEmbeddingTableDDL mirrors the chat_memories table that the memory
 // store reads from and writes to. The column is halfvec(4000) because the
 // store pads every embedding to embedding.MaxDimensions before insert and
-// before querying, so a shorter vector column would reject the padded
-// value; halfvec rather than vector is required because pgvector caps the
-// vector type at 2000 dimensions. The table is created inside a per-test
-// private schema (see newMemoryEmbeddingStore) so it never clobbers the
-// canonical public.chat_memories shared with other tests.
+// before querying, so a shorter column would reject the padded value, and
+// because halfvec is what production uses: store.go casts to ::halfvec and
+// the canonical table carries a halfvec_cosine_ops index. A vector(4000)
+// column would accept the padded value too, so matching production rather
+// than any type limit is the reason to use halfvec here. The table is
+// created inside a per-test private schema (see newMemoryEmbeddingStore)
+// so it never clobbers the canonical public.chat_memories shared with
+// other tests.
 const memoryEmbeddingTableDDL = `
 CREATE TABLE chat_memories (
     id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## The problem

The `chat_memories` fixture used by the embedding integration tests in
`server/src/internal/tools/memory_tools_embedding_db_test.go` still declared its
embedding column as `vector(3)`, which was correct back when the mocked Gemini
endpoint's three-element response went into the database verbatim, but has been
wrong since the collector's migration v6 widened the embedding columns to
`halfvec(4000)` for multi-provider support. `memory.Store` now pads every
embedding out to `embeddingpkg.MaxDimensions`, which is 4000, on the insert path
in `server/src/internal/memory/store.go` and again on the query path, so
Postgres rejected the padded value outright with `ERROR: expected 3 dimensions,
not 4000 (SQLSTATE 22000)`. The sibling fixture in the memory package was
updated at the time and reads `halfvec(4000)` already; this one was missed.

The upshot is that both `TestStoreMemoryGeneratesEmbeddingIntegration` and
`TestRecallMemoriesGeneratesQueryEmbeddingIntegration` failed on any host where
pgvector is actually installed, which includes the development host.

## Why halfvec rather than a wider vector

**Corrected after review:** an earlier version of this description claimed
pgvector caps the `vector` type at 2000 dimensions. It does not. `vector` goes
to 16,000 dimensions, and 2,000 is the HNSW and IVFFlat index limit for
`vector`. Verified on pgvector 0.8.2: a `vector(4000)` column accepts the
store's padded value, and only an HNSW index on it is refused.

So `vector(4000)` would work for this fixture, which has no index. The reason
to use `halfvec` is simply that it matches production: `store.go` casts to
`::halfvec`, the canonical table carries a `halfvec_cosine_ops` index, and the
sibling memory-package fixture already reads `halfvec(4000)`. Matching the real
schema is the point, not any type limit.

## Why CI never caught this

These two tests have never actually executed in CI. The workflow's Postgres
service is a plain `postgres:<version>` image with no pgvector available, so
`CREATE EXTENSION IF NOT EXISTS vector` fails, the helper calls
`t.Skipf("pgvector extension unavailable")`, and the run reports green whilst
quietly skipping the whole seam. A follow-up PR adds pgvector to the CI Postgres
service so that this path is genuinely gated; no workflow files are touched
here, keeping the two concerns separate.

## Scope

This is a fixture and comment correction only: no production code changes, no
test restructuring, and no new tests. The stale comments asserting that the
mock's three-element vector matches the column type have been reworded to
explain the padding, since the mock returning three elements remains correct and
should stay.

## Verification

Run on the development host, where pgvector is installed, against the local
loopback Postgres:

- `gofmt -l` on the touched file is clean, and `go build ./...` succeeds.
- Both tests now PASS rather than skip:

  ```
  === RUN   TestStoreMemoryGeneratesEmbeddingIntegration
  --- PASS: TestStoreMemoryGeneratesEmbeddingIntegration (0.04s)
  === RUN   TestRecallMemoriesGeneratesQueryEmbeddingIntegration
  --- PASS: TestRecallMemoriesGeneratesQueryEmbeddingIntegration (0.02s)
  PASS
  ok      github.com/pgedge/ai-workbench/server/internal/tools     0.331s
  ```

- The whole `internal/tools` package is green, and coverage rises from 49.3% to
  51.1% now that these two tests execute rather than skip.
- `make lint` in `server` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nPEZyXgN1zK7EuEXhfZvW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated memory embedding integration coverage to use production-compatible 4,000-dimensional half-precision vectors.
  * Clarified documentation describing how smaller embedding responses are padded to the required dimensionality before database operations.
  * Improved alignment between test scenarios and production embedding storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
