### PR TITLE
Hide the Workbench's own datastore queries from Top Queries

### DIFF
--- a/.claude/golang-expert/internal-query-markers.md
+++ b/.claude/golang-expert/internal-query-markers.md
@@ -25,9 +25,10 @@ monitored database with a synthetic column alias:
 - `ai_dba_wb_probe`, injected by `WrapQuery` in
   `collector/src/probes/base.go`.
 
-Everything the Workbench runs against its own datastore carries an
-in-statement comment instead, because those statements are inserts,
-deletes, DDL, and multi-column reads whose shape must not change:
+The statements the collector and the alerter run against the
+Workbench's own datastore carry an in-statement comment instead,
+because those statements are inserts, deletes, DDL, and multi-column
+reads whose shape must not change:
 
 - `ai_dba_wb_internal`, injected by `Tag` in `pkg/sqlmarker`.
 
@@ -71,9 +72,12 @@ current chokepoints are:
   which every probe's bulk metric writes pass.
 - `HasDataChanged` in `collector/src/probes/change_tracking.go`, which
   tags the caller-supplied stored-snapshot query.
-- The SQL builders in `collector/src/probes/partition.go`
-  (`partitionExistsQuery`, `createPartitionSQL`, `dropPartitionSQL`,
-  `protectedPartitionsQuery`, `partitionCandidatesQuery`).
+- The partition maintenance statements in
+  `collector/src/probes/partition.go`: the `partitionExistsQuery` and
+  `partitionCandidatesQuery` variables, and the `createPartitionSQL`,
+  `dropPartitionSQL`, and `protectedPartitionsQuery` builders. See
+  `partitioning.md` for the identifier-quoting and suppression rules
+  those five carry.
 - `lastCollectionTimeQuery` in `collector/src/probes/config_loader.go`.
 - `probeAvailabilityUpsert` in
   `collector/src/database/probe_availability.go`.
@@ -81,22 +85,32 @@ current chokepoints are:
   (`monitoredConnectionsQuery`, `monitoredConnectionByIDQuery`,
   `setConnectionErrorStatement`).
 - `databaseListQuery` in `collector/src/scheduler/scheduler.go`.
-- `queryInternal` in `alerter/src/internal/database/metric_queries.go`,
-  through which every `metricRegistry` statement is executed; the
-  registry holds over a hundred SQL literals and tagging them
-  individually would guarantee the next addition went untagged.
+- `queryTagged` in `alerter/src/internal/database/metric_queries.go`,
+  reached through the `Datastore.queryInternal` method, through which
+  every `metricRegistry` statement is executed; the registry holds over
+  a hundred SQL literals and tagging them individually would guarantee
+  the next addition went untagged. `queryTagged` takes a `rowQuerier`
+  interface rather than the pool so that the tagging can be asserted
+  with a fake, without a database.
 
 Probe queries that run against monitored databases must not be tagged
 with `ai_dba_wb_internal`; they already carry `ai_dba_wb_probe`.
 
 ## Still Untagged
 
-The server's own traffic against the datastore (sessions, RBAC,
-conversations, timeline, and the API handlers generally) is the same
-class of noise and is not yet tagged. It needs a sweep across many
-handler-level chokepoints and is tracked separately from issue #364.
-The collector's `probe_configs` resolution path
-(`LoadProbeConfigs` and `EnsureProbeConfig`) is also untagged.
+Two classes of Workbench traffic remain untagged and therefore still
+appear in the Top Queries panel with the toggle on; do not describe the
+tagging as complete:
+
+- The server's own traffic against the datastore (sessions, RBAC,
+  conversations, timeline, and the API handlers generally). It needs a
+  sweep across many handler-level chokepoints and is tracked
+  separately from issue #364.
+- The collector's `probe_configs` resolution path, namely
+  `LoadProbeConfigs` and `EnsureProbeConfig` in
+  `collector/src/probes/config_loader.go`. Note that
+  `lastCollectionTimeQuery`, in that same file, *is* tagged, so the
+  file is a mixture.
 
 ## Testing Notes for pg_stat_statements
 
@@ -116,3 +130,26 @@ Use a uniquely named relation to give the statement its own `queryid`,
 and match on that relation name. Do not call
 `pg_stat_statements_reset()`; it discards the whole instance's history,
 including whatever the developer was looking at.
+
+A third trap is environmental, and it broke CI once already:
+`CREATE EXTENSION pg_stat_statements` succeeds on a server that does
+not list the library in `shared_preload_libraries`, and every read of
+the view then fails with SQLSTATE 55000. The CI PostgreSQL containers
+are configured exactly that way, so a test that only guards on
+`CREATE EXTENSION` fails on every matrix job. Guard by attempting the
+read and skipping on any error, which also covers the extension being
+absent or unprivileged:
+
+- `requirePgStatStatementsReadable` in
+  `collector/src/probes/integration_helpers_test.go`.
+- `requirePgStatStatements` in
+  `alerter/src/internal/database/sql_marker_test.go`.
+
+Because those end-to-end tests skip wherever the extension is not
+loaded, the tagging itself must also be asserted by tests that need no
+database at all, so that CI still proves the behavior: see
+`TestBuildMetricsInsert_Tagged` and the partition builder tests in
+`collector/src/probes/sql_marker_test.go`, and
+`TestQueryTagged_TagsSQL` with
+`TestQueryTagged_TagsEveryRegistryStatement` in the alerter. Never
+weaken or skip those.

--- a/.claude/golang-expert/internal-query-markers.md
+++ b/.claude/golang-expert/internal-query-markers.md
@@ -1,0 +1,118 @@
+/*-----------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench - Internal Query Markers
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-----------------------------------------------------------
+ */
+
+# Marking Workbench-Internal SQL
+
+The Top Queries panel reads `metrics.pg_stat_statements`, which holds
+instance-wide activity for a monitored server. The Workbench's own
+datastore usually lives on that same PostgreSQL instance, so its
+overhead lands in the same view as the user's workload. Two markers
+distinguish Workbench traffic, and the panel's "Hide monitoring
+queries" toggle filters on both.
+
+## The Two Markers
+
+The collector wraps every read-only probe query that runs against a
+monitored database with a synthetic column alias:
+
+- `ai_dba_wb_probe`, injected by `WrapQuery` in
+  `collector/src/probes/base.go`.
+
+Everything the Workbench runs against its own datastore carries an
+in-statement comment instead, because those statements are inserts,
+deletes, DDL, and multi-column reads whose shape must not change:
+
+- `ai_dba_wb_internal`, injected by `Tag` in `pkg/sqlmarker`.
+
+The server filters on both in `excludeWorkbenchQueriesClause` in
+`server/src/internal/api/perf_summary_handlers.go`. That clause is a
+compile-time constant built from `sqlmarker.Marker` and a local copy of
+the probe alias; the collector is a separate Go module, so the alias is
+duplicated rather than imported, and the two must be kept in step.
+
+The filter is deliberately per-statement. Excluding the whole datastore
+database was rejected: users legitimately run other tools against that
+database and expect to see them in the panel.
+
+## Marker Placement Is Not Negotiable
+
+PostgreSQL does not preserve a comment in every position when it
+normalises a statement for `pg_stat_statements`. Measured on
+PostgreSQL 18:
+
+| Placement                          | Survives? |
+|------------------------------------|-----------|
+| `/* m */ INSERT INTO t ...`        | No        |
+| `INSERT /* m */ INTO t ...`        | Yes       |
+| `INSERT INTO t VALUES (1) /* m */` | Yes       |
+| `INSERT INTO t VALUES (1); -- m`   | No        |
+
+`sqlmarker.Tag` therefore inserts the comment immediately after the
+leading keyword token. Never "tidy" the marker to the front of the
+string; it will be stripped and the filter will silently stop working.
+`Tag` is idempotent, tolerates leading whitespace and newlines, and
+returns its input unchanged when there is no leading alphabetic
+keyword (a parenthesised sub-select, or SQL already prefixed with a
+comment).
+
+## Where the Tagging Lives
+
+Tag at chokepoints, never by hand-editing individual SQL literals. The
+current chokepoints are:
+
+- `buildMetricsInsert` in `collector/src/probes/storage.go`, through
+  which every probe's bulk metric writes pass.
+- `HasDataChanged` in `collector/src/probes/change_tracking.go`, which
+  tags the caller-supplied stored-snapshot query.
+- The SQL builders in `collector/src/probes/partition.go`
+  (`partitionExistsQuery`, `createPartitionSQL`, `dropPartitionSQL`,
+  `protectedPartitionsQuery`, `partitionCandidatesQuery`).
+- `lastCollectionTimeQuery` in `collector/src/probes/config_loader.go`.
+- `probeAvailabilityUpsert` in
+  `collector/src/database/probe_availability.go`.
+- The connections statements in `collector/src/database/datastore.go`
+  (`monitoredConnectionsQuery`, `monitoredConnectionByIDQuery`,
+  `setConnectionErrorStatement`).
+- `databaseListQuery` in `collector/src/scheduler/scheduler.go`.
+- `queryInternal` in `alerter/src/internal/database/metric_queries.go`,
+  through which every `metricRegistry` statement is executed; the
+  registry holds over a hundred SQL literals and tagging them
+  individually would guarantee the next addition went untagged.
+
+Probe queries that run against monitored databases must not be tagged
+with `ai_dba_wb_internal`; they already carry `ai_dba_wb_probe`.
+
+## Still Untagged
+
+The server's own traffic against the datastore (sessions, RBAC,
+conversations, timeline, and the API handlers generally) is the same
+class of noise and is not yet tagged. It needs a sweep across many
+handler-level chokepoints and is tracked separately from issue #364.
+The collector's `probe_configs` resolution path
+(`LoadProbeConfigs` and `EnsureProbeConfig`) is also untagged.
+
+## Testing Notes for pg_stat_statements
+
+Writing an integration test that reads a statement back out of
+`pg_stat_statements` is the only real proof that a marker survives. Two
+traps make naive tests useless:
+
+- `queryid` is computed from the parse tree, which ignores both
+  comments and column aliases, and the view keeps the text of whichever
+  form of a statement it saw first. A statement that differs from an
+  existing entry only by a comment or an alias therefore collapses onto
+  that entry and the new text is never stored.
+- Literals are normalised into `$n` placeholders, so a unique string
+  constant cannot be used to identify a statement either.
+
+Use a uniquely named relation to give the statement its own `queryid`,
+and match on that relation name. Do not call
+`pg_stat_statements_reset()`; it discards the whole instance's history,
+including whatever the developer was looking at.

--- a/.claude/golang-expert/internal-query-markers.md
+++ b/.claude/golang-expert/internal-query-markers.md
@@ -98,7 +98,7 @@ with `ai_dba_wb_internal`; they already carry `ai_dba_wb_probe`.
 
 ## Still Untagged
 
-Two classes of Workbench traffic remain untagged and therefore still
+Three classes of Workbench traffic remain untagged and therefore still
 appear in the Top Queries panel with the toggle on; do not describe the
 tagging as complete:
 
@@ -111,6 +111,41 @@ tagging as complete:
   `collector/src/probes/config_loader.go`. Note that
   `lastCollectionTimeQuery`, in that same file, *is* tagged, so the
   file is a mixture.
+- Most of the alerter's datastore traffic. Only `GetClusterPeers` moved
+  onto `queryInternal`; the direct `pool.Query`, `QueryRow` and `Exec`
+  sites across `alert_queries.go`, `anomaly_queries.go`,
+  `notification_queries.go` and `queries.go` are untagged, and they run
+  on the 60-second evaluation cycle so they are prominent in the panel.
+  Tagging them needs `QueryRow` and `Exec` twins of `queryInternal`,
+  since the existing helper only wraps `Query`.
+
+## Tagging Does Not Hide an Entry That Already Exists
+
+This is the trap that matters on upgrade, and it is the same mechanism
+as the testing note below, seen from the operator's side.
+
+Adding a marker to an existing statement does not hide it from a
+deployment that has already been running. `pg_stat_statements` keys on
+the parse tree, which ignores comments, so the tagged form collapses
+onto the untagged entry that is already there, and that entry keeps the
+untagged text it was first recorded with. The Workbench's own
+statements run every collection cycle, so they are never evicted
+either. The filter matches on text, so it never matches, and the panel
+looks exactly as it did before the upgrade.
+
+Measured on PostgreSQL 18: five untagged executions followed by 25
+tagged ones leave one row, 30 calls, still showing the untagged text.
+
+Two consequences worth remembering:
+
+- Only statements first seen after the upgrade are hidden. Operators
+  need a one-off `SELECT pg_stat_statements_reset()` on the monitored
+  instance for the filter to cover what is already recorded, and both
+  the changelog and the dashboard documentation must say so.
+- A statement whose parse tree changed in the same release is exempt,
+  because it gets a fresh `queryid`. That is why
+  `loadPartitionCandidates` was hidden immediately: it gained a `$1`
+  bind in the same change.
 
 ## Testing Notes for pg_stat_statements
 

--- a/.claude/golang-expert/partitioning.md
+++ b/.claude/golang-expert/partitioning.md
@@ -38,11 +38,15 @@ the datastore session's `TimeZone` setting cannot reinterpret them.
 Use the layout `"2006-01-02 15:04:05Z07:00"` with a UTC value; Go
 emits `Z` for UTC which Postgres accepts as a timestamptz literal.
 
-The shared helper lives at
-`collector/src/probes/base.go`:
+The shared helpers live at
+`collector/src/probes/partition.go`:
 
 - `weeklyPartitionBounds(t time.Time) (nameSuffix string, from, to time.Time)`
 - `const partitionBoundLayout = "2006-01-02 15:04:05Z07:00"`
+- `createPartitionSQL`, `dropPartitionSQL`, `protectedPartitionsQuery`,
+  and `partitionCandidatesQuery`, which build every partition
+  maintenance statement and tag it as Workbench-internal; see
+  `internal-query-markers.md`.
 
 Unit tests in `collector/src/probes/base_test.go` cover the known
 off-by-one timezone cases (Sunday-in-UTC that looks like Monday in a
@@ -78,11 +82,17 @@ error `"conn busy"`. This is distinct from pool exhaustion, which
 surfaces as an acquire timeout.
 
 `DropExpiredPartitions` in
-`collector/src/probes/base.go` previously tripped this by calling
+`collector/src/probes/partition.go` previously tripped this by calling
 `conn.Exec(ctx, dropSQL)` inside a `for rows.Next()` loop that was
 iterating the partition catalog on the same connection. It was
 fixed (issue #62) by reading the catalog query fully into a slice,
 letting the Rows close, and only then issuing the DROP statements.
+
+The partition helpers take the `DatastoreQuerier` interface rather than
+`*pgxpool.Conn`. `*pgxpool.Conn` satisfies it, so callers are
+unaffected, but unit tests can inject a fake that records the SQL
+issued and returns errors from `Query`, `Scan`, and `Exec`. Prefer that
+over an integration test when covering an error branch.
 
 Rules for the datastore connection shared across a GC pass:
 

--- a/.claude/golang-expert/partitioning.md
+++ b/.claude/golang-expert/partitioning.md
@@ -43,10 +43,30 @@ The shared helpers live at
 
 - `weeklyPartitionBounds(t time.Time) (nameSuffix string, from, to time.Time)`
 - `const partitionBoundLayout = "2006-01-02 15:04:05Z07:00"`
-- `createPartitionSQL`, `dropPartitionSQL`, `protectedPartitionsQuery`,
-  and `partitionCandidatesQuery`, which build every partition
-  maintenance statement and tag it as Workbench-internal; see
-  `internal-query-markers.md`.
+- The statements the maintenance pass issues, each tagged as
+  Workbench-internal (see `internal-query-markers.md`): the
+  `partitionExistsQuery` and `partitionCandidatesQuery` variables,
+  which are fixed literals that bind their one variable as `$1`, and
+  the `createPartitionSQL`, `dropPartitionSQL`, and
+  `protectedPartitionsQuery` builders, which have to interpolate a
+  relation name because an identifier cannot be a bind parameter.
+
+Every relation name interpolated by those three builders is quoted
+with `pgx.Identifier{"metrics", name}.Sanitize()`, and the range
+bounds are formatted from `time.Time` values, so no caller-supplied
+text reaches a statement verbatim. The suppressions come in pairs and
+sit in different places: `#nosec G201` goes on the builder, because
+gosec flags the `fmt.Sprintf` that assembles the SQL, whilst
+`//nosemgrep: go_sql_rule-concat-sqli` goes on the line immediately
+before the `Query`, `QueryRow`, or `Exec` call, because Opengrep flags
+the sink and honours the annotation only on the finding's own line or
+the one above it. Every partition call site needs the `//nosemgrep`
+form, including the two that bind their variable as `$1`, because the
+tagging alone makes the SQL non-constant; the `#nosec` form is only
+needed where a builder actually formats a string. Keep whichever
+annotations a site already has when moving this code around.
+`lastCollectionTimeQuery` in
+`collector/src/probes/config_loader.go` follows the same pattern.
 
 Unit tests in `collector/src/probes/base_test.go` cover the known
 off-by-one timezone cases (Sunday-in-UTC that looks like Monday in a

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ all:
 # Run tests for all sub-projects
 test:
 	@echo "Running tests for all sub-projects..."
+	@echo "Testing shared pkg module..."
+	@cd pkg && go test ./...
 	@echo "Testing collector..."
 	@cd collector && $(MAKE) test
 	@echo "Testing server..."
@@ -67,6 +69,8 @@ lint:
 # Run all tests (sub-project test-all)
 test-all:
 	@echo "Running all tests for sub-projects..."
+	@echo "Running all tests for shared pkg module..."
+	@cd pkg && go test ./...
 	@echo "Running all tests for collector..."
 	@cd collector && $(MAKE) test-all
 	@echo "Running all tests for server..."

--- a/alerter/src/internal/database/metric_queries.go
+++ b/alerter/src/internal/database/metric_queries.go
@@ -13,6 +13,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
 
 // Sentinel errors returned by GetLatestMetricValues. Callers need to tell
@@ -33,10 +37,26 @@ var (
 	ErrNoMetricData = errors.New("no data found for metric")
 )
 
+// queryInternal runs a datastore query on behalf of the metric
+// registry, tagging the SQL as Workbench-internal first.
+//
+// Every registry query (latestSQL and historicalSQL alike) funnels
+// through this one function, which is deliberate: the registry in
+// metric_registry.go holds well over a hundred SQL literals, and
+// tagging them individually would guarantee that the next one added
+// went untagged. Tagging here means the alerter's metric-evaluation
+// traffic against metrics.* never shows up in the server's Top Queries
+// panel when monitoring queries are hidden. See sqlmarker.Tag for why
+// the marker has to sit after the leading keyword rather than in front
+// of the statement.
+func (d *Datastore) queryInternal(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	return d.pool.Query(ctx, sqlmarker.Tag(sql), args...)
+}
+
 // queryMetricValues executes a SQL query that returns rows with three columns
 // (connection_id, value, collected_at) and scans them into MetricValue structs.
 func (d *Datastore) queryMetricValues(ctx context.Context, sql string) ([]MetricValue, error) {
-	rows, err := d.pool.Query(ctx, sql)
+	rows, err := d.queryInternal(ctx, sql)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +79,7 @@ func (d *Datastore) queryMetricValues(ctx context.Context, sql string) ([]Metric
 // queryMetricValuesWithDB executes a SQL query that returns rows with four columns
 // (connection_id, database_name, value, collected_at) and scans them into MetricValue structs.
 func (d *Datastore) queryMetricValuesWithDB(ctx context.Context, sql string) ([]MetricValue, error) {
-	rows, err := d.pool.Query(ctx, sql)
+	rows, err := d.queryInternal(ctx, sql)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +104,7 @@ func (d *Datastore) queryMetricValuesWithDB(ctx context.Context, sql string) ([]
 // queryMetricValuesWithDBAndObject executes a SQL query that returns rows with five columns
 // (connection_id, database_name, object_name, value, collected_at) and scans them into MetricValue structs.
 func (d *Datastore) queryMetricValuesWithDBAndObject(ctx context.Context, sql string) ([]MetricValue, error) {
-	rows, err := d.pool.Query(ctx, sql)
+	rows, err := d.queryInternal(ctx, sql)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +166,7 @@ func (d *Datastore) GetLatestMetricValues(ctx context.Context, metricName string
 // (connection_id, database_name, value, collected_at) where database_name is scanned as-is
 // (typically NULL for basic metrics).
 func (d *Datastore) queryHistoricalMetricValuesBasic(ctx context.Context, sql string, lookbackDays int) ([]HistoricalMetricValue, error) {
-	rows, err := d.pool.Query(ctx, sql, lookbackDays)
+	rows, err := d.queryInternal(ctx, sql, lookbackDays)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +189,7 @@ func (d *Datastore) queryHistoricalMetricValuesBasic(ctx context.Context, sql st
 // queryHistoricalMetricValuesWithDB executes a historical SQL query that returns rows with
 // (connection_id, database_name, value, collected_at) where database_name is a non-null string.
 func (d *Datastore) queryHistoricalMetricValuesWithDB(ctx context.Context, sql string, lookbackDays int) ([]HistoricalMetricValue, error) {
-	rows, err := d.pool.Query(ctx, sql, lookbackDays)
+	rows, err := d.queryInternal(ctx, sql, lookbackDays)
 	if err != nil {
 		return nil, err
 	}

--- a/alerter/src/internal/database/metric_queries.go
+++ b/alerter/src/internal/database/metric_queries.go
@@ -37,6 +37,22 @@ var (
 	ErrNoMetricData = errors.New("no data found for metric")
 )
 
+// rowQuerier is the subset of *pgxpool.Pool that queryTagged needs. It
+// exists so the tagging behavior can be asserted without a database:
+// the end-to-end proof that the marker survives into
+// pg_stat_statements needs a live server with the extension loaded,
+// which is not available everywhere, whilst the tagging itself must be
+// verified on every run.
+type rowQuerier interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+// queryTagged tags sql as Workbench-internal and runs it on q.
+func queryTagged(ctx context.Context, q rowQuerier, sql string,
+	args ...any) (pgx.Rows, error) {
+	return q.Query(ctx, sqlmarker.Tag(sql), args...)
+}
+
 // queryInternal runs a datastore query on behalf of the metric
 // registry, tagging the SQL as Workbench-internal first.
 //
@@ -50,7 +66,7 @@ var (
 // the marker has to sit after the leading keyword rather than in front
 // of the statement.
 func (d *Datastore) queryInternal(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
-	return d.pool.Query(ctx, sqlmarker.Tag(sql), args...)
+	return queryTagged(ctx, d.pool, sql, args...)
 }
 
 // queryMetricValues executes a SQL query that returns rows with three columns

--- a/alerter/src/internal/database/queries.go
+++ b/alerter/src/internal/database/queries.go
@@ -430,7 +430,9 @@ func (d *Datastore) GetAlertRuleByName(ctx context.Context, name string) (*Alert
 // cluster as the given connection, including their latest node role.
 // Returns an empty slice if the connection has no cluster.
 func (d *Datastore) GetClusterPeers(ctx context.Context, connectionID int) ([]*ClusterPeerInfo, error) {
-	rows, err := d.pool.Query(ctx, `
+	// Tagged internal: this reads metrics.pg_node_role on the
+	// Workbench's own datastore on every alert evaluation cycle.
+	rows, err := d.queryInternal(ctx, `
 		SELECT c.id, c.name, COALESCE(lr.primary_role, 'unknown')
 		FROM connections c
 		LEFT JOIN LATERAL (

--- a/alerter/src/internal/database/sql_marker_test.go
+++ b/alerter/src/internal/database/sql_marker_test.go
@@ -1,0 +1,349 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Tests for the Workbench-internal SQL marker applied to the alerter's
+// metric-evaluation queries against its own datastore. See GitHub issue
+// #364: these queries previously leaked into the server's Top Queries
+// panel even with "Hide monitoring queries" enabled.
+package database
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
+)
+
+// assertTaggable fails the test unless Tag inserts the marker into sql
+// after the leading keyword. Registry SQL that fails this check would be
+// silently passed through untagged by queryInternal.
+func assertTaggable(t *testing.T, what, sql string) {
+	t.Helper()
+
+	tagged := sqlmarker.Tag(sql)
+	if !strings.Contains(tagged, sqlmarker.Marker) {
+		t.Errorf("%s cannot be tagged; it has no leading keyword: %q",
+			what, first80(sql))
+		return
+	}
+	trimmed := strings.TrimLeft(tagged, " \t\r\n")
+	if strings.HasPrefix(trimmed, sqlmarker.Comment) {
+		t.Errorf("%s would carry the marker before its leading keyword, "+
+			"where PostgreSQL strips it: %q", what, first80(tagged))
+	}
+}
+
+// first80 truncates SQL for readable failure messages.
+func first80(sql string) string {
+	s := strings.Join(strings.Fields(sql), " ")
+	if len(s) > 80 {
+		return s[:80] + "..."
+	}
+	return s
+}
+
+// TestMetricRegistrySQLIsTaggable walks the whole metric registry and
+// asserts that every latest and historical statement is in a shape that
+// queryInternal can tag. This is the guard for statements added to the
+// registry in future: the tagging happens centrally, so a statement that
+// Tag cannot recognize would silently go unmarked.
+func TestMetricRegistrySQLIsTaggable(t *testing.T) {
+	if len(metricRegistry) == 0 {
+		t.Fatal("metricRegistry is empty")
+	}
+
+	for name, cfg := range metricRegistry {
+		if strings.TrimSpace(cfg.latestSQL) != "" {
+			assertTaggable(t, name+".latestSQL", cfg.latestSQL)
+		}
+		if strings.TrimSpace(cfg.historicalSQL) != "" {
+			assertTaggable(t, name+".historicalSQL", cfg.historicalSQL)
+		}
+	}
+}
+
+// markerTestDatastore returns a Datastore over the integration test
+// database. It is deliberately lighter than
+// newMetricRegistryTestDatastore because the metric scan helpers can be
+// driven with literal SELECTs that touch no tables at all.
+func markerTestDatastore(t *testing.T) *Datastore {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set; skipping")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	return &Datastore{pool: pool}
+}
+
+// TestQueryInternal_TagsSQL proves end-to-end that a registry-style query
+// reaches PostgreSQL with the marker intact, by reading its own entry
+// back out of pg_stat_statements. This is the behavior the server's
+// filter depends on, and the reason the marker sits after the leading
+// keyword rather than in front of the statement.
+func TestQueryInternal_TagsSQL(t *testing.T) {
+	ds := markerTestDatastore(t)
+	ctx := context.Background()
+
+	if _, err := ds.pool.Exec(ctx,
+		"CREATE EXTENSION IF NOT EXISTS pg_stat_statements"); err != nil {
+		t.Skipf("pg_stat_statements unavailable: %v", err)
+	}
+
+	// The statement must be identifiable in the view and must have a
+	// queryid of its own, so it reads from a uniquely named scratch
+	// table. Neither a string literal nor a column alias would do:
+	// literals are normalized into $n placeholders, and aliases do not
+	// contribute to the queryid, so a statement differing only in its
+	// aliases collapses onto an existing entry and keeps that entry's
+	// original text.
+	tag := fmt.Sprintf("marker_probe_%d", time.Now().UnixNano())
+	if _, err := ds.pool.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (
+			connection_id INTEGER,
+			value DOUBLE PRECISION,
+			collected_at TIMESTAMPTZ
+		)`, tag)); err != nil {
+		t.Fatalf("create scratch table: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := ds.pool.Exec(context.Background(),
+			fmt.Sprintf("DROP TABLE IF EXISTS %s", tag)); err != nil {
+			t.Logf("cleanup: drop %s: %v", tag, err)
+		}
+	})
+
+	sql := fmt.Sprintf(
+		"SELECT connection_id, value, collected_at FROM %s", tag)
+
+	rows, err := ds.queryInternal(ctx, sql)
+	if err != nil {
+		t.Fatalf("queryInternal() error = %v", err)
+	}
+	// Drain the result so PostgreSQL finishes executing the statement
+	// and pg_stat_statements records it before the assertion below.
+	for rows.Next() {
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating tagged query: %v", err)
+	}
+
+	var count int
+	err = ds.pool.QueryRow(ctx, `
+        SELECT count(*) FROM pg_stat_statements
+        WHERE query LIKE '%' || $1 || '%'
+          AND query LIKE '%' || $2 || '%'
+    `, tag, sqlmarker.Marker).Scan(&count)
+	if err != nil {
+		t.Fatalf("read pg_stat_statements: %v", err)
+	}
+	if count == 0 {
+		t.Errorf("no pg_stat_statements entry for the tagged query "+
+			"carries %q", sqlmarker.Marker)
+	}
+}
+
+// TestMetricScanHelpers drives each scan helper through its happy path,
+// its query-error path, and its scan-error path. The SQL is literal so
+// the tests do not depend on the metrics schema.
+func TestMetricScanHelpers(t *testing.T) {
+	ds := markerTestDatastore(t)
+	ctx := context.Background()
+
+	t.Run("queryMetricValues", func(t *testing.T) {
+		got, err := ds.queryMetricValues(ctx,
+			"SELECT 7::int, 1.5::float8, now()")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(got) != 1 || got[0].ConnectionID != 7 || got[0].Value != 1.5 {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+
+		if _, err := ds.queryMetricValues(ctx, "SELECT nonsense("); err == nil {
+			t.Error("expected a query error for invalid SQL")
+		}
+		if _, err := ds.queryMetricValues(ctx,
+			"SELECT 'x'::text, 'y'::text, 'z'::text"); err == nil {
+			t.Error("expected a scan error for mistyped columns")
+		}
+	})
+
+	t.Run("queryMetricValuesWithDB", func(t *testing.T) {
+		got, err := ds.queryMetricValuesWithDB(ctx,
+			"SELECT 7::int, 'appdb'::text, 1.5::float8, now()")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(got) != 1 || got[0].DatabaseName == nil ||
+			*got[0].DatabaseName != "appdb" {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+
+		if _, err := ds.queryMetricValuesWithDB(
+			ctx, "SELECT nonsense("); err == nil {
+			t.Error("expected a query error for invalid SQL")
+		}
+		if _, err := ds.queryMetricValuesWithDB(ctx,
+			"SELECT 'x'::text, 'y'::text, 'z'::text, 'w'::text"); err == nil {
+			t.Error("expected a scan error for mistyped columns")
+		}
+	})
+
+	t.Run("queryMetricValuesWithDBAndObject", func(t *testing.T) {
+		got, err := ds.queryMetricValuesWithDBAndObject(ctx,
+			"SELECT 7::int, 'appdb'::text, 'slot_a'::text, "+
+				"1.5::float8, now()")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(got) != 1 || got[0].ObjectName == nil ||
+			*got[0].ObjectName != "slot_a" {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+
+		if _, err := ds.queryMetricValuesWithDBAndObject(
+			ctx, "SELECT nonsense("); err == nil {
+			t.Error("expected a query error for invalid SQL")
+		}
+		if _, err := ds.queryMetricValuesWithDBAndObject(ctx,
+			"SELECT 'x'::text, 'y'::text, 'z'::text, 'w'::text, "+
+				"'v'::text"); err == nil {
+			t.Error("expected a scan error for mistyped columns")
+		}
+	})
+
+	t.Run("queryHistoricalMetricValuesBasic", func(t *testing.T) {
+		got, err := ds.queryHistoricalMetricValuesBasic(ctx,
+			"SELECT 7::int, NULL::text, 1.5::float8, now() "+
+				"WHERE $1::int > 0", 7)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(got) != 1 || got[0].ConnectionID != 7 {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+
+		if _, err := ds.queryHistoricalMetricValuesBasic(
+			ctx, "SELECT nonsense($1", 7); err == nil {
+			t.Error("expected a query error for invalid SQL")
+		}
+		if _, err := ds.queryHistoricalMetricValuesBasic(ctx,
+			"SELECT 'x'::text, 'y'::text, 'z'::text, 'w'::text "+
+				"WHERE $1::int > 0", 7); err == nil {
+			t.Error("expected a scan error for mistyped columns")
+		}
+	})
+
+	t.Run("queryHistoricalMetricValuesWithDB", func(t *testing.T) {
+		got, err := ds.queryHistoricalMetricValuesWithDB(ctx,
+			"SELECT 7::int, 'appdb'::text, 1.5::float8, now() "+
+				"WHERE $1::int > 0", 7)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(got) != 1 || got[0].DatabaseName == nil ||
+			*got[0].DatabaseName != "appdb" {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+
+		if _, err := ds.queryHistoricalMetricValuesWithDB(
+			ctx, "SELECT nonsense($1", 7); err == nil {
+			t.Error("expected a query error for invalid SQL")
+		}
+		if _, err := ds.queryHistoricalMetricValuesWithDB(ctx,
+			"SELECT 'x'::text, 'y'::text, 'z'::text, 'w'::text "+
+				"WHERE $1::int > 0", 7); err == nil {
+			t.Error("expected a scan error for mistyped columns")
+		}
+	})
+}
+
+// TestGetClusterPeers_ScanError covers the scan-error branch of
+// GetClusterPeers, which now runs through queryInternal.
+//
+// The branch is only reachable when a column cannot be scanned into its
+// destination, so the test puts a scratch schema holding a deliberately
+// mistyped connections table ahead of public on the search path. The
+// full schema is still created because the query also reads
+// metrics.pg_node_role, which is schema-qualified and therefore not
+// affected by the search path.
+func TestGetClusterPeers_ScanError(t *testing.T) {
+	_, pool, cleanup := newFullTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	schema := fmt.Sprintf("marker_scan_%d", time.Now().UnixNano())
+
+	// name is boolean rather than text, so scanning it into a string
+	// destination fails on the first row.
+	if _, err := pool.Exec(ctx, fmt.Sprintf(`
+		CREATE SCHEMA %[1]s;
+		CREATE TABLE %[1]s.connections (
+			id INTEGER PRIMARY KEY,
+			name BOOLEAN NOT NULL,
+			cluster_id INTEGER
+		);
+		INSERT INTO %[1]s.connections VALUES (1, TRUE, 10), (2, FALSE, 10);
+	`, schema)); err != nil {
+		t.Fatalf("create scratch schema: %v", err)
+	}
+	// Registered with defer rather than t.Cleanup so the drop runs
+	// while the pool is still open: the fixture's own cleanup closes
+	// the pool, and deferred calls unwind before t.Cleanup functions.
+	defer func() {
+		if _, err := pool.Exec(context.Background(),
+			fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema),
+		); err != nil {
+			t.Logf("cleanup: drop schema %s: %v", schema, err)
+		}
+	}()
+
+	cfg, err := pgxpool.ParseConfig(connStr)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	cfg.ConnConfig.RuntimeParams["search_path"] = schema + ",public"
+	scratchPool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	defer scratchPool.Close()
+
+	ds := &Datastore{pool: scratchPool}
+	if _, err := ds.GetClusterPeers(ctx, 1); err == nil {
+		t.Fatal("expected a scan error, got nil")
+	} else if !strings.Contains(err.Error(), "scan cluster peer") {
+		t.Errorf("error = %v, want a scan failure", err)
+	}
+}

--- a/alerter/src/internal/database/sql_marker_test.go
+++ b/alerter/src/internal/database/sql_marker_test.go
@@ -22,10 +22,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
+
+// assertTagged fails the test unless tagged carries the marker in a
+// position that PostgreSQL preserves when it normalizes the statement
+// for pg_stat_statements, which is to say after the leading keyword
+// rather than in front of it.
+func assertTagged(t *testing.T, what, tagged string) {
+	t.Helper()
+
+	if !strings.Contains(tagged, sqlmarker.Marker) {
+		t.Errorf("%s is not tagged: %q", what, first80(tagged))
+		return
+	}
+	trimmed := strings.TrimLeft(tagged, " \t\r\n")
+	if strings.HasPrefix(trimmed, sqlmarker.Comment) {
+		t.Errorf("%s carries the marker before its leading keyword, "+
+			"where PostgreSQL strips it: %q", what, first80(tagged))
+	}
+}
 
 // assertTaggable fails the test unless Tag inserts the marker into sql
 // after the leading keyword. Registry SQL that fails this check would be
@@ -33,16 +52,84 @@ import (
 func assertTaggable(t *testing.T, what, sql string) {
 	t.Helper()
 
-	tagged := sqlmarker.Tag(sql)
-	if !strings.Contains(tagged, sqlmarker.Marker) {
-		t.Errorf("%s cannot be tagged; it has no leading keyword: %q",
-			what, first80(sql))
-		return
+	assertTagged(t, what, sqlmarker.Tag(sql))
+}
+
+// fakeRowQuerier records the statements handed to it, standing in for
+// the connection pool so the tagging can be asserted without a
+// database. Returning a nil pgx.Rows is safe because the tests that use
+// it call queryTagged directly and never iterate the result.
+type fakeRowQuerier struct {
+	sql  []string
+	args [][]any
+}
+
+func (f *fakeRowQuerier) Query(_ context.Context, sql string,
+	args ...any) (pgx.Rows, error) {
+	f.sql = append(f.sql, sql)
+	f.args = append(f.args, args)
+	return nil, nil
+}
+
+// TestQueryTagged_TagsSQL asserts the chokepoint every registry query
+// passes through tags the statement and forwards its arguments
+// untouched. This needs no database, so it guards the fix on every run,
+// including on servers where pg_stat_statements is not loaded and the
+// end-to-end test below skips.
+func TestQueryTagged_TagsSQL(t *testing.T) {
+	q := &fakeRowQuerier{}
+	ctx := context.Background()
+
+	if _, err := queryTagged(ctx, q,
+		"SELECT connection_id FROM metrics.pg_stat_activity "+
+			"WHERE collected_at > now() - ($1 || ' days')::interval",
+		7); err != nil {
+		t.Fatalf("queryTagged() error = %v", err)
 	}
-	trimmed := strings.TrimLeft(tagged, " \t\r\n")
-	if strings.HasPrefix(trimmed, sqlmarker.Comment) {
-		t.Errorf("%s would carry the marker before its leading keyword, "+
-			"where PostgreSQL strips it: %q", what, first80(tagged))
+
+	if len(q.sql) != 1 {
+		t.Fatalf("recorded %d statements, want 1", len(q.sql))
+	}
+	assertTagged(t, "queryTagged statement", q.sql[0])
+	if !strings.HasPrefix(q.sql[0], "SELECT "+sqlmarker.Comment+" ") {
+		t.Errorf("marker is not immediately after the keyword: %q",
+			first80(q.sql[0]))
+	}
+	if len(q.args[0]) != 1 || q.args[0][0] != 7 {
+		t.Errorf("args = %v, want [7]", q.args[0])
+	}
+}
+
+// TestQueryTagged_TagsEveryRegistryStatement drives every statement in
+// the metric registry through the real chokepoint with a fake pool, so
+// the tagging of the alerter's whole metric-evaluation surface is
+// verified without a database. It complements
+// TestMetricRegistrySQLIsTaggable, which checks only that Tag can
+// handle the SQL, by proving that the code path actually applies it.
+func TestQueryTagged_TagsEveryRegistryStatement(t *testing.T) {
+	if len(metricRegistry) == 0 {
+		t.Fatal("metricRegistry is empty")
+	}
+	ctx := context.Background()
+
+	for name, cfg := range metricRegistry {
+		for label, sql := range map[string]string{
+			name + ".latestSQL":     cfg.latestSQL,
+			name + ".historicalSQL": cfg.historicalSQL,
+		} {
+			if strings.TrimSpace(sql) == "" {
+				continue
+			}
+			q := &fakeRowQuerier{}
+			if _, err := queryTagged(ctx, q, sql, 1); err != nil {
+				t.Fatalf("queryTagged(%s) error = %v", label, err)
+			}
+			if len(q.sql) != 1 {
+				t.Fatalf("%s recorded %d statements, want 1",
+					label, len(q.sql))
+			}
+			assertTagged(t, label, q.sql[0])
+		}
 	}
 }
 
@@ -104,19 +191,48 @@ func markerTestDatastore(t *testing.T) *Datastore {
 	return &Datastore{pool: pool}
 }
 
+// requirePgStatStatements skips the test unless pg_stat_statements is
+// both installed and readable on the test server.
+//
+// Readability has to be established by actually reading the view rather
+// than by inspecting shared_preload_libraries or pg_extension, because
+// the extension can be created successfully and still raise SQLSTATE
+// 55000 ("must be loaded via shared_preload_libraries") on every
+// select. That is exactly how the CI PostgreSQL containers are
+// configured, and probing the read also covers the extension being
+// absent, unprivileged, or otherwise unusable, for whatever reason.
+func requirePgStatStatements(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx,
+		"CREATE EXTENSION IF NOT EXISTS pg_stat_statements"); err != nil {
+		t.Skipf("skipping end-to-end marker check: the "+
+			"pg_stat_statements extension cannot be created: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		"SELECT count(*) FROM pg_stat_statements"); err != nil {
+		t.Skipf("skipping end-to-end marker check: the "+
+			"pg_stat_statements view is not readable, most likely "+
+			"because the library is not listed in "+
+			"shared_preload_libraries: %v", err)
+	}
+}
+
 // TestQueryInternal_TagsSQL proves end-to-end that a registry-style query
 // reaches PostgreSQL with the marker intact, by reading its own entry
 // back out of pg_stat_statements. This is the behavior the server's
 // filter depends on, and the reason the marker sits after the leading
 // keyword rather than in front of the statement.
+//
+// The test skips where pg_stat_statements is not loaded; the tagging
+// itself is asserted unconditionally by TestQueryTagged_TagsSQL and
+// TestQueryTagged_TagsEveryRegistryStatement above.
 func TestQueryInternal_TagsSQL(t *testing.T) {
 	ds := markerTestDatastore(t)
 	ctx := context.Background()
 
-	if _, err := ds.pool.Exec(ctx,
-		"CREATE EXTENSION IF NOT EXISTS pg_stat_statements"); err != nil {
-		t.Skipf("pg_stat_statements unavailable: %v", err)
-	}
+	requirePgStatStatements(t, ds.pool)
 
 	// The statement must be identifiable in the view and must have a
 	// queryid of its own, so it reads from a uniquely named scratch
@@ -126,23 +242,29 @@ func TestQueryInternal_TagsSQL(t *testing.T) {
 	// aliases collapses onto an existing entry and keeps that entry's
 	// original text.
 	tag := fmt.Sprintf("marker_probe_%d", time.Now().UnixNano())
+	tagIdent := pgx.Identifier{tag}.Sanitize()
+	// The relation name is generated from a timestamp above and quoted
+	// with pgx.Identifier; CREATE TABLE cannot name its relation with a
+	// bind parameter.
+	//nosemgrep: go_sql_rule-concat-sqli -- test-only DDL; timestamp-derived name sanitized by pgx.Identifier
 	if _, err := ds.pool.Exec(ctx, fmt.Sprintf(
 		`CREATE TABLE %s (
 			connection_id INTEGER,
 			value DOUBLE PRECISION,
 			collected_at TIMESTAMPTZ
-		)`, tag)); err != nil {
+		)`, tagIdent)); err != nil {
 		t.Fatalf("create scratch table: %v", err)
 	}
 	t.Cleanup(func() {
+		//nosemgrep: go_sql_rule-concat-sqli -- test-only DDL; same sanitized identifier as the CREATE above
 		if _, err := ds.pool.Exec(context.Background(),
-			fmt.Sprintf("DROP TABLE IF EXISTS %s", tag)); err != nil {
-			t.Logf("cleanup: drop %s: %v", tag, err)
+			fmt.Sprintf("DROP TABLE IF EXISTS %s", tagIdent)); err != nil {
+			t.Logf("cleanup: drop %s: %v", tagIdent, err)
 		}
 	})
 
 	sql := fmt.Sprintf(
-		"SELECT connection_id, value, collected_at FROM %s", tag)
+		"SELECT connection_id, value, collected_at FROM %s", tagIdent)
 
 	rows, err := ds.queryInternal(ctx, sql)
 	if err != nil {
@@ -158,6 +280,9 @@ func TestQueryInternal_TagsSQL(t *testing.T) {
 	}
 
 	var count int
+	// The SQL is a fixed literal; the table name and the marker are
+	// bound as $1 and $2 rather than concatenated into it.
+	//nosemgrep: go_sql_rule-concat-sqli -- fixed SQL literal; table name and marker bound as $1 and $2
 	err = ds.pool.QueryRow(ctx, `
         SELECT count(*) FROM pg_stat_statements
         WHERE query LIKE '%' || $1 || '%'
@@ -304,9 +429,13 @@ func TestGetClusterPeers_ScanError(t *testing.T) {
 	ctx := context.Background()
 	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
 	schema := fmt.Sprintf("marker_scan_%d", time.Now().UnixNano())
+	schemaIdent := pgx.Identifier{schema}.Sanitize()
 
 	// name is boolean rather than text, so scanning it into a string
-	// destination fails on the first row.
+	// destination fails on the first row. The schema name is generated
+	// from a timestamp above and quoted with pgx.Identifier; CREATE
+	// SCHEMA cannot name its schema with a bind parameter.
+	//nosemgrep: go_sql_rule-concat-sqli -- test-only DDL; timestamp-derived schema name sanitized by pgx.Identifier
 	if _, err := pool.Exec(ctx, fmt.Sprintf(`
 		CREATE SCHEMA %[1]s;
 		CREATE TABLE %[1]s.connections (
@@ -315,15 +444,16 @@ func TestGetClusterPeers_ScanError(t *testing.T) {
 			cluster_id INTEGER
 		);
 		INSERT INTO %[1]s.connections VALUES (1, TRUE, 10), (2, FALSE, 10);
-	`, schema)); err != nil {
+	`, schemaIdent)); err != nil {
 		t.Fatalf("create scratch schema: %v", err)
 	}
 	// Registered with defer rather than t.Cleanup so the drop runs
 	// while the pool is still open: the fixture's own cleanup closes
 	// the pool, and deferred calls unwind before t.Cleanup functions.
 	defer func() {
+		//nosemgrep: go_sql_rule-concat-sqli -- test-only DDL; same sanitized schema identifier as the CREATE above
 		if _, err := pool.Exec(context.Background(),
-			fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema),
+			fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schemaIdent),
 		); err != nil {
 			t.Logf("cleanup: drop schema %s: %v", schema, err)
 		}

--- a/collector/src/database/datastore.go
+++ b/collector/src/database/datastore.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pgedge/ai-workbench/pkg/connstring"
 	"github.com/pgedge/ai-workbench/pkg/datastoreconfig"
 	"github.com/pgedge/ai-workbench/pkg/logger"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
 
 // Config interface defines the minimal configuration needed by Datastore
@@ -176,6 +177,33 @@ func (ds *Datastore) Close() {
 	}
 }
 
+// The collector re-reads its own connections table on every collection
+// cycle and writes back connection errors, so those statements are
+// tagged as Workbench-internal to keep them out of the server's Top
+// Queries panel when monitoring queries are hidden. See sqlmarker.Tag
+// for why the marker sits immediately after the leading keyword.
+var (
+	monitoredConnectionsQuery = sqlmarker.Tag(`
+        SELECT id, name, host, hostaddr, port, database_name, username,
+               password_encrypted, sslmode, sslcert, sslkey, sslrootcert,
+               owner_username, owner_token, updated_at, connection_error
+        FROM connections
+        WHERE is_monitored = TRUE
+    `)
+
+	monitoredConnectionByIDQuery = sqlmarker.Tag(`
+        SELECT id, name, host, hostaddr, port, database_name, username,
+               password_encrypted, sslmode, sslcert, sslkey, sslrootcert,
+               owner_username, owner_token, updated_at, connection_error
+        FROM connections
+        WHERE id = $1 AND is_monitored = TRUE
+    `)
+
+	setConnectionErrorStatement = sqlmarker.Tag(
+		"UPDATE connections SET connection_error = $1, " +
+			"updated_at = NOW() WHERE id = $2")
+)
+
 // GetMonitoredConnections returns all connections that should be monitored
 func (ds *Datastore) GetMonitoredConnections() ([]MonitoredConnection, error) {
 	conn, err := ds.GetConnection()
@@ -186,13 +214,7 @@ func (ds *Datastore) GetMonitoredConnections() ([]MonitoredConnection, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	rows, err := conn.Query(ctx, `
-        SELECT id, name, host, hostaddr, port, database_name, username,
-               password_encrypted, sslmode, sslcert, sslkey, sslrootcert,
-               owner_username, owner_token, updated_at, connection_error
-        FROM connections
-        WHERE is_monitored = TRUE
-    `)
+	rows, err := conn.Query(ctx, monitoredConnectionsQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query monitored connections: %w", err)
 	}
@@ -227,13 +249,8 @@ func (ds *Datastore) GetMonitoredConnectionByID(connectionID int) (MonitoredConn
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	var c MonitoredConnection
-	err = conn.QueryRow(ctx, `
-        SELECT id, name, host, hostaddr, port, database_name, username,
-               password_encrypted, sslmode, sslcert, sslkey, sslrootcert,
-               owner_username, owner_token, updated_at, connection_error
-        FROM connections
-        WHERE id = $1 AND is_monitored = TRUE
-    `, connectionID).Scan(
+	err = conn.QueryRow(ctx, monitoredConnectionByIDQuery,
+		connectionID).Scan(
 		&c.ID, &c.Name, &c.Host, &c.HostAddr, &c.Port,
 		&c.DatabaseName, &c.Username, &c.PasswordEncrypted,
 		&c.SSLMode, &c.SSLCert, &c.SSLKey, &c.SSLRootCert,
@@ -250,8 +267,7 @@ func (ds *Datastore) GetMonitoredConnectionByID(connectionID int) (MonitoredConn
 // SetConnectionError updates the connection_error column for a connection.
 // Pass nil to clear the error, or a string pointer to set it.
 func SetConnectionError(ctx context.Context, conn *pgxpool.Conn, connectionID int, errorMsg *string) error {
-	_, err := conn.Exec(ctx,
-		"UPDATE connections SET connection_error = $1, updated_at = NOW() WHERE id = $2",
+	_, err := conn.Exec(ctx, setConnectionErrorStatement,
 		errorMsg, connectionID)
 	return err
 }

--- a/collector/src/database/probe_availability.go
+++ b/collector/src/database/probe_availability.go
@@ -14,7 +14,28 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
+
+// probeAvailabilityUpsert records probe availability for a monitored
+// connection. It runs once per probe per collection cycle against the
+// Workbench's own datastore, so it is tagged as Workbench-internal to
+// keep it out of the server's Top Queries panel when monitoring queries
+// are hidden; see sqlmarker.Tag for why the marker sits immediately
+// after the leading keyword.
+var probeAvailabilityUpsert = sqlmarker.Tag(`
+        INSERT INTO probe_availability
+            (connection_id, database_name, probe_name, extension_name,
+             is_available, last_checked, last_collected, unavailable_reason)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        ON CONFLICT (connection_id, database_name, probe_name)
+        DO UPDATE SET
+            extension_name = EXCLUDED.extension_name,
+            is_available = EXCLUDED.is_available,
+            last_checked = EXCLUDED.last_checked,
+            last_collected = COALESCE(EXCLUDED.last_collected, probe_availability.last_collected),
+            unavailable_reason = EXCLUDED.unavailable_reason
+    `)
 
 // UpsertProbeAvailability records the availability status of a probe for
 // a monitored connection. It inserts a new row or updates an existing one
@@ -37,19 +58,8 @@ func UpsertProbeAvailability(ctx context.Context, conn *pgxpool.Conn, connection
 		dbName = *databaseName
 	}
 
-	_, err := conn.Exec(ctx, `
-        INSERT INTO probe_availability
-            (connection_id, database_name, probe_name, extension_name,
-             is_available, last_checked, last_collected, unavailable_reason)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-        ON CONFLICT (connection_id, database_name, probe_name)
-        DO UPDATE SET
-            extension_name = EXCLUDED.extension_name,
-            is_available = EXCLUDED.is_available,
-            last_checked = EXCLUDED.last_checked,
-            last_collected = COALESCE(EXCLUDED.last_collected, probe_availability.last_collected),
-            unavailable_reason = EXCLUDED.unavailable_reason
-    `, connectionID, dbName, probeName, extensionName,
+	_, err := conn.Exec(ctx, probeAvailabilityUpsert,
+		connectionID, dbName, probeName, extensionName,
 		isAvailable, now, lastCollected, unavailableReason)
 
 	return err

--- a/collector/src/database/probe_availability_test.go
+++ b/collector/src/database/probe_availability_test.go
@@ -1,0 +1,204 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
+)
+
+// seedProbeAvailabilityConnection clears the connections table and
+// inserts a single monitored connection, returning its ID.
+func seedProbeAvailabilityConnection(t *testing.T, ds *Datastore) int {
+	t.Helper()
+
+	conn, err := ds.GetConnection()
+	if err != nil {
+		t.Fatalf("GetConnection() error = %v", err)
+	}
+	defer ds.ReturnConnection(conn)
+
+	ctx := context.Background()
+	if _, err := conn.Exec(ctx, "DELETE FROM connections"); err != nil {
+		t.Fatalf("cleanup error = %v", err)
+	}
+
+	var id int
+	err = conn.QueryRow(ctx, `
+		INSERT INTO connections
+			(name, host, port, database_name, username, owner_username,
+			 is_monitored)
+		VALUES ('probe-avail', 'h', 5432, 'd', 'u', 'o', TRUE)
+		RETURNING id
+	`).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed error = %v", err)
+	}
+	return id
+}
+
+// TestUpsertProbeAvailability covers the insert path, the ON CONFLICT
+// update path, and the nil-databaseName coalescing that makes the
+// unique constraint match for server-level probes.
+func TestUpsertProbeAvailability(t *testing.T) {
+	ds := newDatastoreForTest(t)
+	connectionID := seedProbeAvailabilityConnection(t, ds)
+
+	conn, err := ds.GetConnection()
+	if err != nil {
+		t.Fatalf("GetConnection() error = %v", err)
+	}
+	defer ds.ReturnConnection(conn)
+
+	ctx := context.Background()
+	dbName := "appdb"
+	extName := "pg_stat_statements"
+	reason := "extension missing"
+
+	// Insert: available, with a database name.
+	if err := UpsertProbeAvailability(ctx, conn, connectionID, &dbName,
+		"pg_stat_statements", &extName, true, nil); err != nil {
+		t.Fatalf("UpsertProbeAvailability(insert) error = %v", err)
+	}
+
+	var rows int
+	var isAvailable bool
+	var lastCollected *string
+	err = conn.QueryRow(ctx, `
+		SELECT count(*), bool_and(is_available),
+		       max(last_collected)::text
+		FROM probe_availability
+		WHERE connection_id = $1 AND probe_name = 'pg_stat_statements'
+	`, connectionID).Scan(&rows, &isAvailable, &lastCollected)
+	if err != nil {
+		t.Fatalf("readback error = %v", err)
+	}
+	if rows != 1 || !isAvailable {
+		t.Fatalf("rows = %d, isAvailable = %v; want 1, true",
+			rows, isAvailable)
+	}
+	if lastCollected == nil {
+		t.Error("expected last_collected to be set for an available probe")
+	}
+
+	// Upsert the same key as unavailable: the row must be updated in
+	// place and last_collected preserved.
+	if err := UpsertProbeAvailability(ctx, conn, connectionID, &dbName,
+		"pg_stat_statements", &extName, false, &reason); err != nil {
+		t.Fatalf("UpsertProbeAvailability(update) error = %v", err)
+	}
+
+	var gotReason *string
+	var stillCollected *string
+	err = conn.QueryRow(ctx, `
+		SELECT count(*), bool_and(is_available), max(unavailable_reason),
+		       max(last_collected)::text
+		FROM probe_availability
+		WHERE connection_id = $1 AND probe_name = 'pg_stat_statements'
+	`, connectionID).Scan(&rows, &isAvailable, &gotReason, &stillCollected)
+	if err != nil {
+		t.Fatalf("readback error = %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("rows = %d, want 1 after the upsert", rows)
+	}
+	if isAvailable {
+		t.Error("expected is_available to be false after the upsert")
+	}
+	if gotReason == nil || *gotReason != reason {
+		t.Errorf("unavailable_reason = %v, want %q", gotReason, reason)
+	}
+	if stillCollected == nil {
+		t.Error("expected last_collected to be preserved")
+	}
+
+	// A nil database name must be coalesced to an empty string so the
+	// unique constraint still matches on a second call.
+	for i := 0; i < 2; i++ {
+		if err := UpsertProbeAvailability(ctx, conn, connectionID, nil,
+			"pg_server_info", nil, true, nil); err != nil {
+			t.Fatalf("UpsertProbeAvailability(server-level) error = %v", err)
+		}
+	}
+	err = conn.QueryRow(ctx, `
+		SELECT count(*) FROM probe_availability
+		WHERE connection_id = $1 AND probe_name = 'pg_server_info'
+	`, connectionID).Scan(&rows)
+	if err != nil {
+		t.Fatalf("readback error = %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("rows = %d, want 1 for the server-level probe", rows)
+	}
+}
+
+// TestUpsertProbeAvailability_Error covers the error return by pointing
+// the upsert at a connection ID that violates the foreign key.
+func TestUpsertProbeAvailability_Error(t *testing.T) {
+	ds := newDatastoreForTest(t)
+	seedProbeAvailabilityConnection(t, ds)
+
+	conn, err := ds.GetConnection()
+	if err != nil {
+		t.Fatalf("GetConnection() error = %v", err)
+	}
+	defer ds.ReturnConnection(conn)
+
+	err = UpsertProbeAvailability(context.Background(), conn, 999_999,
+		nil, "pg_server_info", nil, true, nil)
+	if err == nil {
+		t.Fatal("expected a foreign key violation, got nil")
+	}
+}
+
+// TestProbeAvailabilityUpsertIsTagged asserts the upsert statement
+// carries the Workbench-internal marker, in the position that
+// pg_stat_statements preserves. See GitHub issue #364.
+func TestProbeAvailabilityUpsertIsTagged(t *testing.T) {
+	if !strings.Contains(probeAvailabilityUpsert, sqlmarker.Marker) {
+		t.Fatalf("probe availability upsert is untagged: %s",
+			probeAvailabilityUpsert)
+	}
+	trimmed := strings.TrimLeft(probeAvailabilityUpsert, " \t\r\n")
+	if strings.HasPrefix(trimmed, sqlmarker.Comment) {
+		t.Errorf("marker precedes the leading keyword, where "+
+			"PostgreSQL strips it: %s", probeAvailabilityUpsert)
+	}
+	if !strings.HasPrefix(trimmed, "INSERT "+sqlmarker.Comment) {
+		t.Errorf("marker is not immediately after the keyword: %s",
+			probeAvailabilityUpsert)
+	}
+}
+
+// TestConnectionQueriesAreTagged asserts the collector's recurring reads
+// and writes against its own connections table carry the marker.
+func TestConnectionQueriesAreTagged(t *testing.T) {
+	cases := map[string]string{
+		"monitoredConnectionsQuery":    monitoredConnectionsQuery,
+		"monitoredConnectionByIDQuery": monitoredConnectionByIDQuery,
+		"setConnectionErrorStatement":  setConnectionErrorStatement,
+	}
+
+	for name, sql := range cases {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(sql, sqlmarker.Marker) {
+				t.Fatalf("%s is untagged: %s", name, sql)
+			}
+			trimmed := strings.TrimLeft(sql, " \t\r\n")
+			if strings.HasPrefix(trimmed, sqlmarker.Comment) {
+				t.Errorf("%s carries the marker before the leading "+
+					"keyword: %s", name, sql)
+			}
+		})
+	}
+}

--- a/collector/src/probes/base.go
+++ b/collector/src/probes/base.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
 
 // WrapQuery wraps a SQL query with a probe marker column so the server
@@ -29,7 +31,7 @@ func WrapQuery(probeName, query string) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"SELECT '%s' AS ai_dba_wb_probe, subq.* FROM (%s) AS subq",
+		"SELECT '%s' AS "+sqlmarker.ProbeAlias+", subq.* FROM (%s) AS subq",
 		probeName, query,
 	)
 }

--- a/collector/src/probes/change_tracking.go
+++ b/collector/src/probes/change_tracking.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/collector/src/utils"
 	"github.com/pgedge/ai-workbench/pkg/logger"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
 
 // probeMarkerColumn is the column name injected by WrapQuery into
@@ -68,8 +69,11 @@ func HasDataChanged(
 			"failed to compute current metrics hash: %w", err)
 	}
 
+	// The stored-snapshot read runs against the Workbench's own
+	// datastore, so tag it as internal to keep it out of the Top
+	// Queries panel when monitoring queries are hidden.
 	rows, err := datastoreConn.Query(
-		ctx, fetchStoredQuery, connectionID)
+		ctx, sqlmarker.Tag(fetchStoredQuery), connectionID)
 	if err != nil {
 		return false, fmt.Errorf(
 			"failed to query most recent data: %w", err)

--- a/collector/src/probes/change_tracking.go
+++ b/collector/src/probes/change_tracking.go
@@ -24,7 +24,7 @@ import (
 // column, so it must be stripped before hashing or the live and
 // stored hashes will never match and change-detection will misfire on
 // every collection cycle. See WrapQuery in base.go.
-const probeMarkerColumn = "ai_dba_wb_probe"
+const probeMarkerColumn = sqlmarker.ProbeAlias
 
 // HasDataChanged checks whether currentMetrics differ from the
 // most recently stored data for the given connection. The

--- a/collector/src/probes/config_loader.go
+++ b/collector/src/probes/config_loader.go
@@ -270,14 +270,19 @@ func getDefaultInterval(probeName string) int {
 // Workbench-internal to keep it out of the server's Top Queries panel
 // when monitoring queries are hidden.
 //
+// The probe name names the metrics table, so it is quoted with
+// pgx.Identifier rather than bound: a relation cannot be supplied as a
+// placeholder. The connection ID is bound as $1.
+//
 // #nosec G201 - the probe name is not user-provided; it comes from the
-// probe definitions compiled into the collector.
+// probe definitions compiled into the collector, and it is quoted by
+// pgx.Identifier.
 func lastCollectionTimeQuery(probeName string) string {
 	return sqlmarker.Tag(fmt.Sprintf(`
         SELECT MAX(collected_at)
-        FROM metrics.%s
+        FROM %s
         WHERE connection_id = $1
-    `, probeName))
+    `, pgx.Identifier{"metrics", probeName}.Sanitize()))
 }
 
 // GetLastCollectionTime queries the last collection timestamp for a probe/connection pair

--- a/collector/src/probes/config_loader.go
+++ b/collector/src/probes/config_loader.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/pkg/logger"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
 
 // loadProbeConfigsQuery is the SELECT used by LoadProbeConfigs.
@@ -263,18 +264,28 @@ func getDefaultInterval(probeName string) int {
 	return 300 // Default 5 minutes
 }
 
+// lastCollectionTimeQuery builds the query used by
+// GetLastCollectionTime. The statement runs against the Workbench's own
+// datastore on every scheduling decision, so it is tagged as
+// Workbench-internal to keep it out of the server's Top Queries panel
+// when monitoring queries are hidden.
+//
+// #nosec G201 - the probe name is not user-provided; it comes from the
+// probe definitions compiled into the collector.
+func lastCollectionTimeQuery(probeName string) string {
+	return sqlmarker.Tag(fmt.Sprintf(`
+        SELECT MAX(collected_at)
+        FROM metrics.%s
+        WHERE connection_id = $1
+    `, probeName))
+}
+
 // GetLastCollectionTime queries the last collection timestamp for a probe/connection pair
 // Returns the timestamp of the most recent metrics collection, or zero time if no data exists
 func GetLastCollectionTime(ctx context.Context, conn *pgxpool.Conn, probeName string, connectionID int) (time.Time, error) {
-	tableName := fmt.Sprintf("metrics.%s", probeName)
-
 	// Query the maximum collected_at timestamp for this probe and connection
 	var lastCollected *time.Time
-	query := fmt.Sprintf(`
-        SELECT MAX(collected_at)
-        FROM %s
-        WHERE connection_id = $1
-    `, tableName)
+	query := lastCollectionTimeQuery(probeName)
 
 	err := conn.QueryRow(ctx, query, connectionID).Scan(&lastCollected)
 	if err != nil {

--- a/collector/src/probes/config_loader.go
+++ b/collector/src/probes/config_loader.go
@@ -274,10 +274,13 @@ func getDefaultInterval(probeName string) int {
 // pgx.Identifier rather than bound: a relation cannot be supplied as a
 // placeholder. The connection ID is bound as $1.
 //
-// #nosec G201 - the probe name is not user-provided; it comes from the
-// probe definitions compiled into the collector, and it is quoted by
-// pgx.Identifier.
+// The G201 suppression below sits on the formatting call itself rather
+// than on this comment, because a doc-comment annotation would silence
+// the rule for the whole function body.
 func lastCollectionTimeQuery(probeName string) string {
+	// #nosec G201 -- the probe name is not user-provided; it comes from
+	// the probe definitions compiled into the collector, and it is
+	// quoted by pgx.Identifier.
 	return sqlmarker.Tag(fmt.Sprintf(`
         SELECT MAX(collected_at)
         FROM %s

--- a/collector/src/probes/integration_helpers_test.go
+++ b/collector/src/probes/integration_helpers_test.go
@@ -278,6 +278,27 @@ func acquireConn(t *testing.T, pool *pgxpool.Pool) *pgxpool.Conn {
 	return conn
 }
 
+// requirePgStatStatementsReadable skips the test unless the
+// pg_stat_statements view can actually be read on conn.
+//
+// The check has to be a real read rather than an inspection of
+// shared_preload_libraries or pg_extension, because CREATE EXTENSION
+// can succeed whilst every select on the view still raises SQLSTATE
+// 55000 ("must be loaded via shared_preload_libraries"). That is how
+// the CI PostgreSQL containers are configured, and probing the read
+// also covers the extension being absent, unprivileged, or otherwise
+// unusable for any other reason.
+func requirePgStatStatementsReadable(t *testing.T, conn *pgxpool.Conn) {
+	t.Helper()
+
+	if _, err := conn.Exec(context.Background(),
+		"SELECT count(*) FROM pg_stat_statements"); err != nil {
+		t.Skipf("skipping: the pg_stat_statements view is not readable "+
+			"on this server, most likely because the library is not "+
+			"listed in shared_preload_libraries: %v", err)
+	}
+}
+
 // applyMetricsSchema creates the minimal `metrics` schema and the
 // partitioned parent tables required by every probe Store path. The
 // schema deliberately mirrors the production DDL only for columns

--- a/collector/src/probes/partition.go
+++ b/collector/src/probes/partition.go
@@ -79,10 +79,13 @@ var partitionExistsQuery = sqlmarker.Tag(`
 // pgx.Identifier, and the range bounds are formatted from time.Time
 // values, so no caller-supplied text reaches the statement verbatim.
 //
-// #nosec G201 - the table name comes from a probe definition, both
-// identifiers are quoted by pgx.Identifier, and DDL cannot bind an
-// identifier as a placeholder.
+// The G201 suppression below sits on the formatting call itself rather
+// than on this comment, because a doc-comment annotation would silence
+// the rule for the whole function body.
 func createPartitionSQL(partitionName, tableName string, weekStart, weekEnd time.Time) string {
+	// #nosec G201 -- the table name comes from a probe definition, both
+	// identifiers are quoted by pgx.Identifier, and DDL cannot bind an
+	// identifier as a placeholder.
 	return sqlmarker.Tag(fmt.Sprintf(`
         CREATE TABLE IF NOT EXISTS %s
         PARTITION OF %s
@@ -105,11 +108,14 @@ func dropPartitionSQL(partitionName string) string {
 // per connection. The relation name is quoted with pgx.Identifier
 // because a table cannot be named by a bind parameter.
 //
-// #nosec G201 - the table name comes from a probe definition and is
-// quoted by pgx.Identifier; a relation cannot be bound as a
-// placeholder.
+// The G201 suppression below sits on the formatting call itself rather
+// than on this comment, because a doc-comment annotation would silence
+// the rule for the whole function body.
 func protectedPartitionsQuery(tableName string) string {
 	table := pgx.Identifier{"metrics", tableName}.Sanitize()
+	// #nosec G201 -- the table name comes from a probe definition and is
+	// quoted by pgx.Identifier; a relation cannot be bound as a
+	// placeholder.
 	return sqlmarker.Tag(fmt.Sprintf(`
         SELECT DISTINCT
             c.relname AS partition_name

--- a/collector/src/probes/partition.go
+++ b/collector/src/probes/partition.go
@@ -75,16 +75,20 @@ var partitionExistsQuery = sqlmarker.Tag(`
     `)
 
 // createPartitionSQL builds the tagged DDL that attaches a weekly
-// partition to a metrics table.
+// partition to a metrics table. Both relation names are quoted with
+// pgx.Identifier, and the range bounds are formatted from time.Time
+// values, so no caller-supplied text reaches the statement verbatim.
 //
-// #nosec G201 - table names are not user-provided, they come from probe
-// definitions, and the bounds are formatted from time.Time values.
-func createPartitionSQL(fullPartitionName, fullTableName string, weekStart, weekEnd time.Time) string {
+// #nosec G201 - the table name comes from a probe definition, both
+// identifiers are quoted by pgx.Identifier, and DDL cannot bind an
+// identifier as a placeholder.
+func createPartitionSQL(partitionName, tableName string, weekStart, weekEnd time.Time) string {
 	return sqlmarker.Tag(fmt.Sprintf(`
         CREATE TABLE IF NOT EXISTS %s
         PARTITION OF %s
         FOR VALUES FROM ('%s') TO ('%s')
-    `, fullPartitionName, fullTableName,
+    `, pgx.Identifier{"metrics", partitionName}.Sanitize(),
+		pgx.Identifier{"metrics", tableName}.Sanitize(),
 		weekStart.Format(partitionBoundLayout),
 		weekEnd.Format(partitionBoundLayout)))
 }
@@ -98,30 +102,33 @@ func dropPartitionSQL(partitionName string) string {
 
 // protectedPartitionsQuery builds the tagged query that finds, for a
 // change-tracked probe, the partitions holding the most recent sample
-// per connection.
+// per connection. The relation name is quoted with pgx.Identifier
+// because a table cannot be named by a bind parameter.
 //
-// #nosec G201 - the table name comes from a probe definition.
+// #nosec G201 - the table name comes from a probe definition and is
+// quoted by pgx.Identifier; a relation cannot be bound as a
+// placeholder.
 func protectedPartitionsQuery(tableName string) string {
+	table := pgx.Identifier{"metrics", tableName}.Sanitize()
 	return sqlmarker.Tag(fmt.Sprintf(`
         SELECT DISTINCT
             c.relname AS partition_name
         FROM (
             SELECT connection_id, MAX(collected_at) as max_collected_at
-            FROM metrics.%s
+            FROM %[1]s
             GROUP BY connection_id
         ) latest
-        JOIN metrics.%s tbl ON tbl.connection_id = latest.connection_id
+        JOIN %[1]s tbl ON tbl.connection_id = latest.connection_id
             AND tbl.collected_at = latest.max_collected_at
         JOIN pg_class c ON c.oid = tbl.tableoid
-    `, tableName, tableName))
+    `, table))
 }
 
-// partitionCandidatesQuery builds the tagged catalog query listing every
-// partition of tableName together with its bound expression.
-//
-// #nosec G201 - the table name comes from a probe definition.
-func partitionCandidatesQuery(tableName string) string {
-	return sqlmarker.Tag(fmt.Sprintf(`
+// partitionCandidatesQuery is the tagged catalog query listing every
+// partition of a parent table together with its bound expression. The
+// parent name is compared as a value rather than interpolated as an
+// identifier, so it binds as $1.
+var partitionCandidatesQuery = sqlmarker.Tag(`
         SELECT
             c.relname AS partition_name,
             pg_get_expr(c.relpartbound, c.oid) AS partition_bound
@@ -130,22 +137,23 @@ func partitionCandidatesQuery(tableName string) string {
         JOIN pg_inherits i ON c.oid = i.inhrelid
         JOIN pg_class p ON i.inhparent = p.oid
         WHERE n.nspname = 'metrics'
-        AND p.relname = '%s'
+        AND p.relname = $1
         AND c.relkind = 'r'
         ORDER BY c.relname
-    `, tableName))
-}
+    `)
 
 // EnsurePartition creates a partition for the given week if it doesn't exist
 func EnsurePartition(ctx context.Context, conn DatastoreQuerier, tableName string, timestamp time.Time) error {
 	nameSuffix, weekStart, weekEnd := weeklyPartitionBounds(timestamp)
 
 	partitionName := fmt.Sprintf("%s_%s", tableName, nameSuffix)
-	fullTableName := fmt.Sprintf("metrics.%s", tableName)
-	fullPartitionName := fmt.Sprintf("metrics.%s", partitionName)
 
 	// Check if partition already exists
 	var exists bool
+	// partitionExistsQuery is a fixed SQL literal that is only non-constant
+	// because sqlmarker.Tag inserts the internal marker comment into it;
+	// the partition name is bound as $1 and never interpolated.
+	//nosemgrep: go_sql_rule-concat-sqli -- fixed literal tagged by sqlmarker.Tag; partition name bound as $1
 	err := conn.QueryRow(ctx, partitionExistsQuery, partitionName).Scan(&exists)
 	if err != nil {
 		return fmt.Errorf("failed to check if partition exists: %w", err)
@@ -157,8 +165,12 @@ func EnsurePartition(ctx context.Context, conn DatastoreQuerier, tableName strin
 
 	// Create the partition
 	createSQL := createPartitionSQL(
-		fullPartitionName, fullTableName, weekStart, weekEnd)
+		partitionName, tableName, weekStart, weekEnd)
 
+	// createPartitionSQL interpolates only an internal probe table name,
+	// quoted with pgx.Identifier, and range bounds formatted from
+	// time.Time; CREATE TABLE cannot name a relation with a placeholder.
+	//nosemgrep: go_sql_rule-concat-sqli -- DDL identifiers come from probe definitions and are sanitized by pgx.Identifier
 	_, err = conn.Exec(ctx, createSQL)
 	if err != nil {
 		// Check if this is a "relation already exists" error (42P07)
@@ -220,6 +232,10 @@ func DropExpiredPartitions(ctx context.Context, conn DatastoreQuerier, tableName
 			continue
 		}
 
+		// c.name is a partition name read back from pg_class, and
+		// dropPartitionSQL quotes it with pgx.Identifier; DROP TABLE
+		// cannot name its relation with a bind parameter.
+		//nosemgrep: go_sql_rule-concat-sqli -- partition name comes from pg_class and is sanitized by pgx.Identifier
 		if _, err := conn.Exec(ctx, dropPartitionSQL(c.name)); err != nil {
 			logger.Errorf("Warning: failed to drop partition %s: %v", c.name, err)
 			continue
@@ -260,6 +276,10 @@ func loadProtectedPartitions(ctx context.Context, conn DatastoreQuerier, tableNa
 		return protected, nil
 	}
 
+	// tableName is one of the four change-tracked probe names matched by
+	// the switch above, and protectedPartitionsQuery quotes it with
+	// pgx.Identifier; a relation cannot be bound as a placeholder.
+	//nosemgrep: go_sql_rule-concat-sqli -- table name is one of four internal probe names, sanitized by pgx.Identifier
 	rows, err := conn.Query(ctx, protectedPartitionsQuery(tableName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query protected partitions for %s: %w", tableName, err)
@@ -289,7 +309,11 @@ func loadProtectedPartitions(ctx context.Context, conn DatastoreQuerier, tableNa
 // connection. This is required because pgx reports "conn busy" when
 // a command is sent on a connection that still has open rows.
 func loadPartitionCandidates(ctx context.Context, conn DatastoreQuerier, tableName string) ([]partitionCandidate, error) {
-	rows, err := conn.Query(ctx, partitionCandidatesQuery(tableName))
+	// partitionCandidatesQuery is a fixed SQL literal that is only
+	// non-constant because sqlmarker.Tag inserts the internal marker
+	// comment into it; the parent table name is bound as $1.
+	//nosemgrep: go_sql_rule-concat-sqli -- fixed literal tagged by sqlmarker.Tag; parent table name bound as $1
+	rows, err := conn.Query(ctx, partitionCandidatesQuery, tableName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query partitions: %w", err)
 	}

--- a/collector/src/probes/partition.go
+++ b/collector/src/probes/partition.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/pkg/logger"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
 
 // weeklyPartitionBounds returns the partition name suffix and the
@@ -49,8 +49,95 @@ func weeklyPartitionBounds(t time.Time) (nameSuffix string, from, to time.Time) 
 // session's TimeZone setting cannot reinterpret it.
 const partitionBoundLayout = "2006-01-02 15:04:05Z07:00"
 
+// DatastoreQuerier is the subset of *pgxpool.Conn that the partition
+// maintenance helpers use. Accepting the interface rather than the
+// concrete connection type keeps the helpers testable: unit tests can
+// inject a fake that both records the SQL actually issued (so the
+// Workbench-internal marker can be asserted without a database) and
+// returns errors from Query, Scan, and Exec.
+type DatastoreQuerier interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// partitionExistsQuery checks whether a partition of the given name has
+// already been created. Tagged as Workbench-internal so partition
+// maintenance does not show up in the server's Top Queries panel when
+// monitoring queries are hidden; see sqlmarker.Tag for why the marker
+// sits immediately after the leading keyword.
+var partitionExistsQuery = sqlmarker.Tag(`
+        SELECT EXISTS (
+            SELECT 1 FROM pg_tables
+            WHERE schemaname = 'metrics'
+            AND tablename = $1
+        )
+    `)
+
+// createPartitionSQL builds the tagged DDL that attaches a weekly
+// partition to a metrics table.
+//
+// #nosec G201 - table names are not user-provided, they come from probe
+// definitions, and the bounds are formatted from time.Time values.
+func createPartitionSQL(fullPartitionName, fullTableName string, weekStart, weekEnd time.Time) string {
+	return sqlmarker.Tag(fmt.Sprintf(`
+        CREATE TABLE IF NOT EXISTS %s
+        PARTITION OF %s
+        FOR VALUES FROM ('%s') TO ('%s')
+    `, fullPartitionName, fullTableName,
+		weekStart.Format(partitionBoundLayout),
+		weekEnd.Format(partitionBoundLayout)))
+}
+
+// dropPartitionSQL builds the tagged DDL that drops an expired
+// partition. The partition name is quoted with pgx.Identifier.
+func dropPartitionSQL(partitionName string) string {
+	return sqlmarker.Tag(fmt.Sprintf("DROP TABLE IF EXISTS %s",
+		pgx.Identifier{"metrics", partitionName}.Sanitize()))
+}
+
+// protectedPartitionsQuery builds the tagged query that finds, for a
+// change-tracked probe, the partitions holding the most recent sample
+// per connection.
+//
+// #nosec G201 - the table name comes from a probe definition.
+func protectedPartitionsQuery(tableName string) string {
+	return sqlmarker.Tag(fmt.Sprintf(`
+        SELECT DISTINCT
+            c.relname AS partition_name
+        FROM (
+            SELECT connection_id, MAX(collected_at) as max_collected_at
+            FROM metrics.%s
+            GROUP BY connection_id
+        ) latest
+        JOIN metrics.%s tbl ON tbl.connection_id = latest.connection_id
+            AND tbl.collected_at = latest.max_collected_at
+        JOIN pg_class c ON c.oid = tbl.tableoid
+    `, tableName, tableName))
+}
+
+// partitionCandidatesQuery builds the tagged catalog query listing every
+// partition of tableName together with its bound expression.
+//
+// #nosec G201 - the table name comes from a probe definition.
+func partitionCandidatesQuery(tableName string) string {
+	return sqlmarker.Tag(fmt.Sprintf(`
+        SELECT
+            c.relname AS partition_name,
+            pg_get_expr(c.relpartbound, c.oid) AS partition_bound
+        FROM pg_class c
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        JOIN pg_inherits i ON c.oid = i.inhrelid
+        JOIN pg_class p ON i.inhparent = p.oid
+        WHERE n.nspname = 'metrics'
+        AND p.relname = '%s'
+        AND c.relkind = 'r'
+        ORDER BY c.relname
+    `, tableName))
+}
+
 // EnsurePartition creates a partition for the given week if it doesn't exist
-func EnsurePartition(ctx context.Context, conn *pgxpool.Conn, tableName string, timestamp time.Time) error {
+func EnsurePartition(ctx context.Context, conn DatastoreQuerier, tableName string, timestamp time.Time) error {
 	nameSuffix, weekStart, weekEnd := weeklyPartitionBounds(timestamp)
 
 	partitionName := fmt.Sprintf("%s_%s", tableName, nameSuffix)
@@ -59,13 +146,7 @@ func EnsurePartition(ctx context.Context, conn *pgxpool.Conn, tableName string, 
 
 	// Check if partition already exists
 	var exists bool
-	err := conn.QueryRow(ctx, `
-        SELECT EXISTS (
-            SELECT 1 FROM pg_tables
-            WHERE schemaname = 'metrics'
-            AND tablename = $1
-        )
-    `, partitionName).Scan(&exists)
+	err := conn.QueryRow(ctx, partitionExistsQuery, partitionName).Scan(&exists)
 	if err != nil {
 		return fmt.Errorf("failed to check if partition exists: %w", err)
 	}
@@ -75,14 +156,8 @@ func EnsurePartition(ctx context.Context, conn *pgxpool.Conn, tableName string, 
 	}
 
 	// Create the partition
-	// #nosec G201 - table names are not user-provided, they come from probe definitions
-	createSQL := fmt.Sprintf(`
-        CREATE TABLE IF NOT EXISTS %s
-        PARTITION OF %s
-        FOR VALUES FROM ('%s') TO ('%s')
-    `, fullPartitionName, fullTableName,
-		weekStart.Format(partitionBoundLayout),
-		weekEnd.Format(partitionBoundLayout))
+	createSQL := createPartitionSQL(
+		fullPartitionName, fullTableName, weekStart, weekEnd)
 
 	_, err = conn.Exec(ctx, createSQL)
 	if err != nil {
@@ -108,7 +183,7 @@ func EnsurePartition(ctx context.Context, conn *pgxpool.Conn, tableName string, 
 // Rows result set. Doing so surfaces as a "conn busy" error. The two
 // catalog queries used here are therefore fully drained and closed
 // before any DROP TABLE is issued against the same connection.
-func DropExpiredPartitions(ctx context.Context, conn *pgxpool.Conn, tableName string, retentionDays int) (int, error) {
+func DropExpiredPartitions(ctx context.Context, conn DatastoreQuerier, tableName string, retentionDays int) (int, error) {
 	// Calculate the cutoff timestamp
 	cutoff := time.Now().AddDate(0, 0, -retentionDays)
 
@@ -145,8 +220,7 @@ func DropExpiredPartitions(ctx context.Context, conn *pgxpool.Conn, tableName st
 			continue
 		}
 
-		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s", pgx.Identifier{"metrics", c.name}.Sanitize())
-		if _, err := conn.Exec(ctx, dropSQL); err != nil {
+		if _, err := conn.Exec(ctx, dropPartitionSQL(c.name)); err != nil {
 			logger.Errorf("Warning: failed to drop partition %s: %v", c.name, err)
 			continue
 		}
@@ -176,7 +250,7 @@ type partitionCandidate struct {
 // are not change-tracked. The query's Rows is fully drained and
 // closed before the function returns so the caller can safely reuse
 // the same connection for subsequent commands.
-func loadProtectedPartitions(ctx context.Context, conn *pgxpool.Conn, tableName string) (map[string]bool, error) {
+func loadProtectedPartitions(ctx context.Context, conn DatastoreQuerier, tableName string) (map[string]bool, error) {
 	protected := make(map[string]bool)
 
 	switch tableName {
@@ -186,21 +260,7 @@ func loadProtectedPartitions(ctx context.Context, conn *pgxpool.Conn, tableName 
 		return protected, nil
 	}
 
-	// #nosec G201 - table name is from probe definition
-	protQuery := fmt.Sprintf(`
-        SELECT DISTINCT
-            c.relname AS partition_name
-        FROM (
-            SELECT connection_id, MAX(collected_at) as max_collected_at
-            FROM metrics.%s
-            GROUP BY connection_id
-        ) latest
-        JOIN metrics.%s tbl ON tbl.connection_id = latest.connection_id
-            AND tbl.collected_at = latest.max_collected_at
-        JOIN pg_class c ON c.oid = tbl.tableoid
-    `, tableName, tableName)
-
-	rows, err := conn.Query(ctx, protQuery)
+	rows, err := conn.Query(ctx, protectedPartitionsQuery(tableName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query protected partitions for %s: %w", tableName, err)
 	}
@@ -228,23 +288,8 @@ func loadProtectedPartitions(ctx context.Context, conn *pgxpool.Conn, tableName 
 // result is closed before the caller issues DROP TABLE on the same
 // connection. This is required because pgx reports "conn busy" when
 // a command is sent on a connection that still has open rows.
-func loadPartitionCandidates(ctx context.Context, conn *pgxpool.Conn, tableName string) ([]partitionCandidate, error) {
-	// #nosec G201 - table name is not user-provided, it comes from probe definitions
-	query := fmt.Sprintf(`
-        SELECT
-            c.relname AS partition_name,
-            pg_get_expr(c.relpartbound, c.oid) AS partition_bound
-        FROM pg_class c
-        JOIN pg_namespace n ON c.relnamespace = n.oid
-        JOIN pg_inherits i ON c.oid = i.inhrelid
-        JOIN pg_class p ON i.inhparent = p.oid
-        WHERE n.nspname = 'metrics'
-        AND p.relname = '%s'
-        AND c.relkind = 'r'
-        ORDER BY c.relname
-    `, tableName)
-
-	rows, err := conn.Query(ctx, query)
+func loadPartitionCandidates(ctx context.Context, conn DatastoreQuerier, tableName string) ([]partitionCandidate, error) {
+	rows, err := conn.Query(ctx, partitionCandidatesQuery(tableName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query partitions: %w", err)
 	}

--- a/collector/src/probes/pg_stat_statements_probe_test.go
+++ b/collector/src/probes/pg_stat_statements_probe_test.go
@@ -117,10 +117,7 @@ func TestPgStatStatementsProbe_ExecuteWithExtension(t *testing.T) {
 	if !ok {
 		t.Skip("pg_stat_statements extension not available")
 	}
-	if _, err := conn.Exec(ctx,
-		"SELECT count(*) FROM pg_stat_statements LIMIT 1"); err != nil {
-		t.Skipf("pg_stat_statements view not queryable: %v", err)
-	}
+	requirePgStatStatementsReadable(t, conn)
 
 	metrics, err := p.Execute(ctx, "stmts-with-ext", conn, pgVersion)
 	if err != nil {

--- a/collector/src/probes/sql_marker_integration_test.go
+++ b/collector/src/probes/sql_marker_integration_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
 
@@ -28,6 +30,10 @@ import (
 // proof of the fix: the collector's bulk metric INSERT is recorded by
 // pg_stat_statements with the marker intact, so the server's Top Queries
 // filter can exclude it.
+//
+// The test skips where pg_stat_statements is not loaded; the tagging
+// itself is asserted unconditionally, and without a database, by
+// TestBuildMetricsInsert_Tagged and its neighbors in sql_marker_test.go.
 func TestStoreMetrics_MarkerSurvivesInPgStatStatements(t *testing.T) {
 	pool := requireIntegrationPool(t)
 	conn := acquireConn(t, pool)
@@ -35,8 +41,10 @@ func TestStoreMetrics_MarkerSurvivesInPgStatStatements(t *testing.T) {
 
 	if _, err := conn.Exec(ctx,
 		"CREATE EXTENSION IF NOT EXISTS pg_stat_statements"); err != nil {
-		t.Skipf("pg_stat_statements unavailable: %v", err)
+		t.Skipf("skipping end-to-end marker check: the "+
+			"pg_stat_statements extension cannot be created: %v", err)
 	}
+	requirePgStatStatementsReadable(t, conn)
 	// A unique table name keeps this test independent of the shared
 	// metrics tables used by the other integration tests, and gives the
 	// statement a queryid of its own: pg_stat_statements normalizes
@@ -45,18 +53,24 @@ func TestStoreMetrics_MarkerSurvivesInPgStatStatements(t *testing.T) {
 	// only reliable discriminator. The statistics are deliberately not
 	// reset, because that would discard the whole instance's history.
 	table := fmt.Sprintf("marker_probe_%d", time.Now().UnixNano())
+	ident := pgx.Identifier{"metrics", table}.Sanitize()
+	// The relation name is generated from a timestamp above and quoted
+	// with pgx.Identifier; CREATE TABLE cannot name its relation with a
+	// bind parameter.
+	//nosemgrep: go_sql_rule-concat-sqli -- test-only DDL; timestamp-derived name sanitized by pgx.Identifier
 	if _, err := conn.Exec(ctx, fmt.Sprintf(
-		`CREATE TABLE metrics.%s (
+		`CREATE TABLE %s (
 			connection_id INTEGER NOT NULL,
 			collected_at TIMESTAMPTZ NOT NULL
-		)`, table)); err != nil {
+		)`, ident)); err != nil {
 		t.Fatalf("create test table: %v", err)
 	}
 	t.Cleanup(func() {
+		//nosemgrep: go_sql_rule-concat-sqli -- test-only DDL; same sanitized identifier as the CREATE above
 		if _, err := conn.Exec(context.Background(),
-			fmt.Sprintf("DROP TABLE IF EXISTS metrics.%s", table),
+			fmt.Sprintf("DROP TABLE IF EXISTS %s", ident),
 		); err != nil {
-			t.Logf("cleanup: drop metrics.%s: %v", table, err)
+			t.Logf("cleanup: drop %s: %v", ident, err)
 		}
 	})
 
@@ -68,6 +82,9 @@ func TestStoreMetrics_MarkerSurvivesInPgStatStatements(t *testing.T) {
 	}
 
 	var count int
+	// The SQL is a fixed literal; the table name and the marker are
+	// bound as $1 and $2 rather than concatenated into it.
+	//nosemgrep: go_sql_rule-concat-sqli -- fixed SQL literal; table name and marker bound as $1 and $2
 	err = conn.QueryRow(ctx, `
         SELECT count(*)
         FROM pg_stat_statements
@@ -78,7 +95,9 @@ func TestStoreMetrics_MarkerSurvivesInPgStatStatements(t *testing.T) {
 		t.Fatalf("read pg_stat_statements: %v", err)
 	}
 	if count == 0 {
-		// Dump what was recorded to make a regression obvious.
+		// Dump what was recorded to make a regression obvious. The SQL
+		// is a fixed literal and the table name is bound as $1.
+		//nosemgrep: go_sql_rule-concat-sqli -- fixed SQL literal; table name bound as $1
 		rows, qerr := conn.Query(ctx, `
             SELECT query FROM pg_stat_statements
             WHERE query LIKE '%' || $1 || '%'
@@ -106,19 +125,22 @@ func TestStoreMetrics_CommitError(t *testing.T) {
 	ctx := context.Background()
 
 	table := fmt.Sprintf("marker_commit_%d", time.Now().UnixNano())
+	ident := pgx.Identifier{"metrics", table}.Sanitize()
+	//nosemgrep: go_sql_rule-concat-sqli -- test-only DDL; timestamp-derived name sanitized by pgx.Identifier
 	if _, err := conn.Exec(ctx, fmt.Sprintf(
-		`CREATE TABLE metrics.%s (
+		`CREATE TABLE %s (
 			connection_id INTEGER NOT NULL,
 			collected_at TIMESTAMPTZ NOT NULL,
 			UNIQUE (connection_id) DEFERRABLE INITIALLY DEFERRED
-		)`, table)); err != nil {
+		)`, ident)); err != nil {
 		t.Fatalf("create test table: %v", err)
 	}
 	t.Cleanup(func() {
+		//nosemgrep: go_sql_rule-concat-sqli -- test-only DDL; same sanitized identifier as the CREATE above
 		if _, err := conn.Exec(context.Background(),
-			fmt.Sprintf("DROP TABLE IF EXISTS metrics.%s", table),
+			fmt.Sprintf("DROP TABLE IF EXISTS %s", ident),
 		); err != nil {
-			t.Logf("cleanup: drop metrics.%s: %v", table, err)
+			t.Logf("cleanup: drop %s: %v", ident, err)
 		}
 	})
 

--- a/collector/src/probes/sql_marker_integration_test.go
+++ b/collector/src/probes/sql_marker_integration_test.go
@@ -1,0 +1,193 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Integration tests for the Workbench-internal SQL marker (issue #364).
+// These verify against a live PostgreSQL instance that the marker
+// survives into pg_stat_statements, which is the whole point of putting
+// it after the leading keyword rather than in front of the statement.
+package probes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
+)
+
+// TestStoreMetrics_MarkerSurvivesInPgStatStatements is the end-to-end
+// proof of the fix: the collector's bulk metric INSERT is recorded by
+// pg_stat_statements with the marker intact, so the server's Top Queries
+// filter can exclude it.
+func TestStoreMetrics_MarkerSurvivesInPgStatStatements(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	ctx := context.Background()
+
+	if _, err := conn.Exec(ctx,
+		"CREATE EXTENSION IF NOT EXISTS pg_stat_statements"); err != nil {
+		t.Skipf("pg_stat_statements unavailable: %v", err)
+	}
+	// A unique table name keeps this test independent of the shared
+	// metrics tables used by the other integration tests, and gives the
+	// statement a queryid of its own: pg_stat_statements normalizes
+	// literals into $n placeholders and ignores both comments and column
+	// aliases when computing the queryid, so the relation name is the
+	// only reliable discriminator. The statistics are deliberately not
+	// reset, because that would discard the whole instance's history.
+	table := fmt.Sprintf("marker_probe_%d", time.Now().UnixNano())
+	if _, err := conn.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE metrics.%s (
+			connection_id INTEGER NOT NULL,
+			collected_at TIMESTAMPTZ NOT NULL
+		)`, table)); err != nil {
+		t.Fatalf("create test table: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := conn.Exec(context.Background(),
+			fmt.Sprintf("DROP TABLE IF EXISTS metrics.%s", table),
+		); err != nil {
+			t.Logf("cleanup: drop metrics.%s: %v", table, err)
+		}
+	})
+
+	err := StoreMetrics(ctx, conn, table,
+		[]string{"connection_id", "collected_at"},
+		[][]any{{1, time.Now().UTC()}})
+	if err != nil {
+		t.Fatalf("StoreMetrics() error = %v", err)
+	}
+
+	var count int
+	err = conn.QueryRow(ctx, `
+        SELECT count(*)
+        FROM pg_stat_statements
+        WHERE query LIKE '%INSERT%' || $1 || '%'
+          AND query LIKE '%' || $2 || '%'
+    `, table, sqlmarker.Marker).Scan(&count)
+	if err != nil {
+		t.Fatalf("read pg_stat_statements: %v", err)
+	}
+	if count == 0 {
+		// Dump what was recorded to make a regression obvious.
+		rows, qerr := conn.Query(ctx, `
+            SELECT query FROM pg_stat_statements
+            WHERE query LIKE '%' || $1 || '%'
+        `, table)
+		if qerr == nil {
+			defer rows.Close()
+			for rows.Next() {
+				var q string
+				if scanErr := rows.Scan(&q); scanErr == nil {
+					t.Logf("recorded: %s", q)
+				}
+			}
+		}
+		t.Errorf("no pg_stat_statements entry for the INSERT into "+
+			"metrics.%s carries %q", table, sqlmarker.Marker)
+	}
+}
+
+// TestStoreMetrics_CommitError covers the commit-failure branch of
+// StoreMetrics using a deferred unique constraint: the INSERT succeeds
+// and the COMMIT fails.
+func TestStoreMetrics_CommitError(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	ctx := context.Background()
+
+	table := fmt.Sprintf("marker_commit_%d", time.Now().UnixNano())
+	if _, err := conn.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE metrics.%s (
+			connection_id INTEGER NOT NULL,
+			collected_at TIMESTAMPTZ NOT NULL,
+			UNIQUE (connection_id) DEFERRABLE INITIALLY DEFERRED
+		)`, table)); err != nil {
+		t.Fatalf("create test table: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := conn.Exec(context.Background(),
+			fmt.Sprintf("DROP TABLE IF EXISTS metrics.%s", table),
+		); err != nil {
+			t.Logf("cleanup: drop metrics.%s: %v", table, err)
+		}
+	})
+
+	now := time.Now().UTC()
+	err := StoreMetrics(ctx, conn, table,
+		[]string{"connection_id", "collected_at"},
+		[][]any{{1, now}, {1, now}})
+	if err == nil {
+		t.Fatal("expected a commit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to commit transaction") {
+		t.Errorf("error = %v, want a commit failure", err)
+	}
+}
+
+// TestGetLastCollectionTime_WithRow covers the branch that returns a
+// real timestamp, and confirms the tagged query still works against a
+// live datastore.
+func TestGetLastCollectionTime_WithRow(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	ctx := context.Background()
+
+	const connectionID = 987654
+	collectedAt := time.Now().UTC().Truncate(time.Millisecond)
+
+	if err := EnsurePartition(
+		ctx, conn, "pg_stat_activity", collectedAt); err != nil {
+		t.Fatalf("EnsurePartition() error = %v", err)
+	}
+	if _, err := conn.Exec(ctx, `
+        INSERT INTO metrics.pg_stat_activity (connection_id, collected_at)
+        VALUES ($1, $2)
+    `, connectionID, collectedAt); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := conn.Exec(context.Background(),
+			"DELETE FROM metrics.pg_stat_activity WHERE connection_id = $1",
+			connectionID); err != nil {
+			t.Logf("cleanup: delete seeded rows: %v", err)
+		}
+	})
+
+	got, err := GetLastCollectionTime(
+		ctx, conn, "pg_stat_activity", connectionID)
+	if err != nil {
+		t.Fatalf("GetLastCollectionTime() error = %v", err)
+	}
+	if !got.Equal(collectedAt) {
+		t.Errorf("got %v, want %v", got, collectedAt)
+	}
+}
+
+// TestGetLastCollectionTime_QueryError covers the error branch for a
+// failure that is not a missing table, by breaking the connection first.
+func TestGetLastCollectionTime_QueryError(t *testing.T) {
+	pool := requireIntegrationPool(t)
+	conn := acquireConn(t, pool)
+	ctx := context.Background()
+
+	breakConn(t, conn)
+
+	_, err := GetLastCollectionTime(ctx, conn, "pg_stat_activity", 1)
+	if err == nil {
+		t.Fatal("expected an error from a closed connection, got nil")
+	}
+	if !strings.Contains(
+		err.Error(), "failed to query last collection time") {
+		t.Errorf("error = %v, want a query failure", err)
+	}
+}

--- a/collector/src/probes/sql_marker_test.go
+++ b/collector/src/probes/sql_marker_test.go
@@ -1,0 +1,491 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Tests covering the Workbench-internal SQL marker applied to the
+// statements the collector runs against its own datastore, and the
+// partition maintenance helpers that carry it. See GitHub issue #364.
+package probes
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
+)
+
+// assertTagged fails the test unless sql carries the internal marker in
+// a position that PostgreSQL preserves in pg_stat_statements, which is
+// to say after the leading keyword rather than before it.
+func assertTagged(t *testing.T, what, sql string) {
+	t.Helper()
+	if !strings.Contains(sql, sqlmarker.Marker) {
+		t.Errorf("%s is missing the internal marker: %s", what, sql)
+		return
+	}
+	trimmed := strings.TrimLeft(sql, " \t\r\n")
+	if strings.HasPrefix(trimmed, sqlmarker.Comment) {
+		t.Errorf("%s carries the marker before the leading keyword, "+
+			"where PostgreSQL strips it: %s", what, sql)
+	}
+}
+
+// fakeRow implements pgx.Row for the partition existence check.
+type fakeRow struct {
+	exists  bool
+	scanErr error
+}
+
+func (f *fakeRow) Scan(dest ...any) error {
+	if f.scanErr != nil {
+		return f.scanErr
+	}
+	if len(dest) == 1 {
+		if p, ok := dest[0].(*bool); ok {
+			*p = f.exists
+		}
+	}
+	return nil
+}
+
+// fakeRows implements pgx.Rows over a fixed set of string rows, with
+// optional Scan and iteration errors so every error branch in the
+// partition helpers can be exercised.
+type fakeRows struct {
+	data    [][]string
+	index   int
+	scanErr error
+	iterErr error
+	closed  bool
+}
+
+func (f *fakeRows) Close()                                       { f.closed = true }
+func (f *fakeRows) Err() error                                   { return f.iterErr }
+func (f *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (f *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (f *fakeRows) RawValues() [][]byte                          { return nil }
+func (f *fakeRows) Conn() *pgx.Conn                              { return nil }
+func (f *fakeRows) Values() ([]any, error)                       { return nil, nil }
+
+func (f *fakeRows) Next() bool {
+	if f.index >= len(f.data) {
+		return false
+	}
+	f.index++
+	return true
+}
+
+func (f *fakeRows) Scan(dest ...any) error {
+	if f.scanErr != nil {
+		return f.scanErr
+	}
+	row := f.data[f.index-1]
+	for i := range dest {
+		if i >= len(row) {
+			break
+		}
+		p, ok := dest[i].(*string)
+		if !ok {
+			return errors.New("fakeRows: destination is not *string")
+		}
+		*p = row[i]
+	}
+	return nil
+}
+
+// fakeQuerier implements DatastoreQuerier, recording every statement it
+// is handed so tests can assert on the SQL actually issued.
+type fakeQuerier struct {
+	queries  []string
+	execs    []string
+	rows     *fakeRows
+	row      *fakeRow
+	queryErr error
+	execErr  error
+}
+
+func (f *fakeQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	f.queries = append(f.queries, sql)
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	if f.rows == nil {
+		return &fakeRows{}, nil
+	}
+	return f.rows, nil
+}
+
+func (f *fakeQuerier) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+	f.queries = append(f.queries, sql)
+	if f.row == nil {
+		return &fakeRow{}
+	}
+	return f.row
+}
+
+func (f *fakeQuerier) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	f.execs = append(f.execs, sql)
+	return pgconn.CommandTag{}, f.execErr
+}
+
+// TestBuildMetricsInsert_Tagged covers the chokepoint from issue #364:
+// every probe's metric writes are built here, and the resulting INSERT
+// must carry the internal marker.
+func TestBuildMetricsInsert_Tagged(t *testing.T) {
+	fullTableName := pgx.Identifier{"metrics", "pg_stat_statements"}.Sanitize()
+	columns := []string{"connection_id", "queryid"}
+	batch := [][]any{{1, "abc"}, {2, "def"}}
+
+	query, args := buildMetricsInsert(fullTableName, columns, batch)
+
+	assertTagged(t, "metrics INSERT", query)
+	if !strings.HasPrefix(query, "INSERT "+sqlmarker.Comment+" INTO ") {
+		t.Errorf("marker is not immediately after the keyword: %s", query)
+	}
+	want := `INSERT ` + sqlmarker.Comment +
+		` INTO "metrics"."pg_stat_statements" ` +
+		`("connection_id", "queryid") VALUES ($1, $2), ($3, $4)`
+	if query != want {
+		t.Errorf("query = %q, want %q", query, want)
+	}
+	if len(args) != 4 {
+		t.Fatalf("len(args) = %d, want 4", len(args))
+	}
+	if args[0] != 1 || args[1] != "abc" || args[2] != 2 || args[3] != "def" {
+		t.Errorf("args = %v, want [1 abc 2 def]", args)
+	}
+}
+
+// TestPartitionSQLBuilders_Tagged asserts every partition maintenance
+// statement carries the marker.
+func TestPartitionSQLBuilders_Tagged(t *testing.T) {
+	weekStart := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+	weekEnd := weekStart.AddDate(0, 0, 7)
+
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"partitionExistsQuery", partitionExistsQuery},
+		{"createPartitionSQL", createPartitionSQL(
+			"metrics.pg_stat_activity_20260727",
+			"metrics.pg_stat_activity", weekStart, weekEnd)},
+		{"dropPartitionSQL", dropPartitionSQL("pg_settings_20260727")},
+		{"protectedPartitionsQuery",
+			protectedPartitionsQuery("pg_settings")},
+		{"partitionCandidatesQuery",
+			partitionCandidatesQuery("pg_stat_activity")},
+		{"lastCollectionTimeQuery",
+			lastCollectionTimeQuery("pg_stat_activity")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertTagged(t, tc.name, tc.sql)
+		})
+	}
+}
+
+// TestCreatePartitionSQL_Content confirms the tagging refactor did not
+// disturb the DDL the collector has always issued.
+func TestCreatePartitionSQL_Content(t *testing.T) {
+	weekStart := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+	weekEnd := weekStart.AddDate(0, 0, 7)
+
+	got := createPartitionSQL("metrics.t_20260727", "metrics.t",
+		weekStart, weekEnd)
+
+	for _, want := range []string{
+		"CREATE " + sqlmarker.Comment,
+		"IF NOT EXISTS metrics.t_20260727",
+		"PARTITION OF metrics.t",
+		"FROM ('2026-07-27 00:00:00Z') TO ('2026-08-03 00:00:00Z')",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("createPartitionSQL missing %q: %s", want, got)
+		}
+	}
+}
+
+// TestDropPartitionSQL_QuotesIdentifier confirms the partition name is
+// still quoted after the marker was introduced.
+func TestDropPartitionSQL_QuotesIdentifier(t *testing.T) {
+	got := dropPartitionSQL("pg_settings_20260727")
+	want := `DROP ` + sqlmarker.Comment +
+		` TABLE IF EXISTS "metrics"."pg_settings_20260727"`
+	if got != want {
+		t.Errorf("dropPartitionSQL = %q, want %q", got, want)
+	}
+}
+
+// TestEnsurePartition_FakeQuerier exercises EnsurePartition against a
+// fake connection, covering the already-exists short circuit, the
+// creation path, the duplicate-relation race, and the two error paths,
+// whilst asserting that both statements carry the marker.
+func TestEnsurePartition_FakeQuerier(t *testing.T) {
+	ctx := context.Background()
+	ts := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+
+	t.Run("already exists", func(t *testing.T) {
+		q := &fakeQuerier{row: &fakeRow{exists: true}}
+		if err := EnsurePartition(ctx, q, "pg_stat_activity", ts); err != nil {
+			t.Fatalf("EnsurePartition() error = %v", err)
+		}
+		if len(q.queries) != 1 {
+			t.Fatalf("expected 1 query, got %d", len(q.queries))
+		}
+		assertTagged(t, "exists check", q.queries[0])
+		if len(q.execs) != 0 {
+			t.Errorf("expected no DDL, got %v", q.execs)
+		}
+	})
+
+	t.Run("creates partition", func(t *testing.T) {
+		q := &fakeQuerier{row: &fakeRow{exists: false}}
+		if err := EnsurePartition(ctx, q, "pg_stat_activity", ts); err != nil {
+			t.Fatalf("EnsurePartition() error = %v", err)
+		}
+		if len(q.execs) != 1 {
+			t.Fatalf("expected 1 DDL statement, got %d", len(q.execs))
+		}
+		assertTagged(t, "create partition", q.execs[0])
+		if !strings.Contains(q.execs[0],
+			"metrics.pg_stat_activity_20260727") {
+			t.Errorf("unexpected DDL: %s", q.execs[0])
+		}
+	})
+
+	t.Run("exists check error", func(t *testing.T) {
+		q := &fakeQuerier{row: &fakeRow{scanErr: errors.New("boom")}}
+		err := EnsurePartition(ctx, q, "pg_stat_activity", ts)
+		if err == nil ||
+			!strings.Contains(err.Error(), "check if partition exists") {
+			t.Fatalf("expected exists-check error, got %v", err)
+		}
+	})
+
+	t.Run("duplicate relation is tolerated", func(t *testing.T) {
+		q := &fakeQuerier{
+			row:     &fakeRow{exists: false},
+			execErr: &pgconn.PgError{Code: "42P07"},
+		}
+		if err := EnsurePartition(ctx, q, "pg_stat_activity", ts); err != nil {
+			t.Fatalf("EnsurePartition() error = %v", err)
+		}
+	})
+
+	t.Run("create error", func(t *testing.T) {
+		q := &fakeQuerier{
+			row:     &fakeRow{exists: false},
+			execErr: errors.New("disk on fire"),
+		}
+		err := EnsurePartition(ctx, q, "pg_stat_activity", ts)
+		if err == nil ||
+			!strings.Contains(err.Error(), "failed to create partition") {
+			t.Fatalf("expected create error, got %v", err)
+		}
+	})
+}
+
+// TestLoadProtectedPartitions_FakeQuerier covers the change-tracked and
+// non-change-tracked branches plus every error path.
+func TestLoadProtectedPartitions_FakeQuerier(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("not change tracked", func(t *testing.T) {
+		q := &fakeQuerier{}
+		got, err := loadProtectedPartitions(ctx, q, "pg_stat_activity")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+		if len(q.queries) != 0 {
+			t.Errorf("expected no query, got %v", q.queries)
+		}
+	})
+
+	t.Run("returns protected names", func(t *testing.T) {
+		q := &fakeQuerier{rows: &fakeRows{
+			data: [][]string{{"pg_settings_20260727"}},
+		}}
+		got, err := loadProtectedPartitions(ctx, q, "pg_settings")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if !got["pg_settings_20260727"] {
+			t.Errorf("expected the partition to be protected, got %v", got)
+		}
+		assertTagged(t, "protected partitions query", q.queries[0])
+	})
+
+	t.Run("query error", func(t *testing.T) {
+		q := &fakeQuerier{queryErr: errors.New("boom")}
+		if _, err := loadProtectedPartitions(ctx, q, "pg_settings"); err == nil ||
+			!strings.Contains(err.Error(), "query protected partitions") {
+			t.Fatalf("expected query error, got %v", err)
+		}
+	})
+
+	t.Run("scan error", func(t *testing.T) {
+		q := &fakeQuerier{rows: &fakeRows{
+			data:    [][]string{{"x"}},
+			scanErr: errors.New("bad scan"),
+		}}
+		if _, err := loadProtectedPartitions(ctx, q, "pg_settings"); err == nil ||
+			!strings.Contains(err.Error(), "scan protected partition name") {
+			t.Fatalf("expected scan error, got %v", err)
+		}
+	})
+
+	t.Run("iteration error", func(t *testing.T) {
+		q := &fakeQuerier{rows: &fakeRows{iterErr: errors.New("late")}}
+		if _, err := loadProtectedPartitions(ctx, q, "pg_settings"); err == nil ||
+			!strings.Contains(err.Error(), "iterating protected partitions") {
+			t.Fatalf("expected iteration error, got %v", err)
+		}
+	})
+}
+
+// TestLoadPartitionCandidates_FakeQuerier covers the happy path and
+// every error path of the catalog read.
+func TestLoadPartitionCandidates_FakeQuerier(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns candidates", func(t *testing.T) {
+		q := &fakeQuerier{rows: &fakeRows{data: [][]string{
+			{"pg_stat_activity_20260720", "FOR VALUES FROM ('a') TO ('b')"},
+		}}}
+		got, err := loadPartitionCandidates(ctx, q, "pg_stat_activity")
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(got) != 1 || got[0].name != "pg_stat_activity_20260720" {
+			t.Fatalf("unexpected candidates: %v", got)
+		}
+		assertTagged(t, "partition candidates query", q.queries[0])
+	})
+
+	t.Run("query error", func(t *testing.T) {
+		q := &fakeQuerier{queryErr: errors.New("boom")}
+		if _, err := loadPartitionCandidates(ctx, q, "t"); err == nil ||
+			!strings.Contains(err.Error(), "query partitions") {
+			t.Fatalf("expected query error, got %v", err)
+		}
+	})
+
+	t.Run("scan error", func(t *testing.T) {
+		q := &fakeQuerier{rows: &fakeRows{
+			data:    [][]string{{"a", "b"}},
+			scanErr: errors.New("bad scan"),
+		}}
+		if _, err := loadPartitionCandidates(ctx, q, "t"); err == nil ||
+			!strings.Contains(err.Error(), "scan partition info") {
+			t.Fatalf("expected scan error, got %v", err)
+		}
+	})
+
+	t.Run("iteration error", func(t *testing.T) {
+		q := &fakeQuerier{rows: &fakeRows{iterErr: errors.New("late")}}
+		if _, err := loadPartitionCandidates(ctx, q, "t"); err == nil {
+			t.Fatalf("expected iteration error, got nil")
+		}
+	})
+}
+
+// TestDropExpiredPartitions_FakeQuerier drives the retention sweep
+// through a fake connection so the protected, unparseable, in-retention,
+// expired, and failed-drop cases are all covered, and asserts the DROP
+// statements carry the marker.
+func TestDropExpiredPartitions_FakeQuerier(t *testing.T) {
+	ctx := context.Background()
+
+	// Bound expressions are parsed by parsePartitionEnd; use a bound
+	// well in the past so the partition counts as expired.
+	expiredBound := "FOR VALUES FROM ('2020-01-06 00:00:00+00') " +
+		"TO ('2020-01-13 00:00:00+00')"
+	futureBound := "FOR VALUES FROM ('2999-01-04 00:00:00+00') " +
+		"TO ('2999-01-11 00:00:00+00')"
+
+	t.Run("drops expired and keeps the rest", func(t *testing.T) {
+		q := &fakeQuerier{rows: &fakeRows{data: [][]string{
+			{"pg_stat_activity_20200106", expiredBound},
+			{"pg_stat_activity_29990104", futureBound},
+			{"pg_stat_activity_bogus", "nonsense"},
+		}}}
+		dropped, err := DropExpiredPartitions(
+			ctx, q, "pg_stat_activity", 7)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if dropped != 1 {
+			t.Fatalf("dropped = %d, want 1", dropped)
+		}
+		if len(q.execs) != 1 {
+			t.Fatalf("expected 1 DROP, got %v", q.execs)
+		}
+		assertTagged(t, "drop partition", q.execs[0])
+	})
+
+	t.Run("skips protected partitions", func(t *testing.T) {
+		// pg_settings is change-tracked, so the first query returns the
+		// protected set and the second the candidate list. The fake
+		// returns the same rows for both, which is enough to make the
+		// candidate look protected.
+		q := &fakeQuerier{rows: &fakeRows{data: [][]string{
+			{"pg_settings_20200106", expiredBound},
+		}}}
+		dropped, err := DropExpiredPartitions(ctx, q, "pg_settings", 7)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if dropped != 0 {
+			t.Errorf("dropped = %d, want 0", dropped)
+		}
+	})
+
+	t.Run("protected query error", func(t *testing.T) {
+		q := &fakeQuerier{queryErr: errors.New("boom")}
+		if _, err := DropExpiredPartitions(
+			ctx, q, "pg_settings", 7); err == nil {
+			t.Fatal("expected an error from the protected query")
+		}
+	})
+
+	t.Run("candidate query error", func(t *testing.T) {
+		q := &fakeQuerier{queryErr: errors.New("boom")}
+		if _, err := DropExpiredPartitions(
+			ctx, q, "pg_stat_activity", 7); err == nil {
+			t.Fatal("expected an error from the candidate query")
+		}
+	})
+
+	t.Run("drop failure is logged and skipped", func(t *testing.T) {
+		q := &fakeQuerier{
+			rows: &fakeRows{data: [][]string{
+				{"pg_stat_activity_20200106", expiredBound},
+			}},
+			execErr: errors.New("cannot drop"),
+		}
+		dropped, err := DropExpiredPartitions(
+			ctx, q, "pg_stat_activity", 7)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if dropped != 0 {
+			t.Errorf("dropped = %d, want 0", dropped)
+		}
+	})
+}

--- a/collector/src/probes/sql_marker_test.go
+++ b/collector/src/probes/sql_marker_test.go
@@ -107,16 +107,18 @@ func (f *fakeRows) Scan(dest ...any) error {
 // fakeQuerier implements DatastoreQuerier, recording every statement it
 // is handed so tests can assert on the SQL actually issued.
 type fakeQuerier struct {
-	queries  []string
-	execs    []string
-	rows     *fakeRows
-	row      *fakeRow
-	queryErr error
-	execErr  error
+	queries   []string
+	queryArgs [][]any
+	execs     []string
+	rows      *fakeRows
+	row       *fakeRow
+	queryErr  error
+	execErr   error
 }
 
-func (f *fakeQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+func (f *fakeQuerier) Query(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
 	f.queries = append(f.queries, sql)
+	f.queryArgs = append(f.queryArgs, args)
 	if f.queryErr != nil {
 		return nil, f.queryErr
 	}
@@ -126,8 +128,9 @@ func (f *fakeQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, 
 	return f.rows, nil
 }
 
-func (f *fakeQuerier) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+func (f *fakeQuerier) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
 	f.queries = append(f.queries, sql)
+	f.queryArgs = append(f.queryArgs, args)
 	if f.row == nil {
 		return &fakeRow{}
 	}
@@ -179,13 +182,12 @@ func TestPartitionSQLBuilders_Tagged(t *testing.T) {
 	}{
 		{"partitionExistsQuery", partitionExistsQuery},
 		{"createPartitionSQL", createPartitionSQL(
-			"metrics.pg_stat_activity_20260727",
-			"metrics.pg_stat_activity", weekStart, weekEnd)},
+			"pg_stat_activity_20260727",
+			"pg_stat_activity", weekStart, weekEnd)},
 		{"dropPartitionSQL", dropPartitionSQL("pg_settings_20260727")},
 		{"protectedPartitionsQuery",
 			protectedPartitionsQuery("pg_settings")},
-		{"partitionCandidatesQuery",
-			partitionCandidatesQuery("pg_stat_activity")},
+		{"partitionCandidatesQuery", partitionCandidatesQuery},
 		{"lastCollectionTimeQuery",
 			lastCollectionTimeQuery("pg_stat_activity")},
 	}
@@ -198,18 +200,18 @@ func TestPartitionSQLBuilders_Tagged(t *testing.T) {
 }
 
 // TestCreatePartitionSQL_Content confirms the tagging refactor did not
-// disturb the DDL the collector has always issued.
+// disturb the DDL the collector has always issued, and that both
+// relation names are quoted by pgx.Identifier.
 func TestCreatePartitionSQL_Content(t *testing.T) {
 	weekStart := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
 	weekEnd := weekStart.AddDate(0, 0, 7)
 
-	got := createPartitionSQL("metrics.t_20260727", "metrics.t",
-		weekStart, weekEnd)
+	got := createPartitionSQL("t_20260727", "t", weekStart, weekEnd)
 
 	for _, want := range []string{
 		"CREATE " + sqlmarker.Comment,
-		"IF NOT EXISTS metrics.t_20260727",
-		"PARTITION OF metrics.t",
+		`IF NOT EXISTS "metrics"."t_20260727"`,
+		`PARTITION OF "metrics"."t"`,
 		"FROM ('2026-07-27 00:00:00Z') TO ('2026-08-03 00:00:00Z')",
 	} {
 		if !strings.Contains(got, want) {
@@ -226,6 +228,58 @@ func TestDropPartitionSQL_QuotesIdentifier(t *testing.T) {
 		` TABLE IF EXISTS "metrics"."pg_settings_20260727"`
 	if got != want {
 		t.Errorf("dropPartitionSQL = %q, want %q", got, want)
+	}
+}
+
+// TestPartitionQueries_IdentifiersAreQuoted asserts the identifier
+// handling the Semgrep suppressions in partition.go rely on: relation
+// names that cannot be bound as placeholders are quoted with
+// pgx.Identifier, and the one name that is a value binds as $1.
+func TestPartitionQueries_IdentifiersAreQuoted(t *testing.T) {
+	weekStart := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+
+	// A name containing a quote proves the escaping is real rather than
+	// incidental; production names never look like this.
+	got := createPartitionSQL(`ev"il`, `ta"ble`, weekStart,
+		weekStart.AddDate(0, 0, 7))
+	for _, want := range []string{
+		`"metrics"."ev""il"`,
+		`"metrics"."ta""ble"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("createPartitionSQL missing %q: %s", want, got)
+		}
+	}
+
+	prot := protectedPartitionsQuery(`ev"il`)
+	if !strings.Contains(prot, `"metrics"."ev""il"`) {
+		t.Errorf("protectedPartitionsQuery does not quote its table: %s",
+			prot)
+	}
+
+	if strings.Contains(partitionCandidatesQuery, "%s") ||
+		!strings.Contains(partitionCandidatesQuery, "p.relname = $1") {
+		t.Errorf("partitionCandidatesQuery should bind the parent "+
+			"table name: %s", partitionCandidatesQuery)
+	}
+}
+
+// TestLoadPartitionCandidates_BindsTableName confirms the parent table
+// name reaches PostgreSQL as a bind parameter rather than being
+// interpolated into the catalog query.
+func TestLoadPartitionCandidates_BindsTableName(t *testing.T) {
+	q := &fakeQuerier{}
+	if _, err := loadPartitionCandidates(
+		context.Background(), q, "pg_stat_activity"); err != nil {
+		t.Fatalf("loadPartitionCandidates() error = %v", err)
+	}
+	if len(q.queryArgs) != 1 || len(q.queryArgs[0]) != 1 ||
+		q.queryArgs[0][0] != "pg_stat_activity" {
+		t.Errorf("args = %v, want [pg_stat_activity]", q.queryArgs)
+	}
+	if strings.Contains(q.queries[0], "pg_stat_activity") {
+		t.Errorf("table name was interpolated into the SQL: %s",
+			q.queries[0])
 	}
 }
 
@@ -261,7 +315,7 @@ func TestEnsurePartition_FakeQuerier(t *testing.T) {
 		}
 		assertTagged(t, "create partition", q.execs[0])
 		if !strings.Contains(q.execs[0],
-			"metrics.pg_stat_activity_20260727") {
+			`"metrics"."pg_stat_activity_20260727"`) {
 			t.Errorf("unexpected DDL: %s", q.execs[0])
 		}
 	})

--- a/collector/src/probes/storage.go
+++ b/collector/src/probes/storage.go
@@ -17,7 +17,56 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/pkg/logger"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 )
+
+// buildMetricsInsert builds one multi-row INSERT for a batch of metric
+// rows, returning the statement and its bind arguments. Column and
+// table identifiers are quoted by the caller and by pgx.Identifier, and
+// every value is passed as a bind parameter, so the statement carries
+// no interpolated data.
+//
+// The statement is tagged as Workbench-internal so the server's Top
+// Queries panel can filter out the collector's own write traffic
+// against the datastore; see sqlmarker.Tag for why the marker has to
+// sit immediately after the leading keyword. This is the single
+// chokepoint through which every probe's metric writes pass, which is
+// why the tagging lives here rather than in the individual probes.
+func buildMetricsInsert(fullTableName string, columns []string, batch [][]any) (string, []any) {
+	// Build column list with quoted identifiers
+	columnList := ""
+	for idx, col := range columns {
+		if idx > 0 {
+			columnList += ", "
+		}
+		columnList += pgx.Identifier{col}.Sanitize()
+	}
+
+	// Build VALUES clause with placeholders
+	valuesClause := ""
+	args := make([]any, 0, len(batch)*len(columns))
+	for rowIdx, row := range batch {
+		if rowIdx > 0 {
+			valuesClause += ", "
+		}
+		valuesClause += "("
+		for colIdx := range columns {
+			if colIdx > 0 {
+				valuesClause += ", "
+			}
+			placeholderNum := rowIdx*len(columns) + colIdx + 1
+			valuesClause += fmt.Sprintf("$%d", placeholderNum)
+			args = append(args, row[colIdx])
+		}
+		valuesClause += ")"
+	}
+
+	query := sqlmarker.Tag(fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES %s",
+		fullTableName, columnList, valuesClause))
+
+	return query, args
+}
 
 // StoreMetrics stores metrics using batched INSERT statements.
 func StoreMetrics(ctx context.Context, conn *pgxpool.Conn, tableName string, columns []string, values [][]any) error {
@@ -51,36 +100,7 @@ func StoreMetrics(ctx context.Context, conn *pgxpool.Conn, tableName string, col
 		}
 		batch := values[i:end]
 
-		// Build column list with quoted identifiers
-		columnList := ""
-		for idx, col := range columns {
-			if idx > 0 {
-				columnList += ", "
-			}
-			columnList += pgx.Identifier{col}.Sanitize()
-		}
-
-		// Build VALUES clause with placeholders
-		valuesClause := ""
-		args := make([]any, 0, len(batch)*len(columns))
-		for rowIdx, row := range batch {
-			if rowIdx > 0 {
-				valuesClause += ", "
-			}
-			valuesClause += "("
-			for colIdx := range columns {
-				if colIdx > 0 {
-					valuesClause += ", "
-				}
-				placeholderNum := rowIdx*len(columns) + colIdx + 1
-				valuesClause += fmt.Sprintf("$%d", placeholderNum)
-				args = append(args, row[colIdx])
-			}
-			valuesClause += ")"
-		}
-
-		// Execute INSERT
-		query := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s", fullTableName, columnList, valuesClause)
+		query, args := buildMetricsInsert(fullTableName, columns, batch)
 		if _, err := txn.Exec(ctx, query, args...); err != nil {
 			return fmt.Errorf("failed to execute INSERT: %w", err)
 		}

--- a/collector/src/scheduler/scheduler.go
+++ b/collector/src/scheduler/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pgedge/ai-workbench/collector/src/database"
 	"github.com/pgedge/ai-workbench/collector/src/probes"
 	"github.com/pgedge/ai-workbench/pkg/logger"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 
 	"context"
 	"fmt"
@@ -628,15 +629,23 @@ func (ps *ProbeScheduler) executeProbeForAllDatabases(ctx context.Context, probe
 	return allMetrics, databases, false, ""
 }
 
-// getDatabaseList queries pg_database to get list of accessible databases
-func (ps *ProbeScheduler) getDatabaseList(ctx context.Context, conn *pgxpool.Conn) ([]string, error) {
-	rows, err := conn.Query(ctx, `
+// databaseListQuery lists the databases the collector should visit on a
+// monitored server. It runs on every collection cycle and, unlike the
+// probe queries, does not pass through probes.WrapQuery, so it is tagged
+// as Workbench-internal to keep it out of the server's Top Queries panel
+// when monitoring queries are hidden. See sqlmarker.Tag for why the
+// marker sits immediately after the leading keyword.
+var databaseListQuery = sqlmarker.Tag(`
 		SELECT datname
 		FROM pg_database
 		WHERE datallowconn = true
 		  AND NOT datistemplate
 		ORDER BY datname
 	`)
+
+// getDatabaseList queries pg_database to get list of accessible databases
+func (ps *ProbeScheduler) getDatabaseList(ctx context.Context, conn *pgxpool.Conn) ([]string, error) {
+	rows, err := conn.Query(ctx, databaseListQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query pg_database: %w", err)
 	}

--- a/collector/src/scheduler/sql_marker_test.go
+++ b/collector/src/scheduler/sql_marker_test.go
@@ -1,0 +1,68 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Tests for the Workbench-internal SQL marker on the scheduler's own
+// query against monitored servers. See GitHub issue #364.
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
+)
+
+// TestDatabaseListQueryIsTagged asserts the database enumeration query
+// carries the marker in a position pg_stat_statements preserves.
+func TestDatabaseListQueryIsTagged(t *testing.T) {
+	if !strings.Contains(databaseListQuery, sqlmarker.Marker) {
+		t.Fatalf("database list query is untagged: %s", databaseListQuery)
+	}
+	trimmed := strings.TrimLeft(databaseListQuery, " \t\r\n")
+	if strings.HasPrefix(trimmed, sqlmarker.Comment) {
+		t.Errorf("marker precedes the leading keyword, where "+
+			"PostgreSQL strips it: %s", databaseListQuery)
+	}
+	if !strings.HasPrefix(trimmed, "SELECT "+sqlmarker.Comment) {
+		t.Errorf("marker is not immediately after the keyword: %s",
+			databaseListQuery)
+	}
+}
+
+// TestSchedulerGetDatabaseList_QueryError covers the query-failure
+// branch of getDatabaseList by closing the underlying connection before
+// the query is issued.
+func TestSchedulerGetDatabaseList_QueryError(t *testing.T) {
+	f := setupIntegration(t)
+	ps := NewProbeScheduler(
+		f.ds, f.pool, integrationTestConfig(), testServerSecret)
+	defer ps.Stop()
+
+	mc := makeMonitoredConn(f)
+	ctx := context.Background()
+	conn, err := ps.poolManager.GetConnection(ctx, mc, testServerSecret)
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	defer ps.poolManager.ReturnConnection(mc.ID, conn)
+
+	// Closing the underlying pgx connection makes the next Query fail
+	// outright rather than failing mid-iteration.
+	if err := conn.Conn().Close(ctx); err != nil {
+		t.Fatalf("close underlying conn: %v", err)
+	}
+
+	if _, err := ps.getDatabaseList(ctx, conn); err == nil {
+		t.Fatal("expected an error from a closed connection, got nil")
+	} else if !strings.Contains(err.Error(), "failed to query pg_database") {
+		t.Errorf("error = %v, want a pg_database query failure", err)
+	}
+}

--- a/docs/admin-guide/api/openapi.json
+++ b/docs/admin-guide/api/openapi.json
@@ -6009,7 +6009,7 @@
           {
             "name": "exclude_collector",
             "in": "query",
-            "description": "Exclude collector queries",
+            "description": "Exclude Workbench-internal queries, including collector probe queries and the collector's and alerter's own datastore queries",
             "schema": {
               "type": "boolean"
             }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -286,7 +286,19 @@ project adheres to
   visible. Two classes stay untagged by design and still appear in the
   panel: the server's own datastore traffic for sessions, RBAC,
   conversations, and the timeline; and the collector's `probe_configs`
-  resolution path. (#364)
+  resolution path, along with the alerter's remaining direct datastore
+  queries in `alert_queries.go`, `anomaly_queries.go`,
+  `notification_queries.go` and `queries.go`.
+
+  On an existing installation the toggle only hides statements that
+  PostgreSQL first recorded after the upgrade. `pg_stat_statements`
+  identifies a statement by its parse tree, which ignores comments, so
+  an entry already present keeps the untagged text it was first seen
+  with and the filter never matches it; those entries run every
+  collection cycle, so they are never evicted either. Run `SELECT
+  pg_stat_statements_reset();` once on each monitored instance after
+  upgrading for the toggle to take effect on statements already in the
+  view. (#364)
 
 ### Removed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -273,18 +273,20 @@ project adheres to
   documented in the sample configuration. (#308)
 
 - Fix the "Hide monitoring queries" toggle on the Server dashboard's
-  Top Queries panel failing to hide most of the Workbench's own query
-  overhead. Only the collector's probe queries against monitored
-  databases carried a marker, so the Workbench's own traffic against
-  the metadata datastore stayed in the panel whenever that datastore
-  shared a PostgreSQL instance with the monitored databases, which is
-  the usual deployment. The toggle now also hides the collector's
-  bulk `metrics.*` inserts, partition maintenance, and
-  change-detection reads, together with the alerter's
-  metric-evaluation queries. Each of the Workbench's own statements is
-  tagged individually rather than excluding the metadata database
-  wholesale, so queries that other tools run against that same
-  database remain visible in the panel. (#364)
+  Top Queries panel failing to hide the collector's and alerter's
+  datastore query overhead. Only the collector's probe queries against
+  monitored databases carried a marker, so its bulk `metrics.*`
+  inserts, partition maintenance, and change-detection reads, together
+  with the alerter's metric-evaluation queries, stayed in the panel
+  whenever the metadata datastore shared a PostgreSQL instance with
+  the monitored databases, which is the usual deployment. The toggle
+  now hides those statements as well. Each statement is tagged
+  individually rather than excluding the metadata database wholesale,
+  so queries that other tools run against that same database remain
+  visible. Two classes stay untagged by design and still appear in the
+  panel: the server's own datastore traffic for sessions, RBAC,
+  conversations, and the timeline; and the collector's `probe_configs`
+  resolution path. (#364)
 
 ### Removed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,11 @@ project adheres to
   only the server default left the client-facing bug unchanged for
   real users. (#329)
 
+- Run the tests for the shared `pkg` module from the root `make test`
+  and `make test-all` targets, which previously skipped that module
+  entirely. This change affects test infrastructure only and does not
+  alter application behavior. (#364)
+
 ### Fixed
 
 - Fix the `metric_staleness` alert rule firing and clearing in a
@@ -266,6 +271,20 @@ project adheres to
   shutdown, and raising the memory limit modestly from 256M to
   512M; the collector connection-pool and timeout options are now
   documented in the sample configuration. (#308)
+
+- Fix the "Hide monitoring queries" toggle on the Server dashboard's
+  Top Queries panel failing to hide most of the Workbench's own query
+  overhead. Only the collector's probe queries against monitored
+  databases carried a marker, so the Workbench's own traffic against
+  the metadata datastore stayed in the panel whenever that datastore
+  shared a PostgreSQL instance with the monitored databases, which is
+  the usual deployment. The toggle now also hides the collector's
+  bulk `metrics.*` inserts, partition maintenance, and
+  change-detection reads, together with the alerter's
+  metric-evaluation queries. Each of the Workbench's own statements is
+  tagged individually rather than excluding the metadata database
+  wholesale, so queries that other tools run against that same
+  database remain visible in the panel. (#364)
 
 ### Removed
 

--- a/docs/user-guide/dashboards/server.md
+++ b/docs/user-guide/dashboards/server.md
@@ -57,3 +57,10 @@ The "Hide monitoring queries" toggle filters out the
 workbench's own monitoring queries from the list. The
 toggle is on by default to focus on application
 queries.
+
+The toggle is a display convenience rather than a
+security or audit control. The filter matches a marker
+comment in the statement text, so a database user who
+can run arbitrary SQL can hide a query by including
+that marker. Switching the toggle off restores the
+full list of statements.

--- a/docs/user-guide/dashboards/server.md
+++ b/docs/user-guide/dashboards/server.md
@@ -58,6 +58,18 @@ workbench's own monitoring queries from the list. The
 toggle is on by default to focus on application
 queries.
 
+On an existing installation, the toggle only hides
+statements that PostgreSQL first recorded after the
+upgrade. `pg_stat_statements` identifies a statement by
+its parse tree, which ignores comments, so a statement
+already recorded before the upgrade keeps the untagged
+text it was first seen with, and the filter never
+matches it. Those entries also run on every collection
+cycle, so they are never evicted. Run `SELECT
+pg_stat_statements_reset();` once on each monitored
+instance after upgrading if you want the toggle to hide
+the monitoring queries already in the view.
+
 The toggle is a display convenience rather than a
 security or audit control. The filter matches a marker
 comment in the statement text, so a database user who

--- a/pkg/sqlmarker/sqlmarker.go
+++ b/pkg/sqlmarker/sqlmarker.go
@@ -1,0 +1,118 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Package sqlmarker provides a shared marker used to tag SQL statements
+// that the Workbench itself issues against its own metadata datastore,
+// so that monitoring panels can distinguish Workbench overhead from the
+// user's own workload.
+//
+// The collector wraps its read-only probe queries against monitored
+// databases with the separate "ai_dba_wb_probe" column alias (see
+// WrapQuery in the collector's probes package). That marker cannot be
+// used for the Workbench's own statements against the datastore,
+// because those statements are inserts, deletes, DDL, and multi-column
+// reads whose shape must not change. This package supplies the
+// complementary comment marker for those statements.
+package sqlmarker
+
+import "strings"
+
+// Marker is the token identifying a statement as Workbench-internal.
+// The server's "Hide monitoring queries" filter on the Top Queries
+// panel matches on this value, so it must not be changed without
+// updating that filter (and accepting that already-collected
+// pg_stat_statements rows will keep the old text).
+const Marker = "ai_dba_wb_internal"
+
+// Comment is the SQL block comment carrying Marker. A block comment is
+// used rather than a line comment so that the marker is safe to embed
+// in single-line SQL and in statements built by string concatenation.
+const Comment = "/* " + Marker + " */"
+
+// Tag returns sql with Comment inserted immediately after its leading
+// keyword token, for example:
+//
+//	INSERT /* ai_dba_wb_internal */ INTO "metrics"."pg_stat_statements" ...
+//
+// Placement matters, and it is far from obvious why, so do not "tidy"
+// the marker to the front of the string: PostgreSQL does not preserve a
+// comment in every position when it normalizes a statement for
+// pg_stat_statements. Measured on PostgreSQL 18, with the marker in
+// each of four positions:
+//
+//	/* m */ INSERT INTO t ...        marker is stripped
+//	INSERT /* m */ INTO t ...        marker is preserved
+//	INSERT INTO t VALUES (1) /* m */ marker is preserved
+//	INSERT INTO t VALUES (1); -- m   marker is stripped
+//
+// Only a marker inside the statement survives, and the position
+// immediately after the leading keyword is the robust choice because it
+// does not depend on where the statement happens to end.
+//
+// Note also that queryid is computed from the parse tree and ignores
+// comments, so a tagged statement and an otherwise identical untagged
+// one share a queryid, and pg_stat_statements keeps the text of
+// whichever form it saw first. That is acceptable here because these
+// statements are unique to the Workbench and no other client issues
+// them.
+//
+// Tag is idempotent: sql already containing Marker is returned
+// unchanged. Leading whitespace and newlines are tolerated, so
+// indented raw string literals are handled correctly. Tag deliberately
+// does not parse SQL; it only locates the leading token, and returns
+// sql unchanged when the input is empty, whitespace-only, or does not
+// begin with an alphabetic keyword (for example a parenthesised
+// sub-select or a statement already prefixed with a comment).
+func Tag(sql string) string {
+	if strings.Contains(sql, Marker) {
+		return sql
+	}
+
+	// Locate the first non-whitespace byte; raw string literals in the
+	// collector and alerter commonly begin with a newline and indent.
+	start := -1
+	for i := 0; i < len(sql); i++ {
+		if !isSpaceByte(sql[i]) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return sql
+	}
+
+	// The leading token must be a bare alphabetic keyword. Anything
+	// else (a comment introducer, an open parenthesis, a placeholder)
+	// means we cannot place the marker safely, so leave sql alone
+	// rather than risk corrupting it.
+	end := start
+	for end < len(sql) && isAlphaByte(sql[end]) {
+		end++
+	}
+	if end == start {
+		return sql
+	}
+
+	return sql[:end] + " " + Comment + sql[end:]
+}
+
+// isSpaceByte reports whether b is an ASCII whitespace byte. SQL
+// keywords and whitespace are ASCII, so a byte-wise test is both
+// correct and cheap here; multi-byte UTF-8 sequences never match
+// because their bytes all have the high bit set.
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r' ||
+		b == '\v' || b == '\f'
+}
+
+// isAlphaByte reports whether b is an ASCII letter.
+func isAlphaByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}

--- a/pkg/sqlmarker/sqlmarker.go
+++ b/pkg/sqlmarker/sqlmarker.go
@@ -69,7 +69,19 @@ const Comment = "/* " + Marker + " */"
 // does not parse SQL; it only locates the leading token, and returns
 // sql unchanged when the input is empty, whitespace-only, or does not
 // begin with an alphabetic keyword (for example a parenthesised
-// sub-select or a statement already prefixed with a comment).
+// sub-select or a statement already prefixed with a comment). Where sql
+// is a semicolon-separated batch, only the first statement is tagged,
+// because Tag locates a single leading token.
+//
+// One input class would be corrupted rather than merely left alone: a
+// string-literal prefix letter at the very start of sql, as in E'x',
+// B'1011', X'1f', U&'x', or N'x'. The prefix letter and the opening
+// quote must be adjacent, so inserting the marker between them changes
+// the meaning; on PostgreSQL 18, SELECT E /* m */ 'x' fails with
+// `type "e" does not exist`. No guard is needed because the class is
+// unreachable: no valid statement begins with a bare string literal, and
+// every call site passes SQL that begins with a keyword. Do not start
+// passing caller-composed fragments to Tag without revisiting this.
 func Tag(sql string) string {
 	if strings.Contains(sql, Marker) {
 		return sql

--- a/pkg/sqlmarker/sqlmarker.go
+++ b/pkg/sqlmarker/sqlmarker.go
@@ -20,6 +20,11 @@
 // because those statements are inserts, deletes, DDL, and multi-column
 // reads whose shape must not change. This package supplies the
 // complementary comment marker for those statements.
+//
+// Almost all tagged statements run against the datastore, but not
+// quite all: the collector also tags the database-list query in its
+// scheduler, which runs against each monitored server rather than
+// against the datastore.
 package sqlmarker
 
 import "strings"
@@ -30,6 +35,17 @@ import "strings"
 // updating that filter (and accepting that already-collected
 // pg_stat_statements rows will keep the old text).
 const Marker = "ai_dba_wb_internal"
+
+// ProbeAlias is the synthetic column alias the collector wraps around
+// every read-only probe query it runs against a monitored database;
+// see WrapQuery in the collector's probes package. It lives here, next
+// to Marker, because the server's "Hide monitoring queries" filter
+// matches on both and the two values were previously hand-copied
+// across module boundaries with nothing to catch a drift.
+//
+// The same caveat as Marker applies: changing it leaves
+// already-collected pg_stat_statements rows carrying the old value.
+const ProbeAlias = "ai_dba_wb_probe"
 
 // Comment is the SQL block comment carrying Marker. A block comment is
 // used rather than a line comment so that the marker is safe to embed
@@ -59,9 +75,25 @@ const Comment = "/* " + Marker + " */"
 // Note also that queryid is computed from the parse tree and ignores
 // comments, so a tagged statement and an otherwise identical untagged
 // one share a queryid, and pg_stat_statements keeps the text of
-// whichever form it saw first. That is acceptable here because these
-// statements are unique to the Workbench and no other client issues
-// them.
+// whichever form it saw first.
+//
+// That has a consequence for upgrades, and it is the opposite of
+// reassuring: because these statements are unique to the Workbench,
+// the untagged entry already in pg_stat_statements is the one that
+// stays. It was recorded before the upgrade, it runs on every
+// collection cycle so is never evicted, and its stored text is frozen
+// at the untagged form. Tagging the statement therefore does not hide
+// it; the marker never appears in the text the view returns, and the
+// filter never matches. Only statements first seen after the upgrade
+// are hidden, so an existing deployment needs a one-off
+// SELECT pg_stat_statements_reset() on the monitored instance for the
+// filter to take effect on everything else.
+//
+// Measured on PostgreSQL 18: five untagged executions followed by 25
+// tagged ones leave a single row, 30 calls, with the untagged text.
+// The only statements exempt are those whose parse tree also changed,
+// which in practice means ones that gained a bind parameter in the
+// same change.
 //
 // Tag is idempotent: sql already containing Marker is returned
 // unchanged. Leading whitespace and newlines are tolerated, so

--- a/pkg/sqlmarker/sqlmarker_test.go
+++ b/pkg/sqlmarker/sqlmarker_test.go
@@ -1,0 +1,199 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package sqlmarker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarkerConstants(t *testing.T) {
+	if Marker != "ai_dba_wb_internal" {
+		t.Fatalf("Marker = %q, want ai_dba_wb_internal", Marker)
+	}
+	if Comment != "/* ai_dba_wb_internal */" {
+		t.Fatalf("Comment = %q, want /* ai_dba_wb_internal */", Comment)
+	}
+}
+
+func TestTag(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "select",
+			sql:  "SELECT * FROM metrics.pg_settings WHERE connection_id = $1",
+			want: "SELECT /* ai_dba_wb_internal */ * FROM metrics.pg_settings WHERE connection_id = $1",
+		},
+		{
+			name: "insert",
+			sql:  `INSERT INTO "metrics"."pg_stat_statements" ("a") VALUES ($1)`,
+			want: `INSERT /* ai_dba_wb_internal */ INTO "metrics"."pg_stat_statements" ("a") VALUES ($1)`,
+		},
+		{
+			name: "with",
+			sql:  "WITH recent_statements AS (SELECT 1) SELECT * FROM recent_statements",
+			want: "WITH /* ai_dba_wb_internal */ recent_statements AS (SELECT 1) SELECT * FROM recent_statements",
+		},
+		{
+			name: "update",
+			sql:  "UPDATE probe_configs SET is_enabled = true",
+			want: "UPDATE /* ai_dba_wb_internal */ probe_configs SET is_enabled = true",
+		},
+		{
+			name: "delete",
+			sql:  "DELETE FROM metrics.pg_stat_activity WHERE collected_at < now()",
+			want: "DELETE /* ai_dba_wb_internal */ FROM metrics.pg_stat_activity WHERE collected_at < now()",
+		},
+		{
+			name: "create table ddl",
+			sql:  "CREATE TABLE IF NOT EXISTS metrics.x PARTITION OF metrics.y",
+			want: "CREATE /* ai_dba_wb_internal */ TABLE IF NOT EXISTS metrics.x PARTITION OF metrics.y",
+		},
+		{
+			name: "drop table ddl",
+			sql:  `DROP TABLE IF EXISTS "metrics"."pg_settings_20260101"`,
+			want: `DROP /* ai_dba_wb_internal */ TABLE IF EXISTS "metrics"."pg_settings_20260101"`,
+		},
+		{
+			name: "lowercase keyword",
+			sql:  "select 1",
+			want: "select /* ai_dba_wb_internal */ 1",
+		},
+		{
+			name: "leading newline and indent",
+			sql: `
+        SELECT connection_id, value
+        FROM metrics.pg_stat_database
+    `,
+			want: `
+        SELECT /* ai_dba_wb_internal */ connection_id, value
+        FROM metrics.pg_stat_database
+    `,
+		},
+		{
+			name: "leading tabs and carriage return",
+			sql:  "\r\n\t\vSELECT 1",
+			want: "\r\n\t\vSELECT /* ai_dba_wb_internal */ 1",
+		},
+		{
+			name: "keyword immediately followed by star",
+			sql:  "SELECT*FROM t",
+			want: "SELECT /* ai_dba_wb_internal */*FROM t",
+		},
+		{
+			name: "empty input unchanged",
+			sql:  "",
+			want: "",
+		},
+		{
+			name: "whitespace only input unchanged",
+			sql:  "  \n\t ",
+			want: "  \n\t ",
+		},
+		{
+			name: "parenthesised leading token unchanged",
+			sql:  "(SELECT 1) UNION (SELECT 2)",
+			want: "(SELECT 1) UNION (SELECT 2)",
+		},
+		{
+			name: "leading comment unchanged",
+			sql:  "/* hint */ SELECT 1",
+			want: "/* hint */ SELECT 1",
+		},
+		{
+			name: "leading line comment unchanged",
+			sql:  "-- note\nSELECT 1",
+			want: "-- note\nSELECT 1",
+		},
+		{
+			name: "already tagged is unchanged",
+			sql:  "SELECT /* ai_dba_wb_internal */ 1",
+			want: "SELECT /* ai_dba_wb_internal */ 1",
+		},
+		{
+			name: "marker present anywhere is unchanged",
+			sql:  "SELECT 'ai_dba_wb_internal' AS m",
+			want: "SELECT 'ai_dba_wb_internal' AS m",
+		},
+		{
+			name: "multibyte leading character unchanged",
+			sql:  "é SELECT 1",
+			want: "é SELECT 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Tag(tt.sql)
+			if got != tt.want {
+				t.Errorf("Tag(%q) = %q, want %q", tt.sql, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTagIsIdempotent guards against double-tagging when a statement
+// passes through more than one helper on its way to the datastore.
+func TestTagIsIdempotent(t *testing.T) {
+	sql := "INSERT INTO metrics.pg_stat_activity (a) VALUES ($1)"
+	once := Tag(sql)
+	twice := Tag(once)
+	if once != twice {
+		t.Errorf("Tag is not idempotent: %q vs %q", once, twice)
+	}
+	if strings.Count(once, Marker) != 1 {
+		t.Errorf("expected exactly one marker, got %d in %q",
+			strings.Count(once, Marker), once)
+	}
+}
+
+// TestTagDoesNotPrefixStatement is the regression guard for the
+// pg_stat_statements behavior documented on Tag: PostgreSQL strips a
+// comment that precedes the leading keyword, so the marker must never
+// appear at the start of the statement text.
+func TestTagDoesNotPrefixStatement(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT 1",
+		"INSERT INTO t (a) VALUES (1)",
+		"\n    WITH x AS (SELECT 1) SELECT * FROM x",
+	} {
+		tagged := Tag(sql)
+		trimmed := strings.TrimLeft(tagged, " \t\r\n\v\f")
+		if strings.HasPrefix(trimmed, Comment) {
+			t.Errorf("Tag(%q) placed the marker at the start: %q",
+				sql, tagged)
+		}
+		if !strings.Contains(tagged, Comment) {
+			t.Errorf("Tag(%q) did not insert the marker: %q", sql, tagged)
+		}
+		// The marker must follow the first keyword, never precede it.
+		markerAt := strings.Index(tagged, Comment)
+		keywordAt := len(tagged) - len(trimmed)
+		if markerAt <= keywordAt {
+			t.Errorf("Tag(%q) put the marker at %d, before or at the "+
+				"keyword at %d: %q", sql, markerAt, keywordAt, tagged)
+		}
+	}
+}
+
+// TestTagPreservesTrailingSQL confirms the remainder of the statement,
+// including bind-parameter placeholders, survives untouched.
+func TestTagPreservesTrailingSQL(t *testing.T) {
+	sql := "UPDATE t SET a = $1, b = $2 WHERE id = $3 RETURNING id"
+	tagged := Tag(sql)
+	rest := strings.TrimPrefix(tagged, "UPDATE "+Comment)
+	if rest != strings.TrimPrefix(sql, "UPDATE") {
+		t.Errorf("Tag altered the statement body: %q", tagged)
+	}
+}

--- a/pkg/sqlmarker/sqlmarker_test.go
+++ b/pkg/sqlmarker/sqlmarker_test.go
@@ -131,6 +131,26 @@ func TestTag(t *testing.T) {
 			sql:  "é SELECT 1",
 			want: "é SELECT 1",
 		},
+		{
+			// A dollar-quoted body is never entered, because the marker
+			// lands at the leading token; the $$ ... $$ text is left
+			// byte-for-byte alone.
+			name: "dollar quoted block is not entered",
+			sql:  "DO $$ BEGIN PERFORM 1; END $$",
+			want: "DO /* ai_dba_wb_internal */ $$ BEGIN PERFORM 1; END $$",
+		},
+		{
+			name: "tagged dollar quoted function body",
+			sql: "CREATE FUNCTION f() RETURNS int LANGUAGE plpgsql AS " +
+				"$body$ BEGIN RETURN 1; END $body$",
+			want: "CREATE /* ai_dba_wb_internal */ FUNCTION f() RETURNS " +
+				"int LANGUAGE plpgsql AS $body$ BEGIN RETURN 1; END $body$",
+		},
+		{
+			name: "dollar quoted literal in a select list",
+			sql:  "SELECT $$SELECT 1$$ AS t",
+			want: "SELECT /* ai_dba_wb_internal */ $$SELECT 1$$ AS t",
+		},
 	}
 
 	for _, tt := range tests {
@@ -184,6 +204,114 @@ func TestTagDoesNotPrefixStatement(t *testing.T) {
 			t.Errorf("Tag(%q) put the marker at %d, before or at the "+
 				"keyword at %d: %q", sql, markerAt, keywordAt, tagged)
 		}
+	}
+}
+
+// TestTagOnlyTagsTheFirstStatementOfABatch pins the current handling of
+// a semicolon-separated batch: Tag locates one leading token and so the
+// marker reaches only the first statement, leaving the rest untagged and
+// therefore visible in the Top Queries panel when monitoring queries are
+// hidden.
+//
+// This is a pinning test rather than an assertion of desired behavior.
+// No call site passes a batch today (every caller passes a single
+// statement, and pgx's simple protocol is not used for these queries),
+// so the gap is latent. The test exists so that a future change either
+// to Tag or to a caller has to update it deliberately.
+func TestTagOnlyTagsTheFirstStatementOfABatch(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "two selects",
+			sql:  "SELECT 1; SELECT 2",
+			want: "SELECT /* ai_dba_wb_internal */ 1; SELECT 2",
+		},
+		{
+			name: "insert then delete",
+			sql: "INSERT INTO t (a) VALUES (1); " +
+				"DELETE FROM t WHERE a = 2",
+			want: "INSERT /* ai_dba_wb_internal */ INTO t (a) VALUES (1); " +
+				"DELETE FROM t WHERE a = 2",
+		},
+		{
+			name: "trailing semicolon on a single statement",
+			sql:  "SELECT 1;",
+			want: "SELECT /* ai_dba_wb_internal */ 1;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Tag(tt.sql)
+			if got != tt.want {
+				t.Errorf("Tag(%q) = %q, want %q", tt.sql, got, tt.want)
+			}
+			if strings.Count(got, Marker) != 1 {
+				t.Errorf("Tag(%q) inserted %d markers, want 1: %q",
+					tt.sql, strings.Count(got, Marker), got)
+			}
+		})
+	}
+}
+
+// TestTagLeadingStringLiteralPrefix pins the one input class Tag would
+// corrupt: a statement beginning with a string-literal prefix letter,
+// where the marker is inserted between the letter and the opening quote.
+// PostgreSQL 18 rejects the result, for example `SELECT E /* m */ 'x'`
+// fails with `type "e" does not exist`, because the prefix letter and
+// the quote must be adjacent.
+//
+// The class is unreachable, so no defensive code guards against it. No
+// valid PostgreSQL statement begins with a bare string literal, and
+// every call site passes SQL beginning with a keyword: the collector's
+// and alerter's tagged statements are compiled-in literals or are built
+// by fmt.Sprintf from a fixed SELECT, INSERT, CREATE, or DROP prefix.
+// The test records the behavior so that if Tag ever does become
+// reachable from such input, the corruption is documented rather than
+// discovered in production.
+func TestTagLeadingStringLiteralPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "escape string prefix",
+			sql:  `E'x\n'`,
+			want: `E /* ai_dba_wb_internal */'x\n'`,
+		},
+		{
+			name: "bit string prefix",
+			sql:  "B'1011'",
+			want: "B /* ai_dba_wb_internal */'1011'",
+		},
+		{
+			name: "hex bit string prefix",
+			sql:  "X'1f'",
+			want: "X /* ai_dba_wb_internal */'1f'",
+		},
+		{
+			name: "unicode escape prefix",
+			sql:  `U&'d\0061t'`,
+			want: `U /* ai_dba_wb_internal */&'d\0061t'`,
+		},
+		{
+			name: "national character prefix",
+			sql:  "N'x'",
+			want: "N /* ai_dba_wb_internal */'x'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Tag(tt.sql)
+			if got != tt.want {
+				t.Errorf("Tag(%q) = %q, want %q", tt.sql, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/server/src/internal/api/openapi.go
+++ b/server/src/internal/api/openapi.go
@@ -3413,7 +3413,10 @@ func buildPaths() map[string]OpenAPIPathItem {
 					queryParamString("order_by", "Column to sort by"),
 					queryParamString("order", "Sort order (asc or desc)"),
 					queryParamString("queryid", "Filter by specific query ID"),
-					queryParamBool("exclude_collector", "Exclude collector queries"),
+					queryParamBool("exclude_collector",
+						"Exclude Workbench-internal queries, including "+
+							"collector probe queries and the collector's "+
+							"and alerter's own datastore queries"),
 				},
 				Responses: map[string]OpenAPIResponse{
 					"200": jsonArrayResponse("TopQueryRow", "Top queries"),

--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -52,9 +52,16 @@ const probeMarkerAlias = "ai_dba_wb_probe"
 // deliberately does not exclude the datastore database wholesale: users
 // legitimately run their own tools against that database and expect to
 // see them here.
-const excludeWorkbenchQueriesClause = "AND pss.query NOT LIKE '%" +
-	probeMarkerAlias + "%' AND pss.query NOT LIKE '%" +
-	sqlmarker.Marker + "%'"
+//
+// The pss.query IS NULL arm is not redundant. metrics.pg_stat_statements
+// stores query as a nullable column, and PostgreSQL evaluates
+// NULL NOT LIKE '...' to NULL rather than true, so without that arm any
+// row whose query text was not captured would be filtered out. A row we
+// cannot positively identify as Workbench traffic must be shown rather
+// than hidden, so NULL query text survives the filter.
+const excludeWorkbenchQueriesClause = "AND (pss.query IS NULL OR (" +
+	"pss.query NOT LIKE '%" + probeMarkerAlias + "%' AND " +
+	"pss.query NOT LIKE '%" + sqlmarker.Marker + "%'))"
 
 // validTimeRanges maps time_range parameter values to their duration.
 var validTimeRanges = map[string]time.Duration{
@@ -1062,20 +1069,53 @@ func (h *PerfSummaryHandler) queryDatabaseCacheHitTimeSeries(
 	}
 }
 
+// defaultTopQueryOrderBy and defaultTopQueryOrder are the ordering used
+// when no ordering is requested, and the fallback buildTopQueriesQuery
+// substitutes for anything it cannot validate.
+const (
+	defaultTopQueryOrderBy = "total_exec_time"
+	defaultTopQueryOrder   = "desc"
+)
+
+// safeTopQueryOrdering maps a requested ORDER BY column and direction on
+// to a pair that is safe to interpolate into SQL, substituting the
+// defaults for anything not on the whitelists.
+//
+// handleTopQueries already rejects invalid values with HTTP 400, so in
+// practice this function never substitutes anything. It exists so that
+// the injection-safety property of buildTopQueriesQuery is local to the
+// code that does the interpolating rather than depending on a caller a
+// call frame away: any future caller, or any future relaxation of the
+// handler's parsing, still cannot reach the ORDER BY clause with
+// arbitrary text.
+func safeTopQueryOrdering(orderBy, order string) (string, string) {
+	if !validTopQueryOrderColumns[orderBy] {
+		orderBy = defaultTopQueryOrderBy
+	}
+	if order != "asc" && order != "desc" {
+		order = defaultTopQueryOrder
+	}
+	return orderBy, order
+}
+
 // buildTopQueriesQuery builds the pg_stat_statements query behind the
 // Top Queries panel, returning the statement and its bind arguments.
 //
 // The connection ID, row limit, and queryid filter are all bound
-// parameters. The ORDER BY column and direction are interpolated, which
-// is safe only because handleTopQueries validates both against
-// whitelists before calling this function, and the optional
-// Workbench-internal exclusion is a compile-time constant clause.
+// parameters. The ORDER BY column and direction are interpolated, so
+// both are passed through safeTopQueryOrdering first and can only ever
+// be whitelisted values; the optional Workbench-internal exclusion is a
+// compile-time constant clause. Callers are still expected to reject
+// invalid ordering parameters themselves, as handleTopQueries does with
+// HTTP 400, rather than relying on the silent fallback here.
 func buildTopQueriesQuery(
 	connID, limit int,
 	queryID string,
 	excludeCollector bool,
 	orderBy, order string,
 ) (string, []any) {
+	orderBy, order = safeTopQueryOrdering(orderBy, order)
+
 	// Build optional queryid filter clause.
 	queryIDClause := ""
 	args := []any{connID, limit}
@@ -1173,7 +1213,7 @@ func (h *PerfSummaryHandler) handleTopQueries(
 	// Parse and validate order_by
 	orderBy := ParseQueryString(r, "order_by")
 	if orderBy == "" {
-		orderBy = "total_exec_time"
+		orderBy = defaultTopQueryOrderBy
 	}
 	if !validTopQueryOrderColumns[orderBy] {
 		RespondError(w, http.StatusBadRequest,
@@ -1185,7 +1225,7 @@ func (h *PerfSummaryHandler) handleTopQueries(
 	// Parse and validate order direction
 	order := strings.ToLower(ParseQueryString(r, "order"))
 	if order == "" {
-		order = "desc"
+		order = defaultTopQueryOrder
 	}
 	if order != "asc" && order != "desc" {
 		RespondError(w, http.StatusBadRequest,
@@ -1228,13 +1268,21 @@ func (h *PerfSummaryHandler) handleTopQueries(
 	results := make([]TopQueryRow, 0)
 	for rows.Next() {
 		var row TopQueryRow
+		// query is nullable in metrics.pg_stat_statements, so it is
+		// scanned through a pointer; a row whose text was not captured
+		// is still reported, with an empty query string, rather than
+		// being dropped as an unscannable row.
+		var queryText *string
 		if err := rows.Scan(
-			&row.QueryID, &row.DatabaseName, &row.Query, &row.Calls,
+			&row.QueryID, &row.DatabaseName, &queryText, &row.Calls,
 			&row.TotalExecTime, &row.MeanExecTime, &row.Rows,
 			&row.SharedBlksHit, &row.SharedBlksRead,
 		); err != nil {
 			log.Printf("[DEBUG] Error scanning top query row: %v", err)
 			continue
+		}
+		if queryText != nil {
+			row.Query = *queryText
 		}
 		results = append(results, row)
 	}

--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -20,10 +20,41 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
 	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/database"
 	"github.com/pgedge/ai-workbench/server/internal/logging"
 )
+
+// probeMarkerAlias is the synthetic column alias that the collector
+// wraps around every read-only probe query it runs against a monitored
+// database; see WrapQuery in the collector's probes package. The
+// collector is a separate Go module, so the value is repeated here
+// rather than imported. Keep the two in step.
+const probeMarkerAlias = "ai_dba_wb_probe"
+
+// excludeWorkbenchQueriesClause filters out the Workbench's own
+// statements from the Top Queries panel when the caller asks to hide
+// monitoring queries.
+//
+// Two markers are needed. The collector's probe queries against
+// monitored databases carry probeMarkerAlias as a column alias, whilst
+// the Workbench's statements against its own datastore (the collector's
+// bulk metrics writes and partition maintenance, and the alerter's
+// metric-evaluation queries) carry sqlmarker.Marker as an in-statement
+// comment. Because the datastore usually shares a PostgreSQL instance
+// with the databases being monitored, pg_stat_statements captures both
+// classes, and before the second marker existed the datastore traffic
+// leaked through this filter (GitHub issue #364).
+//
+// The clause is a compile-time constant built from two constants, so it
+// carries no user input and needs no bound parameters. Note that it
+// deliberately does not exclude the datastore database wholesale: users
+// legitimately run their own tools against that database and expect to
+// see them here.
+const excludeWorkbenchQueriesClause = "AND pss.query NOT LIKE '%" +
+	probeMarkerAlias + "%' AND pss.query NOT LIKE '%" +
+	sqlmarker.Marker + "%'"
 
 // validTimeRanges maps time_range parameter values to their duration.
 var validTimeRanges = map[string]time.Duration{
@@ -1031,6 +1062,72 @@ func (h *PerfSummaryHandler) queryDatabaseCacheHitTimeSeries(
 	}
 }
 
+// buildTopQueriesQuery builds the pg_stat_statements query behind the
+// Top Queries panel, returning the statement and its bind arguments.
+//
+// The connection ID, row limit, and queryid filter are all bound
+// parameters. The ORDER BY column and direction are interpolated, which
+// is safe only because handleTopQueries validates both against
+// whitelists before calling this function, and the optional
+// Workbench-internal exclusion is a compile-time constant clause.
+func buildTopQueriesQuery(
+	connID, limit int,
+	queryID string,
+	excludeCollector bool,
+	orderBy, order string,
+) (string, []any) {
+	// Build optional queryid filter clause.
+	queryIDClause := ""
+	args := []any{connID, limit}
+	if queryID != "" {
+		queryIDClause = fmt.Sprintf(
+			"AND pss.queryid::text = $%d", len(args)+1)
+		args = append(args, queryID)
+	}
+
+	// Build optional clause to exclude Workbench-internal queries,
+	// covering both the collector's probe queries and the collector's
+	// and alerter's own datastore traffic.
+	excludeCollectorClause := ""
+	if excludeCollector {
+		excludeCollectorClause = excludeWorkbenchQueriesClause
+	}
+
+	query := fmt.Sprintf(`
+        WITH db_names AS (
+            SELECT DISTINCT datid, datname
+            FROM metrics.pg_stat_activity
+            WHERE connection_id = $1
+              AND datid IS NOT NULL
+              AND datname IS NOT NULL
+        ),
+        deduped AS (
+            SELECT DISTINCT ON (pss.queryid)
+                pss.queryid::text,
+                COALESCE(dn.datname, pss.database_name) AS database_name,
+                pss.query, pss.calls, pss.total_exec_time,
+                pss.mean_exec_time, pss.rows,
+                pss.shared_blks_hit, pss.shared_blks_read
+            FROM metrics.pg_stat_statements pss
+            LEFT JOIN db_names dn ON pss.dbid = dn.datid
+            WHERE pss.connection_id = $1
+              AND pss.collected_at = (
+                  SELECT MAX(collected_at)
+                  FROM metrics.pg_stat_statements
+                  WHERE connection_id = $1
+              )
+              %s
+              %s
+            ORDER BY pss.queryid
+        )
+        SELECT * FROM deduped
+        ORDER BY %s %s
+        LIMIT $2
+    `, queryIDClause, excludeCollectorClause, orderBy, order)
+
+	return query, args
+}
+
 // handleTopQueries handles GET /api/v1/metrics/top-queries
 func (h *PerfSummaryHandler) handleTopQueries(
 	w http.ResponseWriter,
@@ -1117,54 +1214,8 @@ func (h *PerfSummaryHandler) handleTopQueries(
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // Rollback after commit is a no-op
 
-	// Safe to use string formatting for ORDER BY because orderBy and order
-	// are validated against whitelists above.
-	// Build optional queryid filter clause.
-	queryIDClause := ""
-	args := []any{connID, limit}
-	if queryID != "" {
-		queryIDClause = fmt.Sprintf(
-			"AND pss.queryid::text = $%d", len(args)+1)
-		args = append(args, queryID)
-	}
-
-	// Build optional clause to exclude collector probe queries.
-	excludeCollectorClause := ""
-	if excludeCollector {
-		excludeCollectorClause = "AND pss.query NOT LIKE '%ai_dba_wb_probe%'"
-	}
-
-	query := fmt.Sprintf(`
-        WITH db_names AS (
-            SELECT DISTINCT datid, datname
-            FROM metrics.pg_stat_activity
-            WHERE connection_id = $1
-              AND datid IS NOT NULL
-              AND datname IS NOT NULL
-        ),
-        deduped AS (
-            SELECT DISTINCT ON (pss.queryid)
-                pss.queryid::text,
-                COALESCE(dn.datname, pss.database_name) AS database_name,
-                pss.query, pss.calls, pss.total_exec_time,
-                pss.mean_exec_time, pss.rows,
-                pss.shared_blks_hit, pss.shared_blks_read
-            FROM metrics.pg_stat_statements pss
-            LEFT JOIN db_names dn ON pss.dbid = dn.datid
-            WHERE pss.connection_id = $1
-              AND pss.collected_at = (
-                  SELECT MAX(collected_at)
-                  FROM metrics.pg_stat_statements
-                  WHERE connection_id = $1
-              )
-              %s
-              %s
-            ORDER BY pss.queryid
-        )
-        SELECT * FROM deduped
-        ORDER BY %s %s
-        LIMIT $2
-    `, queryIDClause, excludeCollectorClause, orderBy, order)
+	query, args := buildTopQueriesQuery(
+		connID, limit, queryID, excludeCollector, orderBy, order)
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {

--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -48,7 +48,11 @@ const probeMarkerAlias = sqlmarker.ProbeAlias
 // leaked through this filter (GitHub issue #364).
 //
 // The clause is a compile-time constant built from two constants, so it
-// carries no user input and needs no bound parameters. Note that it
+// carries no user input and needs no bound parameters. It matches with
+// strpos rather than LIKE because both markers contain underscores,
+// which LIKE treats as single-character wildcards: LIKE
+// '%ai_dba_wb_probe%' also matches a user query containing, say,
+// aiXdbaYwbZprobe, and would hide it. Note that it
 // deliberately does not exclude the datastore database wholesale: users
 // legitimately run their own tools against that database and expect to
 // see them here.
@@ -67,8 +71,8 @@ const probeMarkerAlias = sqlmarker.ProbeAlias
 // cannot positively identify as Workbench traffic must be shown rather
 // than hidden, so NULL query text survives the filter.
 const excludeWorkbenchQueriesClause = "AND (pss.query IS NULL OR (" +
-	"pss.query NOT LIKE '%" + probeMarkerAlias + "%' AND " +
-	"pss.query NOT LIKE '%" + sqlmarker.Marker + "%'))"
+	"strpos(pss.query, '" + probeMarkerAlias + "') = 0 AND " +
+	"strpos(pss.query, '" + sqlmarker.Marker + "') = 0))"
 
 // validTimeRanges maps time_range parameter values to their duration.
 var validTimeRanges = map[string]time.Duration{

--- a/server/src/internal/api/perf_summary_handlers.go
+++ b/server/src/internal/api/perf_summary_handlers.go
@@ -28,10 +28,10 @@ import (
 
 // probeMarkerAlias is the synthetic column alias that the collector
 // wraps around every read-only probe query it runs against a monitored
-// database; see WrapQuery in the collector's probes package. The
-// collector is a separate Go module, so the value is repeated here
-// rather than imported. Keep the two in step.
-const probeMarkerAlias = "ai_dba_wb_probe"
+// database; see WrapQuery in the collector's probes package. It comes
+// from pkg/sqlmarker so that the collector and the server cannot drift
+// apart on the value.
+const probeMarkerAlias = sqlmarker.ProbeAlias
 
 // excludeWorkbenchQueriesClause filters out the Workbench's own
 // statements from the Top Queries panel when the caller asks to hide
@@ -52,6 +52,13 @@ const probeMarkerAlias = "ai_dba_wb_probe"
 // deliberately does not exclude the datastore database wholesale: users
 // legitimately run their own tools against that database and expect to
 // see them here.
+//
+// This is a presentation filter and not a security boundary. Anyone
+// able to run SQL on a monitored database can hide their own statement
+// from this panel by including either marker in it, exactly as they
+// already could with the probe alias. That is an acceptable trade-off
+// for a display toggle, but do not build anything on the assumption
+// that a hidden statement is a Workbench statement.
 //
 // The pss.query IS NULL arm is not redundant. metrics.pg_stat_statements
 // stores query as a nullable column, and PostgreSQL evaluates

--- a/server/src/internal/api/top_queries_filter_test.go
+++ b/server/src/internal/api/top_queries_filter_test.go
@@ -1,0 +1,128 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Tests for the Top Queries panel's "Hide monitoring queries" filter.
+// See GitHub issue #364: the filter previously excluded only the
+// collector's probe marker, so the collector's and alerter's own
+// datastore statements still appeared in the panel.
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
+)
+
+// TestExcludeWorkbenchQueriesClause asserts the clause excludes both
+// markers: the collector's probe column alias and the in-statement
+// comment carried by the Workbench's own datastore traffic.
+func TestExcludeWorkbenchQueriesClause(t *testing.T) {
+	for _, marker := range []string{probeMarkerAlias, sqlmarker.Marker} {
+		want := "pss.query NOT LIKE '%" + marker + "%'"
+		if !strings.Contains(excludeWorkbenchQueriesClause, want) {
+			t.Errorf("clause is missing %q: %s",
+				want, excludeWorkbenchQueriesClause)
+		}
+	}
+	if !strings.HasPrefix(excludeWorkbenchQueriesClause, "AND ") {
+		t.Errorf("clause must be appendable to a WHERE list: %s",
+			excludeWorkbenchQueriesClause)
+	}
+	if strings.Contains(excludeWorkbenchQueriesClause, "$") {
+		t.Errorf("clause must not introduce bind parameters: %s",
+			excludeWorkbenchQueriesClause)
+	}
+	if probeMarkerAlias != "ai_dba_wb_probe" {
+		t.Errorf("probeMarkerAlias = %q; it must match WrapQuery in the "+
+			"collector's probes package", probeMarkerAlias)
+	}
+}
+
+// TestBuildTopQueriesQuery covers every combination of the optional
+// queryid filter and the Workbench-internal exclusion.
+func TestBuildTopQueriesQuery(t *testing.T) {
+	tests := []struct {
+		name             string
+		queryID          string
+		excludeCollector bool
+		wantArgs         int
+		wantContains     []string
+		wantMissing      []string
+	}{
+		{
+			name:         "plain",
+			wantArgs:     2,
+			wantContains: []string{"FROM metrics.pg_stat_statements pss"},
+			wantMissing: []string{
+				sqlmarker.Marker, probeMarkerAlias,
+				"pss.queryid::text = $",
+			},
+		},
+		{
+			name:         "with queryid",
+			queryID:      "12345",
+			wantArgs:     3,
+			wantContains: []string{"AND pss.queryid::text = $3"},
+			wantMissing:  []string{sqlmarker.Marker},
+		},
+		{
+			name:             "excluding workbench queries",
+			excludeCollector: true,
+			wantArgs:         2,
+			wantContains: []string{
+				"NOT LIKE '%" + probeMarkerAlias + "%'",
+				"NOT LIKE '%" + sqlmarker.Marker + "%'",
+			},
+		},
+		{
+			name:             "queryid and exclusion together",
+			queryID:          "999",
+			excludeCollector: true,
+			wantArgs:         3,
+			wantContains: []string{
+				"AND pss.queryid::text = $3",
+				"NOT LIKE '%" + probeMarkerAlias + "%'",
+				"NOT LIKE '%" + sqlmarker.Marker + "%'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, args := buildTopQueriesQuery(
+				7, 25, tt.queryID, tt.excludeCollector,
+				"total_exec_time", "desc")
+
+			if len(args) != tt.wantArgs {
+				t.Fatalf("len(args) = %d, want %d", len(args), tt.wantArgs)
+			}
+			if args[0] != 7 || args[1] != 25 {
+				t.Errorf("args = %v, want connection 7 and limit 25", args)
+			}
+			if tt.queryID != "" && args[2] != tt.queryID {
+				t.Errorf("args[2] = %v, want %q", args[2], tt.queryID)
+			}
+			if !strings.Contains(query, "ORDER BY total_exec_time desc") {
+				t.Errorf("ordering clause missing: %s", query)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(query, want) {
+					t.Errorf("query is missing %q", want)
+				}
+			}
+			for _, unwanted := range tt.wantMissing {
+				if strings.Contains(query, unwanted) {
+					t.Errorf("query unexpectedly contains %q", unwanted)
+				}
+			}
+		})
+	}
+}

--- a/server/src/internal/api/top_queries_filter_test.go
+++ b/server/src/internal/api/top_queries_filter_test.go
@@ -44,6 +44,97 @@ func TestExcludeWorkbenchQueriesClause(t *testing.T) {
 		t.Errorf("probeMarkerAlias = %q; it must match WrapQuery in the "+
 			"collector's probes package", probeMarkerAlias)
 	}
+	// A NULL query must survive the filter. NULL NOT LIKE '...' is NULL,
+	// not true, so the clause needs an explicit IS NULL arm; see the
+	// clause's own comment.
+	if !strings.Contains(excludeWorkbenchQueriesClause, "pss.query IS NULL OR") {
+		t.Errorf("clause must let a NULL query through: %s",
+			excludeWorkbenchQueriesClause)
+	}
+}
+
+// TestSafeTopQueryOrdering asserts that the ordering pair interpolated
+// into the ORDER BY clause is whitelisted at the point of use, so the
+// injection-safety property does not depend on the caller.
+func TestSafeTopQueryOrdering(t *testing.T) {
+	tests := []struct {
+		name          string
+		orderBy       string
+		order         string
+		wantOrderBy   string
+		wantOrder     string
+		wantSanitized bool
+	}{
+		{
+			name:        "valid pair passes through",
+			orderBy:     "calls",
+			order:       "asc",
+			wantOrderBy: "calls",
+			wantOrder:   "asc",
+		},
+		{
+			name:          "empty values fall back",
+			wantOrderBy:   defaultTopQueryOrderBy,
+			wantOrder:     defaultTopQueryOrder,
+			wantSanitized: true,
+		},
+		{
+			name:          "injected column falls back",
+			orderBy:       "calls; DROP TABLE connections --",
+			order:         "asc",
+			wantOrderBy:   defaultTopQueryOrderBy,
+			wantOrder:     "asc",
+			wantSanitized: true,
+		},
+		{
+			name:          "injected direction falls back",
+			orderBy:       "rows",
+			order:         "desc; DROP TABLE connections --",
+			wantOrderBy:   "rows",
+			wantOrder:     defaultTopQueryOrder,
+			wantSanitized: true,
+		},
+		{
+			name:          "uppercase direction is not accepted",
+			orderBy:       "rows",
+			order:         "DESC",
+			wantOrderBy:   "rows",
+			wantOrder:     defaultTopQueryOrder,
+			wantSanitized: true,
+		},
+		{
+			name:          "unknown column falls back",
+			orderBy:       "wal_bytes",
+			order:         "desc",
+			wantOrderBy:   defaultTopQueryOrderBy,
+			wantOrder:     "desc",
+			wantSanitized: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOrderBy, gotOrder := safeTopQueryOrdering(tt.orderBy, tt.order)
+			if gotOrderBy != tt.wantOrderBy || gotOrder != tt.wantOrder {
+				t.Fatalf("safeTopQueryOrdering(%q, %q) = (%q, %q), "+
+					"want (%q, %q)", tt.orderBy, tt.order,
+					gotOrderBy, gotOrder, tt.wantOrderBy, tt.wantOrder)
+			}
+
+			// The builder must apply the same fallback, so no
+			// unwhitelisted text can ever reach the ORDER BY clause.
+			query, _ := buildTopQueriesQuery(
+				1, 10, "", false, tt.orderBy, tt.order)
+			want := "ORDER BY " + tt.wantOrderBy + " " + tt.wantOrder
+			if !strings.Contains(query, want) {
+				t.Errorf("query is missing %q: %s", want, query)
+			}
+			if tt.wantSanitized && strings.Contains(query, "DROP TABLE") {
+				t.Errorf("unvalidated ordering text reached the query: %s",
+					query)
+			}
+		})
+	}
 }
 
 // TestBuildTopQueriesQuery covers every combination of the optional

--- a/server/src/internal/api/top_queries_filter_test.go
+++ b/server/src/internal/api/top_queries_filter_test.go
@@ -26,11 +26,19 @@ import (
 // comment carried by the Workbench's own datastore traffic.
 func TestExcludeWorkbenchQueriesClause(t *testing.T) {
 	for _, marker := range []string{probeMarkerAlias, sqlmarker.Marker} {
-		want := "pss.query NOT LIKE '%" + marker + "%'"
+		want := "strpos(pss.query, '" + marker + "') = 0"
 		if !strings.Contains(excludeWorkbenchQueriesClause, want) {
 			t.Errorf("clause is missing %q: %s",
 				want, excludeWorkbenchQueriesClause)
 		}
+	}
+
+	// Both markers contain underscores, which LIKE treats as
+	// single-character wildcards, so LIKE would also match unrelated
+	// user queries and hide them. The match must be literal.
+	if strings.Contains(excludeWorkbenchQueriesClause, "LIKE") {
+		t.Errorf("clause must match literally rather than with LIKE: %s",
+			excludeWorkbenchQueriesClause)
 	}
 	if !strings.HasPrefix(excludeWorkbenchQueriesClause, "AND ") {
 		t.Errorf("clause must be appendable to a WHERE list: %s",
@@ -44,9 +52,9 @@ func TestExcludeWorkbenchQueriesClause(t *testing.T) {
 		t.Errorf("probeMarkerAlias = %q; it must match WrapQuery in the "+
 			"collector's probes package", probeMarkerAlias)
 	}
-	// A NULL query must survive the filter. NULL NOT LIKE '...' is NULL,
-	// not true, so the clause needs an explicit IS NULL arm; see the
-	// clause's own comment.
+	// A NULL query must survive the filter. strpos(NULL, '...') is
+	// NULL and NULL = 0 is NULL rather than true, so the clause needs
+	// an explicit IS NULL arm; see the clause's own comment.
 	if !strings.Contains(excludeWorkbenchQueriesClause, "pss.query IS NULL OR") {
 		t.Errorf("clause must let a NULL query through: %s",
 			excludeWorkbenchQueriesClause)
@@ -169,8 +177,8 @@ func TestBuildTopQueriesQuery(t *testing.T) {
 			excludeCollector: true,
 			wantArgs:         2,
 			wantContains: []string{
-				"NOT LIKE '%" + probeMarkerAlias + "%'",
-				"NOT LIKE '%" + sqlmarker.Marker + "%'",
+				"strpos(pss.query, '" + probeMarkerAlias + "') = 0",
+				"strpos(pss.query, '" + sqlmarker.Marker + "') = 0",
 			},
 		},
 		{
@@ -180,8 +188,8 @@ func TestBuildTopQueriesQuery(t *testing.T) {
 			wantArgs:         3,
 			wantContains: []string{
 				"AND pss.queryid::text = $3",
-				"NOT LIKE '%" + probeMarkerAlias + "%'",
-				"NOT LIKE '%" + sqlmarker.Marker + "%'",
+				"strpos(pss.query, '" + probeMarkerAlias + "') = 0",
+				"strpos(pss.query, '" + sqlmarker.Marker + "') = 0",
 			},
 		},
 	}

--- a/server/src/internal/api/top_queries_handler_test.go
+++ b/server/src/internal/api/top_queries_handler_test.go
@@ -121,6 +121,10 @@ func newTopQueriesHandler(t *testing.T) (*PerfSummaryHandler, int, func()) {
 			" recent_statements AS (SELECT 1) SELECT * FROM recent_statements"},
 	}
 	for _, st := range statements {
+		// The SQL is a fixed literal; st.query is seed data bound as $4,
+		// so the marker text it contains is a value and never part of
+		// the statement being executed.
+		//nosemgrep: go_sql_rule-concat-sqli -- fixed SQL literal; the seeded query text is bound as $4
 		if _, err := pool.Exec(ctx, `
 			INSERT INTO metrics.pg_stat_statements (
 				connection_id, collected_at, queryid, dbid, database_name,

--- a/server/src/internal/api/top_queries_handler_test.go
+++ b/server/src/internal/api/top_queries_handler_test.go
@@ -231,6 +231,74 @@ func TestHandleTopQueries_ExcludesWorkbenchQueries(t *testing.T) {
 	}
 }
 
+// TestHandleTopQueries_NullQueryRetained asserts that a row whose query
+// text was not captured survives the "Hide monitoring queries" filter.
+// The query column is nullable, and NULL NOT LIKE '...' evaluates to
+// NULL rather than true, so a naive pair of NOT LIKE tests would hide
+// every such row; a row we cannot positively identify as Workbench
+// traffic must be shown instead.
+func TestHandleTopQueries_NullQueryRetained(t *testing.T) {
+	handler, connID, cleanup := newTopQueriesHandler(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pool := handler.datastore.GetPool()
+	if _, err := pool.Exec(ctx, `
+		ALTER TABLE metrics.pg_stat_statements ALTER COLUMN query
+			DROP NOT NULL
+	`); err != nil {
+		t.Fatalf("relax constraint: %v", err)
+	}
+
+	var collectedAt time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT max(collected_at) FROM metrics.pg_stat_statements
+	`).Scan(&collectedAt); err != nil {
+		t.Fatalf("read collected_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO metrics.pg_stat_statements (
+			connection_id, collected_at, queryid, dbid, database_name,
+			query, calls, total_exec_time, mean_exec_time, rows,
+			shared_blks_hit, shared_blks_read)
+		VALUES ($1, $2, 100, NULL, 'appdb', NULL, 3, 5.0, 1.5, 2, 0, 0)
+	`, connID, collectedAt); err != nil {
+		t.Fatalf("seed null-query row: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.handleTopQueries(rec, superuserRequest(fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d"+
+			"&exclude_collector=true", connID)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	rows := decodeTopQueries(t, rec)
+	var sawNull bool
+	for _, row := range rows {
+		if row.QueryID == "100" {
+			sawNull = true
+			if row.Query != "" {
+				t.Errorf("query = %q, want the empty string for a NULL "+
+					"query", row.Query)
+			}
+		}
+	}
+	if !sawNull {
+		for _, row := range rows {
+			t.Logf("returned: %s %q", row.QueryID, row.Query)
+		}
+		t.Errorf("the NULL-query row was filtered out by the exclusion")
+	}
+	// The user workload row must still be there, and the two Workbench
+	// rows must still be gone.
+	if len(rows) != 2 {
+		t.Errorf("filtered rows = %d, want 2 (user workload plus the "+
+			"NULL-query row)", len(rows))
+	}
+}
+
 // TestHandleTopQueries_QueryIDAndOrdering covers the queryid filter, the
 // limit clamps, and the ordering parameters.
 func TestHandleTopQueries_QueryIDAndOrdering(t *testing.T) {

--- a/server/src/internal/api/top_queries_handler_test.go
+++ b/server/src/internal/api/top_queries_handler_test.go
@@ -1,0 +1,437 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// HTTP-level tests for the Top Queries endpoint, including the
+// behavioral check for GitHub issue #364: with exclude_collector=true,
+// neither the collector's probe queries nor the Workbench's own
+// datastore statements may appear in the response.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgedge/ai-workbench/pkg/sqlmarker"
+	"github.com/pgedge/ai-workbench/server/internal/auth"
+	"github.com/pgedge/ai-workbench/server/internal/database"
+)
+
+// topQueriesTestSchema creates the minimal connections table and the two
+// metrics tables read by the Top Queries endpoint. Only the columns the
+// endpoint selects are declared.
+const topQueriesTestSchema = `
+DROP SCHEMA IF EXISTS metrics CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    is_shared BOOLEAN NOT NULL DEFAULT TRUE,
+    owner_username VARCHAR(255)
+);
+
+CREATE SCHEMA metrics;
+
+CREATE TABLE metrics.pg_stat_activity (
+    connection_id INTEGER NOT NULL,
+    datid OID,
+    datname TEXT,
+    collected_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE metrics.pg_stat_statements (
+    connection_id INTEGER NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    queryid BIGINT NOT NULL,
+    dbid OID,
+    database_name TEXT,
+    query TEXT NOT NULL,
+    calls BIGINT NOT NULL,
+    total_exec_time DOUBLE PRECISION NOT NULL,
+    mean_exec_time DOUBLE PRECISION NOT NULL,
+    rows BIGINT NOT NULL,
+    shared_blks_hit BIGINT NOT NULL,
+    shared_blks_read BIGINT NOT NULL
+);
+`
+
+// newTopQueriesHandler builds a PerfSummaryHandler over the integration
+// test database, seeding one user workload statement plus one statement
+// of each Workbench-internal flavor.
+func newTopQueriesHandler(t *testing.T) (*PerfSummaryHandler, int, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set; skipping")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+	if _, err := pool.Exec(ctx, topQueriesTestSchema); err != nil {
+		pool.Close()
+		t.Fatalf("create test schema: %v", err)
+	}
+
+	var connID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO connections (name) VALUES ('top-queries')
+		RETURNING id
+	`).Scan(&connID); err != nil {
+		pool.Close()
+		t.Fatalf("seed connection: %v", err)
+	}
+
+	collectedAt := time.Now().UTC()
+	statements := []struct {
+		queryid int64
+		query   string
+	}{
+		{1, "SELECT * FROM orders WHERE id = $1"},
+		{2, "SELECT 'pg_stat_activity' AS ai_dba_wb_probe, subq.* " +
+			"FROM (SELECT * FROM pg_stat_activity) AS subq"},
+		{3, `INSERT ` + sqlmarker.Comment +
+			` INTO "metrics"."pg_stat_statements" ("a") VALUES ($1)`},
+		{4, "WITH " + sqlmarker.Comment +
+			" recent_statements AS (SELECT 1) SELECT * FROM recent_statements"},
+	}
+	for _, st := range statements {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO metrics.pg_stat_statements (
+				connection_id, collected_at, queryid, dbid, database_name,
+				query, calls, total_exec_time, mean_exec_time, rows,
+				shared_blks_hit, shared_blks_read)
+			VALUES ($1, $2, $3, NULL, 'appdb', $4, 10, 100.0, 10.0, 5, 1, 0)
+		`, connID, collectedAt, st.queryid, st.query); err != nil {
+			pool.Close()
+			t.Fatalf("seed statement %d: %v", st.queryid, err)
+		}
+	}
+
+	tmpDir, err := os.MkdirTemp("", "top-queries-auth-*")
+	if err != nil {
+		pool.Close()
+		t.Fatalf("temp dir: %v", err)
+	}
+	authStore, err := auth.NewAuthStore(tmpDir, 0, 0)
+	if err != nil {
+		pool.Close()
+		_ = os.RemoveAll(tmpDir)
+		t.Fatalf("auth store: %v", err)
+	}
+
+	handler := NewPerfSummaryHandler(database.NewTestDatastore(pool), authStore)
+
+	cleanup := func() {
+		authStore.Close()
+		for _, stmt := range []string{
+			"DROP SCHEMA IF EXISTS metrics CASCADE",
+			"DROP TABLE IF EXISTS connections CASCADE",
+		} {
+			if _, err := pool.Exec(context.Background(), stmt); err != nil {
+				t.Logf("cleanup: %s: %v", stmt, err)
+			}
+		}
+		pool.Close()
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("cleanup: remove %s: %v", tmpDir, err)
+		}
+	}
+
+	return handler, connID, cleanup
+}
+
+// superuserRequest builds a GET request for the Top Queries endpoint
+// carrying a superuser context, which is all the RBAC checker needs.
+func superuserRequest(target string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	ctx := context.WithValue(
+		req.Context(), auth.IsSuperuserContextKey, true)
+	return req.WithContext(ctx)
+}
+
+// decodeTopQueries reads the endpoint's JSON array response.
+func decodeTopQueries(t *testing.T, rec *httptest.ResponseRecorder) []TopQueryRow {
+	t.Helper()
+	var rows []TopQueryRow
+	if err := json.NewDecoder(rec.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return rows
+}
+
+// TestHandleTopQueries_ExcludesWorkbenchQueries is the regression test
+// for issue #364: with the filter on, the collector's probe query and
+// both Workbench-internal statements must disappear, leaving only the
+// user's own workload.
+func TestHandleTopQueries_ExcludesWorkbenchQueries(t *testing.T) {
+	handler, connID, cleanup := newTopQueriesHandler(t)
+	defer cleanup()
+
+	// Without the filter, all four statements come back.
+	rec := httptest.NewRecorder()
+	handler.handleTopQueries(rec, superuserRequest(fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d", connID)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := len(decodeTopQueries(t, rec)); got != 4 {
+		t.Errorf("unfiltered rows = %d, want 4", got)
+	}
+
+	// With the filter, only the user workload survives.
+	rec = httptest.NewRecorder()
+	handler.handleTopQueries(rec, superuserRequest(fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d"+
+			"&exclude_collector=true", connID)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	rows := decodeTopQueries(t, rec)
+	if len(rows) != 1 {
+		for _, r := range rows {
+			t.Logf("returned: %s", r.Query)
+		}
+		t.Fatalf("filtered rows = %d, want 1", len(rows))
+	}
+	if rows[0].QueryID != "1" {
+		t.Errorf("surviving queryid = %s, want 1", rows[0].QueryID)
+	}
+	if rows[0].DatabaseName != "appdb" {
+		t.Errorf("database_name = %q, want appdb", rows[0].DatabaseName)
+	}
+}
+
+// TestHandleTopQueries_QueryIDAndOrdering covers the queryid filter, the
+// limit clamps, and the ordering parameters.
+func TestHandleTopQueries_QueryIDAndOrdering(t *testing.T) {
+	handler, connID, cleanup := newTopQueriesHandler(t)
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	handler.handleTopQueries(rec, superuserRequest(fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d&queryid=1"+
+			"&order_by=calls&order=ASC&limit=1000", connID)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	rows := decodeTopQueries(t, rec)
+	if len(rows) != 1 || rows[0].QueryID != "1" {
+		t.Fatalf("unexpected rows: %+v", rows)
+	}
+
+	// A limit below the minimum is clamped rather than rejected.
+	rec = httptest.NewRecorder()
+	handler.handleTopQueries(rec, superuserRequest(fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d&limit=0", connID)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := len(decodeTopQueries(t, rec)); got != 1 {
+		t.Errorf("rows with limit=0 = %d, want 1", got)
+	}
+}
+
+// TestHandleTopQueries_NoData confirms an empty array is returned when
+// the metrics tables are missing, rather than an error.
+func TestHandleTopQueries_NoData(t *testing.T) {
+	handler, connID, cleanup := newTopQueriesHandler(t)
+	defer cleanup()
+
+	pool := handler.datastore.GetPool()
+	if _, err := pool.Exec(context.Background(),
+		"DROP SCHEMA metrics CASCADE"); err != nil {
+		t.Fatalf("drop metrics schema: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.handleTopQueries(rec, superuserRequest(fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d", connID)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := len(decodeTopQueries(t, rec)); got != 0 {
+		t.Errorf("rows = %d, want 0", got)
+	}
+}
+
+// TestHandleTopQueries_RowScanError covers the branch that skips a row
+// which cannot be scanned, by relaxing a NOT NULL constraint and
+// inserting a row with a null count.
+func TestHandleTopQueries_RowScanError(t *testing.T) {
+	handler, connID, cleanup := newTopQueriesHandler(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pool := handler.datastore.GetPool()
+	if _, err := pool.Exec(ctx, `
+		ALTER TABLE metrics.pg_stat_statements ALTER COLUMN calls
+			DROP NOT NULL
+	`); err != nil {
+		t.Fatalf("relax constraint: %v", err)
+	}
+
+	var collectedAt time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT max(collected_at) FROM metrics.pg_stat_statements
+	`).Scan(&collectedAt); err != nil {
+		t.Fatalf("read collected_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO metrics.pg_stat_statements (
+			connection_id, collected_at, queryid, dbid, database_name,
+			query, calls, total_exec_time, mean_exec_time, rows,
+			shared_blks_hit, shared_blks_read)
+		VALUES ($1, $2, 99, NULL, 'appdb', 'SELECT 99', NULL,
+		        1.0, 1.0, 1, 0, 0)
+	`, connID, collectedAt); err != nil {
+		t.Fatalf("seed unscannable row: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.handleTopQueries(rec, superuserRequest(fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d", connID)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	// The four seeded statements are returned; the null row is skipped.
+	if got := len(decodeTopQueries(t, rec)); got != 4 {
+		t.Errorf("rows = %d, want 4 with the unscannable row skipped", got)
+	}
+}
+
+// TestHandleTopQueries_TransactionError covers the failure to open the
+// read-only transaction, by closing the pool first.
+func TestHandleTopQueries_TransactionError(t *testing.T) {
+	handler, connID, cleanup := newTopQueriesHandler(t)
+	defer cleanup()
+
+	handler.datastore.GetPool().Close()
+
+	rec := httptest.NewRecorder()
+	handler.handleTopQueries(rec, superuserRequest(fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d", connID)))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d",
+			rec.Code, http.StatusInternalServerError)
+	}
+}
+
+// TestHandleTopQueries_RequestValidation covers the guard clauses:
+// method, connection identification, parameter validation, and RBAC.
+func TestHandleTopQueries_RequestValidation(t *testing.T) {
+	handler, connID, cleanup := newTopQueriesHandler(t)
+	defer cleanup()
+
+	base := fmt.Sprintf(
+		"/api/v1/metrics/top-queries?connection_id=%d", connID)
+
+	t.Run("method not allowed", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, base, nil)
+		handler.handleTopQueries(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("status = %d, want %d",
+				rec.Code, http.StatusMethodNotAllowed)
+		}
+	})
+
+	t.Run("missing connection id", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.handleTopQueries(rec,
+			superuserRequest("/api/v1/metrics/top-queries"))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d",
+				rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("too many connection ids", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.handleTopQueries(rec, superuserRequest(
+			"/api/v1/metrics/top-queries?connection_ids=1,2"))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d",
+				rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("invalid limit", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.handleTopQueries(rec,
+			superuserRequest(base+"&limit=abc"))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d",
+				rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("invalid order_by", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.handleTopQueries(rec,
+			superuserRequest(base+"&order_by=drop_table"))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d",
+				rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("invalid order", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.handleTopQueries(rec,
+			superuserRequest(base+"&order=sideways"))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d",
+				rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("permission denied", func(t *testing.T) {
+		// A connection that is neither shared nor owned by the caller,
+		// requested without a superuser flag or user context, must be
+		// refused by the RBAC checker.
+		var privateID int
+		err := handler.datastore.GetPool().QueryRow(context.Background(), `
+			INSERT INTO connections (name, is_shared, owner_username)
+			VALUES ('private', FALSE, 'someone-else')
+			RETURNING id
+		`).Scan(&privateID)
+		if err != nil {
+			t.Fatalf("seed private connection: %v", err)
+		}
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf(
+			"/api/v1/metrics/top-queries?connection_id=%d", privateID), nil)
+		handler.handleTopQueries(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want %d",
+				rec.Code, http.StatusForbidden)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The "Hide monitoring queries" toggle on the Server dashboard's Top
Queries panel filtered on the `ai_dba_wb_probe` marker alone, which the
collector wraps only around the read-only probe queries it runs against
monitored databases. Because the metadata datastore normally shares a
PostgreSQL instance with those databases, `pg_stat_statements` also
captures the Workbench's own traffic against its own datastore, and
none of that carried a marker: the collector's bulk `metrics.*`
inserts, its partition maintenance and change-detection reads, and the
alerter's metric-evaluation queries all leaked through the filter.

- Those statements are now tagged with an in-statement comment marker
  (`ai_dba_wb_internal`) from a new shared `pkg/sqlmarker` package,
  applied at the few chokepoints each binary funnels its datastore
  traffic through rather than at the individual SQL literals, so that
  statements added later are tagged by construction. The alerter needed
  a single funnel (`queryInternal`), through which all of the metric
  registry's hundred-odd `latestSQL`/`historicalSQL` literals now pass.
- The server's filter excludes both markers, as a compile-time constant
  clause carrying no user input.
- The Workbench's statements are tagged individually rather than
  excluding the metadata database wholesale, because users legitimately
  run other tools against that same data and expect to keep seeing them
  in this panel.

### Marker placement is load-bearing

Worth knowing before reviewing `sqlmarker.Tag`, because the obvious
tidy-looking placement is the one that does not work: PostgreSQL does
not preserve a comment in every position when it normalises a statement
for `pg_stat_statements`. Measured on PostgreSQL 18:

| Placement | Marker survives? |
|---|---|
| `/* m */ INSERT INTO t ...` | No, stripped |
| `INSERT /* m */ INTO t ...` | Yes |
| `INSERT INTO t VALUES (1) /* m */;` | Yes |
| `INSERT INTO t VALUES (1); -- m` | No, stripped |

The marker therefore sits immediately after the leading keyword, and
the rationale is documented on the helper so that nobody moves it to
the front of the string and silently breaks the filter. Relatedly,
`queryid` is derived from the parse tree and ignores comments, so a
tagged and an untagged form of the same statement share a `queryid` and
the first-seen text wins; that is harmless for statements unique to the
Workbench, and is noted in the helper's doc comment.

Beyond the three categories named in the issue, the sweep also caught
the scheduler's per-cycle database-list query, which runs against the
monitored server every cycle and bypasses `WrapQuery` entirely, so it
was unmarked noise the issue had not spotted.

## Test plan

- [x] New unit tests for `sqlmarker.Tag`: each leading keyword,
  newline-indented raw literals, empty and whitespace-only input,
  idempotency, and a case asserting the marker is *not* placed at the
  start of the string, guarding the behaviour tabled above.
- [x] Tests asserting the tagged SQL at each collector and alerter
  chokepoint, and that the server clause excludes both markers.
- [x] Integration tests proving the marker survives into
  `pg_stat_statements`. These use throwaway tables deliberately: a
  statement differing only by a column alias or a literal collapses
  onto the same `queryid` and keeps the older text, so only a uniquely
  named relation can identify a test statement.
- [x] `make test-all`, plus the alerter target separately, and
  `golangci-lint` clean across collector, server and alerter. Coverage
  meets the 90% floor on touched code; notable movers are
  `handleTopQueries` 0 to 98.5%, `UpsertProbeAvailability` 0 to 100%,
  and `alerter/internal/database` 83.6 to 89.7%.
- [x] `cd server && make openapi` regenerated, OpenAPI tests pass.
- [ ] Two pre-existing failures remain in `server/internal/tools`
  (`TestStoreMemory...` / `TestRecallMemories...`, `expected 3
  dimensions, not 4000`). They reproduce on pristine `main`, stem from
  a stale `vector(3)` fixture, and are unrelated to this change.

## Follow-ups, deliberately not in scope

- The **server's own** datastore traffic (sessions, RBAC,
  conversations, timeline) is the same class of noise and is still
  untagged. Unlike the alerter there is no funnel: roughly 300 direct
  `pool.Query`/`Exec` call sites across about 15 packages. The
  tractable shape is a tagging wrapper trio on the server `Datastore`
  plus a mechanical sweep. The collector's `probe_configs` path belongs
  with it.
- The shared `pkg` module's tests now run from the root `make test` and
  `make test-all`, which previously ran them nowhere. No CI workflow
  covers that module either, so wiring one up remains outstanding.

Closes #364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workbench-generated SQL is now consistently identified, allowing monitoring-query filters to hide collector, probe, and alerter activity more accurately.

* **Bug Fixes**
  * Top Queries filtering and sorting is more robust, including safer ordering and correct handling of missing query text.
  * Improved metric error reporting and partition-maintenance reliability.

* **Documentation**
  * Updated Top Queries API and dashboard guidance, including internal query markers and upgrade considerations.

* **Tests**
  * Expanded SQL-tagging, Top Queries, metric, partition, and integration coverage.
  * Root test commands now include shared module Go tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->