### PR TITLE
Stop the AuthHandler login rate limiter on shutdown

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -142,6 +142,19 @@ project adheres to
   the `pg_stat_database` probe reports on `current_database()` only.
   (#403)
 
+- Stop the login rate limiter that `AuthHandler` creates for itself
+  when the server shuts down. `NewAuthHandler` starts a background
+  cleanup goroutine for an internal rate limiter covering total login
+  attempts per IP, and only its `Close` method stops that goroutine.
+  Nothing called `Close`, because `SetupHandlers` built the handler
+  inside a closure and discarded the reference, so the goroutine and
+  its map of recorded attempts survived for the remaining life of the
+  process. `HandlerDependencies` now carries a `RegisterCloser`
+  callback, which the server uses to collect cleanup functions from the
+  handlers it wires and to run them from `Close`, alongside the
+  overview generator, the shared rate limiter, the auth store, and the
+  datastore it already stopped.
+
 - Fix every chat request that included a tool list failing with
   `anthropic (400): tools.0.custom.input_schema: Input does not
   match the expected shape`, which broke Ask Ellie and the Server,

--- a/server/src/cmd/mcp-server/handler_closers_test.go
+++ b/server/src/cmd/mcp-server/handler_closers_test.go
@@ -1,0 +1,136 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package main
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/pgedge/ai-workbench/server/internal/config"
+)
+
+// TestRegisterHandlerCloser_RecordsClosers verifies that registered
+// closers accumulate in order and that a nil closer is ignored rather
+// than stored, since running a nil func would panic during shutdown.
+func TestRegisterHandlerCloser_RecordsClosers(t *testing.T) {
+	s := &Server{}
+
+	s.registerHandlerCloser(nil)
+	if len(s.handlerClosers) != 0 {
+		t.Fatalf("nil closer should be ignored, got %d entries",
+			len(s.handlerClosers))
+	}
+
+	s.registerHandlerCloser(func() {})
+	s.registerHandlerCloser(func() {})
+	if len(s.handlerClosers) != 2 {
+		t.Errorf("expected 2 registered closers, got %d",
+			len(s.handlerClosers))
+	}
+}
+
+// TestRunHandlerClosers_RunsEachOnce verifies that every registered
+// closer runs, and that the list is cleared afterwards so a second
+// shutdown pass does not stop the same resource twice.
+func TestRunHandlerClosers_RunsEachOnce(t *testing.T) {
+	s := &Server{}
+
+	var calls int
+	s.registerHandlerCloser(func() { calls++ })
+	s.registerHandlerCloser(func() { calls++ })
+
+	s.runHandlerClosers()
+	if calls != 2 {
+		t.Errorf("expected both closers to run, got %d calls", calls)
+	}
+	if len(s.handlerClosers) != 0 {
+		t.Errorf("expected closer list to be cleared, got %d entries",
+			len(s.handlerClosers))
+	}
+
+	s.runHandlerClosers()
+	if calls != 2 {
+		t.Errorf("second run should be a no-op, got %d calls", calls)
+	}
+}
+
+// TestRunHandlerClosers_NoClosers verifies that shutting down a server
+// that never wired any handlers is safe, which is the case for the CLI
+// subcommands that never start the HTTP listener.
+func TestRunHandlerClosers_NoClosers(t *testing.T) {
+	s := &Server{}
+	s.runHandlerClosers()
+	if len(s.handlerClosers) != 0 {
+		t.Errorf("expected no closers, got %d", len(s.handlerClosers))
+	}
+}
+
+// TestRegisterHandlerCloser_ConcurrentRegistration exercises the mutex
+// guarding the closer list. SetupHandlers runs on the HTTP server's
+// goroutine whilst Close may run from the signal handler, so the two
+// must not race.
+func TestRegisterHandlerCloser_ConcurrentRegistration(t *testing.T) {
+	s := &Server{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.registerHandlerCloser(func() {})
+		}()
+	}
+	wg.Wait()
+
+	if len(s.handlerClosers) != 50 {
+		t.Errorf("expected 50 registered closers, got %d",
+			len(s.handlerClosers))
+	}
+}
+
+// TestSetupHandlers_RegistersAuthHandlerCloser verifies the actual
+// defect this addresses: NewAuthHandler starts a cleanup goroutine for
+// its internal login rate limiter, and SetupHandlers must hand that
+// back to the server so shutdown stops it.
+func TestSetupHandlers_RegistersAuthHandlerCloser(t *testing.T) {
+	var registered []func()
+	deps := &HandlerDependencies{
+		// A zero-value Config is enough: setupLLMHandlers reads
+		// cfg.LLM fields unconditionally and panics on a nil Config.
+		Config:         &config.Config{},
+		RegisterCloser: func(c func()) { registered = append(registered, c) },
+	}
+
+	if err := SetupHandlers(deps)(http.NewServeMux()); err != nil {
+		t.Fatalf("SetupHandlers returned an error: %v", err)
+	}
+
+	if len(registered) == 0 {
+		t.Fatal("SetupHandlers registered no closer for the auth handler")
+	}
+
+	// The registered closer must be callable without panicking; it
+	// stops the auth handler's internal rate limiter.
+	for _, c := range registered {
+		c()
+	}
+}
+
+// TestSetupHandlers_NilRegisterCloser verifies that route registration
+// still succeeds when no closer sink is supplied, which keeps existing
+// callers and tests that only exercise routing working unchanged.
+func TestSetupHandlers_NilRegisterCloser(t *testing.T) {
+	deps := &HandlerDependencies{Config: &config.Config{}}
+
+	if err := SetupHandlers(deps)(http.NewServeMux()); err != nil {
+		t.Fatalf("SetupHandlers returned an error: %v", err)
+	}
+}

--- a/server/src/cmd/mcp-server/handler_closers_test.go
+++ b/server/src/cmd/mcp-server/handler_closers_test.go
@@ -134,3 +134,90 @@ func TestSetupHandlers_NilRegisterCloser(t *testing.T) {
 		t.Fatalf("SetupHandlers returned an error: %v", err)
 	}
 }
+
+// TestRegisterHandlerCloser_AfterDrainRunsImmediately verifies that a
+// closer arriving after Close has drained the list is still run, rather
+// than being appended to a list nothing will ever walk again.
+func TestRegisterHandlerCloser_AfterDrainRunsImmediately(t *testing.T) {
+	s := &Server{}
+	s.runHandlerClosers()
+
+	var called bool
+	s.registerHandlerCloser(func() { called = true })
+
+	if !called {
+		t.Error("closer registered after the drain was never run")
+	}
+	if len(s.handlerClosers) != 0 {
+		t.Errorf("expected closer list to stay empty, got %d entries",
+			len(s.handlerClosers))
+	}
+}
+
+// TestRegisterHandlerCloser_NestedRegistrationAfterDrain verifies that a
+// closer which itself registers another closer does not deadlock on
+// closersMu when it runs inline on the post-drain path.
+func TestRegisterHandlerCloser_NestedRegistrationAfterDrain(t *testing.T) {
+	s := &Server{}
+	s.runHandlerClosers()
+
+	var inner bool
+	s.registerHandlerCloser(func() {
+		s.registerHandlerCloser(func() { inner = true })
+	})
+
+	if !inner {
+		t.Error("nested closer registered after the drain was never run")
+	}
+}
+
+// TestRunHandlerClosers_OverlappingRegistration overlaps registration
+// with the shutdown drain and asserts that every closer runs exactly
+// once, whichever side of the drain it lands on. Run with -race, this
+// also covers the closersDrained read/write pair.
+func TestRunHandlerClosers_OverlappingRegistration(t *testing.T) {
+	const closers = 100
+
+	s := &Server{}
+
+	var mu sync.Mutex
+	counts := make(map[int]int)
+	record := func(id int) {
+		mu.Lock()
+		defer mu.Unlock()
+		counts[id]++
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < closers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			s.registerHandlerCloser(func() { record(id) })
+		}(i)
+	}
+
+	// Drain concurrently with the registrations above, which is the
+	// race between the HTTP server's goroutine and the signal handler.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.runHandlerClosers()
+	}()
+	wg.Wait()
+
+	// Registrations that beat the drain are still on the list.
+	s.runHandlerClosers()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(counts) != closers {
+		t.Errorf("expected all %d closers to run, got %d",
+			closers, len(counts))
+	}
+	for id, n := range counts {
+		if n != 1 {
+			t.Errorf("closer %d ran %d times, want exactly 1", id, n)
+		}
+	}
+}

--- a/server/src/cmd/mcp-server/handlers.go
+++ b/server/src/cmd/mcp-server/handlers.go
@@ -54,6 +54,12 @@ type HandlerDependencies struct {
 	OverviewHub  *overview.Hub
 	ToolProvider api.ContextAwareToolProvider
 	AIEnabled    bool
+
+	// RegisterCloser records a cleanup function to be run when the
+	// server shuts down. Handlers that own background goroutines use
+	// it to hand that ownership back to the server. It may be nil in
+	// tests that only exercise route registration.
+	RegisterCloser func(func())
 }
 
 // SetupHandlers configures all HTTP handlers for the server
@@ -80,6 +86,14 @@ func SetupHandlers(deps *HandlerDependencies) func(*http.ServeMux) error {
 		// The TLS enabled flag ensures cookies are marked Secure when using HTTPS
 		tlsEnabled := deps.Config != nil && deps.Config.HTTP.TLS.Enabled
 		authHandler := api.NewAuthHandler(deps.AuthStore, deps.RateLimiter, deps.IPExtractor, tlsEnabled)
+
+		// NewAuthHandler starts a cleanup goroutine for its internal
+		// login rate limiter, which only Close stops. Hand that back
+		// to the server so it is stopped on shutdown rather than
+		// running for the remaining life of the process.
+		if deps.RegisterCloser != nil {
+			deps.RegisterCloser(authHandler.Close)
+		}
 		authHandler.RegisterRoutes(mux)
 
 		// Chat history compaction endpoint

--- a/server/src/cmd/mcp-server/server.go
+++ b/server/src/cmd/mcp-server/server.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -54,6 +55,40 @@ type Server struct {
 	dataDir       string
 	debug         bool
 	aiEnabled     bool
+
+	// handlerClosers holds cleanup functions for background resources
+	// created while wiring HTTP handlers. SetupHandlers runs on the
+	// HTTP server's goroutine, whereas Close may run from the signal
+	// handler, so access is guarded by closersMu.
+	closersMu      sync.Mutex
+	handlerClosers []func()
+}
+
+// registerHandlerCloser records a cleanup function to be run by Close.
+// It is passed to SetupHandlers so that handlers owning background
+// goroutines can hand that ownership back to the server, which is the
+// only component that knows when the process is shutting down.
+func (s *Server) registerHandlerCloser(closer func()) {
+	if closer == nil {
+		return
+	}
+	s.closersMu.Lock()
+	defer s.closersMu.Unlock()
+	s.handlerClosers = append(s.handlerClosers, closer)
+}
+
+// runHandlerClosers invokes every registered handler cleanup function
+// and then clears the list, so a second Close is a no-op rather than a
+// double stop.
+func (s *Server) runHandlerClosers() {
+	s.closersMu.Lock()
+	closers := s.handlerClosers
+	s.handlerClosers = nil
+	s.closersMu.Unlock()
+
+	for _, closer := range closers {
+		closer()
+	}
 }
 
 // ServerConfig holds configuration for creating a new server
@@ -449,6 +484,8 @@ func (s *Server) Run(flags *Flags, configPath string) error {
 		OverviewHub:  s.overviewHub,
 		ToolProvider: s.toolProvider,
 		AIEnabled:    s.aiEnabled,
+
+		RegisterCloser: s.registerHandlerCloser,
 	}
 	httpConfig.SetupHandlers = SetupHandlers(deps)
 
@@ -581,6 +618,10 @@ func (s *Server) Close() {
 	if s.rateLimiter != nil {
 		s.rateLimiter.Stop()
 	}
+
+	// Stop background resources owned by the HTTP handlers, such as the
+	// AuthHandler's internal login rate limiter.
+	s.runHandlerClosers()
 
 	// Close auth store
 	if s.authStore != nil {

--- a/server/src/cmd/mcp-server/server.go
+++ b/server/src/cmd/mcp-server/server.go
@@ -62,28 +62,46 @@ type Server struct {
 	// handler, so access is guarded by closersMu.
 	closersMu      sync.Mutex
 	handlerClosers []func()
+	closersDrained bool
 }
 
 // registerHandlerCloser records a cleanup function to be run by Close.
 // It is passed to SetupHandlers so that handlers owning background
 // goroutines can hand that ownership back to the server, which is the
 // only component that knows when the process is shutting down.
+// A closer registered after Close has already drained the list runs
+// immediately, because nothing else will ever run it; that ordering is
+// possible because SetupHandlers runs lazily on the HTTP server's
+// goroutine and can therefore still be wiring handlers when the signal
+// handler calls Close.
 func (s *Server) registerHandlerCloser(closer func()) {
 	if closer == nil {
 		return
 	}
+
 	s.closersMu.Lock()
-	defer s.closersMu.Unlock()
-	s.handlerClosers = append(s.handlerClosers, closer)
+	drained := s.closersDrained
+	if !drained {
+		s.handlerClosers = append(s.handlerClosers, closer)
+	}
+	s.closersMu.Unlock()
+
+	// Run outside the lock, so a closer that itself registers another
+	// closer cannot deadlock against closersMu.
+	if drained {
+		closer()
+	}
 }
 
 // runHandlerClosers invokes every registered handler cleanup function
 // and then clears the list, so a second Close is a no-op rather than a
-// double stop.
+// double stop. It also marks the list drained, so a closer arriving
+// afterwards is run by registerHandlerCloser rather than dropped.
 func (s *Server) runHandlerClosers() {
 	s.closersMu.Lock()
 	closers := s.handlerClosers
 	s.handlerClosers = nil
+	s.closersDrained = true
 	s.closersMu.Unlock()
 
 	for _, closer := range closers {


### PR DESCRIPTION
Found while triaging the dead-code findings, and flagged in #397.

## The defect

`NewAuthHandler` creates a rate limiter for itself, covering total login
attempts per IP:

```go
totalRateLimiter: auth.NewRateLimiter(1, 20), // 20 total login requests per minute per IP
```

`auth.NewRateLimiter` starts a background cleanup goroutine (`go
rl.cleanupLoop()`). Only `AuthHandler.Close` stops it, and **nothing
called `Close`**: `SetupHandlers` constructs the handler inside the
closure it returns and discards the reference, so neither the server nor
anything else could reach it.

The result is a goroutine plus its map of recorded attempts living for
the remaining life of the process.

## Honest severity

**Bounded, not growing.** `SetupHandlers(deps)` is called once from
`server.go:453` and its closure runs once, so it is one goroutine and one
small map, and the process exits at shutdown anyway. This is not an
unbounded leak and I don't want to oversell it.

It is still worth fixing, for three reasons:

1. `Server.Close` already stops the overview generator, the shared rate
   limiter, the auth store and the datastore. This is an inconsistency in
   that pattern rather than a deliberate exemption.
2. `Close` exists and its doc comment documents exactly this ownership
   split, explaining that the caller-supplied `rateLimiter` is
   deliberately *not* stopped there. Not calling it is an oversight.
3. Because `Close` looks unreachable, static analysis reports it as dead
   code. That is how it nearly got **deleted** rather than wired up: it
   was in the deferred set in #395 and I came close to removing it in
   #397 before checking what it did.

## The fix

`HandlerDependencies` gains an optional `RegisterCloser func(func())`.
`SetupHandlers` uses it to hand `authHandler.Close` back to the server,
and `Server.Close` runs the collected closers alongside the resources it
already stops.

Registration is mutex-guarded, because `SetupHandlers` runs on the HTTP
server's goroutine whilst `Close` may run from the signal handler.
`runHandlerClosers` clears the list, so a second shutdown pass does not
stop the same resource twice. The callback is optional, so existing
callers and tests that only exercise route registration are unaffected.

This also gives any future handler owning background work a place to hand
that ownership back, rather than each one inventing its own escape hatch.

## Verification

- Six new tests: closer registration including the nil guard, run-once
  and list-clearing behaviour, the no-closers case (which is what the CLI
  subcommands hit, since they never start the listener), concurrent
  registration under `-race`, and the actual defect, that `SetupHandlers`
  registers a closer for the auth handler.
- **Both new functions are at 100% statement coverage.**
- Server coverage rises from 55.5% to **55.9%**.
- `gofmt` clean, `golangci-lint` **0 issues**, `go vet` clean.
- Full server suite passes with `-race -p=1`; the only failures are the
  two pre-existing `vector(3)` fixture failures from #337, which
  reproduce identically on unmodified `main`.
- `deadcode` now reports `AuthHandler.Close` as **reachable**, dropping
  the server's unreachable count from 65 to 64. That is the useful
  confirmation the wiring actually took effect.

204 insertions, no deletions.

## Merge order

Cut from `main`. The only file shared with #395, #396 and #397 is
`docs/changelog.md`, and this entry goes under `### Fixed` whilst theirs
go under `### Removed`, so it should merge cleanly in any order. No code
files overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown to reliably stop authentication background processes and release associated resources.
  * Ensured cleanup tasks run safely once, including during concurrent shutdown activity and late registration.

* **Tests**
  * Added coverage for cleanup registration, execution, concurrency, repeated shutdown behavior, and optional or missing cleanup handlers.

* **Documentation**
  * Documented the authentication cleanup improvements in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->