### PR TITLE
Repoint handler tests at the WithSecurity constructors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -391,6 +391,18 @@ project adheres to
   call sites all go together. `EnableAnalytics` defaulted to false, so
   no deployment was collecting these figures in any case.
 
+### Removed
+
+- Remove the superseded `NewConnectionHandler` and
+  `NewNotificationChannelHandler` constructors, along with the
+  `DefaultHostValidator` helper that only they used. The server has
+  wired both handlers through the `NewConnectionHandlerWithSecurity` and
+  `NewNotificationChannelHandlerWithSecurity` variants for some time, so
+  the shorter forms were unreachable in production whilst 49 test call
+  sites still used them. Those call sites now use the `WithSecurity`
+  constructors directly, passing the same host-validation settings the
+  removed helper supplied, so test behaviour is unchanged.
+
 ### Security
 
 - Ignore a blank password when updating a database connection, so an

--- a/server/src/internal/api/connection_handlers.go
+++ b/server/src/internal/api/connection_handlers.go
@@ -36,16 +36,6 @@ type ConnectionHandler struct {
 	visibilityListerFn func() auth.ConnectionVisibilityLister
 }
 
-// NewConnectionHandler creates a new connection handler
-func NewConnectionHandler(datastore *database.Datastore, authStore *auth.AuthStore, rbacChecker *auth.RBACChecker) *ConnectionHandler {
-	return &ConnectionHandler{
-		datastore:     datastore,
-		authStore:     authStore,
-		hostValidator: DefaultHostValidator(),
-		rbacChecker:   rbacChecker,
-	}
-}
-
 // NewConnectionHandlerWithSecurity creates a new connection handler with custom security settings
 func NewConnectionHandlerWithSecurity(datastore *database.Datastore, authStore *auth.AuthStore,
 	rbacChecker *auth.RBACChecker, allowInternal bool, allowedHosts, blockedHosts []string) *ConnectionHandler {

--- a/server/src/internal/api/connection_handlers_test.go
+++ b/server/src/internal/api/connection_handlers_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestNewConnectionHandler(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 	if handler == nil {
 		t.Fatal("NewConnectionHandler returned nil")
 	}
@@ -79,7 +79,7 @@ func TestConnectionHandler_HandleNotConfigured(t *testing.T) {
 }
 
 func TestConnectionHandler_HandleConnections_MethodNotAllowed(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	tests := []struct {
 		name   string
@@ -111,7 +111,7 @@ func TestConnectionHandler_HandleConnections_MethodNotAllowed(t *testing.T) {
 }
 
 func TestConnectionHandler_HandleConnectionSubpath_InvalidID(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/abc", nil)
 	rec := httptest.NewRecorder()
@@ -133,7 +133,7 @@ func TestConnectionHandler_HandleConnectionSubpath_InvalidID(t *testing.T) {
 }
 
 func TestConnectionHandler_HandleConnectionSubpath_MethodNotAllowed(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/connections/1", nil)
 	rec := httptest.NewRecorder()
@@ -151,7 +151,7 @@ func TestConnectionHandler_HandleConnectionSubpath_MethodNotAllowed(t *testing.T
 }
 
 func TestConnectionHandler_HandleConnectionSubpath_DatabasesMethodNotAllowed(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/1/databases", nil)
 	rec := httptest.NewRecorder()
@@ -169,7 +169,7 @@ func TestConnectionHandler_HandleConnectionSubpath_DatabasesMethodNotAllowed(t *
 }
 
 func TestConnectionHandler_HandleCurrentConnection_MethodNotAllowed(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/connections/current", nil)
 	req.Header.Set("Authorization", "Bearer testtoken")
@@ -188,7 +188,7 @@ func TestConnectionHandler_HandleCurrentConnection_MethodNotAllowed(t *testing.T
 }
 
 func TestConnectionHandler_HandleCurrentConnection_MissingAuth(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/current", nil)
 	rec := httptest.NewRecorder()
@@ -210,7 +210,7 @@ func TestConnectionHandler_HandleCurrentConnection_MissingAuth(t *testing.T) {
 }
 
 func TestConnectionHandler_RegisterRoutes_NotConfigured(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 	mux := http.NewServeMux()
 	noopWrapper := func(h http.HandlerFunc) http.HandlerFunc { return h }
 
@@ -237,7 +237,7 @@ func TestConnectionHandler_RegisterRoutes_NotConfigured(t *testing.T) {
 func TestConnectionHandler_CreateConnection_NoAuth(t *testing.T) {
 	// Test that createConnection requires authentication
 	rbac := auth.NewRBACChecker(nil)
-	handler := NewConnectionHandler(nil, nil, rbac)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, rbac, false, nil, nil)
 
 	body, _ := json.Marshal(ConnectionCreateRequest{
 		Name:         "test",
@@ -273,7 +273,7 @@ func TestConnectionHandler_CreateConnection_NoAuth(t *testing.T) {
 func TestConnectionHandler_UpdateConnection_NoAuth(t *testing.T) {
 	// Test that updateConnection requires authentication
 	rbac := auth.NewRBACChecker(nil)
-	handler := NewConnectionHandler(nil, nil, rbac)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, rbac, false, nil, nil)
 
 	body, _ := json.Marshal(ConnectionFullUpdateRequest{})
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/connections/1",
@@ -299,7 +299,7 @@ func TestConnectionHandler_UpdateConnection_NoAuth(t *testing.T) {
 }
 
 func TestConnectionHandler_SetCurrentConnection_InvalidConnectionID(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	body, _ := json.Marshal(CurrentConnectionRequest{ConnectionID: 0})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/current",
@@ -453,7 +453,7 @@ func TestCurrentConnectionResponse_JSON(t *testing.T) {
 }
 
 func TestConnectionHandler_HandleSubpath_NotFound(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	// Test unknown subpath
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/1/unknown", nil)
@@ -467,7 +467,7 @@ func TestConnectionHandler_HandleSubpath_NotFound(t *testing.T) {
 }
 
 func TestConnectionHandler_HandleSubpath_EmptyPath(t *testing.T) {
-	handler := NewConnectionHandler(nil, nil, nil)
+	handler := NewConnectionHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/", nil)
 	rec := httptest.NewRecorder()
@@ -649,7 +649,7 @@ func TestListConnectionsScopedTokenReturnsScopedConnection(t *testing.T) {
 			return ds.GetConnectionSharingInfo(ctx, id)
 		},
 	)
-	handler := NewConnectionHandler(ds, store, checker)
+	handler := NewConnectionHandlerWithSecurity(ds, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections", nil)
 	ctx := req.Context()
@@ -761,7 +761,7 @@ func newListConnectionsIssue68Handler(ds *database.Datastore, store *auth.AuthSt
 			return ds.GetConnectionSharingInfo(ctx, id)
 		},
 	)
-	return NewConnectionHandler(ds, store, checker)
+	return NewConnectionHandlerWithSecurity(ds, store, checker, false, nil, nil)
 }
 
 // TestListConnections_Issue68_Superuser_ReturnsAllConnections locks in

--- a/server/src/internal/api/host_validation.go
+++ b/server/src/internal/api/host_validation.go
@@ -196,10 +196,3 @@ func (v *HostValidator) ValidatePort(port int) error {
 
 	return nil
 }
-
-// DefaultHostValidator returns a validator with secure defaults:
-// - Blocks internal network connections
-// - No allowed/blocked host lists
-func DefaultHostValidator() *HostValidator {
-	return NewHostValidator(false, nil, nil)
-}

--- a/server/src/internal/api/host_validation_test.go
+++ b/server/src/internal/api/host_validation_test.go
@@ -67,22 +67,6 @@ func TestNewHostValidator(t *testing.T) {
 	}
 }
 
-func TestDefaultHostValidator(t *testing.T) {
-	v := DefaultHostValidator()
-	if v == nil {
-		t.Fatal("DefaultHostValidator returned nil")
-	}
-	if v.AllowInternalNetworks {
-		t.Error("Default validator should not allow internal networks")
-	}
-	if len(v.AllowedHosts) != 0 {
-		t.Error("Default validator should have empty allowed hosts")
-	}
-	if len(v.BlockedHosts) != 0 {
-		t.Error("Default validator should have empty blocked hosts")
-	}
-}
-
 func TestHostValidator_ValidateHost(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -239,7 +223,7 @@ func TestHostValidator_ValidateHost(t *testing.T) {
 }
 
 func TestHostValidator_ValidatePort(t *testing.T) {
-	v := DefaultHostValidator()
+	v := NewHostValidator(false, nil, nil)
 
 	tests := []struct {
 		name        string
@@ -403,7 +387,7 @@ func TestHostValidator_CIDRParsing(t *testing.T) {
 }
 
 func TestHostValidator_InternalNetworksList(t *testing.T) {
-	v := DefaultHostValidator()
+	v := NewHostValidator(false, nil, nil)
 
 	// Test that common internal ranges are blocked
 	internalIPs := []string{

--- a/server/src/internal/api/issue269_connection_name_test.go
+++ b/server/src/internal/api/issue269_connection_name_test.go
@@ -216,7 +216,7 @@ func TestConnectionHandler_UpdateConnection_Issue269_InvalidChars(t *testing.T) 
 	seedIssue269Connection(t, pool, connID, owner, "valid-name")
 
 	checker := auth.NewRBACChecker(store)
-	handler := NewConnectionHandler(ds, store, checker)
+	handler := NewConnectionHandlerWithSecurity(ds, store, checker, false, nil, nil)
 
 	invalid := issue269InvalidName
 	body, _ := json.Marshal(ConnectionFullUpdateRequest{Name: &invalid})
@@ -254,7 +254,7 @@ func TestConnectionHandler_UpdateConnection_Issue269_ValidNameSucceeds(t *testin
 	seedIssue269Connection(t, pool, connID, owner, "old-name")
 
 	checker := auth.NewRBACChecker(store)
-	handler := NewConnectionHandler(ds, store, checker)
+	handler := NewConnectionHandlerWithSecurity(ds, store, checker, false, nil, nil)
 
 	valid := "New Cluster (primary) - east_1.db"
 	body, _ := json.Marshal(ConnectionFullUpdateRequest{Name: &valid})

--- a/server/src/internal/api/notification_channel_handlers.go
+++ b/server/src/internal/api/notification_channel_handlers.go
@@ -32,20 +32,6 @@ type NotificationChannelHandler struct {
 	checkPermission func(http.ResponseWriter, *http.Request) bool
 }
 
-// NewNotificationChannelHandler creates a new notification channel handler
-func NewNotificationChannelHandler(datastore *database.Datastore, authStore *auth.AuthStore, rbacChecker *auth.RBACChecker) *NotificationChannelHandler {
-	h := &NotificationChannelHandler{
-		datastore:     datastore,
-		authStore:     authStore,
-		rbacChecker:   rbacChecker,
-		hostValidator: DefaultHostValidator(),
-	}
-	if rbacChecker != nil {
-		h.checkPermission = RequireAdminPermission(rbacChecker, auth.PermManageNotificationChannels, "manage notification channels")
-	}
-	return h
-}
-
 // NewNotificationChannelHandlerWithSecurity creates a new notification channel handler with custom security settings
 func NewNotificationChannelHandlerWithSecurity(datastore *database.Datastore, authStore *auth.AuthStore,
 	rbacChecker *auth.RBACChecker, allowInternal bool, allowedHosts, blockedHosts []string) *NotificationChannelHandler {

--- a/server/src/internal/api/notification_channel_handlers_test.go
+++ b/server/src/internal/api/notification_channel_handlers_test.go
@@ -39,7 +39,7 @@ import (
 // the handler is constructed without a datastore, every route under
 // `/api/v1/notification-channels` returns 503.
 func TestNotificationChannelHandler_NotConfiguredRoutes(t *testing.T) {
-	handler := NewNotificationChannelHandler(nil, nil, nil)
+	handler := NewNotificationChannelHandlerWithSecurity(nil, nil, nil, false, nil, nil)
 	mux := http.NewServeMux()
 	noopWrapper := func(h http.HandlerFunc) http.HandlerFunc { return h }
 	handler.RegisterRoutes(mux, noopWrapper)
@@ -67,7 +67,7 @@ func TestNotificationChannelHandler_NotConfiguredRoutes(t *testing.T) {
 func TestNotificationChannelHandler_MethodNotAllowed(t *testing.T) {
 	authStore, cleanup := newAuthStoreForChannelTests(t)
 	defer cleanup()
-	handler := NewNotificationChannelHandler(nil, authStore, auth.NewRBACChecker(authStore))
+	handler := NewNotificationChannelHandlerWithSecurity(nil, authStore, auth.NewRBACChecker(authStore), false, nil, nil)
 
 	cases := []struct {
 		path        string
@@ -115,7 +115,7 @@ func TestNotificationChannelHandler_MethodNotAllowed(t *testing.T) {
 func TestNotificationChannelHandler_InvalidIDs(t *testing.T) {
 	authStore, cleanup := newAuthStoreForChannelTests(t)
 	defer cleanup()
-	handler := NewNotificationChannelHandler(nil, authStore, auth.NewRBACChecker(authStore))
+	handler := NewNotificationChannelHandlerWithSecurity(nil, authStore, auth.NewRBACChecker(authStore), false, nil, nil)
 
 	cases := []struct {
 		path string
@@ -147,7 +147,7 @@ func TestNotificationChannelHandler_InvalidIDs(t *testing.T) {
 func TestNotificationChannelHandler_PermissionRequired(t *testing.T) {
 	authStore, cleanup := newAuthStoreForChannelTests(t)
 	defer cleanup()
-	handler := NewNotificationChannelHandler(nil, authStore, auth.NewRBACChecker(authStore))
+	handler := NewNotificationChannelHandlerWithSecurity(nil, authStore, auth.NewRBACChecker(authStore), false, nil, nil)
 
 	for _, method := range []string{http.MethodGet, http.MethodPost} {
 		req := httptest.NewRequest(method, "/api/v1/notification-channels", nil)
@@ -172,7 +172,7 @@ func TestNotificationChannelHandler_PermissionRequired(t *testing.T) {
 func TestNotificationChannelHandler_NotFoundPaths(t *testing.T) {
 	authStore, cleanup := newAuthStoreForChannelTests(t)
 	defer cleanup()
-	handler := NewNotificationChannelHandler(nil, authStore, auth.NewRBACChecker(authStore))
+	handler := NewNotificationChannelHandlerWithSecurity(nil, authStore, auth.NewRBACChecker(authStore), false, nil, nil)
 
 	paths := []string{
 		"/api/v1/notification-channels/",
@@ -303,7 +303,7 @@ func setupChannelHandler(t *testing.T, ds *database.Datastore) (*NotificationCha
 	userID := setupUserWithPermission(t, authStore, "channel_admin",
 		auth.PermManageNotificationChannels)
 	checker := auth.NewRBACChecker(authStore)
-	handler := NewNotificationChannelHandler(ds, authStore, checker)
+	handler := NewNotificationChannelHandlerWithSecurity(ds, authStore, checker, false, nil, nil)
 	return handler, userID, cleanup
 }
 
@@ -1178,7 +1178,7 @@ func TestCreateChannel_ValidationErrors(t *testing.T) {
 	userID := setupUserWithPermission(t, authStore, "ch_validator",
 		auth.PermManageNotificationChannels)
 	checker := auth.NewRBACChecker(authStore)
-	handler := NewNotificationChannelHandler(nil, authStore, checker)
+	handler := NewNotificationChannelHandlerWithSecurity(nil, authStore, checker, false, nil, nil)
 
 	cases := []struct {
 		name string

--- a/server/src/internal/api/query_handlers_test.go
+++ b/server/src/internal/api/query_handlers_test.go
@@ -29,7 +29,7 @@ import (
 // RBAC checks pass without requiring a database.
 func newTestConnectionHandlerWithRBAC() *ConnectionHandler {
 	rbac := auth.NewRBACChecker(nil)
-	return NewConnectionHandler(nil, nil, rbac)
+	return NewConnectionHandlerWithSecurity(nil, nil, rbac, false, nil, nil)
 }
 
 func TestExecuteQuery_MethodNotAllowed(t *testing.T) {

--- a/server/src/internal/api/rbac_integration_test.go
+++ b/server/src/internal/api/rbac_integration_test.go
@@ -231,7 +231,7 @@ func TestRBACEnforcement_AdminPermissions(t *testing.T) {
 			url:        "/api/v1/notification-channels",
 			permission: auth.PermManageNotificationChannels,
 			handler: func(store *auth.AuthStore, checker *auth.RBACChecker) http.HandlerFunc {
-				h := NewNotificationChannelHandler(nil, store, checker)
+				h := NewNotificationChannelHandlerWithSecurity(nil, store, checker, false, nil, nil)
 				return h.handleChannels
 			},
 		},
@@ -241,7 +241,7 @@ func TestRBACEnforcement_AdminPermissions(t *testing.T) {
 			url:        "/api/v1/notification-channels/1",
 			permission: auth.PermManageNotificationChannels,
 			handler: func(store *auth.AuthStore, checker *auth.RBACChecker) http.HandlerFunc {
-				h := NewNotificationChannelHandler(nil, store, checker)
+				h := NewNotificationChannelHandlerWithSecurity(nil, store, checker, false, nil, nil)
 				return h.handleChannelSubpath
 			},
 		},
@@ -251,7 +251,7 @@ func TestRBACEnforcement_AdminPermissions(t *testing.T) {
 			url:        "/api/v1/notification-channels/1",
 			permission: auth.PermManageNotificationChannels,
 			handler: func(store *auth.AuthStore, checker *auth.RBACChecker) http.HandlerFunc {
-				h := NewNotificationChannelHandler(nil, store, checker)
+				h := NewNotificationChannelHandlerWithSecurity(nil, store, checker, false, nil, nil)
 				return h.handleChannelSubpath
 			},
 		},
@@ -1070,7 +1070,7 @@ func TestConnectionHandler_GetConnection_NonOwnerUnshared_403(t *testing.T) {
 	bobID, _ := store.GetUserID("bob")
 
 	checker := mockSharingChecker(t, store, 42, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/42", nil)
 	req = withUser(req, bobID)
@@ -1087,7 +1087,7 @@ func TestConnectionHandler_GetConnection_Superuser_NotDenied(t *testing.T) {
 	defer cleanup()
 
 	checker := mockSharingChecker(t, store, 42, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/42", nil)
 	req = withSuperuser(req)
@@ -1115,7 +1115,7 @@ func TestConnectionHandler_GetConnection_Owner_NotDenied(t *testing.T) {
 	aliceID, _ := store.GetUserID("alice")
 
 	checker := mockSharingChecker(t, store, 42, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/42", nil)
 	req = withUser(req, aliceID)
@@ -1143,7 +1143,7 @@ func TestConnectionHandler_GetConnection_SharedNonOwner_NotDenied(t *testing.T) 
 
 	// Shared resource: non-owner should have access.
 	checker := mockSharingChecker(t, store, 42, "alice", true)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/42", nil)
 	req = withUser(req, bobID)
@@ -1182,7 +1182,7 @@ func TestConnectionHandler_GetConnection_GroupGrantedUser_NotDenied(t *testing.T
 	}
 
 	checker := mockSharingChecker(t, store, 42, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/42", nil)
 	req = withUser(req, bobID)

--- a/server/src/internal/api/rbac_issue233_connections_test.go
+++ b/server/src/internal/api/rbac_issue233_connections_test.go
@@ -88,7 +88,7 @@ func setupIssue233CreateConnection(
 	}
 
 	checker := auth.NewRBACChecker(store)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	return handler, userID, token, cleanup
 }
@@ -231,7 +231,7 @@ func TestConnectionHandler_CreateConnection_Issue233_SuperuserAllowed(t *testing
 	}
 
 	checker := auth.NewRBACChecker(store)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	body, _ := json.Marshal(ConnectionCreateRequest{
 		Name:         "super-conn",
@@ -315,7 +315,7 @@ func setupIssue233UpdateConnectionCluster(
 	}
 
 	checker := auth.NewRBACChecker(store)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	return handler, userID, token, cleanup
 }
@@ -412,7 +412,7 @@ func TestConnectionHandler_UpdateConnectionCluster_Issue233(t *testing.T) {
 		}
 
 		checker := auth.NewRBACChecker(store)
-		handler := NewConnectionHandler(nil, store, checker)
+		handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 		clusterID := 1
 		body, _ := json.Marshal(ConnectionClusterUpdateRequest{

--- a/server/src/internal/api/rbac_issue35_test.go
+++ b/server/src/internal/api/rbac_issue35_test.go
@@ -202,7 +202,7 @@ func TestConnectionHandler_PerConnection_NonOwnerUnshared_403(t *testing.T) {
 			bobID := newTestUser(t, store, "bob")
 
 			checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-			handler := NewConnectionHandler(nil, store, checker)
+			handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 			url := fmtURL(tc.urlTemplate, rbacUnsharedConnID)
 			req := httptest.NewRequest(tc.method, url, bytes.NewReader(tc.body))
@@ -232,7 +232,7 @@ func TestConnectionHandler_PerConnection_Owner_NotDenied(t *testing.T) {
 			aliceID := newTestUser(t, store, "alice")
 
 			checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-			handler := NewConnectionHandler(nil, store, checker)
+			handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 			url := fmtURL(tc.urlTemplate, rbacUnsharedConnID)
 			req := httptest.NewRequest(tc.method, url, bytes.NewReader(tc.body))
@@ -262,7 +262,7 @@ func TestConnectionHandler_PerConnection_SharedNonOwner_NotDenied(t *testing.T) 
 			bobID := newTestUser(t, store, "bob")
 
 			checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", true)
-			handler := NewConnectionHandler(nil, store, checker)
+			handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 			url := fmtURL(tc.urlTemplate, rbacUnsharedConnID)
 			req := httptest.NewRequest(tc.method, url, bytes.NewReader(tc.body))
@@ -294,7 +294,7 @@ func TestConnectionHandler_PerConnection_GroupGranted_NotDenied(t *testing.T) {
 				rbacUnsharedConnID, auth.AccessLevelReadWrite)
 
 			checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-			handler := NewConnectionHandler(nil, store, checker)
+			handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 			url := fmtURL(tc.urlTemplate, rbacUnsharedConnID)
 			req := httptest.NewRequest(tc.method, url, bytes.NewReader(tc.body))
@@ -322,7 +322,7 @@ func TestConnectionHandler_PerConnection_Superuser_NotDenied(t *testing.T) {
 			defer cleanup()
 
 			checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-			handler := NewConnectionHandler(nil, store, checker)
+			handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 			url := fmtURL(tc.urlTemplate, rbacUnsharedConnID)
 			req := httptest.NewRequest(tc.method, url, bytes.NewReader(tc.body))
@@ -352,7 +352,7 @@ func TestConnectionHandler_UpdateConnectionCluster_NoDatastoreSideEffect(t *test
 	bobID := newTestUser(t, store, "bob")
 
 	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	body := []byte(`{"cluster_id": 7, "membership_source": "manual"}`)
 	req := httptest.NewRequest(http.MethodPut,
@@ -405,7 +405,7 @@ func TestConnectionHandler_SetCurrentConnection_NonOwnerUnshared_403(t *testing.
 	tokenHash := auth.GetTokenHashByRawToken(rawToken)
 
 	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	body, _ := json.Marshal(CurrentConnectionRequest{ConnectionID: rbacUnsharedConnID})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/current",
@@ -443,7 +443,7 @@ func TestConnectionHandler_SetCurrentConnection_Owner_NotDenied(t *testing.T) {
 	tokenHash := auth.GetTokenHashByRawToken(rawToken)
 
 	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	body, _ := json.Marshal(CurrentConnectionRequest{ConnectionID: rbacUnsharedConnID})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/current",
@@ -473,7 +473,7 @@ func TestConnectionHandler_SetCurrentConnection_SharedNonOwner_NotDenied(t *test
 	tokenHash := auth.GetTokenHashByRawToken(rawToken)
 
 	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", true)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	body, _ := json.Marshal(CurrentConnectionRequest{ConnectionID: rbacUnsharedConnID})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/current",
@@ -511,7 +511,7 @@ func TestConnectionHandler_GetCurrentConnection_NonOwnerUnshared_403(t *testing.
 	}
 
 	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/current", nil)
 	req = withUser(req, bobID)
@@ -540,7 +540,7 @@ func TestConnectionHandler_GetCurrentConnection_Owner_NotDenied(t *testing.T) {
 	}
 
 	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", false)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/current", nil)
 	req = withUser(req, aliceID)
@@ -571,7 +571,7 @@ func TestConnectionHandler_GetCurrentConnection_SharedNonOwner_NotDenied(t *test
 	}
 
 	checker := mockSharingChecker(t, store, rbacUnsharedConnID, "alice", true)
-	handler := NewConnectionHandler(nil, store, checker)
+	handler := NewConnectionHandlerWithSecurity(nil, store, checker, false, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/current", nil)
 	req = withUser(req, bobID)


### PR DESCRIPTION
The follow-up to #395, covering the one piece I deliberately left out of
the mechanical pass.

## Why this needed its own PR

`NewConnectionHandler` and `NewNotificationChannelHandler` are
unreachable from the server binary: `cmd/mcp-server/handlers.go` wires
both handlers through the `...WithSecurity` variants. They survived #395
because **49 test call sites** still used the shorter forms, and deleting
the constructors there would have taken out test suites covering live
handler code, which is exactly the failure mode #395 was tightened to
avoid.

## Why the rewrite is safe

The two constructor pairs are identical apart from a single line:

- short form: `hostValidator: DefaultHostValidator()`
- `WithSecurity`: `hostValidator: NewHostValidator(allowInternal, allowedHosts, blockedHosts)`

and `DefaultHostValidator()` is defined as *exactly*:

```go
func DefaultHostValidator() *HostValidator {
    return NewHostValidator(false, nil, nil)
}
```

So rewriting `NewConnectionHandler(a, b, c)` to
`NewConnectionHandlerWithSecurity(a, b, c, false, nil, nil)` is
precisely equivalent. No test changes behaviour, and nothing needed
reinterpreting: every field the short constructor set is set identically
by the longer one. That is what makes this mechanical rather than a
judgement call, which is the thing I wasn't willing to assume without
checking.

With the short forms gone, `DefaultHostValidator` had no production
caller either, so it goes too. Its two incidental uses in
`host_validation_test.go` (in `TestHostValidator_ValidatePort` and
`TestHostValidator_InternalNetworksList`, which use it only as a
convenient default) now call `NewHostValidator(false, nil, nil)`
directly. `TestDefaultHostValidator` is removed along with the function
it existed to test.

## Scope

| | Lines |
|---|---|
| Production Go removed | 31 (3 functions) |
| Tests | −67 / +51 (net −16) |
| Changelog | +12 |

49 call sites rewritten across 7 test files. No test was deleted except
`TestDefaultHostValidator`.

## Verification

- `gofmt` clean, `golangci-lint` reports **0 issues**, `go vet` clean.
- Full server suite passes with `-race -p=1`. The only failures are the
  two pre-existing `vector(3)` fixture failures from #337, which
  reproduce identically on unmodified `main`.
- **Server coverage 55.5%, matching `main` exactly** (#395 leaves it at
  55.3%). Nothing to top up; no new code is added, so the 90% floor for
  new and modified code does not apply.
- `deadcode` confirms no cascade: the count from the server binary drops
  from 65 to 62, exactly the three functions removed here, with nothing
  newly stranded in the touched area.

## Relationship to #395

Cut from `main`, not stacked on `remove-dead-code`, because a branch
based on a non-`main` branch triggers no CI workflows at all. I verified
the two changesets touch **entirely disjoint files** (52 files in #395,
11 here, zero overlap), so they can merge in either order without
conflict.

## Still outstanding after this

The **42 remaining dead functions** whose tests need editing rather than
deleting, and the **three test helpers** (`NewTestClient`,
`NewTestDatastoreWithSecret`, `NewTestDatastore`) that compile into the
shipped binaries but are used across package boundaries by tests, so
they want extracting into a test-only package rather than deleting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Removed**
  - Removed legacy connection and notification-channel constructors, along with the default host-validation helper.
  - Handler creation now uses security-aware configuration, while host validation requires explicit settings.

- **Documentation**
  - Added an Unreleased changelog entry documenting the removed APIs and migration path.

- **Tests**
  - Updated validation, routing, authentication, and RBAC coverage to use the current security-aware configuration without changing expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->