### PR TITLE
Add regression tests documenting alerter defects

### DIFF
--- a/alerter/src/internal/database/audit_defects_test.go
+++ b/alerter/src/internal/database/audit_defects_test.go
@@ -1,0 +1,984 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// This file holds verification tests for an audit of the alerter
+// subsystem. Each test documents an audit claim and pins the behavior
+// that the code actually exhibits today. Where the audit claim
+// describes a defect, the test asserts the CURRENT (defective)
+// behavior and the comment states what the behavior SHOULD be, so the
+// suite stays green until the defect is fixed; a fix will make the
+// pinned assertion fail, which is the intended signal to update the
+// test alongside the fix.
+//
+// Tests whose name ends in "Demo" assert the CORRECT behavior instead
+// and therefore fail against the current code. They are skipped unless
+// ALERTER_DEFECT_DEMO=1 is set, so CI stays green while the defect can
+// still be demonstrated on demand.
+
+// defectDemoEnabled skips the calling test unless ALERTER_DEFECT_DEMO
+// is set. Demo tests assert the behavior the audit says the code
+// should have, so they fail while the defect is present.
+func defectDemoEnabled(t *testing.T) {
+	t.Helper()
+	if os.Getenv("ALERTER_DEFECT_DEMO") == "" {
+		t.Skip("set ALERTER_DEFECT_DEMO=1 to run the defect demonstration")
+	}
+}
+
+// auditDefectsSchema mirrors the production collector schema for the
+// columns the metric registry queries actually read. The table set is
+// deliberately faithful on one point: metrics.pg_stat_wal exists (it
+// carries the archiver columns in production) and
+// metrics.pg_stat_archiver does NOT, because the collector never
+// creates such a table.
+const auditDefectsSchema = `
+DROP SCHEMA IF EXISTS metrics CASCADE;
+DROP TABLE IF EXISTS metric_baselines CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+
+CREATE TABLE connections (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    is_monitored BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE metric_baselines (
+    id BIGSERIAL PRIMARY KEY,
+    connection_id INTEGER NOT NULL REFERENCES connections(id) ON DELETE CASCADE,
+    database_name TEXT,
+    metric_name TEXT NOT NULL,
+    period_type TEXT NOT NULL,
+    day_of_week INTEGER,
+    hour_of_day INTEGER,
+    mean REAL NOT NULL,
+    stddev REAL NOT NULL,
+    min REAL NOT NULL,
+    max REAL NOT NULL,
+    sample_count BIGINT NOT NULL DEFAULT 0,
+    last_calculated TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    earliest_sample_at TIMESTAMPTZ
+);
+
+CREATE SCHEMA metrics;
+
+CREATE TABLE metrics.pg_settings (
+    connection_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    setting TEXT,
+    collected_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE metrics.pg_stat_activity (
+    connection_id INTEGER NOT NULL,
+    backend_type TEXT,
+    collected_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE metrics.pg_stat_wal (
+    connection_id INTEGER NOT NULL,
+    archived_count BIGINT,
+    failed_count BIGINT,
+    collected_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE metrics.pg_stat_all_tables (
+    connection_id INTEGER NOT NULL,
+    database_name TEXT NOT NULL,
+    schemaname TEXT NOT NULL,
+    relname TEXT NOT NULL,
+    n_live_tup BIGINT,
+    n_dead_tup BIGINT,
+    collected_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE metrics.pg_stat_database (
+    connection_id INTEGER NOT NULL,
+    database_name VARCHAR(255) NOT NULL,
+    datname TEXT,
+    blks_hit BIGINT,
+    blks_read BIGINT,
+    collected_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE metrics.pg_stat_statements (
+    connection_id INTEGER NOT NULL,
+    database_name TEXT NOT NULL,
+    queryid BIGINT NOT NULL,
+    calls BIGINT,
+    mean_exec_time DOUBLE PRECISION,
+    collected_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE metrics.pg_sys_cpu_usage_info (
+    connection_id INTEGER NOT NULL,
+    usermode_normal_process_percent REAL,
+    usermode_niced_process_percent REAL,
+    kernelmode_process_percent REAL,
+    io_completion_percent REAL,
+    servicing_irq_percent REAL,
+    servicing_softirq_percent REAL,
+    idle_mode_percent REAL,
+    user_time_percent REAL,
+    processor_time_percent REAL,
+    privileged_time_percent REAL,
+    interrupt_time_percent REAL,
+    collected_at TIMESTAMPTZ NOT NULL
+);
+`
+
+// auditDefectsTeardown drops everything auditDefectsSchema creates.
+const auditDefectsTeardown = `
+DROP SCHEMA IF EXISTS metrics CASCADE;
+DROP TABLE IF EXISTS metric_baselines CASCADE;
+DROP TABLE IF EXISTS connections CASCADE;
+`
+
+// Seed statements used by the audit tests. They are named constants so
+// the Codacy/Semgrep go_sql_rule-concat-sqli rule does not flag inline
+// multi-line SQL passed to Exec; every value is still bound via $N.
+const (
+	insertAuditConnectionSQL = `
+        INSERT INTO connections (name, enabled, is_monitored)
+        VALUES ($1, TRUE, TRUE)
+        RETURNING id
+    `
+
+	insertAuditPgSettingSQL = `
+        INSERT INTO metrics.pg_settings
+            (connection_id, name, setting, collected_at)
+        VALUES ($1, $2, $3, $4)
+    `
+
+	insertAuditAllTablesSQL = `
+        INSERT INTO metrics.pg_stat_all_tables
+            (connection_id, database_name, schemaname, relname,
+             n_live_tup, n_dead_tup, collected_at)
+        VALUES ($1, $2, 'public', $3, $4, 0, $5)
+    `
+
+	insertAuditStatDatabaseSQL = `
+        INSERT INTO metrics.pg_stat_database
+            (connection_id, database_name, datname, blks_hit, blks_read,
+             collected_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+    `
+
+	insertAuditStatStatementsSQL = `
+        INSERT INTO metrics.pg_stat_statements
+            (connection_id, database_name, queryid, calls, mean_exec_time,
+             collected_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+    `
+
+	insertAuditCPUUsageSQL = `
+        INSERT INTO metrics.pg_sys_cpu_usage_info
+            (connection_id, usermode_normal_process_percent,
+             kernelmode_process_percent, idle_mode_percent,
+             processor_time_percent, collected_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+    `
+
+	insertAuditBaselineSQL = `
+        INSERT INTO metric_baselines
+            (connection_id, database_name, metric_name, period_type,
+             day_of_week, hour_of_day, mean, stddev, min, max,
+             sample_count, earliest_sample_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    `
+)
+
+// newAuditDefectsDatastore returns a Datastore backed by the
+// integration test database with auditDefectsSchema installed. The
+// test is skipped when no test database is configured, matching the
+// convention used by the other integration tests in this package.
+func newAuditDefectsDatastore(t *testing.T) (*Datastore, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	if os.Getenv("SKIP_DB_TESTS") != "" {
+		t.Skip("Skipping database test (SKIP_DB_TESTS is set)")
+	}
+	connStr := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if connStr == "" {
+		t.Skip("TEST_AI_WORKBENCH_SERVER not set, skipping audit defect test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Skipf("Could not connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("Test database ping failed: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, auditDefectsSchema); err != nil {
+		pool.Close()
+		t.Fatalf("Failed to create audit defect schema: %v", err)
+	}
+
+	ds := &Datastore{pool: pool, config: nil}
+
+	cleanup := func() {
+		if _, err := pool.Exec(context.Background(),
+			auditDefectsTeardown); err != nil {
+			t.Logf("audit defect teardown failed: %v", err)
+		}
+		pool.Close()
+	}
+
+	return ds, pool, cleanup
+}
+
+// insertAuditConnection inserts a connection and returns its id.
+func insertAuditConnection(t *testing.T, pool *pgxpool.Pool, name string) int {
+	t.Helper()
+	var id int
+	if err := pool.QueryRow(context.Background(),
+		insertAuditConnectionSQL, name).Scan(&id); err != nil {
+		t.Fatalf("failed to insert connection %q: %v", name, err)
+	}
+	return id
+}
+
+// collectorSchemaMetricsTables scans the collector schema source for
+// every "CREATE TABLE ... metrics.<name>" statement and returns the
+// sorted, de-duplicated table names. The test is skipped when the
+// collector source is not present (for example in a packaged build),
+// because this is a cross-module source inspection rather than a
+// runtime assertion.
+func collectorSchemaMetricsTables(t *testing.T) []string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join(
+		"..", "..", "..", "..", "collector", "src", "database", "schema.go"))
+	if err != nil {
+		t.Skipf("cannot resolve collector schema path: %v", err)
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed repo-relative path
+	if err != nil {
+		t.Skipf("collector schema source unavailable at %s: %v", path, err)
+	}
+
+	re := regexp.MustCompile(`CREATE TABLE (?:IF NOT EXISTS )?metrics\.([a-z0-9_]+)`)
+	seen := make(map[string]struct{})
+	for _, m := range re.FindAllStringSubmatch(string(data), -1) {
+		seen[m[1]] = struct{}{}
+	}
+
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestAuditC2ArchiverTableDoesNotExist verifies audit claim C2: the
+// "wal_archive_failed" rule reads its metric from
+// metrics.pg_stat_archiver, but the collector never creates that
+// table. The archiver columns live on metrics.pg_stat_wal instead, so
+// every evaluation of the rule fails with an undefined-table error.
+//
+// The registry entry SHOULD read failed_count from
+// metrics.pg_stat_wal.
+func TestAuditC2ArchiverTableDoesNotExist(t *testing.T) {
+	t.Run("collector schema never creates metrics.pg_stat_archiver", func(t *testing.T) {
+		tables := collectorSchemaMetricsTables(t)
+
+		index := make(map[string]struct{}, len(tables))
+		for _, name := range tables {
+			index[name] = struct{}{}
+		}
+
+		if _, ok := index["pg_stat_archiver"]; ok {
+			t.Errorf("collector schema unexpectedly creates "+
+				"metrics.pg_stat_archiver; tables=%v", tables)
+		}
+		if _, ok := index["pg_stat_wal"]; !ok {
+			t.Errorf("expected metrics.pg_stat_wal in collector schema; "+
+				"tables=%v", tables)
+		}
+		t.Logf("collector metrics tables (%d): %v", len(tables), tables)
+	})
+
+	t.Run("registry entry targets the missing table", func(t *testing.T) {
+		cfg, ok := metricRegistry["pg_stat_archiver.failed_count_delta"]
+		if !ok {
+			t.Fatal("pg_stat_archiver.failed_count_delta missing from registry")
+		}
+		// Current (defective) behavior. It SHOULD be
+		// "metrics.pg_stat_wal".
+		if !strings.Contains(cfg.latestSQL, "FROM metrics.pg_stat_archiver") {
+			t.Error("expected latestSQL to select FROM metrics.pg_stat_archiver")
+		}
+	})
+
+	t.Run("query errors at runtime", func(t *testing.T) {
+		ds, pool, cleanup := newAuditDefectsDatastore(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		connID := insertAuditConnection(t, pool, "audit-c2")
+
+		// Seed the archiver data where it really lives so the failure
+		// cannot be blamed on missing data.
+		if _, err := pool.Exec(ctx, `
+            INSERT INTO metrics.pg_stat_wal
+                (connection_id, archived_count, failed_count, collected_at)
+            VALUES ($1, 10, 1, NOW() - INTERVAL '10 minutes'),
+                   ($1, 10, 7, NOW() - INTERVAL '1 minute')
+        `, connID); err != nil {
+			t.Fatalf("failed to seed pg_stat_wal: %v", err)
+		}
+
+		_, err := ds.GetLatestMetricValues(ctx,
+			"pg_stat_archiver.failed_count_delta")
+		if err == nil {
+			t.Fatal("expected an error from GetLatestMetricValues, got nil")
+		}
+		if !strings.Contains(err.Error(), "metrics.pg_stat_archiver") {
+			t.Errorf("expected undefined-table error naming "+
+				"metrics.pg_stat_archiver, got: %v", err)
+		}
+		t.Logf("GetLatestMetricValues error: %v", err)
+	})
+}
+
+// TestAuditC3TransactionWraparoundReturnsConstant verifies audit claim
+// C3: the "age_percent" metric backing the transaction_wraparound rule
+// selects the literal 50.0 rather than a computed transaction age. The
+// seeded rule compares with "> 75", so the rule can never fire.
+//
+// The metric SHOULD compute age(relfrozenxid) / autovacuum_freeze_max_age.
+func TestAuditC3TransactionWraparoundReturnsConstant(t *testing.T) {
+	cfg, ok := metricRegistry["age_percent"]
+	if !ok {
+		t.Fatal("age_percent missing from registry")
+	}
+	// Current (defective) behavior: a hardcoded literal.
+	if !strings.Contains(cfg.latestSQL, "50.0::float as value") {
+		t.Error("expected age_percent latestSQL to select the literal 50.0")
+	}
+
+	ds, pool, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertAuditConnection(t, pool, "audit-c3")
+
+	if _, err := pool.Exec(ctx, insertAuditPgSettingSQL,
+		connID, "autovacuum_freeze_max_age", "200000000",
+		nowMinus(t, pool, "1 minute")); err != nil {
+		t.Fatalf("failed to seed pg_settings: %v", err)
+	}
+
+	// Two tables with wildly different live-tuple counts; whatever the
+	// metric claims to measure, the result must not depend on them for
+	// the constant to be provable.
+	for i, relname := range []string{"tiny", "huge"} {
+		liveTup := int64(1)
+		if i == 1 {
+			liveTup = 5_000_000_000
+		}
+		if _, err := pool.Exec(ctx, insertAuditAllTablesSQL,
+			connID, "appdb", relname, liveTup,
+			nowMinus(t, pool, "1 minute")); err != nil {
+			t.Fatalf("failed to seed pg_stat_all_tables: %v", err)
+		}
+	}
+
+	values, err := ds.GetLatestMetricValues(ctx, "age_percent")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues(age_percent) failed: %v", err)
+	}
+	if len(values) != 1 {
+		t.Fatalf("expected one row, got %d", len(values))
+	}
+	if values[0].Value != 50.0 {
+		t.Errorf("expected the hardcoded 50.0, got %v", values[0].Value)
+	}
+
+	// The seeded rule is "age_percent > 75" (critical). 50 > 75 is
+	// false for every possible input, so the rule is inert.
+	const seededThreshold = 75.0
+	if values[0].Value > seededThreshold {
+		t.Errorf("value %v unexpectedly exceeds the seeded threshold %v",
+			values[0].Value, seededThreshold)
+	}
+}
+
+// TestAuditC4PgSettingsMetricsExpireAfterOneHour verifies the alerter
+// half of audit claim C4: both pg_settings.max_connections and
+// connection_utilization_percent require a metrics.pg_settings row
+// collected within the last hour. When the newest row is older, the
+// metric reports no data and the rule silently stops evaluating.
+//
+// The collector half of the claim (the pg_settings probe skips writes
+// when the settings have not changed) is covered by the collector's
+// own TestPgSettingsProbe_StoreUnchanged.
+//
+// The registry entries SHOULD use DISTINCT ON without a recency
+// window, or the probe SHOULD refresh on a heartbeat.
+func TestAuditC4PgSettingsMetricsExpireAfterOneHour(t *testing.T) {
+	ds, pool, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertAuditConnection(t, pool, "audit-c4")
+
+	// A fresh pg_settings snapshot plus current activity: both metrics
+	// resolve.
+	if _, err := pool.Exec(ctx, insertAuditPgSettingSQL,
+		connID, "max_connections", "600",
+		nowMinus(t, pool, "5 minutes")); err != nil {
+		t.Fatalf("failed to seed fresh pg_settings: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := pool.Exec(ctx, `
+            INSERT INTO metrics.pg_stat_activity
+                (connection_id, backend_type, collected_at)
+            VALUES ($1, 'client backend', NOW() - INTERVAL '1 minute')
+        `, connID); err != nil {
+			t.Fatalf("failed to seed pg_stat_activity: %v", err)
+		}
+	}
+
+	if _, err := ds.GetLatestMetricValues(ctx,
+		"pg_settings.max_connections"); err != nil {
+		t.Fatalf("expected max_connections to resolve with a fresh row: %v", err)
+	}
+	if _, err := ds.GetLatestMetricValues(ctx,
+		"connection_utilization_percent"); err != nil {
+		t.Fatalf("expected connection_utilization to resolve with a fresh row: %v",
+			err)
+	}
+
+	// Age the only pg_settings snapshot past the one-hour window, as
+	// happens whenever the configuration has not changed for an hour.
+	if _, err := pool.Exec(ctx, `
+        UPDATE metrics.pg_settings
+        SET collected_at = NOW() - INTERVAL '61 minutes'
+        WHERE connection_id = $1
+    `, connID); err != nil {
+		t.Fatalf("failed to age pg_settings: %v", err)
+	}
+
+	// Current (defective) behavior: both metrics go dark. They SHOULD
+	// continue to report the most recent known configuration.
+	if _, err := ds.GetLatestMetricValues(ctx,
+		"pg_settings.max_connections"); err == nil {
+		t.Error("expected max_connections to report no data after one hour")
+	} else {
+		t.Logf("max_connections after 61 minutes: %v", err)
+	}
+	if _, err := ds.GetLatestMetricValues(ctx,
+		"connection_utilization_percent"); err == nil {
+		t.Error("expected connection_utilization to report no data after one hour")
+	} else {
+		t.Logf("connection_utilization after 61 minutes: %v", err)
+	}
+}
+
+// TestAuditC5CPUUsageNullProcessorTimeReadsZero verifies the alerter
+// half of audit claim C5: the cpu_usage_high rule keys on
+// processor_time_percent, and the registry wraps it in COALESCE(..., 0).
+// When the column is NULL, the metric reports 0, which can never
+// exceed the seeded threshold of 80.
+//
+// Whether system_stats actually leaves processor_time_percent NULL on
+// Linux cannot be verified here; the extension is not installed in the
+// test environment. This test verifies only the consequence.
+//
+// The metric SHOULD derive CPU usage from the Linux-populated columns
+// (for example 100 - idle_mode_percent) or from a COALESCE chain.
+func TestAuditC5CPUUsageNullProcessorTimeReadsZero(t *testing.T) {
+	ds, pool, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name               string
+		processorTime      any
+		usermodeNormal     float64
+		kernelmode         float64
+		idle               float64
+		wantValue          float64
+		wantExceedsDefault bool
+	}{
+		{
+			name:           "linux shape leaves processor_time NULL",
+			processorTime:  nil,
+			usermodeNormal: 71.5,
+			kernelmode:     23.5,
+			idle:           5.0,
+			// COALESCE(NULL, 0) yields 0 even though the machine is
+			// 95% busy. It SHOULD report roughly 95.
+			wantValue:          0,
+			wantExceedsDefault: false,
+		},
+		{
+			name:               "windows shape populates processor_time",
+			processorTime:      92.5,
+			usermodeNormal:     0,
+			kernelmode:         0,
+			idle:               7.5,
+			wantValue:          92.5,
+			wantExceedsDefault: true,
+		},
+	}
+
+	const seededThreshold = 80.0
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := pool.Exec(ctx,
+				`DELETE FROM metrics.pg_sys_cpu_usage_info`); err != nil {
+				t.Fatalf("failed to reset cpu rows: %v", err)
+			}
+			if _, err := pool.Exec(ctx, `DELETE FROM connections`); err != nil {
+				t.Fatalf("failed to reset connections: %v", err)
+			}
+			connID := insertAuditConnection(t, pool, "audit-c5-"+tc.name)
+
+			if _, err := pool.Exec(ctx, insertAuditCPUUsageSQL,
+				connID, tc.usermodeNormal, tc.kernelmode, tc.idle,
+				tc.processorTime, nowMinus(t, pool, "1 minute")); err != nil {
+				t.Fatalf("failed to seed cpu usage: %v", err)
+			}
+
+			values, err := ds.GetLatestMetricValues(ctx,
+				"pg_sys_cpu_usage_info.processor_time_percent")
+			if err != nil {
+				t.Fatalf("GetLatestMetricValues failed: %v", err)
+			}
+			if len(values) != 1 {
+				t.Fatalf("expected one row, got %d", len(values))
+			}
+			if values[0].Value != tc.wantValue {
+				t.Errorf("value = %v, want %v", values[0].Value, tc.wantValue)
+			}
+			if got := values[0].Value > seededThreshold; got != tc.wantExceedsDefault {
+				t.Errorf("value > %v = %v, want %v",
+					seededThreshold, got, tc.wantExceedsDefault)
+			}
+		})
+	}
+}
+
+// TestAuditC6BaselineOrderingPrefersAll verifies audit claim C6:
+// GetMetricBaselines orders by period_type, which is TEXT. The three
+// period types sort alphabetically as 'all' < 'daily' < 'hourly', so
+// the first row is always the 'all' baseline whenever one exists.
+// detectAnomalies reads baselines[0] and therefore never uses the
+// time-aware baselines.
+//
+// The query SHOULD select the baseline matching the current hour or
+// weekday, falling back to 'all'.
+func TestAuditC6BaselineOrderingPrefersAll(t *testing.T) {
+	ds, pool, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertAuditConnection(t, pool, "audit-c6")
+
+	// Insert in an order that would surface a different first row if
+	// the query respected insertion order or specificity.
+	rows := []struct {
+		periodType string
+		dayOfWeek  any
+		hourOfDay  any
+		mean       float64
+	}{
+		{"hourly", nil, 3, 30},
+		{"daily", 2, nil, 20},
+		{"all", nil, nil, 10},
+	}
+	for _, r := range rows {
+		if _, err := pool.Exec(ctx, insertAuditBaselineSQL,
+			connID, nil, "pg_stat_activity.count", r.periodType,
+			r.dayOfWeek, r.hourOfDay, r.mean, 1.0, r.mean-1, r.mean+1,
+			int64(500), nil); err != nil {
+			t.Fatalf("failed to insert %s baseline: %v", r.periodType, err)
+		}
+	}
+
+	baselines, err := ds.GetMetricBaselines(ctx, connID,
+		"pg_stat_activity.count")
+	if err != nil {
+		t.Fatalf("GetMetricBaselines failed: %v", err)
+	}
+	if len(baselines) != 3 {
+		t.Fatalf("expected 3 baselines, got %d", len(baselines))
+	}
+
+	got := make([]string, len(baselines))
+	for i, b := range baselines {
+		got[i] = b.PeriodType
+	}
+	// Current (defective) ordering: strictly alphabetical on the TEXT
+	// column, so 'all' always wins the baselines[0] selection made by
+	// detectAnomalies.
+	want := []string{"all", "daily", "hourly"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("period_type order = %v, want %v", got, want)
+		}
+	}
+	if baselines[0].PeriodType != "all" {
+		t.Errorf("baselines[0].PeriodType = %q, want \"all\"",
+			baselines[0].PeriodType)
+	}
+}
+
+// TestAuditC10BaselineLookupIgnoresDatabase verifies the query half of
+// audit claim C10: GetMetricBaselines filters on connection_id and
+// metric_name only. For a per-database metric it therefore returns one
+// row per database with no way for the caller to pick the right one,
+// and the ORDER BY cannot break the tie because every returned row
+// shares the same period_type, day_of_week, and hour_of_day.
+//
+// The lookup SHOULD accept a database name and filter on it.
+func TestAuditC10BaselineLookupIgnoresDatabase(t *testing.T) {
+	ds, pool, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertAuditConnection(t, pool, "audit-c10-query")
+
+	for _, dbName := range []string{"alpha", "beta"} {
+		if _, err := pool.Exec(ctx, insertAuditBaselineSQL,
+			connID, dbName, "pg_stat_database.deadlocks_delta", "all",
+			nil, nil, 1.0, 0.5, 0.0, 2.0, int64(500), nil); err != nil {
+			t.Fatalf("failed to insert %s baseline: %v", dbName, err)
+		}
+	}
+
+	baselines, err := ds.GetMetricBaselines(ctx, connID,
+		"pg_stat_database.deadlocks_delta")
+	if err != nil {
+		t.Fatalf("GetMetricBaselines failed: %v", err)
+	}
+
+	// Current (defective) behavior: both per-database baselines come
+	// back from a call that had no way to name a database.
+	if len(baselines) != 2 {
+		t.Fatalf("expected both per-database baselines, got %d", len(baselines))
+	}
+	for _, b := range baselines {
+		if b.DatabaseName == nil {
+			t.Fatal("expected per-database baselines to carry a database name")
+		}
+		if b.PeriodType != "all" {
+			t.Fatalf("unexpected period_type %q", b.PeriodType)
+		}
+	}
+	// Every ordering key is identical across the two rows, so
+	// baselines[0] is whichever row the planner happened to emit first.
+	t.Logf("baselines[0] database = %q (arbitrary among %d equal-ranked rows)",
+		*baselines[0].DatabaseName, len(baselines))
+}
+
+// TestAuditC7HistoricalSQLCoverage verifies the counting half of audit
+// claim C7. The audit says "12 of 34 metrics" have an empty
+// historicalSQL; the registry actually holds a different number of
+// entries and a different number of empty ones. The test pins both
+// figures so the discrepancy is explicit.
+//
+// Metrics with an empty historicalSQL fall back to
+// calculateGlobalBaselinesFallback, which cannot produce a warm
+// baseline; see the engine-side test for that half of the claim.
+func TestAuditC7HistoricalSQLCoverage(t *testing.T) {
+	var empty []string
+	for name, cfg := range metricRegistry {
+		if strings.TrimSpace(cfg.historicalSQL) == "" {
+			empty = append(empty, name)
+		}
+	}
+	sort.Strings(empty)
+
+	t.Logf("registry entries: %d; empty historicalSQL: %d",
+		len(metricRegistry), len(empty))
+	for _, name := range empty {
+		t.Logf("  no historical SQL: %s", name)
+	}
+
+	// Pinned figures for the current code. The audit's "12 of 34" is
+	// wrong on both numbers; 34 is the count of seeded alert_rules
+	// rows, not of registry metrics.
+	const (
+		wantRegistryEntries = 32
+		wantEmptyHistorical = 14
+	)
+	if len(metricRegistry) != wantRegistryEntries {
+		t.Errorf("registry entries = %d, want %d",
+			len(metricRegistry), wantRegistryEntries)
+	}
+	if len(empty) != wantEmptyHistorical {
+		t.Errorf("entries with empty historicalSQL = %d, want %d",
+			len(empty), wantEmptyHistorical)
+	}
+
+	// Every empty-historicalSQL metric must in fact fail
+	// GetHistoricalMetricValues, because that is what pushes baseline
+	// calculation onto the fallback path.
+	ds, _, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	for _, name := range empty {
+		if _, err := ds.GetHistoricalMetricValues(ctx, name, 7); err == nil {
+			t.Errorf("GetHistoricalMetricValues(%s) unexpectedly succeeded", name)
+		}
+	}
+}
+
+// TestAuditC8CacheHitRatioReturnsEveryDeltaRow verifies audit claim
+// C8: unlike its sibling delta metrics, pg_stat_database.cache_hit_ratio
+// performs no latest-sample reduction, so it returns one row per
+// sample interval in the 15-minute window.
+//
+// The consequence depends on where the violating interval sits in the
+// window, because the query carries no ORDER BY and PostgreSQL emits
+// the rows in the window-function ordering (collected_at ascending):
+//
+//   - Violation in the oldest interval: the evaluator fires (it scans
+//     every row) and the cleaner never clears (it stops at the first
+//     matching row, which still violates). The alert latches.
+//   - Violation in the newest interval: the evaluator fires and the
+//     cleaner clears on the same data, which flaps.
+//
+// The query SHOULD reduce to the most recent interval, as
+// deadlocks_delta and temp_files_delta do with MAX()/GROUP BY.
+func TestAuditC8CacheHitRatioReturnsEveryDeltaRow(t *testing.T) {
+	ds, pool, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const seededThreshold = 80.0
+
+	// Each case seeds four samples, producing three delta intervals.
+	// Every interval moves at least 10000 blocks so it clears the
+	// query's minimum-activity filter.
+	cases := []struct {
+		name string
+		// hits and reads are cumulative counters per sample.
+		hits  []int64
+		reads []int64
+		// wantFirstRowViolates records whether the row the cleaner
+		// would inspect breaches the threshold.
+		wantFirstRowViolates bool
+	}{
+		{
+			name:                 "violation in oldest interval",
+			hits:                 []int64{0, 10_000, 40_000, 70_000},
+			reads:                []int64{0, 10_000, 10_000, 10_000},
+			wantFirstRowViolates: true,
+		},
+		{
+			name:                 "violation in newest interval",
+			hits:                 []int64{0, 30_000, 60_000, 60_000},
+			reads:                []int64{0, 0, 0, 30_000},
+			wantFirstRowViolates: false,
+		},
+	}
+
+	offsets := []string{"12 minutes", "8 minutes", "4 minutes", "1 minute"}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := pool.Exec(ctx,
+				`DELETE FROM metrics.pg_stat_database`); err != nil {
+				t.Fatalf("failed to reset pg_stat_database: %v", err)
+			}
+			if _, err := pool.Exec(ctx, `DELETE FROM connections`); err != nil {
+				t.Fatalf("failed to reset connections: %v", err)
+			}
+			connID := insertAuditConnection(t, pool, "audit-c8-"+tc.name)
+
+			for i, offset := range offsets {
+				if _, err := pool.Exec(ctx, insertAuditStatDatabaseSQL,
+					connID, "appdb", "appdb", tc.hits[i], tc.reads[i],
+					nowMinus(t, pool, offset)); err != nil {
+					t.Fatalf("failed to seed pg_stat_database: %v", err)
+				}
+			}
+
+			values, err := ds.GetLatestMetricValues(ctx,
+				"pg_stat_database.cache_hit_ratio")
+			if err != nil {
+				t.Fatalf("GetLatestMetricValues failed: %v", err)
+			}
+
+			// Current (defective) behavior: three rows for a single
+			// connection/database pair. There SHOULD be exactly one.
+			if len(values) != 3 {
+				t.Fatalf("expected 3 unreduced delta rows, got %d", len(values))
+			}
+
+			var violating int
+			for _, v := range values {
+				if v.Value < seededThreshold {
+					violating++
+				}
+				t.Logf("row: value=%.2f collected_at=%s", v.Value, v.CollectedAt)
+			}
+			if violating != 1 {
+				t.Fatalf("expected exactly one violating row, got %d", violating)
+			}
+
+			// The evaluator fires because at least one row violates.
+			// The cleaner inspects values[0] only.
+			gotFirstViolates := values[0].Value < seededThreshold
+			if gotFirstViolates != tc.wantFirstRowViolates {
+				t.Errorf("first row violates = %v, want %v (values=%v)",
+					gotFirstViolates, tc.wantFirstRowViolates, values)
+			}
+		})
+	}
+
+	// Contrast with the sibling delta metrics, which do reduce.
+	for _, name := range []string{
+		"pg_stat_database.deadlocks_delta",
+		"pg_stat_database.temp_files_delta",
+	} {
+		cfg := metricRegistry[name]
+		if !strings.Contains(cfg.latestSQL, "GROUP BY") {
+			t.Errorf("%s unexpectedly lacks a GROUP BY reduction", name)
+		}
+	}
+	if strings.Contains(metricRegistry["pg_stat_database.cache_hit_ratio"].latestSQL,
+		"GROUP BY") {
+		t.Error("cache_hit_ratio unexpectedly contains a GROUP BY reduction")
+	}
+}
+
+// TestAuditC9SlowQueryCountUsesLifetimeMean verifies audit claim C9:
+// slow_query_count counts distinct queryids whose mean_exec_time
+// exceeds 1000 ms. pg_stat_statements.mean_exec_time is a lifetime
+// average since the last stats reset, so a query that ran slowly once
+// keeps the count elevated forever, even when it never executes again.
+//
+// The metric SHOULD derive a windowed mean from the deltas of
+// total_exec_time and calls.
+func TestAuditC9SlowQueryCountUsesLifetimeMean(t *testing.T) {
+	cfg := metricRegistry["pg_stat_statements.slow_query_count"]
+	if !strings.Contains(cfg.latestSQL, "mean_exec_time > 1000") {
+		t.Error("expected slow_query_count to filter on mean_exec_time > 1000")
+	}
+	if strings.Contains(cfg.latestSQL, "total_exec_time") {
+		t.Error("slow_query_count unexpectedly references total_exec_time")
+	}
+
+	ds, pool, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertAuditConnection(t, pool, "audit-c9")
+
+	// Twelve queryids whose lifetime mean is above 1000 ms and whose
+	// call counts never change across the window: they have not
+	// executed at all during the last 15 minutes.
+	for queryID := int64(1); queryID <= 12; queryID++ {
+		for _, offset := range []string{"12 minutes", "6 minutes", "1 minute"} {
+			if _, err := pool.Exec(ctx, insertAuditStatStatementsSQL,
+				connID, "appdb", queryID, int64(5), 4200.0,
+				nowMinus(t, pool, offset)); err != nil {
+				t.Fatalf("failed to seed pg_stat_statements: %v", err)
+			}
+		}
+	}
+
+	values, err := ds.GetLatestMetricValues(ctx,
+		"pg_stat_statements.slow_query_count")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues failed: %v", err)
+	}
+	if len(values) != 1 {
+		t.Fatalf("expected one row, got %d", len(values))
+	}
+
+	// Current (defective) behavior: all twelve idle queries are
+	// counted, so the seeded "> 10" rule fires. The count SHOULD be 0
+	// because nothing ran slowly in the window.
+	const seededThreshold = 10.0
+	if values[0].Value != 12 {
+		t.Errorf("slow_query_count = %v, want 12 (every idle queryid counted)",
+			values[0].Value)
+	}
+	if !(values[0].Value > seededThreshold) {
+		t.Errorf("expected the seeded rule to fire on idle queries; value=%v",
+			values[0].Value)
+	}
+}
+
+// TestAuditC9SlowQueryCountDemo asserts the behavior the metric
+// SHOULD have: a query that has not executed during the evaluation
+// window must not be counted as slow. It fails against the current
+// implementation, so it is skipped unless ALERTER_DEFECT_DEMO=1.
+func TestAuditC9SlowQueryCountDemo(t *testing.T) {
+	defectDemoEnabled(t)
+
+	ds, pool, cleanup := newAuditDefectsDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertAuditConnection(t, pool, "audit-c9-demo")
+
+	for _, offset := range []string{"12 minutes", "6 minutes", "1 minute"} {
+		if _, err := pool.Exec(ctx, insertAuditStatStatementsSQL,
+			connID, "appdb", int64(1), int64(5), 4200.0,
+			nowMinus(t, pool, offset)); err != nil {
+			t.Fatalf("failed to seed pg_stat_statements: %v", err)
+		}
+	}
+
+	values, err := ds.GetLatestMetricValues(ctx,
+		"pg_stat_statements.slow_query_count")
+	if err != nil {
+		// A correct implementation reports no slow queries, which the
+		// registry surfaces as a "no data" error; that is acceptable.
+		return
+	}
+	for _, v := range values {
+		if v.Value != 0 {
+			t.Fatalf("slow_query_count = %v for a query that did not run "+
+				"during the window, want 0", v.Value)
+		}
+	}
+}
+
+// nowMinus returns the database's NOW() minus the given interval. The
+// value is computed server-side so the seeded timestamps line up with
+// the NOW() used inside the registry queries regardless of client
+// clock skew or session time zone.
+func nowMinus(t *testing.T, pool *pgxpool.Pool, interval string) (ts any) {
+	t.Helper()
+	if err := pool.QueryRow(context.Background(),
+		`SELECT NOW() - $1::interval`, interval).Scan(&ts); err != nil {
+		t.Fatalf("failed to compute NOW() - %s: %v", interval, err)
+	}
+	return ts
+}

--- a/alerter/src/internal/database/audit_defects_test.go
+++ b/alerter/src/internal/database/audit_defects_test.go
@@ -519,8 +519,14 @@ func TestAuditC5CPUUsageNullProcessorTimeReadsZero(t *testing.T) {
 
 	ctx := context.Background()
 
+	// connName is carried in the table as a literal rather than being
+	// derived from name at the call site. Building it by concatenation
+	// makes the value a taint source for the Opengrep rule
+	// go_sql_rule-concat-sqli, which then reports the pool.Exec below
+	// as SQL injection even though every value is bound via $N.
 	cases := []struct {
 		name               string
+		connName           string
 		processorTime      any
 		usermodeNormal     float64
 		kernelmode         float64
@@ -530,6 +536,7 @@ func TestAuditC5CPUUsageNullProcessorTimeReadsZero(t *testing.T) {
 	}{
 		{
 			name:           "linux shape leaves processor_time NULL",
+			connName:       "audit-c5-linux",
 			processorTime:  nil,
 			usermodeNormal: 71.5,
 			kernelmode:     23.5,
@@ -541,6 +548,7 @@ func TestAuditC5CPUUsageNullProcessorTimeReadsZero(t *testing.T) {
 		},
 		{
 			name:               "windows shape populates processor_time",
+			connName:           "audit-c5-windows",
 			processorTime:      92.5,
 			usermodeNormal:     0,
 			kernelmode:         0,
@@ -561,7 +569,7 @@ func TestAuditC5CPUUsageNullProcessorTimeReadsZero(t *testing.T) {
 			if _, err := pool.Exec(ctx, `DELETE FROM connections`); err != nil {
 				t.Fatalf("failed to reset connections: %v", err)
 			}
-			connID := insertAuditConnection(t, pool, "audit-c5-"+tc.name)
+			connID := insertAuditConnection(t, pool, tc.connName)
 
 			if _, err := pool.Exec(ctx, insertAuditCPUUsageSQL,
 				connID, tc.usermodeNormal, tc.kernelmode, tc.idle,
@@ -704,8 +712,9 @@ func TestAuditC10BaselineLookupIgnoresDatabase(t *testing.T) {
 // TestAuditC7HistoricalSQLCoverage verifies the counting half of audit
 // claim C7. The audit says "12 of 34 metrics" have an empty
 // historicalSQL; the registry actually holds a different number of
-// entries and a different number of empty ones. The test pins both
-// figures so the discrepancy is explicit.
+// entries and a different number of empty ones. The test pins the
+// affected metrics by name so the discrepancy is explicit and any
+// future drift identifies the metric that moved.
 //
 // Metrics with an empty historicalSQL fall back to
 // calculateGlobalBaselinesFallback, which cannot produce a warm
@@ -725,32 +734,67 @@ func TestAuditC7HistoricalSQLCoverage(t *testing.T) {
 		t.Logf("  no historical SQL: %s", name)
 	}
 
-	// Pinned figures for the current code. The audit's "12 of 34" is
+	// Pinned by name rather than by count. The audit's "12 of 34" is
 	// wrong on both numbers; 34 is the count of seeded alert_rules
-	// rows, not of registry metrics.
-	const (
-		wantRegistryEntries = 32
-		wantEmptyHistorical = 14
-	)
-	if len(metricRegistry) != wantRegistryEntries {
-		t.Errorf("registry entries = %d, want %d",
-			len(metricRegistry), wantRegistryEntries)
+	// rows, not of registry metrics. Listing every affected metric
+	// means that adding, removing, or backfilling one produces a
+	// failure naming the metric that changed, rather than an opaque
+	// count mismatch that says nothing about which entry moved.
+	wantEmpty := []string{
+		"age_percent",
+		"pg_node_role.subscription_worker_down",
+		"pg_replication_slots.inactive",
+		"pg_replication_slots.retained_bytes",
+		"pg_stat_activity.max_lock_wait_seconds",
+		"pg_stat_all_tables.dead_tuple_percent",
+		"pg_stat_archiver.failed_count_delta",
+		"pg_stat_checkpointer.checkpoints_req_delta",
+		"pg_stat_replication.lag_bytes",
+		"pg_stat_replication.replay_lag_seconds",
+		"pg_stat_replication.standby_disconnected",
+		"pg_stat_statements.slow_query_count",
+		"table_bloat_ratio",
+		"table_last_autovacuum_hours",
 	}
-	if len(empty) != wantEmptyHistorical {
-		t.Errorf("entries with empty historicalSQL = %d, want %d",
-			len(empty), wantEmptyHistorical)
+	// Both slices are sorted, so a positional diff names the first
+	// metric that differs.
+	if len(empty) != len(wantEmpty) {
+		t.Errorf("metrics with empty historicalSQL = %d, want %d\n"+
+			" got: %v\nwant: %v", len(empty), len(wantEmpty), empty, wantEmpty)
+	}
+	for i := 0; i < len(empty) && i < len(wantEmpty); i++ {
+		if empty[i] != wantEmpty[i] {
+			t.Errorf("metric with empty historicalSQL [%d] = %q, want %q",
+				i, empty[i], wantEmpty[i])
+		}
 	}
 
 	// Every empty-historicalSQL metric must in fact fail
 	// GetHistoricalMetricValues, because that is what pushes baseline
-	// calculation onto the fallback path.
+	// calculation onto the fallback path. The exact message matters:
+	// it proves the registry guard rejected the call before any SQL
+	// ran, so removing the guard or hitting an unrelated query error
+	// both surface as failures here.
 	ds, _, cleanup := newAuditDefectsDatastore(t)
 	defer cleanup()
 
+	// A named const rather than an inline literal so that building the
+	// expected message below is a const-plus-variable expression, which
+	// the Opengrep rule go_sql_rule-concat-sqli does not treat as a
+	// taint source.
+	const notImplementedPrefix = "historical data not implemented for metric "
+
 	ctx := context.Background()
 	for _, name := range empty {
-		if _, err := ds.GetHistoricalMetricValues(ctx, name, 7); err == nil {
+		_, err := ds.GetHistoricalMetricValues(ctx, name, 7)
+		if err == nil {
 			t.Errorf("GetHistoricalMetricValues(%s) unexpectedly succeeded", name)
+			continue
+		}
+		want := notImplementedPrefix + name
+		if err.Error() != want {
+			t.Errorf("GetHistoricalMetricValues(%s) error = %q, want %q",
+				name, err.Error(), want)
 		}
 	}
 }
@@ -760,15 +804,24 @@ func TestAuditC7HistoricalSQLCoverage(t *testing.T) {
 // performs no latest-sample reduction, so it returns one row per
 // sample interval in the 15-minute window.
 //
-// The consequence depends on where the violating interval sits in the
-// window, because the query carries no ORDER BY and PostgreSQL emits
-// the rows in the window-function ordering (collected_at ascending):
+// The consequence depends on which row a caller looks at, because the
+// evaluator scans every row while the cleaner inspects only the first
+// one. The query carries no ORDER BY, so which row comes first is
+// whatever the chosen plan emits first:
 //
-//   - Violation in the oldest interval: the evaluator fires (it scans
-//     every row) and the cleaner never clears (it stops at the first
-//     matching row, which still violates). The alert latches.
-//   - Violation in the newest interval: the evaluator fires and the
-//     cleaner clears on the same data, which flaps.
+//   - When the first row is the violating one, the cleaner never
+//     clears, because the row it stops at still breaches the
+//     threshold. The alert latches.
+//   - When the first row is a healthy one, the cleaner clears the
+//     alert the evaluator just raised on identical data, and the
+//     alert flaps.
+//
+// This test pins the structural defect - three unreduced rows for one
+// connection and one database, exactly one of them violating - and
+// sorts by collected_at before making any positional assertion. The
+// production cleaner's dependence on the unspecified wire order is
+// itself the defect on record here; it is deliberately not an
+// assumption this test relies on.
 //
 // The query SHOULD reduce to the most recent interval, as
 // deadlocks_delta and temp_files_delta do with MAX()/GROUP BY.
@@ -782,26 +835,34 @@ func TestAuditC8CacheHitRatioReturnsEveryDeltaRow(t *testing.T) {
 	// Each case seeds four samples, producing three delta intervals.
 	// Every interval moves at least 10000 blocks so it clears the
 	// query's minimum-activity filter.
+	//
+	// connName is a literal rather than a value derived from name for
+	// the reason given on the C5 table above: concatenating it would
+	// make it a taint source for the Opengrep rule
+	// go_sql_rule-concat-sqli.
 	cases := []struct {
-		name string
+		name     string
+		connName string
 		// hits and reads are cumulative counters per sample.
 		hits  []int64
 		reads []int64
-		// wantFirstRowViolates records whether the row the cleaner
-		// would inspect breaches the threshold.
-		wantFirstRowViolates bool
+		// violatingInterval is the index, in collected_at order, of
+		// the one delta interval that breaches the threshold.
+		violatingInterval int
 	}{
 		{
-			name:                 "violation in oldest interval",
-			hits:                 []int64{0, 10_000, 40_000, 70_000},
-			reads:                []int64{0, 10_000, 10_000, 10_000},
-			wantFirstRowViolates: true,
+			name:              "violation in oldest interval",
+			connName:          "audit-c8-oldest",
+			hits:              []int64{0, 10_000, 40_000, 70_000},
+			reads:             []int64{0, 10_000, 10_000, 10_000},
+			violatingInterval: 0,
 		},
 		{
-			name:                 "violation in newest interval",
-			hits:                 []int64{0, 30_000, 60_000, 60_000},
-			reads:                []int64{0, 0, 0, 30_000},
-			wantFirstRowViolates: false,
+			name:              "violation in newest interval",
+			connName:          "audit-c8-newest",
+			hits:              []int64{0, 30_000, 60_000, 60_000},
+			reads:             []int64{0, 0, 0, 30_000},
+			violatingInterval: 2,
 		},
 	}
 
@@ -816,7 +877,7 @@ func TestAuditC8CacheHitRatioReturnsEveryDeltaRow(t *testing.T) {
 			if _, err := pool.Exec(ctx, `DELETE FROM connections`); err != nil {
 				t.Fatalf("failed to reset connections: %v", err)
 			}
-			connID := insertAuditConnection(t, pool, "audit-c8-"+tc.name)
+			connID := insertAuditConnection(t, pool, tc.connName)
 
 			for i, offset := range offsets {
 				if _, err := pool.Exec(ctx, insertAuditStatDatabaseSQL,
@@ -832,30 +893,74 @@ func TestAuditC8CacheHitRatioReturnsEveryDeltaRow(t *testing.T) {
 				t.Fatalf("GetLatestMetricValues failed: %v", err)
 			}
 
-			// Current (defective) behavior: three rows for a single
-			// connection/database pair. There SHOULD be exactly one.
-			if len(values) != 3 {
-				t.Fatalf("expected 3 unreduced delta rows, got %d", len(values))
+			// Current (defective) behavior, asserted on the rows exactly
+			// as the query returned them: four samples for ONE
+			// connection and ONE database produce three unreduced delta
+			// rows. A metric that reduced to the latest interval would
+			// return exactly one, so this count is the defect itself
+			// and does not depend on row order.
+			const wantRows = 3
+			if len(values) != wantRows {
+				t.Fatalf("expected %d unreduced delta rows for a single "+
+					"connection/database, got %d", wantRows, len(values))
 			}
 
 			var violating int
 			for _, v := range values {
+				if v.ConnectionID != connID {
+					t.Errorf("row connection_id = %d, want %d",
+						v.ConnectionID, connID)
+				}
+				if v.DatabaseName == nil || *v.DatabaseName != "appdb" {
+					t.Errorf("row database_name = %v, want \"appdb\"",
+						v.DatabaseName)
+				}
 				if v.Value < seededThreshold {
 					violating++
 				}
-				t.Logf("row: value=%.2f collected_at=%s", v.Value, v.CollectedAt)
 			}
+			// Exactly one of the unreduced rows breaches the threshold,
+			// so the fire/clear outcome turns entirely on which row a
+			// caller happens to read.
 			if violating != 1 {
 				t.Fatalf("expected exactly one violating row, got %d", violating)
 			}
 
-			// The evaluator fires because at least one row violates.
-			// The cleaner inspects values[0] only.
-			gotFirstViolates := values[0].Value < seededThreshold
-			if gotFirstViolates != tc.wantFirstRowViolates {
-				t.Errorf("first row violates = %v, want %v (values=%v)",
-					gotFirstViolates, tc.wantFirstRowViolates, values)
+			// Sort a copy by collected_at before asserting on positions.
+			// The sort is defensive: the registry query has no ORDER BY,
+			// so the wire order is plan-dependent and asserting on it
+			// directly would let this test flake with no code change.
+			ordered := make([]MetricValue, len(values))
+			copy(ordered, values)
+			sort.Slice(ordered, func(i, j int) bool {
+				return ordered[i].CollectedAt.Before(ordered[j].CollectedAt)
+			})
+			for i, v := range ordered {
+				t.Logf("interval %d: value=%.2f collected_at=%s",
+					i, v.Value, v.CollectedAt)
 			}
+			for i, v := range ordered {
+				gotViolates := v.Value < seededThreshold
+				wantViolates := i == tc.violatingInterval
+				if gotViolates != wantViolates {
+					t.Errorf("interval %d (collected_at=%s, value=%.2f) "+
+						"violates = %v, want %v",
+						i, v.CollectedAt, v.Value, gotViolates, wantViolates)
+				}
+			}
+
+			// Diagnostic only. The cleaner acts on whichever row the
+			// planner emitted first, so this line records what it would
+			// have done on this run. Asserting on it would make the
+			// test flaky, which is exactly the hazard the missing
+			// ORDER BY creates for the production cleaner.
+			cleanerAction := "clear the alert"
+			if values[0].Value < seededThreshold {
+				cleanerAction = "leave the alert active"
+			}
+			t.Logf("wire-order first row: value=%.2f collected_at=%s; "+
+				"the cleaner would %s", values[0].Value,
+				values[0].CollectedAt, cleanerAction)
 		})
 	}
 

--- a/alerter/src/internal/engine/audit_defects_test.go
+++ b/alerter/src/internal/engine/audit_defects_test.go
@@ -1,0 +1,1177 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package engine
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgedge/ai-workbench/alerter/internal/database"
+	"github.com/pgedge/ai-workbench/pkg/worker"
+)
+
+// This file holds verification tests for an audit of the alerter
+// subsystem. Each test documents an audit claim and pins the behavior
+// the engine actually exhibits today. Where the claim describes a
+// defect, the test asserts the CURRENT (defective) behavior and the
+// comment states what the behavior SHOULD be, so the suite stays green
+// until the defect is fixed.
+//
+// Tests whose name ends in "Demo" assert the CORRECT behavior instead
+// and therefore fail against the current code. They are skipped unless
+// ALERTER_DEFECT_DEMO=1 is set, so CI stays green while the defect can
+// still be demonstrated on demand.
+
+// engineDefectDemoEnabled skips the calling test unless
+// ALERTER_DEFECT_DEMO is set.
+func engineDefectDemoEnabled(t *testing.T) {
+	t.Helper()
+	if os.Getenv("ALERTER_DEFECT_DEMO") == "" {
+		t.Skip("set ALERTER_DEFECT_DEMO=1 to run the defect demonstration")
+	}
+}
+
+// Seed and read-back statements used by the audit tests. They are
+// named constants so the Codacy/Semgrep go_sql_rule-concat-sqli rule
+// does not flag inline multi-line SQL passed to Exec/QueryRow; every
+// value is still bound via $N.
+const (
+	insertStalenessRuleSQL = `
+        INSERT INTO alert_rules
+            (name, description, category, metric_name, default_operator,
+             default_threshold, default_severity, default_enabled, is_built_in)
+        VALUES ('metric_staleness',
+                'Metrics collection is stale; dashboards may show outdated data',
+                'availability', 'probe_staleness_ratio', '>', 3, 'warning',
+                TRUE, TRUE)
+        RETURNING id
+    `
+
+	insertArchiverRuleSQL = `
+        INSERT INTO alert_rules
+            (name, description, category, metric_name, default_operator,
+             default_threshold, default_severity, default_enabled, is_built_in)
+        VALUES ('wal_archive_failed', 'WAL archiving failures detected',
+                'wal', 'pg_stat_archiver.failed_count_delta', '>', 0,
+                'critical', TRUE, TRUE)
+        RETURNING id
+    `
+
+	insertCacheHitRuleSQL = `
+        INSERT INTO alert_rules
+            (name, description, category, metric_name, default_operator,
+             default_threshold, default_severity, default_enabled, is_built_in)
+        VALUES ('cache_hit_ratio_low', 'Cache hit ratio below threshold',
+                'performance', 'pg_stat_database.cache_hit_ratio', '<', 80,
+                'warning', TRUE, TRUE)
+        RETURNING id
+    `
+
+	insertProbeConfigSQL = `
+        INSERT INTO probe_configs
+            (name, connection_id, is_enabled, collection_interval_seconds)
+        VALUES ($1, NULL, TRUE, $2)
+    `
+
+	insertProbeAvailabilitySQL = `
+        INSERT INTO probe_availability
+            (connection_id, probe_name, is_available, last_collected)
+        VALUES ($1, $2, TRUE, NOW() - $3::interval)
+    `
+
+	selectAlertsForRuleSQL = `
+        SELECT id, status
+        FROM alerts
+        WHERE rule_id = $1
+        ORDER BY id
+    `
+
+	selectAlertStatusSQL = `
+        SELECT status FROM alerts WHERE id = $1
+    `
+
+	insertSlotSampleSQL = `
+        INSERT INTO metrics.pg_replication_slots
+            (connection_id, slot_name, active, retained_bytes, collected_at)
+        VALUES ($1, $2, $3, $4, NOW())
+    `
+)
+
+// notificationCapture records the notification jobs the engine submits
+// to its worker pool. The pool handler forwards each job onto a
+// buffered channel so tests can await an exact number of jobs without
+// polling.
+type notificationCapture struct {
+	jobs chan notificationJob
+}
+
+// installNotificationCapture replaces the engine's notification worker
+// pool with one whose handler records every submitted job. The pool is
+// stopped via t.Cleanup so no goroutine outlives the test.
+//
+// The engine's own pool is only created when a notification manager is
+// configured; the integration environments in this package build the
+// engine without one, so this helper is the only way to observe
+// queueNotification.
+func installNotificationCapture(t *testing.T, e *Engine) *notificationCapture {
+	t.Helper()
+
+	capture := &notificationCapture{jobs: make(chan notificationJob, 256)}
+	pool := worker.NewWorkerPool(1, 256, func(job notificationJob) {
+		capture.jobs <- job
+	})
+	pool.Start()
+
+	previous := e.notificationPool
+	e.notificationPool = pool
+	t.Cleanup(func() {
+		e.notificationPool = previous
+		pool.Stop()
+	})
+	return capture
+}
+
+// await reads exactly n jobs from the capture channel, failing the
+// test if they do not arrive within the timeout. It then waits a short
+// grace period and fails if any extra job arrives, so the caller's
+// count assertion is exact rather than a lower bound.
+func (c *notificationCapture) await(t *testing.T, n int) []notificationJob {
+	t.Helper()
+
+	jobs := make([]notificationJob, 0, n)
+	deadline := time.After(10 * time.Second)
+	for len(jobs) < n {
+		select {
+		case job := <-c.jobs:
+			jobs = append(jobs, job)
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d notifications; got %d",
+				n, len(jobs))
+		}
+	}
+
+	select {
+	case extra := <-c.jobs:
+		t.Fatalf("received an unexpected extra notification: type=%s alert=%q",
+			extra.notifTyp, extra.alert.Title)
+	case <-time.After(200 * time.Millisecond):
+	}
+	return jobs
+}
+
+// countTypes summarizes the captured jobs by notification type.
+func countTypes(jobs []notificationJob) map[database.NotificationType]int {
+	counts := make(map[database.NotificationType]int)
+	for _, job := range jobs {
+		counts[job.notifTyp]++
+	}
+	return counts
+}
+
+// seedStalenessFixture inserts the metric_staleness rule plus a probe
+// whose last collection is far enough in the past to breach the
+// default staleness ratio of 3. It returns the rule id and the
+// connection id.
+func seedStalenessFixture(t *testing.T, pool *pgxpool.Pool) (int64, int) {
+	t.Helper()
+	ctx := context.Background()
+
+	var ruleID int64
+	if err := pool.QueryRow(ctx, insertStalenessRuleSQL).Scan(&ruleID); err != nil {
+		t.Fatalf("failed to insert metric_staleness rule: %v", err)
+	}
+
+	connID := insertTestConnection(t, pool, "audit-staleness")
+
+	if _, err := pool.Exec(ctx, insertProbeConfigSQL,
+		"pg_stat_activity", 60); err != nil {
+		t.Fatalf("failed to insert probe config: %v", err)
+	}
+	// 30 minutes stale against a 60 second interval is a ratio of 30,
+	// well above the seeded threshold of 3.
+	if _, err := pool.Exec(ctx, insertProbeAvailabilitySQL,
+		connID, "pg_stat_activity", "30 minutes"); err != nil {
+		t.Fatalf("failed to insert probe availability: %v", err)
+	}
+
+	return ruleID, connID
+}
+
+// TestAuditC1StalenessAlertFireClearLoop verifies audit claim C1. The
+// metric_staleness rule stores its alerts with alert_type='threshold'
+// and a non-NULL rule_id, so the alert cleaner picks them up. The
+// cleaner resolves the alert's metric name, "probe_staleness_ratio",
+// through GetLatestMetricValues, which has no registry entry for it
+// and therefore returns an error. checkAlertResolved treats that error
+// as "the condition no longer exists" and clears the alert, queueing
+// an ALERT_CLEAR notification. evaluateMetricStaleness then recreates
+// the alert on its next pass, because unlike triggerThresholdAlert it
+// performs no recently-cleared cooldown check.
+//
+// The result is an unbounded fire/clear notification loop on stable
+// input data, running at the cleaner's 30 second cadence and the
+// evaluator's 60 second cadence.
+//
+// The staleness path SHOULD either be excluded from the cleaner (it
+// has no registry metric) or SHOULD apply the same cooldown guard as
+// triggerThresholdAlert.
+func TestAuditC1StalenessAlertFireClearLoop(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	capture := installNotificationCapture(t, engine)
+	ruleID, _ := seedStalenessFixture(t, pool)
+
+	// Precondition: the metric the cleaner will look up is genuinely
+	// unresolvable, which is what drives the error branch.
+	if _, err := engine.datastore.GetLatestMetricValues(ctx,
+		"probe_staleness_ratio"); err == nil {
+		t.Fatal("expected probe_staleness_ratio to be unimplemented")
+	} else if !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("unexpected error for probe_staleness_ratio: %v", err)
+	}
+
+	const cycles = 3
+	for i := 0; i < cycles; i++ {
+		engine.evaluateThresholds(ctx)
+		engine.cleanResolvedAlerts(ctx)
+	}
+
+	rows, err := pool.Query(ctx, selectAlertsForRuleSQL, ruleID)
+	if err != nil {
+		t.Fatalf("failed to read alerts: %v", err)
+	}
+	defer rows.Close()
+
+	var statuses []string
+	for rows.Next() {
+		var id int64
+		var status string
+		if err := rows.Scan(&id, &status); err != nil {
+			t.Fatalf("failed to scan alert: %v", err)
+		}
+		statuses = append(statuses, status)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration error: %v", err)
+	}
+
+	// Current (defective) behavior: one brand new alert row per cycle,
+	// every one of them already cleared. There SHOULD be a single
+	// alert that stays active while the probe remains stale.
+	if len(statuses) != cycles {
+		t.Errorf("alert rows = %d, want %d (one created and cleared per cycle)",
+			len(statuses), cycles)
+	}
+	for i, status := range statuses {
+		if status != "cleared" {
+			t.Errorf("alert %d status = %q, want \"cleared\"", i, status)
+		}
+	}
+
+	jobs := capture.await(t, 2*cycles)
+	counts := countTypes(jobs)
+	if counts[database.NotificationTypeAlertFire] != cycles {
+		t.Errorf("fire notifications = %d, want %d",
+			counts[database.NotificationTypeAlertFire], cycles)
+	}
+	if counts[database.NotificationTypeAlertClear] != cycles {
+		t.Errorf("clear notifications = %d, want %d",
+			counts[database.NotificationTypeAlertClear], cycles)
+	}
+	t.Logf("after %d evaluate/clean cycles on stable data: %d alert rows, "+
+		"%d fire notifications, %d clear notifications",
+		cycles, len(statuses),
+		counts[database.NotificationTypeAlertFire],
+		counts[database.NotificationTypeAlertClear])
+}
+
+// TestAuditC1StalenessAlertFireClearLoopDemo asserts the behavior the
+// engine SHOULD have: a persistently stale probe produces exactly one
+// alert, which stays active and notifies once. It fails against the
+// current code, so it is skipped unless ALERTER_DEFECT_DEMO=1.
+func TestAuditC1StalenessAlertFireClearLoopDemo(t *testing.T) {
+	engineDefectDemoEnabled(t)
+
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	capture := installNotificationCapture(t, engine)
+	ruleID, _ := seedStalenessFixture(t, pool)
+
+	const cycles = 3
+	for i := 0; i < cycles; i++ {
+		engine.evaluateThresholds(ctx)
+		engine.cleanResolvedAlerts(ctx)
+	}
+
+	var total, active int
+	if err := pool.QueryRow(ctx, `
+        SELECT COUNT(*), COUNT(*) FILTER (WHERE status = 'active')
+        FROM alerts WHERE rule_id = $1
+    `, ruleID).Scan(&total, &active); err != nil {
+		t.Fatalf("failed to count alerts: %v", err)
+	}
+
+	if total != 1 {
+		t.Errorf("alert rows = %d, want 1 for a continuously stale probe", total)
+	}
+	if active != 1 {
+		t.Errorf("active alerts = %d, want 1; the probe is still stale", active)
+	}
+
+	jobs := capture.await(t, 1)
+	if counts := countTypes(jobs); counts[database.NotificationTypeAlertClear] != 0 {
+		t.Errorf("clear notifications = %d, want 0 while the probe is stale",
+			counts[database.NotificationTypeAlertClear])
+	}
+}
+
+// TestAuditC1StalenessPathSkipsCooldownGuard isolates the second half
+// of claim C1: evaluateMetricStaleness performs no
+// GetRecentlyClearedAlert check, so it re-fires immediately after a
+// clear, whereas triggerThresholdAlert suppresses a re-fire for
+// AlertCooldownPeriod. The two paths are driven back to back on the
+// same engine to make the asymmetry explicit.
+func TestAuditC1StalenessPathSkipsCooldownGuard(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installNotificationCapture(t, engine)
+
+	stalenessRuleID, stalenessConnID := seedStalenessFixture(t, pool)
+
+	// Control: a standard registry-backed rule that flows through
+	// triggerThresholdAlert.
+	ruleIDs := seedSpockBuiltInRules(t, pool)
+	slotRuleID := ruleIDs["replication_slot_retention_warn"]
+	slotConnID := insertTestConnection(t, pool, "audit-cooldown-control")
+	if _, err := pool.Exec(ctx, insertSlotSampleSQL,
+		slotConnID, "slot_a", false, int64(5_000_000_000)); err != nil {
+		t.Fatalf("failed to seed replication slot sample: %v", err)
+	}
+
+	// First pass creates both alerts.
+	engine.evaluateThresholds(ctx)
+
+	stalenessAlert, err := ds.GetActiveThresholdAlert(ctx, stalenessRuleID,
+		stalenessConnID, nil)
+	if err != nil || stalenessAlert == nil {
+		t.Fatalf("expected a staleness alert after the first pass "+
+			"(alert=%v err=%v)", stalenessAlert, err)
+	}
+	slotAlert, err := ds.GetActiveThresholdAlert(ctx, slotRuleID,
+		slotConnID, nil)
+	if err != nil || slotAlert == nil {
+		t.Fatalf("expected a slot retention alert after the first pass "+
+			"(alert=%v err=%v)", slotAlert, err)
+	}
+
+	// Clear both alerts right now, so both sit well inside
+	// AlertCooldownPeriod.
+	if err := ds.ClearAlert(ctx, stalenessAlert.ID); err != nil {
+		t.Fatalf("failed to clear staleness alert: %v", err)
+	}
+	if err := ds.ClearAlert(ctx, slotAlert.ID); err != nil {
+		t.Fatalf("failed to clear slot alert: %v", err)
+	}
+
+	// Sanity check that the cooldown lookup sees both clears.
+	for name, spec := range map[string]struct {
+		ruleID int64
+		connID int
+	}{
+		"staleness": {stalenessRuleID, stalenessConnID},
+		"slot":      {slotRuleID, slotConnID},
+	} {
+		recent, err := ds.GetRecentlyClearedAlert(ctx, spec.ruleID,
+			spec.connID, nil, AlertCooldownPeriod)
+		if err != nil {
+			t.Fatalf("GetRecentlyClearedAlert(%s) failed: %v", name, err)
+		}
+		if !recent {
+			t.Fatalf("expected %s alert to be inside the cooldown window", name)
+		}
+	}
+
+	// Second pass on unchanged data.
+	engine.evaluateThresholds(ctx)
+
+	newStaleness, err := ds.GetActiveThresholdAlert(ctx, stalenessRuleID,
+		stalenessConnID, nil)
+	if err != nil {
+		t.Fatalf("GetActiveThresholdAlert(staleness) failed: %v", err)
+	}
+	newSlot, err := ds.GetActiveThresholdAlert(ctx, slotRuleID, slotConnID, nil)
+	if err != nil {
+		t.Fatalf("GetActiveThresholdAlert(slot) failed: %v", err)
+	}
+
+	// Current (defective) behavior: the staleness path re-fires
+	// immediately. It SHOULD respect AlertCooldownPeriod like the
+	// control rule does.
+	if newStaleness == nil {
+		t.Error("expected the staleness path to re-fire inside the cooldown")
+	} else if newStaleness.ID == stalenessAlert.ID {
+		t.Errorf("expected a new staleness alert row, got the cleared one (%d)",
+			newStaleness.ID)
+	}
+	if newSlot != nil {
+		t.Errorf("control rule unexpectedly re-fired inside the cooldown "+
+			"(alert %d)", newSlot.ID)
+	}
+}
+
+// TestAuditC2ArchiverRuleErrorIsSwallowed verifies the engine half of
+// audit claim C2: when the metric query fails because
+// metrics.pg_stat_archiver does not exist,
+// evaluateRuleForAllConnections logs at debug level and returns. With
+// debug disabled - the production default - nothing reaches the log
+// and the wal_archive_failed rule is silently inert.
+//
+// The evaluator SHOULD distinguish "no data" from a query error and
+// surface the latter.
+func TestAuditC2ArchiverRuleErrorIsSwallowed(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installNotificationCapture(t, engine)
+
+	var ruleID int64
+	if err := pool.QueryRow(ctx, insertArchiverRuleSQL).Scan(&ruleID); err != nil {
+		t.Fatalf("failed to insert wal_archive_failed rule: %v", err)
+	}
+	insertTestConnection(t, pool, "audit-c2-engine")
+
+	output := captureStderr(t, func() {
+		engine.evaluateThresholds(ctx)
+	})
+
+	if strings.Contains(output, "pg_stat_archiver") {
+		t.Errorf("expected the archiver query failure to be swallowed, "+
+			"but stderr mentioned it: %s", output)
+	}
+	if strings.Contains(output, "ERROR") {
+		t.Errorf("expected no ERROR log for the failing rule, got: %s", output)
+	}
+
+	var alertCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM alerts WHERE rule_id = $1`,
+		ruleID).Scan(&alertCount); err != nil {
+		t.Fatalf("failed to count alerts: %v", err)
+	}
+	if alertCount != 0 {
+		t.Errorf("alerts for wal_archive_failed = %d, want 0", alertCount)
+	}
+}
+
+// TestAuditC8CacheHitRatioFiresAndClearsOnSameData verifies the engine
+// half of audit claim C8. The cache_hit_ratio metric returns one row
+// per delta interval in the 15 minute window with no ordering
+// guarantee. evaluateRuleForAllConnections fires when ANY row breaches
+// the threshold, while checkAlertResolved inspects only the first
+// matching row. When the breaching interval is not the first row, the
+// evaluator and the cleaner disagree on identical data and the alert
+// flaps once per cleaner tick.
+//
+// The metric SHOULD reduce to the latest interval so both sides read
+// the same value.
+func TestAuditC8CacheHitRatioFiresAndClearsOnSameData(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	capture := installNotificationCapture(t, engine)
+
+	if _, err := pool.Exec(ctx, `
+        CREATE TABLE metrics.pg_stat_database (
+            connection_id INTEGER NOT NULL,
+            database_name VARCHAR(255) NOT NULL,
+            datname TEXT,
+            blks_hit BIGINT,
+            blks_read BIGINT,
+            collected_at TIMESTAMPTZ NOT NULL
+        )
+    `); err != nil {
+		t.Fatalf("failed to create metrics.pg_stat_database: %v", err)
+	}
+
+	var ruleID int64
+	if err := pool.QueryRow(ctx, insertCacheHitRuleSQL).Scan(&ruleID); err != nil {
+		t.Fatalf("failed to insert cache_hit_ratio_low rule: %v", err)
+	}
+	connID := insertTestConnection(t, pool, "audit-c8-engine")
+
+	// Two healthy intervals followed by a cold one. The healthy rows
+	// sort first, so the cleaner sees 100% while the evaluator sees
+	// the 0% row.
+	samples := []struct {
+		offset string
+		hits   int64
+		reads  int64
+	}{
+		{"12 minutes", 0, 0},
+		{"8 minutes", 30_000, 0},
+		{"4 minutes", 60_000, 0},
+		{"1 minute", 60_000, 30_000},
+	}
+	for _, s := range samples {
+		if _, err := pool.Exec(ctx, `
+            INSERT INTO metrics.pg_stat_database
+                (connection_id, database_name, datname, blks_hit, blks_read,
+                 collected_at)
+            VALUES ($1, 'appdb', 'appdb', $2, $3, NOW() - $4::interval)
+        `, connID, s.hits, s.reads, s.offset); err != nil {
+			t.Fatalf("failed to seed pg_stat_database: %v", err)
+		}
+	}
+
+	values, err := ds.GetLatestMetricValues(ctx,
+		"pg_stat_database.cache_hit_ratio")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues failed: %v", err)
+	}
+	if len(values) < 2 {
+		t.Fatalf("expected several unreduced rows, got %d", len(values))
+	}
+	if values[0].Value < 80 {
+		t.Fatalf("test setup expects the first row to be healthy, got %v",
+			values[0].Value)
+	}
+
+	// Cycle the evaluator and the cleaner over unchanged data.
+	const cycles = 2
+	for i := 0; i < cycles; i++ {
+		engine.evaluateThresholds(ctx)
+
+		alert, err := ds.GetActiveThresholdAlert(ctx, ruleID, connID, strPtr("appdb"))
+		if err != nil {
+			t.Fatalf("GetActiveThresholdAlert failed: %v", err)
+		}
+		if alert == nil {
+			t.Fatalf("cycle %d: expected the evaluator to fire on the "+
+				"violating row", i)
+		}
+
+		engine.cleanResolvedAlerts(ctx)
+
+		var status string
+		if err := pool.QueryRow(ctx, selectAlertStatusSQL,
+			alert.ID).Scan(&status); err != nil {
+			t.Fatalf("failed to read alert status: %v", err)
+		}
+		// Current (defective) behavior: the cleaner clears the alert
+		// the evaluator just raised, on byte-identical data. The
+		// alert SHOULD stay active while the latest interval is cold.
+		if status != "cleared" {
+			t.Fatalf("cycle %d: alert status = %q, want \"cleared\" "+
+				"(evaluator and cleaner disagree)", i, status)
+		}
+
+		// The cooldown guard on triggerThresholdAlert bounds the flap
+		// rate but not the flap itself, so advance the cleared_at
+		// timestamp to model the next cycle outside the cooldown.
+		if _, err := pool.Exec(ctx, `
+            UPDATE alerts SET cleared_at = NOW() - $1::interval WHERE id = $2
+        `, "1 hour", alert.ID); err != nil {
+			t.Fatalf("failed to age cleared_at: %v", err)
+		}
+	}
+
+	jobs := capture.await(t, 2*cycles)
+	counts := countTypes(jobs)
+	if counts[database.NotificationTypeAlertFire] != cycles ||
+		counts[database.NotificationTypeAlertClear] != cycles {
+		t.Errorf("notifications = %v, want %d fire and %d clear",
+			counts, cycles, cycles)
+	}
+}
+
+// Additional seed statements for the anomaly-side audit tests.
+const (
+	insertAnomalyRuleForMetricSQL = `
+        INSERT INTO alert_rules
+            (name, description, category, metric_name, default_operator,
+             default_threshold, default_severity, default_enabled, is_built_in)
+        VALUES ($1, 'Audit rule', 'audit', $2, '>', 0, 'warning', TRUE, FALSE)
+    `
+
+	createSlotsTableSQL = `
+        CREATE TABLE metrics.pg_replication_slots (
+            connection_id INTEGER NOT NULL,
+            slot_name TEXT NOT NULL,
+            active BOOLEAN,
+            retained_bytes NUMERIC,
+            collected_at TIMESTAMPTZ NOT NULL
+        )
+    `
+
+	createStatDatabaseTableSQL = `
+        CREATE TABLE metrics.pg_stat_database (
+            connection_id INTEGER NOT NULL,
+            database_name VARCHAR(255) NOT NULL,
+            datname TEXT,
+            deadlocks BIGINT,
+            collected_at TIMESTAMPTZ NOT NULL
+        )
+    `
+
+	selectBaselineRowSQL = `
+        SELECT sample_count, stddev, earliest_sample_at
+        FROM metric_baselines
+        WHERE connection_id = $1 AND metric_name = $2 AND period_type = 'all'
+    `
+
+	selectCandidateDatabaseSQL = `
+        SELECT database_name, metric_value
+        FROM anomaly_candidates
+        WHERE connection_id = $1 AND metric_name = $2
+        ORDER BY id
+    `
+)
+
+// seedAuditBaseline upserts a baseline row through the datastore.
+func seedAuditBaseline(t *testing.T, ds *database.Datastore, b *database.MetricBaseline) {
+	t.Helper()
+	if err := ds.UpsertMetricBaseline(context.Background(), b); err != nil {
+		t.Fatalf("UpsertMetricBaseline(%s) failed: %v", b.PeriodType, err)
+	}
+}
+
+// TestAuditC6DetectAnomaliesIgnoresTimeAwareBaselines verifies the
+// engine half of audit claim C6. detectAnomalies reads baselines[0]
+// from GetMetricBaselines, which orders by the TEXT column
+// period_type. 'all' sorts before 'daily' and 'hourly', so the global
+// baseline always wins and the hourly and daily baselines the
+// baseline calculator writes are never consulted.
+//
+// detectAnomalies SHOULD select the baseline matching the current hour
+// or weekday and fall back to 'all'.
+func TestAuditC6DetectAnomaliesIgnoresTimeAwareBaselines(t *testing.T) {
+	engine, ds, pool, cleanup := newDetectAnomaliesEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if _, err := pool.Exec(ctx, insertAnomalyAlertRuleSQL,
+		"audit_c6_rule", "pg_settings.max_connections"); err != nil {
+		t.Fatalf("failed to insert alert rule: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		// allSampleCount and allEarliest control whether the 'all'
+		// baseline passes the warmup gate.
+		allSampleCount int64
+		allEarliest    time.Time
+		allStdDev      float64
+	}{
+		{
+			// Both baselines are warm, but the 'all' baseline is so
+			// wide that the current value is unremarkable against it,
+			// while the hourly baseline would flag it instantly.
+			name:           "warm wide all baseline masks tight hourly baseline",
+			allSampleCount: 500,
+			allEarliest:    now.Add(-10 * 24 * time.Hour),
+			allStdDev:      1000,
+		},
+		{
+			// The 'all' baseline has not warmed up, so detection is
+			// suppressed entirely even though the hourly baseline is
+			// mature.
+			name:           "cold all baseline suppresses warm hourly baseline",
+			allSampleCount: 5,
+			allEarliest:    now.Add(-1 * time.Hour),
+			allStdDev:      1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := pool.Exec(ctx,
+				`TRUNCATE anomaly_candidates RESTART IDENTITY`); err != nil {
+				t.Fatalf("truncate anomaly_candidates failed: %v", err)
+			}
+			if _, err := pool.Exec(ctx, `DELETE FROM metric_baselines`); err != nil {
+				t.Fatalf("delete metric_baselines failed: %v", err)
+			}
+			if _, err := pool.Exec(ctx, `DELETE FROM metrics.pg_settings`); err != nil {
+				t.Fatalf("delete metrics.pg_settings failed: %v", err)
+			}
+			if _, err := pool.Exec(ctx, `DELETE FROM connections`); err != nil {
+				t.Fatalf("delete connections failed: %v", err)
+			}
+
+			var connID int
+			if err := pool.QueryRow(ctx, insertAnomalyConnectionSQL,
+				"audit-c6").Scan(&connID); err != nil {
+				t.Fatalf("failed to insert connection: %v", err)
+			}
+			if _, err := pool.Exec(ctx, insertAnomalyPgSettingsSQL,
+				connID, "500"); err != nil {
+				t.Fatalf("failed to insert pg_settings sample: %v", err)
+			}
+
+			seedAuditBaseline(t, ds, &database.MetricBaseline{
+				ConnectionID:     connID,
+				MetricName:       "pg_settings.max_connections",
+				PeriodType:       "all",
+				Mean:             100,
+				StdDev:           tc.allStdDev,
+				Min:              0,
+				Max:              200,
+				SampleCount:      tc.allSampleCount,
+				LastCalculated:   now,
+				EarliestSampleAt: tc.allEarliest,
+			})
+
+			hour := time.Now().Hour()
+			seedAuditBaseline(t, ds, &database.MetricBaseline{
+				ConnectionID:     connID,
+				MetricName:       "pg_settings.max_connections",
+				PeriodType:       "hourly",
+				HourOfDay:        &hour,
+				Mean:             100,
+				StdDev:           1,
+				Min:              99,
+				Max:              101,
+				SampleCount:      500,
+				LastCalculated:   now,
+				EarliestSampleAt: now.Add(-10 * 24 * time.Hour),
+			})
+
+			// Confirm the ordering assumption before relying on it.
+			baselines, err := ds.GetMetricBaselines(ctx, connID,
+				"pg_settings.max_connections")
+			if err != nil {
+				t.Fatalf("GetMetricBaselines failed: %v", err)
+			}
+			if len(baselines) != 2 {
+				t.Fatalf("expected 2 baselines, got %d", len(baselines))
+			}
+			if baselines[0].PeriodType != "all" {
+				t.Fatalf("baselines[0].PeriodType = %q, want \"all\"",
+					baselines[0].PeriodType)
+			}
+
+			engine.detectAnomalies(ctx)
+
+			var count int
+			if err := pool.QueryRow(ctx, selectAnomalyCountByConnSQL,
+				connID).Scan(&count); err != nil {
+				t.Fatalf("failed to count candidates: %v", err)
+			}
+
+			// Current (defective) behavior: no candidate, because only
+			// the 'all' baseline is consulted. A time-aware detector
+			// SHOULD emit one, since 500 is 400 standard deviations
+			// away from the hourly baseline.
+			if count != 0 {
+				t.Errorf("anomaly candidates = %d, want 0 "+
+					"(only the 'all' baseline is consulted)", count)
+			}
+		})
+	}
+}
+
+// TestAuditC6DetectAnomaliesIgnoresTimeAwareBaselinesDemo asserts the
+// behavior detection SHOULD have: a value that is wildly anomalous
+// against a mature hourly baseline must produce a candidate. It fails
+// against the current code, so it is skipped unless
+// ALERTER_DEFECT_DEMO=1.
+func TestAuditC6DetectAnomaliesIgnoresTimeAwareBaselinesDemo(t *testing.T) {
+	engineDefectDemoEnabled(t)
+
+	engine, ds, pool, cleanup := newDetectAnomaliesEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if _, err := pool.Exec(ctx, insertAnomalyAlertRuleSQL,
+		"audit_c6_demo_rule", "pg_settings.max_connections"); err != nil {
+		t.Fatalf("failed to insert alert rule: %v", err)
+	}
+
+	var connID int
+	if err := pool.QueryRow(ctx, insertAnomalyConnectionSQL,
+		"audit-c6-demo").Scan(&connID); err != nil {
+		t.Fatalf("failed to insert connection: %v", err)
+	}
+	if _, err := pool.Exec(ctx, insertAnomalyPgSettingsSQL,
+		connID, "500"); err != nil {
+		t.Fatalf("failed to insert pg_settings sample: %v", err)
+	}
+
+	seedAuditBaseline(t, ds, &database.MetricBaseline{
+		ConnectionID:     connID,
+		MetricName:       "pg_settings.max_connections",
+		PeriodType:       "all",
+		Mean:             100,
+		StdDev:           1000,
+		Min:              0,
+		Max:              200,
+		SampleCount:      500,
+		LastCalculated:   now,
+		EarliestSampleAt: now.Add(-10 * 24 * time.Hour),
+	})
+	hour := time.Now().Hour()
+	seedAuditBaseline(t, ds, &database.MetricBaseline{
+		ConnectionID:     connID,
+		MetricName:       "pg_settings.max_connections",
+		PeriodType:       "hourly",
+		HourOfDay:        &hour,
+		Mean:             100,
+		StdDev:           1,
+		Min:              99,
+		Max:              101,
+		SampleCount:      500,
+		LastCalculated:   now,
+		EarliestSampleAt: now.Add(-10 * 24 * time.Hour),
+	})
+
+	engine.detectAnomalies(ctx)
+
+	var count int
+	if err := pool.QueryRow(ctx, selectAnomalyCountByConnSQL,
+		connID).Scan(&count); err != nil {
+		t.Fatalf("failed to count candidates: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("expected an anomaly candidate from the mature hourly " +
+			"baseline, got none")
+	}
+}
+
+// TestAuditC7FallbackBaselineCanNeverWarm verifies audit claim C7.
+// Metrics whose registry entry has an empty historicalSQL make
+// GetHistoricalMetricValues fail, so calculateBaselines falls back to
+// calculateGlobalBaselinesFallback. That path derives a baseline from
+// the single current sample: sample_count is 1, stddev is 0, and
+// earliest_sample_at is left NULL. isBaselineWarm rejects such a row
+// under every default warmup profile, so anomaly detection is
+// permanently disabled for those metrics.
+//
+// The fallback SHOULD either populate a real sample history or be
+// skipped entirely rather than writing an unusable baseline.
+func TestAuditC7FallbackBaselineCanNeverWarm(t *testing.T) {
+	engine, ds, pool, cleanup := newDetectAnomaliesEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, createSlotsTableSQL); err != nil {
+		t.Fatalf("failed to create metrics.pg_replication_slots: %v", err)
+	}
+	// pg_replication_slots.inactive is one of the registry entries
+	// with an empty historicalSQL.
+	if _, err := pool.Exec(ctx, insertAnomalyRuleForMetricSQL,
+		"audit_c7_rule", "pg_replication_slots.inactive"); err != nil {
+		t.Fatalf("failed to insert alert rule: %v", err)
+	}
+
+	var connID int
+	if err := pool.QueryRow(ctx, insertAnomalyConnectionSQL,
+		"audit-c7").Scan(&connID); err != nil {
+		t.Fatalf("failed to insert connection: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+        INSERT INTO metrics.pg_replication_slots
+            (connection_id, slot_name, active, retained_bytes, collected_at)
+        VALUES ($1, 'slot_a', FALSE, 0, NOW())
+    `, connID); err != nil {
+		t.Fatalf("failed to seed replication slot: %v", err)
+	}
+
+	// The historical query must fail; that is what routes the metric
+	// onto the fallback path.
+	if _, err := ds.GetHistoricalMetricValues(ctx,
+		"pg_replication_slots.inactive", 7); err == nil {
+		t.Fatal("expected GetHistoricalMetricValues to fail for a metric " +
+			"with no historical SQL")
+	}
+
+	engine.calculateBaselines(ctx)
+
+	var sampleCount int64
+	var stddev float64
+	var earliest *time.Time
+	if err := pool.QueryRow(ctx, selectBaselineRowSQL,
+		connID, "pg_replication_slots.inactive").Scan(
+		&sampleCount, &stddev, &earliest); err != nil {
+		t.Fatalf("failed to read fallback baseline: %v", err)
+	}
+
+	// Current (defective) behavior.
+	if sampleCount != 1 {
+		t.Errorf("fallback sample_count = %d, want 1", sampleCount)
+	}
+	if stddev != 0 {
+		t.Errorf("fallback stddev = %v, want 0", stddev)
+	}
+	if earliest != nil {
+		t.Errorf("fallback earliest_sample_at = %v, want NULL", *earliest)
+	}
+
+	baselines, err := ds.GetMetricBaselines(ctx, connID,
+		"pg_replication_slots.inactive")
+	if err != nil {
+		t.Fatalf("GetMetricBaselines failed: %v", err)
+	}
+	if len(baselines) != 1 {
+		t.Fatalf("expected exactly one fallback baseline, got %d", len(baselines))
+	}
+	if !baselines[0].EarliestSampleAt.IsZero() {
+		t.Errorf("EarliestSampleAt = %v, want the zero time",
+			baselines[0].EarliestSampleAt)
+	}
+
+	// The warmup gate rejects the fallback row under every default
+	// profile, so no amount of waiting makes it usable.
+	warmup := engine.getConfig().Anomaly.Tier1.Warmup
+	for _, periodType := range []string{"all", "hourly", "daily"} {
+		b := *baselines[0]
+		b.PeriodType = periodType
+		if isBaselineWarm(b, warmup, time.Now().Add(365*24*time.Hour)) {
+			t.Errorf("isBaselineWarm(%s) = true for the fallback baseline, "+
+				"want false even a year later", periodType)
+		}
+	}
+
+	// End to end: detection emits nothing for this metric.
+	engine.detectAnomalies(ctx)
+	var count int
+	if err := pool.QueryRow(ctx, selectAnomalyCountByConnSQL,
+		connID).Scan(&count); err != nil {
+		t.Fatalf("failed to count candidates: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("anomaly candidates = %d, want 0", count)
+	}
+}
+
+// TestAuditC10AnomalyCandidateDropsDatabaseName verifies audit claim
+// C10. For per-database metrics the baseline calculator writes one
+// baseline row per (connection, database), but detectAnomalies fetches
+// baselines by connection and metric only, picks the first metric
+// value whose connection matches regardless of database, and never
+// assigns DatabaseName on the candidate it creates.
+//
+// Detection SHOULD pair each per-database value with the baseline for
+// that database and record the database on the candidate.
+func TestAuditC10AnomalyCandidateDropsDatabaseName(t *testing.T) {
+	engine, ds, pool, cleanup := newDetectAnomaliesEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if _, err := pool.Exec(ctx, createStatDatabaseTableSQL); err != nil {
+		t.Fatalf("failed to create metrics.pg_stat_database: %v", err)
+	}
+	if _, err := pool.Exec(ctx, insertAnomalyRuleForMetricSQL,
+		"audit_c10_rule", "pg_stat_database.deadlocks_delta"); err != nil {
+		t.Fatalf("failed to insert alert rule: %v", err)
+	}
+
+	var connID int
+	if err := pool.QueryRow(ctx, insertAnomalyConnectionSQL,
+		"audit-c10").Scan(&connID); err != nil {
+		t.Fatalf("failed to insert connection: %v", err)
+	}
+
+	// Two databases on one connection with very different deadlock
+	// deltas: alpha jumps by 900, beta by 1.
+	samples := []struct {
+		dbName    string
+		deadlocks []int64
+	}{
+		{"alpha", []int64{100, 1000}},
+		{"beta", []int64{5, 6}},
+	}
+	offsets := []string{"10 minutes", "1 minute"}
+	for _, s := range samples {
+		for i, offset := range offsets {
+			if _, err := pool.Exec(ctx, `
+                INSERT INTO metrics.pg_stat_database
+                    (connection_id, database_name, datname, deadlocks,
+                     collected_at)
+                VALUES ($1, $2, $3, $4, NOW() - $5::interval)
+            `, connID, s.dbName, s.dbName, s.deadlocks[i], offset); err != nil {
+				t.Fatalf("failed to seed pg_stat_database: %v", err)
+			}
+		}
+	}
+
+	values, err := ds.GetLatestMetricValues(ctx,
+		"pg_stat_database.deadlocks_delta")
+	if err != nil {
+		t.Fatalf("GetLatestMetricValues failed: %v", err)
+	}
+	if len(values) != 2 {
+		t.Fatalf("expected one row per database, got %d", len(values))
+	}
+	firstDB := "<nil>"
+	if values[0].DatabaseName != nil {
+		firstDB = *values[0].DatabaseName
+	}
+	t.Logf("detection will use the first row: database=%s value=%v",
+		firstDB, values[0].Value)
+
+	// The baseline calculator does key its output on the database:
+	// running it over this data writes one 'all' baseline per database.
+	engine.calculateBaselines(ctx)
+	var perDatabaseBaselines int
+	if err := pool.QueryRow(ctx, `
+        SELECT COUNT(DISTINCT database_name)
+        FROM metric_baselines
+        WHERE connection_id = $1 AND metric_name = $2
+          AND database_name IS NOT NULL
+    `, connID, "pg_stat_database.deadlocks_delta").Scan(
+		&perDatabaseBaselines); err != nil {
+		t.Fatalf("failed to count per-database baselines: %v", err)
+	}
+	if perDatabaseBaselines != 2 {
+		t.Errorf("distinct baseline database names = %d, want 2",
+			perDatabaseBaselines)
+	}
+
+	// Replace them with a single warm baseline for database "beta"
+	// only, so the mismatch between the baseline's database and the
+	// value detection actually uses is unambiguous.
+	if _, err := pool.Exec(ctx, `DELETE FROM metric_baselines`); err != nil {
+		t.Fatalf("failed to reset baselines: %v", err)
+	}
+	betaName := "beta"
+	seedAuditBaseline(t, ds, &database.MetricBaseline{
+		ConnectionID:     connID,
+		DatabaseName:     &betaName,
+		MetricName:       "pg_stat_database.deadlocks_delta",
+		PeriodType:       "all",
+		Mean:             1,
+		StdDev:           0.5,
+		Min:              0,
+		Max:              2,
+		SampleCount:      500,
+		LastCalculated:   now,
+		EarliestSampleAt: now.Add(-10 * 24 * time.Hour),
+	})
+
+	engine.detectAnomalies(ctx)
+
+	rows, err := pool.Query(ctx, selectCandidateDatabaseSQL,
+		connID, "pg_stat_database.deadlocks_delta")
+	if err != nil {
+		t.Fatalf("failed to read candidates: %v", err)
+	}
+	defer rows.Close()
+
+	type candidateRow struct {
+		dbName *string
+		value  float64
+	}
+	var candidates []candidateRow
+	for rows.Next() {
+		var c candidateRow
+		if err := rows.Scan(&c.dbName, &c.value); err != nil {
+			t.Fatalf("failed to scan candidate: %v", err)
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration error: %v", err)
+	}
+
+	if len(candidates) != 1 {
+		t.Fatalf("expected exactly one candidate, got %d", len(candidates))
+	}
+
+	// Current (defective) behavior: the candidate carries no database
+	// name even though the metric and the baseline are per-database.
+	// It SHOULD record the database the value came from.
+	if candidates[0].dbName != nil {
+		t.Errorf("candidate database_name = %q, want NULL "+
+			"(the field is never assigned)", *candidates[0].dbName)
+	}
+
+	// The value is taken from whichever row the query returned first,
+	// not from the database the baseline describes.
+	if candidates[0].value != float32ish(values[0].Value) {
+		t.Errorf("candidate metric_value = %v, want %v (the first row)",
+			candidates[0].value, values[0].Value)
+	}
+}
+
+// float32ish rounds a float64 through float32, matching the REAL
+// column type used by anomaly_candidates.metric_value.
+func float32ish(v float64) float64 {
+	return float64(float32(v))
+}
+
+// TestAuditC7FallbackBaselineCanNeverWarmDemo asserts the behavior the
+// baseline calculator SHOULD have: any baseline it persists must carry
+// the timestamp of its earliest sample, so the warmup gate can
+// eventually admit it. It fails against the current code, so it is
+// skipped unless ALERTER_DEFECT_DEMO=1.
+func TestAuditC7FallbackBaselineCanNeverWarmDemo(t *testing.T) {
+	engineDefectDemoEnabled(t)
+
+	engine, _, pool, cleanup := newDetectAnomaliesEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, createSlotsTableSQL); err != nil {
+		t.Fatalf("failed to create metrics.pg_replication_slots: %v", err)
+	}
+	if _, err := pool.Exec(ctx, insertAnomalyRuleForMetricSQL,
+		"audit_c7_demo_rule", "pg_replication_slots.inactive"); err != nil {
+		t.Fatalf("failed to insert alert rule: %v", err)
+	}
+
+	var connID int
+	if err := pool.QueryRow(ctx, insertAnomalyConnectionSQL,
+		"audit-c7-demo").Scan(&connID); err != nil {
+		t.Fatalf("failed to insert connection: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+        INSERT INTO metrics.pg_replication_slots
+            (connection_id, slot_name, active, retained_bytes, collected_at)
+        VALUES ($1, 'slot_a', FALSE, 0, NOW())
+    `, connID); err != nil {
+		t.Fatalf("failed to seed replication slot: %v", err)
+	}
+
+	engine.calculateBaselines(ctx)
+
+	var sampleCount int64
+	var stddev float64
+	var earliest *time.Time
+	if err := pool.QueryRow(ctx, selectBaselineRowSQL,
+		connID, "pg_replication_slots.inactive").Scan(
+		&sampleCount, &stddev, &earliest); err != nil {
+		t.Fatalf("failed to read fallback baseline: %v", err)
+	}
+	if earliest == nil {
+		t.Fatal("persisted baseline has a NULL earliest_sample_at, so the " +
+			"warmup gate can never admit it")
+	}
+}

--- a/alerter/src/internal/engine/audit_defects_test.go
+++ b/alerter/src/internal/engine/audit_defects_test.go
@@ -107,6 +107,25 @@ const (
             (connection_id, slot_name, active, retained_bytes, collected_at)
         VALUES ($1, $2, $3, $4, NOW())
     `
+
+	// createStatDatabaseTableSQL carries every metrics.pg_stat_database
+	// column the audit tests read, so a single definition serves both
+	// the cache_hit_ratio tests (blks_hit, blks_read) and the
+	// deadlocks_delta tests (deadlocks). Keeping one fixture avoids the
+	// two definitions drifting apart, which would make a test fail with
+	// an undefined-column error that has nothing to do with the defect
+	// under examination.
+	createStatDatabaseTableSQL = `
+        CREATE TABLE metrics.pg_stat_database (
+            connection_id INTEGER NOT NULL,
+            database_name VARCHAR(255) NOT NULL,
+            datname TEXT,
+            blks_hit BIGINT,
+            blks_read BIGINT,
+            deadlocks BIGINT,
+            collected_at TIMESTAMPTZ NOT NULL
+        )
+    `
 )
 
 // notificationCapture records the notification jobs the engine submits
@@ -500,16 +519,7 @@ func TestAuditC8CacheHitRatioFiresAndClearsOnSameData(t *testing.T) {
 	ctx := context.Background()
 	capture := installNotificationCapture(t, engine)
 
-	if _, err := pool.Exec(ctx, `
-        CREATE TABLE metrics.pg_stat_database (
-            connection_id INTEGER NOT NULL,
-            database_name VARCHAR(255) NOT NULL,
-            datname TEXT,
-            blks_hit BIGINT,
-            blks_read BIGINT,
-            collected_at TIMESTAMPTZ NOT NULL
-        )
-    `); err != nil {
+	if _, err := pool.Exec(ctx, createStatDatabaseTableSQL); err != nil {
 		t.Fatalf("failed to create metrics.pg_stat_database: %v", err)
 	}
 
@@ -619,16 +629,6 @@ const (
             slot_name TEXT NOT NULL,
             active BOOLEAN,
             retained_bytes NUMERIC,
-            collected_at TIMESTAMPTZ NOT NULL
-        )
-    `
-
-	createStatDatabaseTableSQL = `
-        CREATE TABLE metrics.pg_stat_database (
-            connection_id INTEGER NOT NULL,
-            database_name VARCHAR(255) NOT NULL,
-            datname TEXT,
-            deadlocks BIGINT,
             collected_at TIMESTAMPTZ NOT NULL
         )
     `


### PR DESCRIPTION
## Summary

Adds test-only coverage that empirically verifies ten claimed defects
in the alerting subsystem. No production code is changed; the tests
establish a baseline so that each fix has something concrete to break.

This came out of a review of dashboard charts showing cumulative
rather than point-in-time statistics. The chart findings are tracked in
#400, #401, #402, #403 and #404. The alerter findings verified here are
tracked in #405, #406, #407, #408 and #409.

## Two test styles

`TestAudit*` tests assert the current, defective behaviour with a doc
comment stating what the behaviour should be. They pass in CI today
and fail once a fix lands, which is the signal to update them
alongside the fix.

`TestAudit*Demo` tests assert the correct behaviour and therefore fail
against current code. They are skipped unless `ALERTER_DEFECT_DEMO=1`
so CI stays green. Four exist, covering the staleness loop, baseline
ordering, the fallback baseline warmup gate, and the slow query
lifetime average.

Running the demo tests produces:

```
=== RUN   TestAuditC1StalenessAlertFireClearLoopDemo
    audit_defects_test.go:331: alert rows = 3, want 1 for a continuously stale probe
    audit_defects_test.go:334: active alerts = 0, want 1; the probe is still stale
    audit_defects_test.go:337: received an unexpected extra notification: type=alert_clear
--- FAIL: TestAuditC1StalenessAlertFireClearLoopDemo (0.08s)
=== RUN   TestAuditC6DetectAnomaliesIgnoresTimeAwareBaselinesDemo
    audit_defects_test.go:859: expected an anomaly candidate from the mature hourly baseline, got none
--- FAIL: TestAuditC6DetectAnomaliesIgnoresTimeAwareBaselinesDemo (0.04s)
=== RUN   TestAuditC7FallbackBaselineCanNeverWarmDemo
    audit_defects_test.go:1151: persisted baseline has a NULL earliest_sample_at, so the warmup gate can never admit it
--- FAIL: TestAuditC7FallbackBaselineCanNeverWarmDemo (0.04s)
=== RUN   TestAuditC9SlowQueryCountDemo
    audit_defects_test.go:919: slow_query_count = 1 for a query that did not run during the window, want 0
--- FAIL: TestAuditC9SlowQueryCountDemo (0.03s)
```

## What was verified

Confirmed: the `metric_staleness` fire and clear loop and its missing
cooldown guard (#405); the missing `metrics.pg_stat_archiver` table,
the hardcoded `transaction_wraparound` metric, the `pg_settings` one
hour window, and the NULL CPU column consequence on Linux (#406); the
`slow_query_count` lifetime average (#407); the anomaly baseline
ordering bug and the ignored `database_name` (#408).

Partially confirmed, with corrections to the original claims:

- The fallback baseline mechanism is real, but the count was wrong.
  The registry has 32 entries with 14 empty `historicalSQL`, not 12 of
  34; 34 is the number of seeded alert rules, not registry metrics.

- `cache_hit_ratio_low` has two failure modes rather than one. A
  violation in the newest interval flaps; a violation in the oldest
  interval latches, because the cleaner breaks on the first row of an
  unordered result.

Not provable here: that `system_stats` leaves `processor_time_percent`
NULL on Linux. The extension cannot be installed in this environment,
so the premise is confirmed from the upstream C source while the
consequence is covered by a table-driven test.

## Testing

Tests use the existing integration harness (`TEST_AI_WORKBENCH_SERVER`,
`NewTestDatastore`, `newEngineSpockTestEnv`, `newDetectAnomaliesEnv`)
against a live PostgreSQL 16 instance. The full alerter suite passes
under `-race -p=1`.

```
$ cd alerter/src && gofmt -l .    # no output
$ go vet ./...                    # no output
$ cd alerter && make coverage
ok   .../alerter/internal/database          coverage: 83.6%
ok   .../alerter/internal/engine     4.476s coverage: 57.0%
```

One caveat to flag: `make test-all` fails at `lint` for a pre-existing
environmental reason, reproduced on a clean tree with no changes:

```
Error: can't load config: the Go language version (go1.25) used to build
golangci-lint is lower than the targeted Go version (1.26.2)
```

`golangci-lint 2.5.0` is built with `go1.25.1` while the modules target
`go 1.26.1`. The linter cannot run in this environment at all; this is
unrelated to the change but means lint has not been verified.

The project's 90% coverage floor applies to new and modified
production code. This change adds no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2VcS2NfYNkagXRo7khohq

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2VcS2NfYNkagXRo7khohq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration coverage for database metrics, audit data, anomaly baselines, cache-hit ratios, slow-query detection, and alert behavior.
  * Added scenarios covering stale data, missing database context, archiver errors, transaction age, CPU metrics, and notification handling.
  * Included opt-in demonstration tests for corrected slow-query and alerting behavior.
* **Documentation**
  * Documented current edge cases and expected behavior through representative test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->