### PR TITLE
fix(llm): honour configured max_tokens on AI analysis paths

### DIFF
--- a/.claude/golang-expert/testing-strategy.md
+++ b/.claude/golang-expert/testing-strategy.md
@@ -136,6 +136,56 @@ one produces 401s or 403s that look like permission bugs.
 holding a named permission. The gate-ordering tests for mutating
 handlers are described in `rbac-patterns.md`.
 
+## HTTP Handler Tests: Never Point at Unreachable URLs
+
+The analysis paths build a real HTTP client through
+`(*llmproxy.Config).BuildClientOptions`, which sets
+`pgllm.Options.RequestTimeout` from `llm.timeout_seconds`; that setting
+defaults to 120 seconds in `server/src/internal/config/config.go`. A
+handler test that reaches a live provider endpoint, or an address that
+accepts the connection without answering, therefore blocks for up to two
+minutes instead of failing fast, and the cost lands on every `make test`
+and `make coverage` run. A locally refused connection is the benign
+case and returns at once.
+
+Stub the endpoint with `httptest.NewServer` and return a minimal valid
+body. The stubs in `server/src/internal/overview/generator_test.go` and
+`server/src/internal/api/server_info_handlers_test.go` are the patterns
+to copy; both decode the request body, which is also how the
+`max_tokens` assertions described below are made.
+
+When auditing a slow test, look for a base URL set to a literal
+`http://localhost:...` or to a real provider address.
+
+## AI Analysis Paths: Token Budget and Empty Responses
+
+The non-streaming analysis paths, the estate and scoped overview in
+`internal/overview/` and the server-info database analysis in
+`internal/api/server_info_handlers.go`, share two conventions that
+tests must uphold.
+
+The first convention is that no caller hardcodes an output-token
+budget. `(*llmproxy.Config).BuildClientOptions(temperature)` resolves
+the budget internally from `llm.max_tokens` through
+`AnalysisMaxTokens`, falling back to
+`llmproxy.DefaultAnalysisMaxTokens`, which is 4096, when the setting is
+unset, zero or negative. A caller that also stamps `MaxTokens` onto a
+`pgllm.ChatRequest` must read `AnalysisMaxTokens` rather than a local
+constant. Cover the configured, unset and negative cases, and assert
+the value on the wire by decoding `max_tokens` from the request body
+inside the `httptest` stub.
+
+The second convention is that a response carrying no text block, or
+whitespace-only text, is an error rather than an empty summary. Both
+paths return `llmproxy.ErrNoTextContent`, which the server-info handler
+maps to HTTP 502. Reasoning models charge their thinking blocks against
+the same budget as the answer, so this is the shape a starved budget
+produces; reproduce it with a content block of type `"thinking"`, for
+which the library exposes no named constant, or with an empty assistant
+message. The alerter mirrors both conventions in
+`alerter/src/internal/llm/reasoning.go`, using
+`config.DefaultLLMMaxTokens` and its own `ErrNoTextContent`.
+
 ## Linting
 
 Every sub-project runs golangci-lint v2 (`version: "2"` configs; note

--- a/alerter/src/internal/config/config.go
+++ b/alerter/src/internal/config/config.go
@@ -20,6 +20,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// DefaultLLMMaxTokens is the default output-token budget for tier-3
+// reasoning calls (llm.max_tokens).
+//
+// The previous hardcoded 500-token budget was sized for a classification
+// verdict alone. Reasoning models served through an OpenAI-compatible
+// endpoint (llama.cpp hosting Qwen3, DeepSeek-R1 distills, gpt-oss, and
+// similar) charge their thinking tokens against the same budget, so 500
+// tokens are routinely consumed in full by the thinking block and the
+// model never emits the verdict. 4096 leaves several thousand tokens of
+// thinking room ahead of the small JSON verdict, and matches the server's
+// llm.max_tokens default so operators see one number across the estate.
+const DefaultLLMMaxTokens = 4096
+
 // Config holds all configuration options for the alerter
 type Config struct {
 	// Datastore connection settings
@@ -147,13 +160,21 @@ type CorrelationConfig struct {
 
 // LLMConfig holds LLM provider settings
 type LLMConfig struct {
-	EmbeddingProvider string          `yaml:"embedding_provider"`
-	ReasoningProvider string          `yaml:"reasoning_provider"`
-	Ollama            OllamaConfig    `yaml:"ollama"`
-	OpenAI            OpenAIConfig    `yaml:"openai"`
-	Anthropic         AnthropicConfig `yaml:"anthropic"`
-	Voyage            VoyageConfig    `yaml:"voyage"`
-	Gemini            GeminiConfig    `yaml:"gemini"`
+	EmbeddingProvider string `yaml:"embedding_provider"`
+	ReasoningProvider string `yaml:"reasoning_provider"`
+
+	// MaxTokens caps the output tokens of a tier-3 reasoning call.
+	// Reasoning models charge their thinking blocks against this same
+	// budget, so a small value leaves no room for the classification
+	// verdict itself. A value of 0 or less selects
+	// llm.DefaultReasoningMaxTokens. Default: 4096.
+	MaxTokens int `yaml:"max_tokens"`
+
+	Ollama    OllamaConfig    `yaml:"ollama"`
+	OpenAI    OpenAIConfig    `yaml:"openai"`
+	Anthropic AnthropicConfig `yaml:"anthropic"`
+	Voyage    VoyageConfig    `yaml:"voyage"`
+	Gemini    GeminiConfig    `yaml:"gemini"`
 }
 
 // NotificationsConfig holds notification settings
@@ -340,6 +361,7 @@ func NewConfig() *Config {
 		LLM: LLMConfig{
 			EmbeddingProvider: "ollama",
 			ReasoningProvider: "ollama",
+			MaxTokens:         DefaultLLMMaxTokens,
 			Ollama: OllamaConfig{
 				BaseURL:        "http://localhost:11434",
 				EmbeddingModel: "nomic-embed-text",
@@ -374,8 +396,9 @@ func (c *Config) LoadFromFile(filename string) error {
 		return fmt.Errorf("failed to parse YAML config: %w", err)
 	}
 
-	// Apply defaults for notification settings
+	// Apply defaults for notification and LLM settings
 	c.SetNotificationDefaults()
+	c.SetLLMDefaults()
 
 	return nil
 }
@@ -512,6 +535,16 @@ func GetDefaultConfigPath(binaryPath string) string {
 // ConfigFileExists checks if a config file exists at the given path
 func ConfigFileExists(path string) bool {
 	return fileutil.FileExists(path)
+}
+
+// SetLLMDefaults sets default values for LLM config that a YAML file may
+// have left unset. NewConfig already seeds these defaults, but a caller
+// that loads into a bare Config (or a YAML file that sets llm.max_tokens
+// to 0) must still end up with a usable budget.
+func (c *Config) SetLLMDefaults() {
+	if c.LLM.MaxTokens <= 0 {
+		c.LLM.MaxTokens = DefaultLLMMaxTokens
+	}
 }
 
 // SetNotificationDefaults sets default values for notification config

--- a/alerter/src/internal/config/config_test.go
+++ b/alerter/src/internal/config/config_test.go
@@ -633,7 +633,7 @@ llm:
 			want int
 		}{
 			{
-				name: "explicit value is honoured",
+				name: "explicit value is honored",
 				yaml: "llm:\n  max_tokens: 16384\n",
 				want: 16384,
 			},

--- a/alerter/src/internal/config/config_test.go
+++ b/alerter/src/internal/config/config_test.go
@@ -51,6 +51,7 @@ func TestNewConfig(t *testing.T) {
 		{"correlation window", cfg.Correlation.WindowSeconds, 120},
 		{"llm embedding provider", cfg.LLM.EmbeddingProvider, "ollama"},
 		{"llm reasoning provider", cfg.LLM.ReasoningProvider, "ollama"},
+		{"llm max tokens", cfg.LLM.MaxTokens, DefaultLLMMaxTokens},
 		{"gemini embedding model", cfg.LLM.Gemini.EmbeddingModel, "gemini-embedding-001"},
 		{"gemini reasoning model", cfg.LLM.Gemini.ReasoningModel, "gemini-2.5-flash"},
 	}
@@ -617,6 +618,67 @@ llm:
 		if cfg.LLM.Gemini.ReasoningModel != "gemini-2.5-pro" {
 			t.Errorf("gemini reasoning_model = %q, expected %q",
 				cfg.LLM.Gemini.ReasoningModel, "gemini-2.5-pro")
+		}
+	})
+
+	t.Run("llm max_tokens round-trip and fallback", func(t *testing.T) {
+		// llm.max_tokens caps the tier-3 reasoning budget (issue #399).
+		// An explicit positive value must survive the merge; an omitted
+		// or non-positive value must resolve to DefaultLLMMaxTokens so a
+		// reasoning model always has room for both its thinking block and
+		// the verdict.
+		tests := []struct {
+			name string
+			yaml string
+			want int
+		}{
+			{
+				name: "explicit value is honoured",
+				yaml: "llm:\n  max_tokens: 16384\n",
+				want: 16384,
+			},
+			{
+				name: "omitted key keeps the default",
+				yaml: "llm:\n  reasoning_provider: ollama\n",
+				want: DefaultLLMMaxTokens,
+			},
+			{
+				name: "explicit zero falls back to the default",
+				yaml: "llm:\n  max_tokens: 0\n",
+				want: DefaultLLMMaxTokens,
+			},
+			{
+				name: "negative value falls back to the default",
+				yaml: "llm:\n  max_tokens: -1\n",
+				want: DefaultLLMMaxTokens,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				configFile := filepath.Join(t.TempDir(), "llm.yaml")
+				if err := os.WriteFile(configFile, []byte(tt.yaml), 0644); err != nil {
+					t.Fatalf("failed to create config file: %v", err)
+				}
+
+				cfg := NewConfig()
+				if err := cfg.LoadFromFile(configFile); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if cfg.LLM.MaxTokens != tt.want {
+					t.Errorf("llm.max_tokens = %d, want %d", cfg.LLM.MaxTokens, tt.want)
+				}
+
+				// A bare Config (no NewConfig defaults) must reach the
+				// same value through LoadFromFile's defaulting pass.
+				bare := &Config{}
+				if err := bare.LoadFromFile(configFile); err != nil {
+					t.Fatalf("unexpected error loading into bare config: %v", err)
+				}
+				if bare.LLM.MaxTokens != tt.want {
+					t.Errorf("bare llm.max_tokens = %d, want %d", bare.LLM.MaxTokens, tt.want)
+				}
+			})
 		}
 	})
 

--- a/alerter/src/internal/llm/llm.go
+++ b/alerter/src/internal/llm/llm.go
@@ -163,10 +163,17 @@ func NewEmbeddingProvider(cfg *config.Config) (EmbeddingProvider, error) {
 
 // NewReasoningProvider creates a reasoning provider based on configuration.
 // Returns nil and no error if reasoning is disabled or provider is not configured.
+//
+// The operator-configured llm.max_tokens is passed to every provider so a
+// reasoning model has room for both its thinking block and the
+// classification verdict; newLibReasoning substitutes
+// DefaultReasoningMaxTokens when the setting is unset or non-positive.
 func NewReasoningProvider(cfg *config.Config) (ReasoningProvider, error) {
 	if cfg == nil {
 		return nil, nil
 	}
+
+	maxTokens := cfg.LLM.MaxTokens
 
 	switch cfg.LLM.ReasoningProvider {
 	case "openai":
@@ -174,28 +181,28 @@ func NewReasoningProvider(cfg *config.Config) (ReasoningProvider, error) {
 		if apiKey == "" && cfg.LLM.OpenAI.BaseURL == "" {
 			return nil, fmt.Errorf("openai: %w", ErrAPIKeyMissing)
 		}
-		return newLibReasoning("openai", apiKey, cfg.LLM.OpenAI.ReasoningModel, cfg.LLM.OpenAI.BaseURL)
+		return newLibReasoning("openai", apiKey, cfg.LLM.OpenAI.ReasoningModel, cfg.LLM.OpenAI.BaseURL, maxTokens)
 
 	case "anthropic":
 		apiKey := cfg.GetAnthropicAPIKey()
 		if apiKey == "" {
 			return nil, fmt.Errorf("anthropic: %w", ErrAPIKeyMissing)
 		}
-		return newLibReasoning("anthropic", apiKey, cfg.LLM.Anthropic.ReasoningModel, cfg.LLM.Anthropic.BaseURL)
+		return newLibReasoning("anthropic", apiKey, cfg.LLM.Anthropic.ReasoningModel, cfg.LLM.Anthropic.BaseURL, maxTokens)
 
 	case "gemini":
 		apiKey := cfg.GetGeminiAPIKey()
 		if apiKey == "" {
 			return nil, fmt.Errorf("gemini: %w", ErrAPIKeyMissing)
 		}
-		return newLibReasoning("gemini", apiKey, cfg.LLM.Gemini.ReasoningModel, cfg.LLM.Gemini.BaseURL)
+		return newLibReasoning("gemini", apiKey, cfg.LLM.Gemini.ReasoningModel, cfg.LLM.Gemini.BaseURL, maxTokens)
 
 	case "ollama":
 		baseURL := cfg.LLM.Ollama.BaseURL
 		if baseURL == "" {
 			baseURL = "http://localhost:11434"
 		}
-		return newLibReasoning("ollama", "", cfg.LLM.Ollama.ReasoningModel, baseURL)
+		return newLibReasoning("ollama", "", cfg.LLM.Ollama.ReasoningModel, baseURL, maxTokens)
 
 	case "", "none", "disabled":
 		return nil, nil

--- a/alerter/src/internal/llm/reasoning.go
+++ b/alerter/src/internal/llm/reasoning.go
@@ -12,6 +12,7 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -31,34 +32,70 @@ var defaultReasoningModels = map[string]string{
 	"ollama":    "llama3.2",
 }
 
+// DefaultReasoningMaxTokens is the output-token budget used for a tier-3
+// classification when the configuration leaves llm.max_tokens unset or
+// non-positive. It mirrors config.DefaultLLMMaxTokens; the constant is
+// duplicated here so this package resolves a usable budget even when a
+// caller builds a provider without going through config.NewConfig.
+const DefaultReasoningMaxTokens = 4096
+
+// reasoningTemperature keeps classification deterministic.
+const reasoningTemperature = 0.1
+
+// ErrNoTextContent reports that a reasoning response carried no usable
+// text. The engine treats a Classify error as a tier-3 failure (failing
+// safe to "alert") and records the message, so naming the likely cause
+// here puts an actionable hint in the candidate's tier-3 error field.
+var ErrNoTextContent = errors.New(
+	"LLM response contained no text content; the model may have " +
+		"exhausted its output token budget on reasoning tokens: " +
+		"increase llm.max_tokens or select a model that emits less reasoning")
+
 // libReasoning implements ReasoningProvider by delegating to the
 // pgedge-go-llm-lib Client.Chat method. A single implementation serves
 // every provider; the provider-specific behavior lives in the library.
 type libReasoning struct {
 	client pgllm.Client
+
+	// maxTokens is the resolved (always positive) output-token budget for
+	// each classification request.
+	maxTokens int
 }
 
 // Classify sends the classification system prompt and the supplied prompt
 // to the underlying LLM and returns the concatenated text of the
 // response's text blocks. Non-text content blocks are ignored.
+//
+// A response with no text block, or whose text is whitespace only, yields
+// ErrNoTextContent rather than an empty string. Reasoning models charge
+// their thinking blocks against the same output budget as the verdict, so
+// an under-sized budget produces exactly this shape of response; returning
+// an error stops the engine from parsing an empty verdict and recording a
+// blank tier-3 result.
 func (r *libReasoning) Classify(ctx context.Context, prompt string) (string, error) {
 	resp, err := r.client.Chat(ctx, pgllm.ChatRequest{
 		SystemPrompt: classificationSystemPrompt,
 		Messages:     []pgllm.Message{pgllm.UserText(prompt)},
-		MaxTokens:    pgllm.Int(500),
-		Temperature:  pgllm.Float(0.1),
+		MaxTokens:    pgllm.Int(r.maxTokens),
+		Temperature:  pgllm.Float(reasoningTemperature),
 	})
 	if err != nil {
 		return "", err
 	}
 
 	var sb strings.Builder
-	for _, b := range resp.Content {
-		if b.Type == pgllm.BlockText {
-			sb.WriteString(b.Text)
+	if resp != nil {
+		for _, b := range resp.Content {
+			if b.Type == pgllm.BlockText {
+				sb.WriteString(b.Text)
+			}
 		}
 	}
-	return sb.String(), nil
+	text := sb.String()
+	if strings.TrimSpace(text) == "" {
+		return "", ErrNoTextContent
+	}
+	return text, nil
 }
 
 // ModelName returns the reasoning model configured on the client.
@@ -68,10 +105,15 @@ func (r *libReasoning) ModelName() string {
 
 // newLibReasoning builds a libReasoning for the named provider. When model
 // is empty, the per-provider default from defaultReasoningModels is used.
-// apiKey and baseURL are passed straight through to the library.
-func newLibReasoning(provider, apiKey, model, baseURL string) (ReasoningProvider, error) {
+// When maxTokens is zero or negative, DefaultReasoningMaxTokens is used, so
+// an unset llm.max_tokens can never produce an unusable budget. apiKey and
+// baseURL are passed straight through to the library.
+func newLibReasoning(provider, apiKey, model, baseURL string, maxTokens int) (ReasoningProvider, error) {
 	if model == "" {
 		model = defaultReasoningModels[provider]
+	}
+	if maxTokens <= 0 {
+		maxTokens = DefaultReasoningMaxTokens
 	}
 
 	client, err := pgllm.NewClient(provider, pgllm.Options{
@@ -83,5 +125,5 @@ func newLibReasoning(provider, apiKey, model, baseURL string) (ReasoningProvider
 		return nil, fmt.Errorf("create %s reasoning client: %w", provider, err)
 	}
 
-	return &libReasoning{client: client}, nil
+	return &libReasoning{client: client, maxTokens: maxTokens}, nil
 }

--- a/alerter/src/internal/llm/reasoning_test.go
+++ b/alerter/src/internal/llm/reasoning_test.go
@@ -162,7 +162,7 @@ func TestNewLibReasoningMaxTokensResolution(t *testing.T) {
 		{"configured value used", 8192, 8192},
 		{"unset falls back", 0, DefaultReasoningMaxTokens},
 		{"negative falls back", -1, DefaultReasoningMaxTokens},
-		{"small configured value still honoured", 32, 32},
+		{"small configured value still honored", 32, 32},
 	}
 
 	for _, tt := range tests {

--- a/alerter/src/internal/llm/reasoning_test.go
+++ b/alerter/src/internal/llm/reasoning_test.go
@@ -14,11 +14,17 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	pgllm "github.com/pgEdge/pgedge-go-llm-lib/llm"
 	"github.com/pgedge/ai-workbench/alerter/internal/config"
 )
+
+// thinkingBlock is the content-block type a reasoning model emits for its
+// chain of thought. The library has no named constant for it, so the tests
+// use the wire value directly to reproduce the issue #399 response shape.
+const thinkingBlock pgllm.ContentBlockType = "thinking"
 
 // fakeChatClient is a test double for pgllm.Client. It embeds the
 // interface so it satisfies every method, but only Chat and Model are
@@ -49,7 +55,7 @@ func TestLibReasoningClassify(t *testing.T) {
 			{Type: pgllm.BlockText, Text: `"confidence":0.9}`},
 		}},
 	}
-	r := &libReasoning{client: fc}
+	r := &libReasoning{client: fc, maxTokens: 4096}
 	out, err := r.Classify(context.Background(), "analyze this anomaly")
 	if err != nil {
 		t.Fatalf("Classify: %v", err)
@@ -68,8 +74,8 @@ func TestLibReasoningClassify(t *testing.T) {
 		fc.gotReq.Messages[0].Content[0].Text != "analyze this anomaly" {
 		t.Fatalf("user message content = %+v", fc.gotReq.Messages[0].Content)
 	}
-	if fc.gotReq.MaxTokens == nil || *fc.gotReq.MaxTokens != 500 {
-		t.Fatalf("MaxTokens = %v, want 500", fc.gotReq.MaxTokens)
+	if fc.gotReq.MaxTokens == nil || *fc.gotReq.MaxTokens != 4096 {
+		t.Fatalf("MaxTokens = %v, want 4096", fc.gotReq.MaxTokens)
 	}
 	if fc.gotReq.Temperature == nil || *fc.gotReq.Temperature != 0.1 {
 		t.Fatalf("Temperature = %v, want 0.1", fc.gotReq.Temperature)
@@ -86,21 +92,154 @@ func TestLibReasoningClassifyError(t *testing.T) {
 	}
 }
 
-// TestLibReasoningClassifyEmptyContent verifies that Classify returns ("", nil)
-// when the response contains no text blocks; the caller's parser treats an
-// empty string as the "no-decision" fallback.
-func TestLibReasoningClassifyEmptyContent(t *testing.T) {
-	fc := &fakeChatClient{
-		model: "gpt-4o-mini",
-		resp:  &pgllm.ChatResponse{Content: []pgllm.ContentBlock{}},
+// TestLibReasoningClassifyNoTextContent verifies that a response carrying
+// no usable text is reported as ErrNoTextContent rather than an empty
+// string. A reasoning model whose thinking exhausts the output budget
+// produces exactly these shapes (issue #399), and the engine must see a
+// failure instead of parsing an empty verdict.
+func TestLibReasoningClassifyNoTextContent(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *pgllm.ChatResponse
+	}{
+		{
+			name: "no content blocks",
+			resp: &pgllm.ChatResponse{Content: []pgllm.ContentBlock{}},
+		},
+		{
+			name: "nil response",
+			resp: nil,
+		},
+		{
+			name: "reasoning block only",
+			resp: &pgllm.ChatResponse{Content: []pgllm.ContentBlock{
+				{Type: thinkingBlock, Text: "weighing the evidence at length"},
+			}},
+		},
+		{
+			name: "whitespace-only text",
+			resp: &pgllm.ChatResponse{Content: []pgllm.ContentBlock{
+				{Type: pgllm.BlockText, Text: " \n\t "},
+			}},
+		},
 	}
-	r := &libReasoning{client: fc}
-	out, err := r.Classify(context.Background(), "prompt")
-	if err != nil {
-		t.Fatalf("Classify: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := &fakeChatClient{model: "gpt-4o-mini", resp: tt.resp}
+			r := &libReasoning{client: fc, maxTokens: DefaultReasoningMaxTokens}
+			out, err := r.Classify(context.Background(), "prompt")
+			if !errors.Is(err, ErrNoTextContent) {
+				t.Fatalf("expected ErrNoTextContent, got %v", err)
+			}
+			if out != "" {
+				t.Fatalf("out = %q, want empty string", out)
+			}
+		})
 	}
-	if out != "" {
-		t.Fatalf("out = %q, want empty string", out)
+}
+
+// TestErrNoTextContentMessage verifies the sentinel names the actionable
+// cause, since the engine records it in the candidate tier-3 error field.
+func TestErrNoTextContentMessage(t *testing.T) {
+	msg := ErrNoTextContent.Error()
+	for _, want := range []string{"no text content", "reasoning tokens", "llm.max_tokens"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ErrNoTextContent message %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// TestNewLibReasoningMaxTokensResolution verifies that a positive
+// configured budget reaches the chat request unchanged and that an unset,
+// zero, or negative budget falls back to DefaultReasoningMaxTokens.
+func TestNewLibReasoningMaxTokensResolution(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      int
+	}{
+		{"configured value used", 8192, 8192},
+		{"unset falls back", 0, DefaultReasoningMaxTokens},
+		{"negative falls back", -1, DefaultReasoningMaxTokens},
+		{"small configured value still honoured", 32, 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := newLibReasoning("openai", "test-key", "gpt-4o", "", tt.maxTokens)
+			if err != nil {
+				t.Fatalf("newLibReasoning: %v", err)
+			}
+			lr, ok := p.(*libReasoning)
+			if !ok {
+				t.Fatalf("expected *libReasoning, got %T", p)
+			}
+			if lr.maxTokens != tt.want {
+				t.Fatalf("maxTokens = %d, want %d", lr.maxTokens, tt.want)
+			}
+
+			// The resolved budget must reach the request itself.
+			fc := &fakeChatClient{resp: &pgllm.ChatResponse{Content: []pgllm.ContentBlock{
+				{Type: pgllm.BlockText, Text: `{"decision":"alert"}`},
+			}}}
+			lr.client = fc
+			if _, err := lr.Classify(context.Background(), "prompt"); err != nil {
+				t.Fatalf("Classify: %v", err)
+			}
+			if fc.gotReq.MaxTokens == nil || *fc.gotReq.MaxTokens != tt.want {
+				t.Fatalf("request MaxTokens = %v, want %d", fc.gotReq.MaxTokens, tt.want)
+			}
+		})
+	}
+}
+
+// TestDefaultReasoningMaxTokensIsGenerousEnough guards the issue #399
+// regression: the fallback must leave a reasoning model room for both its
+// thinking block and the verdict, so it must exceed the old 500-token cap.
+func TestDefaultReasoningMaxTokensIsGenerousEnough(t *testing.T) {
+	const oldCap = 500
+	if DefaultReasoningMaxTokens <= oldCap {
+		t.Fatalf("DefaultReasoningMaxTokens = %d, want > %d",
+			DefaultReasoningMaxTokens, oldCap)
+	}
+	if DefaultReasoningMaxTokens != config.DefaultLLMMaxTokens {
+		t.Errorf("DefaultReasoningMaxTokens = %d, want it to match config.DefaultLLMMaxTokens = %d",
+			DefaultReasoningMaxTokens, config.DefaultLLMMaxTokens)
+	}
+}
+
+// TestNewReasoningProviderPassesConfiguredMaxTokens verifies the config
+// value is plumbed all the way to the provider, and that an unset value
+// resolves to the package default.
+func TestNewReasoningProviderPassesConfiguredMaxTokens(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      int
+	}{
+		{"configured value used", 1024, 1024},
+		{"unset falls back", 0, DefaultReasoningMaxTokens},
+		{"negative falls back", -2, DefaultReasoningMaxTokens},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewConfig()
+			cfg.LLM.ReasoningProvider = "ollama"
+			cfg.LLM.MaxTokens = tt.maxTokens
+			p, err := NewReasoningProvider(cfg)
+			if err != nil {
+				t.Fatalf("NewReasoningProvider: %v", err)
+			}
+			lr, ok := p.(*libReasoning)
+			if !ok {
+				t.Fatalf("expected *libReasoning, got %T", p)
+			}
+			if lr.maxTokens != tt.want {
+				t.Fatalf("maxTokens = %d, want %d", lr.maxTokens, tt.want)
+			}
+		})
 	}
 }
 
@@ -108,7 +247,7 @@ func TestLibReasoningClassifyEmptyContent(t *testing.T) {
 // accepted and that the default model (llama3.2) is applied when none is given.
 // No network is attempted: the library constructs the client without dialing.
 func TestNewLibReasoningOllamaExplicitBaseURL(t *testing.T) {
-	r, err := newLibReasoning("ollama", "", "", "http://localhost:11434")
+	r, err := newLibReasoning("ollama", "", "", "http://localhost:11434", 0)
 	if err != nil {
 		t.Fatalf("newLibReasoning: %v", err)
 	}
@@ -120,7 +259,7 @@ func TestNewLibReasoningOllamaExplicitBaseURL(t *testing.T) {
 // TestNewLibReasoningDefaultModel verifies that an empty model falls back
 // to the per-provider default and that the resulting client reports it.
 func TestNewLibReasoningDefaultModel(t *testing.T) {
-	r, err := newLibReasoning("openai", "test-key", "", "")
+	r, err := newLibReasoning("openai", "test-key", "", "", 4096)
 	if err != nil {
 		t.Fatalf("newLibReasoning: %v", err)
 	}
@@ -131,7 +270,7 @@ func TestNewLibReasoningDefaultModel(t *testing.T) {
 
 // TestNewLibReasoningExplicitModel verifies an explicit model is preserved.
 func TestNewLibReasoningExplicitModel(t *testing.T) {
-	r, err := newLibReasoning("openai", "test-key", "gpt-4o", "")
+	r, err := newLibReasoning("openai", "test-key", "gpt-4o", "", 4096)
 	if err != nil {
 		t.Fatalf("newLibReasoning: %v", err)
 	}
@@ -143,7 +282,7 @@ func TestNewLibReasoningExplicitModel(t *testing.T) {
 // TestNewLibReasoningUnknownProvider verifies NewClient errors propagate
 // through newLibReasoning as a wrapped error.
 func TestNewLibReasoningUnknownProvider(t *testing.T) {
-	if _, err := newLibReasoning("does-not-exist", "k", "m", ""); err == nil {
+	if _, err := newLibReasoning("does-not-exist", "k", "m", "", 4096); err == nil {
 		t.Fatal("expected error for unknown provider")
 	}
 }

--- a/docs/admin-guide/api/openapi.json
+++ b/docs/admin-guide/api/openapi.json
@@ -9330,6 +9330,16 @@
                 }
               }
             }
+          },
+          "502": {
+            "description": "The model returned no usable analysis text",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/docs/admin-guide/api/server-info.md
+++ b/docs/admin-guide/api/server-info.md
@@ -211,7 +211,14 @@ response fields:
 
 The server returns `null` when no LLM provider is
 configured. The server also returns `null` when the
-connection has no databases to analyze.
+connection has no databases to analyze, and when the
+call to the provider fails.
+
+The server returns `502` when the provider answers
+with no usable text. A reasoning model produces this
+result when its thinking tokens exhaust the configured
+`llm.max_tokens` budget. Raise the budget, or select a
+model that emits less reasoning.
 
 ### Caching
 
@@ -254,6 +261,10 @@ following table describes the possible error statuses:
 | 401 | The request lacks a valid authentication token. |
 | 403 | The user does not have access to the connection. |
 | 500 | An internal server error occurred. |
+| 502 | The model returned no usable analysis text. |
+
+The `502` status applies to the AI analysis endpoint
+only.
 
 ## Configuration
 
@@ -263,8 +274,9 @@ The endpoint returns empty fields when the collector
 has not yet gathered data for a metric category.
 
 The AI analysis endpoint requires an LLM provider to
-be configured in the server settings. For LLM provider
-setup instructions, see
+be configured in the server settings. The `llm.max_tokens`
+setting caps the length of each analysis response. For
+LLM provider setup instructions, see
 [Server Configuration](../../getting-started/configuration/server.md).
 
 ## Related Documentation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -81,6 +81,14 @@ project adheres to
   count so that a truncated response can be recognised, and it
   honours a custom time range through the same `time_start` and
   `time_end` parameters as the metrics query endpoint. (#346)
+- Add an `llm.max_tokens` setting to the alerter, which caps the
+  output tokens of a reasoning call. The cap applies to tier 3
+  anomaly classification and to acknowledged-alert re-evaluation.
+  The setting defaults to `4096` tokens and replaces a hardcoded
+  500-token limit. A reasoning model could consume that smaller
+  limit entirely on its thinking block, leaving no room for the
+  classification verdict. A value of zero or less selects the
+  default. (#399)
 
 ### Changed
 
@@ -466,6 +474,20 @@ project adheres to
   pg_stat_statements_reset();` once on each monitored instance after
   upgrading for the toggle to take effect on statements already in the
   view. (#364)
+
+- Fix the AI Overview and the server-info AI database analysis
+  rendering blank with no error. The failure appeared when a local
+  reasoning model served the request. Both paths capped their
+  responses at a hardcoded 512 output tokens and ignored the
+  configured `llm.max_tokens` value. A reasoning model counts its
+  thinking tokens against that budget. The model therefore spent
+  the whole budget before emitting any answer text. Both paths now
+  honour `llm.max_tokens`, which defaults to `4096` tokens and
+  previously governed only the streaming chat proxy. A response
+  that carries no text is now reported rather than cached as an
+  empty result. The `GET /api/v1/server-info/{id}/ai-analysis`
+  endpoint returns `502` with a message that names the likely
+  cause. (#399)
 
 ### Removed
 

--- a/docs/getting-started/configuration/alerter.md
+++ b/docs/getting-started/configuration/alerter.md
@@ -326,17 +326,17 @@ tokens a reasoning model may generate for a single
 call. The budget applies to the following reasoning
 work:
 
-- The tier 3 classification of an anomaly candidate
-  uses the budget for each candidate it examines.
-- The re-evaluation of an acknowledged alert uses the
-  budget for each alert it revisits.
+- The tier 3 anomaly classification applies the budget
+  to each candidate that the alerter examines.
+- The re-evaluation of acknowledged alerts applies the
+  budget to each alert that the alerter revisits.
 
 The default value is `4096` tokens; a value less than
 or equal to zero falls back to the default. Earlier
 releases capped both calls at 500 tokens and offered
 no way to change the limit.
 
-A reasoning model counts the internal thinking tokens
+A reasoning model counts its internal thinking tokens
 against this same budget. A budget that suits a
 conventional model can therefore leave no room for the
 verdict itself. The model then returns a response that

--- a/docs/getting-started/configuration/alerter.md
+++ b/docs/getting-started/configuration/alerter.md
@@ -317,6 +317,48 @@ an older pgvector causes the embedding-column migration to fail.
 |--------|------|---------|-------------|
 | `embedding_provider` | string | `ollama` | Embedding provider |
 | `reasoning_provider` | string | `ollama` | Classification provider |
+| `max_tokens` | integer | `4096` | Max output tokens per reasoning call |
+
+#### Output Token Budget (`max_tokens`)
+
+The `max_tokens` option caps the number of output
+tokens a reasoning model may generate for a single
+call. The budget applies to the following reasoning
+work:
+
+- The tier 3 classification of an anomaly candidate
+  uses the budget for each candidate it examines.
+- The re-evaluation of an acknowledged alert uses the
+  budget for each alert it revisits.
+
+The default value is `4096` tokens; a value less than
+or equal to zero falls back to the default. Earlier
+releases capped both calls at 500 tokens and offered
+no way to change the limit.
+
+A reasoning model counts the internal thinking tokens
+against this same budget. A budget that suits a
+conventional model can therefore leave no room for the
+verdict itself. The model then returns a response that
+contains no text, which the alerter treats as a tier 3
+failure. A failed tier 3 classification fails safe and
+raises the alert; the alerter records the cause in the
+candidate's tier 3 error field. Raise `max_tokens`
+when these failures appear; alternatively, select a
+model that emits less reasoning.
+
+In the following example, the `llm` section raises the
+budget for a reasoning model that a local llama.cpp
+server hosts:
+
+```yaml
+llm:
+  reasoning_provider: openai
+  max_tokens: 8192
+  openai:
+    base_url: http://localhost:8080/v1
+    reasoning_model: qwen3-8b
+```
 
 #### Ollama Configuration
 
@@ -368,6 +410,11 @@ llm:
     base_url: http://localhost:8080/v1
     reasoning_model: my-local-model
 ```
+
+A local server that hosts a reasoning model usually
+needs a larger output budget than the default. For
+details, see
+[Output Token Budget](#output-token-budget-max_tokens).
 
 #### Anthropic Configuration
 

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -118,7 +118,7 @@ embedding:
   # gemini_api_key_file: "~/.gemini-api-key"
 
 #=====================================================
-# LLM CONFIGURATION (Web Client Chat Proxy)
+# LLM CONFIGURATION (Chat Proxy and AI Analysis)
 #=====================================================
 llm:
   provider: "anthropic"
@@ -458,7 +458,7 @@ releases capped the AI Overview and the server-info
 analysis at 512 tokens and ignored the configured
 value on both paths.
 
-A reasoning model counts the internal thinking tokens
+A reasoning model counts its internal thinking tokens
 against this same budget. A budget that suits a
 conventional model can therefore leave no room for the
 answer itself. The model then returns a response that
@@ -467,10 +467,10 @@ to render. Raise `max_tokens` when a summary or an
 analysis comes back empty; alternatively, select a
 model that emits less reasoning.
 
-The server reports an empty response rather than
-hiding the response. A scoped AI Overview request
-fails with an error, and the estate summary records
-the failure in the server log. The
+The server reports an empty response instead of
+discarding the response silently. A scoped AI Overview
+request fails with an error, and the estate summary
+records the failure in the server log. The
 `GET /api/v1/server-info/{id}/ai-analysis` endpoint
 returns `502` with a message that names the likely
 cause.

--- a/docs/getting-started/configuration/server.md
+++ b/docs/getting-started/configuration/server.md
@@ -417,6 +417,11 @@ does not require an API key. For Anthropic, OpenAI,
 and Gemini, the corresponding API key file must
 contain a valid key.
 
+The settings in this section govern every AI feature
+the server drives. The features include the Ask Ellie
+chat proxy, the AI Overview, and the server-info AI
+database analysis.
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `provider` | string | `anthropic` | LLM provider |
@@ -425,7 +430,7 @@ contain a valid key.
 | `openai_api_key_file` | string | | OpenAI key path |
 | `gemini_api_key_file` | string | | Gemini key path |
 | `ollama_url` | string | `http://localhost:11434` | Ollama URL |
-| `max_tokens` | int | `4096` | Max response tokens |
+| `max_tokens` | int | `4096` | Max output tokens per response |
 | `temperature` | float | `0.7` | Sampling temperature |
 | `max_iterations` | int | `50` | Max tool-call iterations |
 | `compact_tool_descriptions` | string | `auto` | Tool description mode |
@@ -433,6 +438,54 @@ contain a valid key.
 | `anthropic_base_url` | string | `https://api.anthropic.com/v1` | Anthropic base URL |
 | `openai_base_url` | string | `https://api.openai.com/v1` | OpenAI base URL |
 | `gemini_base_url` | string | `https://generativelanguage.googleapis.com` | Gemini base URL |
+
+#### Output Token Budget (`max_tokens`)
+
+The `max_tokens` option caps the number of output
+tokens a model may generate for a single response.
+The budget applies to the following AI features:
+
+- The Ask Ellie chat proxy sends the budget with every
+  chat request that the proxy forwards to a provider.
+- The AI Overview applies the budget to the estate
+  summary and to each scoped summary.
+- The server-info AI database analysis applies the
+  budget to the per-database descriptions.
+
+The default value is `4096` tokens; a value less than
+or equal to zero falls back to the default. Earlier
+releases capped the AI Overview and the server-info
+analysis at 512 tokens and ignored the configured
+value on both paths.
+
+A reasoning model counts the internal thinking tokens
+against this same budget. A budget that suits a
+conventional model can therefore leave no room for the
+answer itself. The model then returns a response that
+contains no text, and the affected panel has nothing
+to render. Raise `max_tokens` when a summary or an
+analysis comes back empty; alternatively, select a
+model that emits less reasoning.
+
+The server reports an empty response rather than
+hiding the response. A scoped AI Overview request
+fails with an error, and the estate summary records
+the failure in the server log. The
+`GET /api/v1/server-info/{id}/ai-analysis` endpoint
+returns `502` with a message that names the likely
+cause.
+
+In the following example, the `llm` section raises the
+budget for a reasoning model that a local llama.cpp
+server hosts:
+
+```yaml
+llm:
+  provider: "openai"
+  model: "qwen3-8b"
+  openai_base_url: "http://localhost:8080/v1"
+  max_tokens: 8192
+```
 
 #### Request Timeout (`timeout_seconds`)
 
@@ -521,6 +574,11 @@ llm:
   model: "my-local-model"
   openai_base_url: "http://localhost:8080/v1"
 ```
+
+A local server that hosts a reasoning model usually
+needs a larger output budget than the default. For
+details, see
+[Output Token Budget](#output-token-budget-max_tokens).
 
 ### Knowledgebase (`knowledgebase`)
 

--- a/examples/ai-dba-alerter.yaml
+++ b/examples/ai-dba-alerter.yaml
@@ -324,6 +324,17 @@ llm:
   # Default: ollama
   reasoning_provider: ollama
 
+  # Maximum number of output tokens for a tier 3 classification.
+  # Default: 4096
+  #
+  # Reasoning models (for example Qwen3, DeepSeek-R1 distills, or
+  # gpt-oss served through llama.cpp) charge their thinking tokens
+  # against this same budget. A small budget is consumed entirely by
+  # the thinking block, so the model never emits the classification
+  # verdict. Raise this value if tier 3 reports empty responses; a
+  # value of 0 or less selects the default.
+  max_tokens: 4096
+
   #-------------------------------------------------------------------------
   # Ollama Settings (local LLM)
   #-------------------------------------------------------------------------

--- a/examples/ai-dba-alerter.yaml
+++ b/examples/ai-dba-alerter.yaml
@@ -324,7 +324,9 @@ llm:
   # Default: ollama
   reasoning_provider: ollama
 
-  # Maximum number of output tokens for a tier 3 classification.
+  # Maximum number of output tokens for a tier 3 reasoning call. The
+  # budget applies both to anomaly candidate classification and to
+  # acknowledged-alert re-evaluation.
   # Default: 4096
   #
   # Reasoning models (for example Qwen3, DeepSeek-R1 distills, or

--- a/examples/ai-dba-server.yaml
+++ b/examples/ai-dba-server.yaml
@@ -266,12 +266,14 @@ embedding:
   ollama_url: "http://localhost:11434"
 
 #=========================================================================
-# LLM CONFIGURATION (Web Client Chat Proxy)
+# LLM CONFIGURATION (Chat Proxy and AI Analysis)
 #=========================================================================
 #
 # The server proxies LLM requests for web clients and CLI tools that
-# don't have direct access to LLM APIs. API keys must be configured
-# for the chosen provider.
+# don't have direct access to LLM APIs. These settings also govern the
+# AI Overview and the server-info AI database analysis, which the
+# server generates itself. API keys must be configured for the chosen
+# provider.
 #
 llm:
   # LLM provider: "anthropic", "openai", "gemini", or "ollama"
@@ -342,8 +344,17 @@ llm:
   # Generation Parameters
   #-----------------------------------------------------------------------
 
-  # Maximum tokens for LLM response
+  # Maximum number of output tokens for a single LLM response.
   # Default: 4096
+  #
+  # This budget applies to the chat proxy, the AI Overview, and the
+  # server-info AI database analysis. Reasoning models (for example
+  # Qwen3, DeepSeek-R1 distills, or gpt-oss served through llama.cpp)
+  # charge their thinking tokens against this same budget. A small
+  # budget is consumed entirely by the thinking block, so the model
+  # never emits any answer text. Raise this value if a summary or an
+  # analysis comes back empty; a value of 0 or less selects the
+  # default.
   max_tokens: 4096
 
   # Maximum iterations for agentic tool-calling loops

--- a/server/src/internal/api/openapi.go
+++ b/server/src/internal/api/openapi.go
@@ -3354,6 +3354,8 @@ func buildPaths() map[string]OpenAPIPathItem {
 					"400": jsonResponse("ErrorResponse", "Invalid connection ID"),
 					"401": jsonResponse("ErrorResponse", "Unauthorized"),
 					"403": jsonResponse("ErrorResponse", "Permission denied"),
+					"502": jsonResponse("ErrorResponse",
+						"The model returned no usable analysis text"),
 				},
 			},
 		},

--- a/server/src/internal/api/server_info_handlers.go
+++ b/server/src/internal/api/server_info_handlers.go
@@ -30,11 +30,15 @@ import (
 // aiAnalysisCacheTTL is how long AI database analysis is cached.
 const aiAnalysisCacheTTL = 5 * time.Minute
 
-// llmAnalysisMaxTokens caps the AI analysis response length.
-const llmAnalysisMaxTokens = 512
-
 // llmAnalysisTemperature controls response creativity for analysis.
 const llmAnalysisTemperature = 0.3
+
+// aiAnalysisUnusableMessage is returned to the client when the model
+// produced no usable analysis text. It names the actionable cause: a
+// reasoning model that spent its whole output budget on thinking tokens.
+const aiAnalysisUnusableMessage = "AI analysis unavailable: the model returned no text. " +
+	"It may have exhausted its output token budget on reasoning tokens; " +
+	"increase llm.max_tokens or select a model that emits less reasoning."
 
 // keySettings lists the PostgreSQL configuration parameters included
 // in the server info response.
@@ -316,8 +320,33 @@ func (h *ServerInfoHandler) handleServerInfoAI(w http.ResponseWriter, r *http.Re
 	extensions := h.queryExtensions(ctx, pool, connectionID)
 	h.attachExtensionsToDatabases(extensions, databases)
 
-	// Generate AI analysis
-	analysis := h.getAIAnalysis(ctx, connectionID, databases, extensions)
+	// Generate AI analysis and write whichever response its outcome calls
+	// for.
+	analysis, err := h.getAIAnalysis(ctx, connectionID, databases, extensions)
+	writeAIAnalysisResponse(w, connectionID, analysis, err)
+}
+
+// writeAIAnalysisResponse writes the HTTP response for an AI-analysis
+// outcome.
+//
+// A nil analysis with no error means analysis is simply unavailable (AI
+// disabled, no databases, or an upstream call that already logged its own
+// failure); that stays a 200 with a null body, which the client renders as
+// "no analysis". A non-nil error means the model answered but produced
+// nothing usable, which is an actionable misconfiguration, so it is
+// reported as 502 with a message naming the likely cause.
+func writeAIAnalysisResponse(
+	w http.ResponseWriter,
+	connectionID int,
+	analysis *AIAnalysisInfo,
+	err error,
+) {
+	if err != nil {
+		log.Printf("[ERROR] AI analysis unusable for connection %d: %v",
+			connectionID, err)
+		RespondError(w, http.StatusBadGateway, aiAnalysisUnusableMessage)
+		return
+	}
 	if analysis == nil {
 		RespondJSON(w, http.StatusOK, nil)
 		return
@@ -644,14 +673,22 @@ func (h *ServerInfoHandler) queryKeySettings(
 
 // getAIAnalysis returns a cached or freshly generated AI analysis of
 // the databases on the given connection.
+//
+// It returns (nil, nil) when analysis is unavailable for a benign reason:
+// AI is not configured, there are no databases to analyze, or the client
+// or chat call failed (those failures are logged here and left as a null
+// body so a transient provider outage does not turn the dialog into an
+// error). It returns a non-nil error only when the provider answered with
+// no usable text, which is an actionable misconfiguration rather than a
+// transient failure.
 func (h *ServerInfoHandler) getAIAnalysis(
 	ctx context.Context,
 	connectionID int,
 	databases []DatabaseInfo,
 	extensions []ExtensionInfo,
-) *AIAnalysisInfo {
+) (*AIAnalysisInfo, error) {
 	if h.llmConfig == nil || h.llmConfig.Provider == "" {
-		return nil
+		return nil, nil
 	}
 
 	// Check cache
@@ -662,14 +699,14 @@ func (h *ServerInfoHandler) getAIAnalysis(
 			return &AIAnalysisInfo{
 				Databases:   entry.analysis,
 				GeneratedAt: entry.generatedAt,
-			}
+			}, nil
 		}
 	}
 	h.cacheMu.RUnlock()
 
 	// No databases to analyze
 	if len(databases) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Build prompt
@@ -678,23 +715,32 @@ func (h *ServerInfoHandler) getAIAnalysis(
 	// Create LLM client
 	client, err := h.createLLMClient()
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
+	// The request budget is resolved from the operator's llm.max_tokens
+	// through the same helper the client options use, so the request and
+	// the client agree on the budget.
 	resp, err := client.Chat(ctx, pgllm.ChatRequest{
 		Messages:     []pgllm.Message{pgllm.UserText(prompt)},
 		SystemPrompt: "",
-		MaxTokens:    pgllm.Int(llmAnalysisMaxTokens),
+		MaxTokens:    pgllm.Int(h.llmConfig.AnalysisMaxTokens()),
 		Temperature:  pgllm.Float(llmAnalysisTemperature),
 	})
 	if err != nil {
 		log.Printf("[ERROR] AI analysis failed for connection %d: %v",
 			connectionID, err)
-		return nil
+		return nil, nil
 	}
 
-	// Parse the response into per-database analysis
-	analysis := parseDatabaseAnalysisResponse(resp, databases)
+	// Parse the response into per-database analysis. A response with no
+	// text block (the shape a reasoning model produces when its thinking
+	// exhausts the output budget) is reported rather than cached as an
+	// empty analysis.
+	analysis, err := parseDatabaseAnalysisResponse(resp, databases)
+	if err != nil {
+		return nil, err
+	}
 
 	// Cache the result
 	now := time.Now().UTC()
@@ -709,7 +755,7 @@ func (h *ServerInfoHandler) getAIAnalysis(
 	return &AIAnalysisInfo{
 		Databases:   analysis,
 		GeneratedAt: now,
-	}
+	}, nil
 }
 
 // buildDatabaseAnalysisPrompt constructs the LLM prompt for database
@@ -750,10 +796,17 @@ func buildDatabaseAnalysisPrompt(databases []DatabaseInfo) string {
 
 // parseDatabaseAnalysisResponse extracts per-database descriptions from
 // the LLM response text.
+//
+// A response that carries no text block, or whose text is whitespace
+// only, yields llmproxy.ErrNoTextContent. Reasoning models charge their
+// thinking blocks against the same output budget as the answer, so an
+// under-sized budget produces exactly this shape of response; reporting
+// it as an error surfaces the misconfiguration instead of caching an
+// empty analysis for the whole cache TTL.
 func parseDatabaseAnalysisResponse(
 	resp *pgllm.ChatResponse,
 	databases []DatabaseInfo,
-) map[string]string {
+) (map[string]string, error) {
 	// Extract text from response
 	var text string
 	if resp != nil {
@@ -762,6 +815,9 @@ func parseDatabaseAnalysisResponse(
 				text += b.Text
 			}
 		}
+	}
+	if strings.TrimSpace(text) == "" {
+		return nil, llmproxy.ErrNoTextContent
 	}
 
 	result := make(map[string]string, len(databases))
@@ -806,7 +862,7 @@ func parseDatabaseAnalysisResponse(
 		}
 	}
 
-	return result
+	return result, nil
 }
 
 // createLLMClient builds a pgedge-go-llm-lib client based on the
@@ -816,10 +872,11 @@ func parseDatabaseAnalysisResponse(
 func (h *ServerInfoHandler) createLLMClient() (pgllm.Client, error) {
 	provider := h.llmConfig.Provider
 
-	// Credential selection, custom-header wiring, and the
-	// timeout-only-when-positive rule live in the shared llmproxy helper
-	// so the overview and server-info analysis paths stay in lock-step.
-	opts := h.llmConfig.BuildClientOptions(llmAnalysisMaxTokens, llmAnalysisTemperature)
+	// Credential selection, custom-header wiring, max-token resolution,
+	// and the timeout-only-when-positive rule live in the shared llmproxy
+	// helper so the overview and server-info analysis paths stay in
+	// lock-step.
+	opts := h.llmConfig.BuildClientOptions(llmAnalysisTemperature)
 
 	client, err := pgllm.NewClient(provider, opts)
 	if err != nil {

--- a/server/src/internal/api/server_info_handlers.go
+++ b/server/src/internal/api/server_info_handlers.go
@@ -735,8 +735,10 @@ func (h *ServerInfoHandler) getAIAnalysis(
 
 	// Parse the response into per-database analysis. A response with no
 	// text block (the shape a reasoning model produces when its thinking
-	// exhausts the output budget) is reported rather than cached as an
-	// empty analysis.
+	// exhausts the output budget), and one whose text describes none of
+	// the databases, are both reported rather than cached as an empty
+	// analysis. The empty-databases gate above has already returned, so
+	// an empty parse can only mean unusable model output.
 	analysis, err := parseDatabaseAnalysisResponse(resp, databases)
 	if err != nil {
 		return nil, err
@@ -797,12 +799,16 @@ func buildDatabaseAnalysisPrompt(databases []DatabaseInfo) string {
 // parseDatabaseAnalysisResponse extracts per-database descriptions from
 // the LLM response text.
 //
-// A response that carries no text block, or whose text is whitespace
-// only, yields llmproxy.ErrNoTextContent. Reasoning models charge their
+// A response that carries no text block, whose text is whitespace only,
+// or whose text yields no description for any of the supplied databases,
+// yields llmproxy.ErrNoTextContent. Reasoning models charge their
 // thinking blocks against the same output budget as the answer, so an
-// under-sized budget produces exactly this shape of response; reporting
-// it as an error surfaces the misconfiguration instead of caching an
+// under-sized budget produces exactly these shapes of response; reporting
+// them as an error surfaces the misconfiguration instead of caching an
 // empty analysis for the whole cache TTL.
+//
+// The caller guarantees a non-empty databases slice, so an empty result
+// always means unusable model output rather than nothing to analyze.
 func parseDatabaseAnalysisResponse(
 	resp *pgllm.ChatResponse,
 	databases []DatabaseInfo,
@@ -860,6 +866,12 @@ func parseDatabaseAnalysisResponse(
 		if dbNames[name] && desc != "" {
 			result[name] = desc
 		}
+	}
+
+	// Text that matched no known database is as unusable as no text at
+	// all: returning it would cache a blank analysis for the whole TTL.
+	if len(result) == 0 {
+		return nil, llmproxy.ErrNoTextContent
 	}
 
 	return result, nil

--- a/server/src/internal/api/server_info_handlers_test.go
+++ b/server/src/internal/api/server_info_handlers_test.go
@@ -11,15 +11,28 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	pgllm "github.com/pgEdge/pgedge-go-llm-lib/llm"
+	"github.com/pgedge/ai-workbench/server/internal/auth"
 	"github.com/pgedge/ai-workbench/server/internal/config"
+	"github.com/pgedge/ai-workbench/server/internal/database"
 	"github.com/pgedge/ai-workbench/server/internal/llmproxy"
 )
+
+// thinkingBlock is the content-block type a reasoning model emits for its
+// chain of thought. The library has no named constant for it, so the tests
+// use the wire value directly to reproduce the issue #399 response shape.
+const thinkingBlock pgllm.ContentBlockType = "thinking"
 
 func TestPgEncodingName(t *testing.T) {
 	tests := []struct {
@@ -122,7 +135,10 @@ func TestParseDatabaseAnalysisResponse(t *testing.T) {
 		},
 	}
 
-	result := parseDatabaseAnalysisResponse(resp, databases)
+	result, err := parseDatabaseAnalysisResponse(resp, databases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(result) != 2 {
 		t.Errorf("expected 2 entries, got %d", len(result))
@@ -157,7 +173,10 @@ func TestParseDatabaseAnalysisResponseHandlesMarkdownFormatting(t *testing.T) {
 		},
 	}
 
-	result := parseDatabaseAnalysisResponse(resp, databases)
+	result, err := parseDatabaseAnalysisResponse(resp, databases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(result) != 5 {
 		t.Errorf("expected 5 entries, got %d", len(result))
@@ -193,7 +212,10 @@ func TestParseDatabaseAnalysisResponseIgnoresUnknownDatabases(t *testing.T) {
 		},
 	}
 
-	result := parseDatabaseAnalysisResponse(resp, databases)
+	result, err := parseDatabaseAnalysisResponse(resp, databases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(result) != 1 {
 		t.Errorf("expected 1 entry, got %d", len(result))
@@ -218,18 +240,65 @@ func TestParseDatabaseAnalysisResponseConcatenatesTextBlocksOnly(t *testing.T) {
 		},
 	}
 
-	result := parseDatabaseAnalysisResponse(resp, databases)
+	result, err := parseDatabaseAnalysisResponse(resp, databases)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if result["testdb"] != "A test database." {
 		t.Errorf("unexpected testdb description: %q", result["testdb"])
 	}
 }
 
-func TestParseDatabaseAnalysisResponseNilResponse(t *testing.T) {
+// TestParseDatabaseAnalysisResponseNoTextContent covers the responses that
+// carry no usable text: a nil response, a response whose only block is a
+// reasoning/thinking block (the issue #399 shape produced when the model
+// spends its whole output budget thinking), and whitespace-only text. Each
+// must report llmproxy.ErrNoTextContent rather than an empty analysis that
+// would be cached and rendered as a blank panel.
+func TestParseDatabaseAnalysisResponseNoTextContent(t *testing.T) {
 	databases := []DatabaseInfo{{Name: "testdb"}}
-	result := parseDatabaseAnalysisResponse(nil, databases)
-	if len(result) != 0 {
-		t.Errorf("expected empty result for nil response, got %d entries", len(result))
+
+	tests := []struct {
+		name string
+		resp *pgllm.ChatResponse
+	}{
+		{
+			name: "nil response",
+			resp: nil,
+		},
+		{
+			name: "no content blocks",
+			resp: &pgllm.ChatResponse{},
+		},
+		{
+			name: "reasoning block only",
+			resp: &pgllm.ChatResponse{
+				Content: []pgllm.ContentBlock{
+					{Type: thinkingBlock, Text: "let me consider each database"},
+				},
+			},
+		},
+		{
+			name: "whitespace-only text",
+			resp: &pgllm.ChatResponse{
+				Content: []pgllm.ContentBlock{
+					{Type: pgllm.BlockText, Text: " \n\t "},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseDatabaseAnalysisResponse(tc.resp, databases)
+			if !errors.Is(err, llmproxy.ErrNoTextContent) {
+				t.Fatalf("expected ErrNoTextContent, got %v", err)
+			}
+			if result != nil {
+				t.Errorf("expected nil result on error, got %v", result)
+			}
+		})
 	}
 }
 
@@ -460,9 +529,12 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			cache:     make(map[int]*aiCacheEntry),
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 1, []DatabaseInfo{{Name: "db"}}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result != nil {
 			t.Error("expected nil when llmConfig is nil")
 		}
@@ -474,9 +546,12 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			cache:     make(map[int]*aiCacheEntry),
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 1, []DatabaseInfo{{Name: "db"}}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result != nil {
 			t.Error("expected nil when provider is empty")
 		}
@@ -488,9 +563,12 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			cache:     make(map[int]*aiCacheEntry),
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 1, []DatabaseInfo{}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result != nil {
 			t.Error("expected nil when databases is empty")
 		}
@@ -509,10 +587,13 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			},
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 1,
 			[]DatabaseInfo{{Name: "mydb"}}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result == nil {
 			t.Fatal("expected non-nil cached result")
 		}
@@ -541,10 +622,13 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			},
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 1,
 			[]DatabaseInfo{{Name: "mydb"}}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		// With empty provider, getAIAnalysis returns nil early
 		if result != nil {
 			t.Error("expected nil for empty provider after expired cache")
@@ -565,10 +649,13 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			},
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 2,
 			[]DatabaseInfo{{Name: "mydb"}}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result != nil {
 			t.Error("expected nil for cache miss on different connection ID")
 		}
@@ -583,10 +670,13 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			cache:     make(map[int]*aiCacheEntry),
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 1,
 			[]DatabaseInfo{{Name: "mydb"}}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result != nil {
 			t.Error("expected nil when client construction fails")
 		}
@@ -619,10 +709,13 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			cache: make(map[int]*aiCacheEntry),
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 7,
 			[]DatabaseInfo{{Name: "mydb"}}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result == nil {
 			t.Fatal("expected non-nil analysis on successful LLM call")
 		}
@@ -660,10 +753,13 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			cache: make(map[int]*aiCacheEntry),
 		}
 
-		result := h.getAIAnalysis(
+		result, err := h.getAIAnalysis(
 			context.Background(), 8,
 			[]DatabaseInfo{{Name: "mydb"}}, nil,
 		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if result != nil {
 			t.Error("expected nil when the LLM call fails")
 		}
@@ -674,6 +770,261 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 			t.Error("expected no cache entry when the LLM call fails")
 		}
 	})
+
+	t.Run("reports an error when the model returns no text", func(t *testing.T) {
+		// The issue #399 shape: the provider answers successfully but the
+		// message carries no text because the reasoning consumed the whole
+		// output budget. getAIAnalysis must report it and cache nothing.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"choices": [{"message": {"role": "assistant", "content": ""}, "finish_reason": "length"}]
+			}`))
+		}))
+		defer srv.Close()
+
+		h := &ServerInfoHandler{
+			llmConfig: &llmproxy.Config{
+				Provider:      "openai",
+				Model:         "gpt-4o",
+				OpenAIAPIKey:  "test-key",
+				OpenAIBaseURL: srv.URL,
+			},
+			cache: make(map[int]*aiCacheEntry),
+		}
+
+		result, err := h.getAIAnalysis(
+			context.Background(), 9,
+			[]DatabaseInfo{{Name: "mydb"}}, nil,
+		)
+		if !errors.Is(err, llmproxy.ErrNoTextContent) {
+			t.Fatalf("expected ErrNoTextContent, got %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil analysis on error, got %v", result)
+		}
+		h.cacheMu.RLock()
+		_, ok := h.cache[9]
+		h.cacheMu.RUnlock()
+		if ok {
+			t.Error("expected no cache entry when the model returns no text")
+		}
+	})
+}
+
+// TestServerInfoAIAnalysisMaxTokensHonoursConfig verifies that the analysis
+// chat request carries the operator-configured llm.max_tokens, falling back
+// to llmproxy.DefaultAnalysisMaxTokens when the setting is unset or
+// non-positive. Regression cover for issue #399, where a hardcoded
+// 512-token cap starved reasoning models of output budget.
+func TestServerInfoAIAnalysisMaxTokensHonoursConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      float64
+	}{
+		{"configured value used", 8192, 8192},
+		{"unset falls back", 0, llmproxy.DefaultAnalysisMaxTokens},
+		{"negative falls back", -3, llmproxy.DefaultAnalysisMaxTokens},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				var payload map[string]any
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+				got = payload["max_tokens"]
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{
+					"choices": [{"message": {"role": "assistant", "content": "mydb: A store.\n"}, "finish_reason": "stop"}]
+				}`)
+			}))
+			defer srv.Close()
+
+			h := &ServerInfoHandler{
+				llmConfig: &llmproxy.Config{
+					Provider:      "openai",
+					Model:         "gpt-4o",
+					OpenAIAPIKey:  "test-key",
+					OpenAIBaseURL: srv.URL,
+					MaxTokens:     tc.maxTokens,
+				},
+				cache: make(map[int]*aiCacheEntry),
+			}
+
+			if _, err := h.getAIAnalysis(
+				context.Background(), 1,
+				[]DatabaseInfo{{Name: "mydb"}}, nil,
+			); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			num, ok := got.(float64)
+			if !ok {
+				t.Fatalf("max_tokens missing or not a number in request: %#v", got)
+			}
+			if num != tc.want {
+				t.Errorf("max_tokens: got %v, want %v", num, tc.want)
+			}
+		})
+	}
+}
+
+// unreachablePool returns a lazily-created pool aimed at a closed port.
+// pgxpool does not dial until a query runs, so every query fails with a
+// connection error instead of panicking; that lets the handler-routing
+// tests exercise the full request path without a live datastore.
+func unreachablePool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(context.Background(),
+		"postgres://nobody@127.0.0.1:1/none?connect_timeout=1")
+	if err != nil {
+		t.Fatalf("failed to create pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// TestHandleServerInfoAI covers the AI-analysis route: method and
+// connection-ID validation, and the delegation to the analysis response
+// writer. A nil auth store makes the RBAC checker grant access, and the
+// unreachable pool makes the database queries fail benignly so the handler
+// reaches the analysis step with no databases.
+func TestHandleServerInfoAI(t *testing.T) {
+	h := &ServerInfoHandler{
+		datastore:   database.NewTestDatastore(unreachablePool(t)),
+		rbacChecker: auth.NewRBACChecker(nil),
+		llmConfig:   &llmproxy.Config{Provider: "openai", OpenAIAPIKey: "k"},
+		cache:       make(map[int]*aiCacheEntry),
+	}
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "non-GET is rejected",
+			method:     http.MethodPost,
+			path:       "/api/v1/server-info/1/ai-analysis",
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "missing connection ID",
+			method:     http.MethodGet,
+			path:       "/api/v1/server-info/ai-analysis",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "non-numeric connection ID",
+			method:     http.MethodGet,
+			path:       "/api/v1/server-info/abc/ai-analysis",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "no databases yields a null body",
+			method:     http.MethodGet,
+			path:       "/api/v1/server-info/1/ai-analysis",
+			wantStatus: http.StatusOK,
+			wantBody:   "null",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+			h.handleServerInfoRouting(w, req)
+			if w.Code != tc.wantStatus {
+				t.Errorf("status: got %d, want %d (%s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+			if tc.wantBody != "" && !strings.Contains(w.Body.String(), tc.wantBody) {
+				t.Errorf("body %q does not contain %q", w.Body.String(), tc.wantBody)
+			}
+		})
+	}
+
+	t.Run("RBAC denial is a 403", func(t *testing.T) {
+		// A real auth store plus a sharing lookup that reports the
+		// connection as private makes the RBAC check deny an
+		// unauthenticated caller before any analysis happens.
+		tmpDir := t.TempDir()
+		store, err := auth.NewAuthStore(tmpDir, 0, 0)
+		if err != nil {
+			t.Fatalf("failed to create auth store: %v", err)
+		}
+		defer store.Close()
+
+		sharing := func(context.Context, int) (bool, string, error) {
+			return false, "someone-else", nil
+		}
+
+		denied := &ServerInfoHandler{
+			datastore:   h.datastore,
+			rbacChecker: auth.NewRBACCheckerWithSharing(store, sharing),
+			llmConfig:   h.llmConfig,
+			cache:       make(map[int]*aiCacheEntry),
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/server-info/1/ai-analysis", nil)
+		w := httptest.NewRecorder()
+		denied.handleServerInfoRouting(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status: got %d, want %d (%s)", w.Code, http.StatusForbidden, w.Body.String())
+		}
+	})
+}
+
+// TestWriteAIAnalysisResponse verifies the three response shapes the
+// endpoint can produce: a 502 with an actionable message when the model
+// returned nothing usable, a 200 null body when analysis is simply
+// unavailable, and a 200 with the analysis on success.
+func TestWriteAIAnalysisResponse(t *testing.T) {
+	tests := []struct {
+		name         string
+		analysis     *AIAnalysisInfo
+		err          error
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name:         "no usable text is reported as 502",
+			err:          llmproxy.ErrNoTextContent,
+			wantStatus:   http.StatusBadGateway,
+			wantContains: "llm.max_tokens",
+		},
+		{
+			name:         "unavailable analysis is a null 200",
+			wantStatus:   http.StatusOK,
+			wantContains: "null",
+		},
+		{
+			name: "analysis is returned on success",
+			analysis: &AIAnalysisInfo{
+				Databases: map[string]string{"mydb": "A store."},
+			},
+			wantStatus:   http.StatusOK,
+			wantContains: "A store.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			writeAIAnalysisResponse(w, 1, tc.analysis, tc.err)
+			if w.Code != tc.wantStatus {
+				t.Errorf("status: got %d, want %d", w.Code, tc.wantStatus)
+			}
+			if !strings.Contains(w.Body.String(), tc.wantContains) {
+				t.Errorf("body %q does not contain %q", w.Body.String(), tc.wantContains)
+			}
+		})
+	}
 }
 
 func TestServerInfoInvalidateCache(t *testing.T) {

--- a/server/src/internal/api/server_info_handlers_test.go
+++ b/server/src/internal/api/server_info_handlers_test.go
@@ -812,12 +812,12 @@ func TestServerInfoGetAIAnalysis(t *testing.T) {
 	})
 }
 
-// TestServerInfoAIAnalysisMaxTokensHonoursConfig verifies that the analysis
+// TestServerInfoAIAnalysisMaxTokensHonorsConfig verifies that the analysis
 // chat request carries the operator-configured llm.max_tokens, falling back
 // to llmproxy.DefaultAnalysisMaxTokens when the setting is unset or
 // non-positive. Regression cover for issue #399, where a hardcoded
 // 512-token cap starved reasoning models of output budget.
-func TestServerInfoAIAnalysisMaxTokensHonoursConfig(t *testing.T) {
+func TestServerInfoAIAnalysisMaxTokensHonorsConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		maxTokens int

--- a/server/src/internal/api/server_info_handlers_test.go
+++ b/server/src/internal/api/server_info_handlers_test.go
@@ -302,6 +302,114 @@ func TestParseDatabaseAnalysisResponseNoTextContent(t *testing.T) {
 	}
 }
 
+// TestParseDatabaseAnalysisResponseUnparseableText covers responses that
+// carry real text which nonetheless describes none of the supplied
+// databases. An empty parse is as unusable as no text at all, so it must
+// report llmproxy.ErrNoTextContent rather than hand back an empty map
+// that getAIAnalysis would cache and render as a blank panel.
+func TestParseDatabaseAnalysisResponseUnparseableText(t *testing.T) {
+	databases := []DatabaseInfo{{Name: "myapp"}, {Name: "analytics"}}
+
+	tests := []struct {
+		name    string
+		text    string
+		wantErr bool
+	}{
+		{
+			name:    "no colon-delimited lines",
+			text:    "I was unable to determine the purpose of these.\n",
+			wantErr: true,
+		},
+		{
+			name:    "names match no known database",
+			text:    "postgres: The default database.\ntemplate1: A template.\n",
+			wantErr: true,
+		},
+		{
+			name:    "descriptions are empty",
+			text:    "myapp:   \nanalytics:\n",
+			wantErr: true,
+		},
+		{
+			name:    "markdown fence only",
+			text:    "```\n```\n",
+			wantErr: true,
+		},
+		{
+			name:    "one valid line still succeeds",
+			text:    "Here is the analysis.\nmyapp: A web application store.\n",
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &pgllm.ChatResponse{
+				Content: []pgllm.ContentBlock{
+					{Type: pgllm.BlockText, Text: tc.text},
+				},
+			}
+
+			result, err := parseDatabaseAnalysisResponse(resp, databases)
+			if tc.wantErr {
+				if !errors.Is(err, llmproxy.ErrNoTextContent) {
+					t.Fatalf("expected ErrNoTextContent, got %v", err)
+				}
+				if result != nil {
+					t.Errorf("expected nil result on error, got %v", result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result["myapp"] != "A web application store." {
+				t.Errorf("unexpected myapp description: %q", result["myapp"])
+			}
+		})
+	}
+}
+
+// TestServerInfoGetAIAnalysisUnparseableText verifies that the empty parse
+// reaches the caller as an error and caches nothing, so the endpoint
+// reports a 502 instead of serving a blank analysis for the cache TTL.
+func TestServerInfoGetAIAnalysisUnparseableText(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices": [{"message": {"role": "assistant", "content": "I cannot determine their purpose."}, "finish_reason": "stop"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	h := &ServerInfoHandler{
+		llmConfig: &llmproxy.Config{
+			Provider:      "openai",
+			Model:         "gpt-4o",
+			OpenAIAPIKey:  "test-key",
+			OpenAIBaseURL: srv.URL,
+		},
+		cache: make(map[int]*aiCacheEntry),
+	}
+
+	result, err := h.getAIAnalysis(
+		context.Background(), 11,
+		[]DatabaseInfo{{Name: "mydb"}}, nil,
+	)
+	if !errors.Is(err, llmproxy.ErrNoTextContent) {
+		t.Fatalf("expected ErrNoTextContent, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil analysis on error, got %v", result)
+	}
+	h.cacheMu.RLock()
+	_, ok := h.cache[11]
+	h.cacheMu.RUnlock()
+	if ok {
+		t.Error("expected no cache entry when the analysis is unusable")
+	}
+}
+
 func TestServerInfoAttachExtensionsToDatabases(t *testing.T) {
 	h := &ServerInfoHandler{}
 

--- a/server/src/internal/llmproxy/proxy.go
+++ b/server/src/internal/llmproxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,6 +67,36 @@ type Config struct {
 // accommodate tool definitions and message history, consistent with the
 // DecodeJSONBody pattern used elsewhere in the API layer.
 const maxChatBodySize = 5 << 20 // 5 MB
+
+// DefaultAnalysisMaxTokens is the output-token budget applied to the
+// direct (non-proxy) analysis clients when the operator has not
+// configured llm.max_tokens.
+//
+// The value matches the documented default of the server's
+// llm.max_tokens setting, so an analysis request behaves identically
+// whether the operator leaves the key unset or writes the default value
+// explicitly.
+//
+// It deliberately replaces the previous 512-token cap. Reasoning models
+// served through an OpenAI-compatible endpoint (llama.cpp hosting Qwen3,
+// DeepSeek-R1 distills, gpt-oss, and similar) emit their thinking tokens
+// against the same max_tokens budget as the answer. A 512-token budget is
+// routinely consumed in full by the thinking block, so the model never
+// emits a text block and the caller sees an empty summary. 4096 leaves
+// several thousand tokens of thinking room ahead of the 3-5 sentence
+// (roughly 150-token) answer these prompts request, while still bounding
+// the response for non-reasoning models.
+const DefaultAnalysisMaxTokens = 4096
+
+// ErrNoTextContent reports that an LLM response carried no usable text
+// content. It is returned by the analysis paths instead of an empty
+// summary so the failure surfaces to the operator rather than rendering
+// as a blank panel. The message names the most common cause: a reasoning
+// model that spent its whole output budget on thinking tokens.
+var ErrNoTextContent = errors.New(
+	"LLM response contained no text content; the model may have " +
+		"exhausted its output token budget on reasoning tokens: " +
+		"increase llm.max_tokens or select a model that emits less reasoning")
 
 // NewHandler builds the library LLM proxy from cfg and returns the
 // http.Handler that serves the /api/v1/llm routes. The provider map
@@ -270,24 +301,52 @@ func (c *Config) providerOptions(name, apiKey, baseURL string) pgllm.Options {
 	return opts
 }
 
+// AnalysisMaxTokens resolves the output-token budget for the direct
+// (non-proxy) analysis clients. It returns the operator-configured
+// llm.max_tokens when that value is positive and DefaultAnalysisMaxTokens
+// otherwise, so an unset, zero, or negative setting can never produce an
+// unusable budget.
+//
+// The method is nil-receiver safe: callers that have not yet proven the
+// config is present (AI may be disabled entirely) can still ask for a
+// budget without a panic.
+func (c *Config) AnalysisMaxTokens() int {
+	if c == nil || c.MaxTokens <= 0 {
+		return DefaultAnalysisMaxTokens
+	}
+	return c.MaxTokens
+}
+
 // BuildClientOptions constructs the library Options for a direct
 // (non-proxy) LLM client that targets c.Provider. It is the single
 // source of truth for the per-provider credential selection, custom-header
-// wiring, and timeout-only-when-positive rule shared by the overview and
-// server-info analysis paths, mirroring the proxy shim's providerOptions.
+// wiring, max-token resolution, and timeout-only-when-positive rule shared
+// by the overview and server-info analysis paths, mirroring the proxy
+// shim's providerOptions.
+//
+// Design note: max-tokens is resolved here from c.MaxTokens (via
+// AnalysisMaxTokens) rather than accepted as a parameter. The two analysis
+// call sites previously each passed their own hardcoded 512-token
+// constant, which silently ignored the operator's llm.max_tokens setting
+// and let the paths drift apart. Resolving inside the shared helper makes
+// divergence impossible: a caller cannot pass a different budget. Callers
+// that must also stamp the budget onto their pgllm.ChatRequest read the
+// same value from AnalysisMaxTokens, so request and client stay in step.
+// Temperature remains a parameter because the two paths legitimately tune
+// it per prompt.
 //
 // Unlike providerOptions (which serves the streaming gateway and applies
 // the operator-configured MaxTokens/Temperature only when positive), the
-// analysis callers always supply their own positive MaxTokens and
-// Temperature constants, so both are set unconditionally from the
-// arguments. The caller is responsible for guarding a nil *Config or an
-// empty Provider before calling; this method assumes c is non-nil.
+// analysis path always sets both: the resolved max-tokens is positive by
+// construction and the callers supply positive temperature constants. The
+// caller is responsible for guarding a nil *Config or an empty Provider
+// before calling; this method assumes c is non-nil.
 //
 // Header-loading failures are logged to stderr and treated as no headers,
 // so a header misconfiguration never blocks analysis. The returned Options
 // still needs pgllm.NewClient(c.Provider, opts) at the call site so each
 // caller keeps its own client-construction error logging.
-func (c *Config) BuildClientOptions(maxTokens int, temperature float64) pgllm.Options {
+func (c *Config) BuildClientOptions(temperature float64) pgllm.Options {
 	var apiKey, baseURL string
 	switch c.Provider {
 	case "anthropic":
@@ -311,7 +370,7 @@ func (c *Config) BuildClientOptions(maxTokens int, temperature float64) pgllm.Op
 		Model:         c.Model,
 		BaseURL:       baseURL,
 		CustomHeaders: headers,
-		MaxTokens:     pgllm.Int(maxTokens),
+		MaxTokens:     pgllm.Int(c.AnalysisMaxTokens()),
 		Temperature:   pgllm.Float(temperature),
 	}
 	if c.LLMConfig != nil && c.LLMConfig.TimeoutSeconds > 0 {

--- a/server/src/internal/llmproxy/proxy_test.go
+++ b/server/src/internal/llmproxy/proxy_test.go
@@ -1214,8 +1214,9 @@ func TestProviderOptions_NoLLMConfig(t *testing.T) {
 
 // TestBuildClientOptions_ProviderCredentialSelection verifies that each
 // provider branch selects the matching API key and base URL, that unknown
-// providers select neither, and that the caller-supplied max-tokens and
-// temperature are always applied along with the shared model.
+// providers select neither, and that the configured max-tokens and the
+// caller-supplied temperature are always applied along with the shared
+// model.
 func TestBuildClientOptions_ProviderCredentialSelection(t *testing.T) {
 	cfg := &Config{
 		Model:            "shared-model",
@@ -1243,7 +1244,8 @@ func TestBuildClientOptions_ProviderCredentialSelection(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.provider, func(t *testing.T) {
 			cfg.Provider = tc.provider
-			opts := cfg.BuildClientOptions(1234, 0.25)
+			cfg.MaxTokens = 1234
+			opts := cfg.BuildClientOptions(0.25)
 			if opts.APIKey != tc.wantAPIKey {
 				t.Errorf("APIKey: got %q, want %q", opts.APIKey, tc.wantAPIKey)
 			}
@@ -1276,7 +1278,7 @@ func TestBuildClientOptions_TimeoutAndHeaders(t *testing.T) {
 			AnthropicCustomHeaders: map[string]string{"X-Test": "value"},
 		},
 	}
-	opts := cfg.BuildClientOptions(100, 0.5)
+	opts := cfg.BuildClientOptions(0.5)
 	if opts.RequestTimeout.Seconds() != 45 {
 		t.Errorf("RequestTimeout: got %v, want 45s", opts.RequestTimeout)
 	}
@@ -1287,18 +1289,18 @@ func TestBuildClientOptions_TimeoutAndHeaders(t *testing.T) {
 
 // TestBuildClientOptions_NoLLMConfig verifies the nil-LLMConfig guard: no
 // headers are loaded and no timeout is applied, while the caller-supplied
-// max-tokens and temperature are still set.
+// the fallback max-tokens and the caller's temperature are still set.
 func TestBuildClientOptions_NoLLMConfig(t *testing.T) {
 	cfg := &Config{Provider: "openai", Model: "m", OpenAIAPIKey: "k"}
-	opts := cfg.BuildClientOptions(50, 0.1)
+	opts := cfg.BuildClientOptions(0.1)
 	if opts.CustomHeaders != nil {
 		t.Errorf("expected nil headers with no LLMConfig, got %v", opts.CustomHeaders)
 	}
 	if opts.RequestTimeout != 0 {
 		t.Errorf("expected zero timeout with no LLMConfig, got %v", opts.RequestTimeout)
 	}
-	if opts.MaxTokens == nil || *opts.MaxTokens != 50 {
-		t.Errorf("MaxTokens: got %v, want 50", opts.MaxTokens)
+	if opts.MaxTokens == nil || *opts.MaxTokens != DefaultAnalysisMaxTokens {
+		t.Errorf("MaxTokens: got %v, want %d", opts.MaxTokens, DefaultAnalysisMaxTokens)
 	}
 	if opts.Temperature == nil || *opts.Temperature != 0.1 {
 		t.Errorf("Temperature: got %v, want 0.1", opts.Temperature)
@@ -1319,7 +1321,7 @@ func TestBuildClientOptions_HeaderLoadErrorTreatedAsNoHeaders(t *testing.T) {
 			},
 		},
 	}
-	opts := cfg.BuildClientOptions(10, 0.2)
+	opts := cfg.BuildClientOptions(0.2)
 	if opts.CustomHeaders != nil {
 		t.Errorf("expected nil headers when header loading fails, got %v", opts.CustomHeaders)
 	}
@@ -1338,8 +1340,96 @@ func TestBuildClientOptions_ZeroTimeoutNotApplied(t *testing.T) {
 		AnthropicAPIKey: "k",
 		LLMConfig:       &config.LLMConfig{TimeoutSeconds: 0},
 	}
-	opts := cfg.BuildClientOptions(10, 0.2)
+	opts := cfg.BuildClientOptions(0.2)
 	if opts.RequestTimeout != 0 {
 		t.Errorf("expected zero timeout when TimeoutSeconds=0, got %v", opts.RequestTimeout)
+	}
+}
+
+// -----------------------------------------------------------------------
+// AnalysisMaxTokens — output-token budget resolution for the analysis
+// paths (see issue #399: a hardcoded 512-token cap starved reasoning
+// models of the budget needed to emit a text block).
+// -----------------------------------------------------------------------
+
+// TestAnalysisMaxTokens verifies that a positive configured budget is
+// honoured and that an unset, zero, or negative budget falls back to
+// DefaultAnalysisMaxTokens. A nil receiver is also exercised because the
+// overview generator may hold a nil config when AI is disabled.
+func TestAnalysisMaxTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want int
+	}{
+		{"configured value used", &Config{MaxTokens: 8192}, 8192},
+		{"configured default value used", &Config{MaxTokens: 4096}, 4096},
+		{"small configured value still honoured", &Config{MaxTokens: 16}, 16},
+		{"unset falls back", &Config{}, DefaultAnalysisMaxTokens},
+		{"zero falls back", &Config{MaxTokens: 0}, DefaultAnalysisMaxTokens},
+		{"negative falls back", &Config{MaxTokens: -1}, DefaultAnalysisMaxTokens},
+		{"nil config falls back", nil, DefaultAnalysisMaxTokens},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.AnalysisMaxTokens(); got != tc.want {
+				t.Errorf("AnalysisMaxTokens() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnalysisMaxTokens_DefaultIsGenerousEnoughForReasoning guards the
+// regression in issue #399: the fallback must leave a reasoning model room
+// for both its thinking block and the answer, so it must be far above the
+// old 512-token cap.
+func TestAnalysisMaxTokens_DefaultIsGenerousEnoughForReasoning(t *testing.T) {
+	const oldCap = 512
+	if DefaultAnalysisMaxTokens <= oldCap {
+		t.Fatalf("DefaultAnalysisMaxTokens = %d, want > %d",
+			DefaultAnalysisMaxTokens, oldCap)
+	}
+}
+
+// TestBuildClientOptions_MaxTokensResolution verifies that
+// BuildClientOptions stamps the resolved budget onto the returned Options
+// for both the configured and fallback cases, keeping the two analysis
+// call sites in lock-step.
+func TestBuildClientOptions_MaxTokensResolution(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      int
+	}{
+		{"configured", 2048, 2048},
+		{"unset", 0, DefaultAnalysisMaxTokens},
+		{"negative", -7, DefaultAnalysisMaxTokens},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Provider:     "openai",
+				Model:        "m",
+				OpenAIAPIKey: "k",
+				MaxTokens:    tc.maxTokens,
+			}
+			opts := cfg.BuildClientOptions(0.3)
+			if opts.MaxTokens == nil || *opts.MaxTokens != tc.want {
+				t.Errorf("MaxTokens: got %v, want %d", opts.MaxTokens, tc.want)
+			}
+		})
+	}
+}
+
+// TestErrNoTextContentMessage verifies that the shared sentinel names the
+// actionable cause so operators see why a summary is missing.
+func TestErrNoTextContentMessage(t *testing.T) {
+	msg := ErrNoTextContent.Error()
+	for _, want := range []string{"no text content", "reasoning tokens", "llm.max_tokens"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ErrNoTextContent message %q does not mention %q", msg, want)
+		}
 	}
 }

--- a/server/src/internal/llmproxy/proxy_test.go
+++ b/server/src/internal/llmproxy/proxy_test.go
@@ -1353,7 +1353,7 @@ func TestBuildClientOptions_ZeroTimeoutNotApplied(t *testing.T) {
 // -----------------------------------------------------------------------
 
 // TestAnalysisMaxTokens verifies that a positive configured budget is
-// honoured and that an unset, zero, or negative budget falls back to
+// honored and that an unset, zero, or negative budget falls back to
 // DefaultAnalysisMaxTokens. A nil receiver is also exercised because the
 // overview generator may hold a nil config when AI is disabled.
 func TestAnalysisMaxTokens(t *testing.T) {
@@ -1364,7 +1364,7 @@ func TestAnalysisMaxTokens(t *testing.T) {
 	}{
 		{"configured value used", &Config{MaxTokens: 8192}, 8192},
 		{"configured default value used", &Config{MaxTokens: 4096}, 4096},
-		{"small configured value still honoured", &Config{MaxTokens: 16}, 16},
+		{"small configured value still honored", &Config{MaxTokens: 16}, 16},
 		{"unset falls back", &Config{}, DefaultAnalysisMaxTokens},
 		{"zero falls back", &Config{MaxTokens: 0}, DefaultAnalysisMaxTokens},
 		{"negative falls back", &Config{MaxTokens: -1}, DefaultAnalysisMaxTokens},

--- a/server/src/internal/overview/generator.go
+++ b/server/src/internal/overview/generator.go
@@ -31,9 +31,6 @@ const (
 	// staleDuration is how long an overview is considered fresh.
 	staleDuration = 5 * time.Minute
 
-	// llmMaxTokens caps the summary length for concise output.
-	llmMaxTokens = 512
-
 	// llmTemperature controls response creativity; low for factual output.
 	llmTemperature = 0.3
 
@@ -510,17 +507,20 @@ func (g *Generator) generateSummaryFromPrompt(ctx context.Context, system, data 
 		return "", fmt.Errorf("no LLM provider configured: %w", err)
 	}
 
+	// The request budget is resolved from the operator's llm.max_tokens
+	// through the same helper the client options use, so the request and
+	// the client agree on the budget.
 	resp, err := client.Chat(ctx, pgllm.ChatRequest{
 		Messages:     []pgllm.Message{pgllm.UserText(data)},
 		SystemPrompt: system,
-		MaxTokens:    pgllm.Int(llmMaxTokens),
+		MaxTokens:    pgllm.Int(g.llmConfig.AnalysisMaxTokens()),
 		Temperature:  pgllm.Float(llmTemperature),
 	})
 	if err != nil {
 		return "", fmt.Errorf("LLM chat failed: %w", err)
 	}
 
-	return extractTextFromResponse(resp), nil
+	return extractTextFromResponse(resp)
 }
 
 // createLLMClient builds a pgedge-go-llm-lib client based on the
@@ -539,10 +539,11 @@ func (g *Generator) createLLMClient() (pgllm.Client, error) {
 
 	provider := g.llmConfig.Provider
 
-	// Credential selection, custom-header wiring, and the
-	// timeout-only-when-positive rule live in the shared llmproxy helper
-	// so the overview and server-info analysis paths stay in lock-step.
-	opts := g.llmConfig.BuildClientOptions(llmMaxTokens, llmTemperature)
+	// Credential selection, custom-header wiring, max-token resolution,
+	// and the timeout-only-when-positive rule live in the shared llmproxy
+	// helper so the overview and server-info analysis paths stay in
+	// lock-step.
+	opts := g.llmConfig.BuildClientOptions(llmTemperature)
 
 	client, err := pgllm.NewClient(provider, opts)
 	if err != nil {
@@ -554,9 +555,16 @@ func (g *Generator) createLLMClient() (pgllm.Client, error) {
 
 // extractTextFromResponse walks the LLM response content blocks and
 // concatenates all text content into a single string.
-func extractTextFromResponse(resp *pgllm.ChatResponse) string {
+//
+// A response that carries no text block, or whose text is whitespace
+// only, yields llmproxy.ErrNoTextContent rather than an empty summary.
+// Reasoning models charge their thinking blocks against the same output
+// budget as the answer, so an under-sized budget produces exactly this
+// shape of response; reporting it as an error surfaces the
+// misconfiguration instead of silently caching a blank summary.
+func extractTextFromResponse(resp *pgllm.ChatResponse) (string, error) {
 	if resp == nil {
-		return ""
+		return "", llmproxy.ErrNoTextContent
 	}
 	var parts []string
 	for _, b := range resp.Content {
@@ -564,7 +572,11 @@ func extractTextFromResponse(resp *pgllm.ChatResponse) string {
 			parts = append(parts, b.Text)
 		}
 	}
-	return strings.Join(parts, "")
+	text := strings.Join(parts, "")
+	if strings.TrimSpace(text) == "" {
+		return "", llmproxy.ErrNoTextContent
+	}
+	return text, nil
 }
 
 // buildPrompt constructs the system instruction and user data sent to

--- a/server/src/internal/overview/generator_test.go
+++ b/server/src/internal/overview/generator_test.go
@@ -989,12 +989,12 @@ func TestGenerateSummaryFromPrompt_ChatError(t *testing.T) {
 	}
 }
 
-// TestGenerateSummaryFromPrompt_MaxTokensHonoursConfig verifies that the
+// TestGenerateSummaryFromPrompt_MaxTokensHonorsConfig verifies that the
 // chat request carries the operator-configured llm.max_tokens, and falls
 // back to llmproxy.DefaultAnalysisMaxTokens when the setting is unset or
 // non-positive. Regression cover for issue #399, where a hardcoded
 // 512-token cap starved reasoning models of output budget.
-func TestGenerateSummaryFromPrompt_MaxTokensHonoursConfig(t *testing.T) {
+func TestGenerateSummaryFromPrompt_MaxTokensHonorsConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		maxTokens int
@@ -1168,7 +1168,7 @@ func TestGenerateSummaryFromPrompt_NilConfigNoPanic(t *testing.T) {
 	}
 }
 
-func TestCreateLLMClient_TimeoutSecondsHonoured(t *testing.T) {
+func TestCreateLLMClient_TimeoutSecondsHonored(t *testing.T) {
 	// A positive TimeoutSeconds on the underlying config must produce a
 	// usable client; the timeout is applied to the library Options. The
 	// library defers credential validation, so a valid provider with a

--- a/server/src/internal/overview/generator_test.go
+++ b/server/src/internal/overview/generator_test.go
@@ -11,6 +11,8 @@ package overview
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -221,16 +223,22 @@ func TestHasSignificantChange(t *testing.T) {
 
 // --- extractTextFromResponse tests -----------------------------------------
 
+// thinkingBlock is the content-block type a reasoning model emits for its
+// chain of thought. The library has no named constant for it, so the tests
+// use the wire value directly to reproduce the issue #399 response shape.
+const thinkingBlock pgllm.ContentBlockType = "thinking"
+
 func TestExtractTextFromResponse(t *testing.T) {
 	tests := []struct {
 		name    string
 		content []pgllm.ContentBlock
 		want    string
+		wantErr bool
 	}{
 		{
-			name:    "empty content",
+			name:    "empty content is an error",
 			content: nil,
-			want:    "",
+			wantErr: true,
 		},
 		{
 			name: "single text block",
@@ -248,11 +256,28 @@ func TestExtractTextFromResponse(t *testing.T) {
 			want: "Hello World",
 		},
 		{
-			name: "non-text block ignored",
+			name: "non-text block only is an error",
 			content: []pgllm.ContentBlock{
 				{Type: pgllm.BlockToolUse, Text: "ignored"},
 			},
-			want: "",
+			wantErr: true,
+		},
+		{
+			// The regression from issue #399: a reasoning model that
+			// spends its whole budget thinking emits a thinking block
+			// and no text block.
+			name: "reasoning-only response is an error",
+			content: []pgllm.ContentBlock{
+				{Type: thinkingBlock, Text: "let me think about this at length"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "whitespace-only text is an error",
+			content: []pgllm.ContentBlock{
+				{Type: pgllm.BlockText, Text: "  \n\t "},
+			},
+			wantErr: true,
 		},
 		{
 			name: "mixed blocks concatenate only text",
@@ -263,12 +288,32 @@ func TestExtractTextFromResponse(t *testing.T) {
 			},
 			want: "Part1Part2",
 		},
+		{
+			name: "text alongside thinking passes through unchanged",
+			content: []pgllm.ContentBlock{
+				{Type: thinkingBlock, Text: "thinking"},
+				{Type: pgllm.BlockText, Text: " Estate is healthy. "},
+			},
+			want: " Estate is healthy. ",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			resp := &pgllm.ChatResponse{Content: tc.content}
-			got := extractTextFromResponse(resp)
+			got, err := extractTextFromResponse(resp)
+			if tc.wantErr {
+				if !errors.Is(err, llmproxy.ErrNoTextContent) {
+					t.Fatalf("expected ErrNoTextContent, got %v", err)
+				}
+				if got != "" {
+					t.Errorf("expected empty text on error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if got != tc.want {
 				t.Errorf("expected %q, got %q", tc.want, got)
 			}
@@ -276,7 +321,11 @@ func TestExtractTextFromResponse(t *testing.T) {
 	}
 
 	t.Run("nil response", func(t *testing.T) {
-		if got := extractTextFromResponse(nil); got != "" {
+		got, err := extractTextFromResponse(nil)
+		if !errors.Is(err, llmproxy.ErrNoTextContent) {
+			t.Fatalf("expected ErrNoTextContent for nil response, got %v", err)
+		}
+		if got != "" {
 			t.Errorf("expected empty string for nil response, got %q", got)
 		}
 	})
@@ -937,6 +986,103 @@ func TestGenerateSummaryFromPrompt_ChatError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "LLM chat failed") {
 		t.Errorf("expected 'LLM chat failed' in error, got %v", err)
+	}
+}
+
+// TestGenerateSummaryFromPrompt_MaxTokensHonoursConfig verifies that the
+// chat request carries the operator-configured llm.max_tokens, and falls
+// back to llmproxy.DefaultAnalysisMaxTokens when the setting is unset or
+// non-positive. Regression cover for issue #399, where a hardcoded
+// 512-token cap starved reasoning models of output budget.
+func TestGenerateSummaryFromPrompt_MaxTokensHonoursConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      float64
+	}{
+		{"configured value used", 8192, 8192},
+		{"unset falls back", 0, llmproxy.DefaultAnalysisMaxTokens},
+		{"negative falls back", -5, llmproxy.DefaultAnalysisMaxTokens},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				var payload map[string]any
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+				got = payload["max_tokens"]
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}]
+				}`))
+			}))
+			defer srv.Close()
+
+			g := NewGenerator(nil, &llmproxy.Config{
+				Provider:      "openai",
+				Model:         "gpt-4o",
+				OpenAIAPIKey:  "test-key",
+				OpenAIBaseURL: srv.URL,
+				MaxTokens:     tc.maxTokens,
+			})
+
+			if _, err := g.generateSummaryFromPrompt(context.Background(), "system", "data"); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			num, ok := got.(float64)
+			if !ok {
+				t.Fatalf("max_tokens missing or not a number in request: %#v", got)
+			}
+			if num != tc.want {
+				t.Errorf("max_tokens: got %v, want %v", num, tc.want)
+			}
+		})
+	}
+}
+
+// TestGenerateSummaryFromPrompt_NoTextContentIsError verifies that a
+// response carrying no usable text (the shape a reasoning model produces
+// when its thinking consumes the whole output budget) surfaces as an
+// error rather than a silently empty summary.
+func TestGenerateSummaryFromPrompt_NoTextContentIsError(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"empty string content", `""`},
+		{"whitespace-only content", `"   \n  "`},
+		{"null content", `null`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{
+					"choices": [{"message": {"role": "assistant", "content": %s}, "finish_reason": "length"}]
+				}`, tc.content)
+			}))
+			defer srv.Close()
+
+			g := NewGenerator(nil, &llmproxy.Config{
+				Provider:      "openai",
+				Model:         "gpt-4o",
+				OpenAIAPIKey:  "test-key",
+				OpenAIBaseURL: srv.URL,
+			})
+
+			summary, err := g.generateSummaryFromPrompt(context.Background(), "system", "data")
+			if !errors.Is(err, llmproxy.ErrNoTextContent) {
+				t.Fatalf("expected ErrNoTextContent, got %v", err)
+			}
+			if summary != "" {
+				t.Errorf("expected empty summary on error, got %q", summary)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #399

## Problem

Three AI-analysis paths hardcoded a small output-token cap that ignored the operator's configured `llm.max_tokens`:

| Path | Old value |
|---|---|
| Estate summary (`overview/generator.go`) | `llmMaxTokens = 512` |
| Server-info AI analysis (`api/server_info_handlers.go`) | `llmAnalysisMaxTokens = 512` |
| Alerter reasoning (`alerter/.../llm/reasoning.go`) | `pgllm.Int(500)` |

Reasoning models served through an OpenAI-compatible endpoint charge their thinking tokens against the same `max_tokens` budget as the answer. A 512-token budget is routinely consumed in full by the thinking block, so the model never emits a text block.

`extractTextFromResponse` collected only `pgllm.BlockText` blocks and returned an empty string, which callers treated as a successful generation. The estate summary therefore rendered blank with no error. This reproduces against a local llama.cpp server and was originally hit while building an all-in-one Docker stack.

The constants predate the `pgedge-go-llm-lib` migration and the `BuildClientOptions` extraction; both of those were behaviour-preserving refactors that carried the values through unchanged.

## Changes

- Resolve the output budget from configuration on all three paths, falling back to `4096` when the setting is unset, zero, or negative.
- `BuildClientOptions` now resolves max-tokens internally via the new nil-safe `AnalysisMaxTokens()` rather than accepting it as a parameter. A max-tokens *parameter* is exactly what let the two analysis call sites drift into hardcoding their own constants; removing it makes divergence impossible. Temperature stays a parameter because the two paths legitimately tune it.
- Treat a response carrying no usable text as an error (`ErrNoTextContent`) rather than an empty summary, so the condition surfaces instead of silently caching a blank panel. The error message names the likely cause and the setting to change.
- Map that condition to `502` on `GET /api/v1/server-info/{id}/ai-analysis`, documented in `openapi.go` and the regenerated `openapi.json`.
- Add `llm.max_tokens` to the alerter, which had no equivalent setting, with a `4096` default plus the config merge and defaulting passes.

## Note on the exported API

`BuildClientOptions` changes signature from `(maxTokens int, temperature float64)` to `(temperature float64)`. Both call sites are internal to this repository and are updated here.

## Behaviour deliberately left unchanged

The transient failure paths in `getAIAnalysis` (nil LLM config, no databases, client construction failure, chat error) still return `200` with a `null` body meaning "analysis unavailable". Only the "model answered but produced nothing usable" case becomes an error. Turning a provider outage into a `502` would reach well beyond this issue.

The web client's existing `.catch` in `ServerInfoDialog.tsx` already logs and leaves the panel empty, so no client change is needed.

## Testing

Table-driven tests cover each path for: configured value used; fallback on unset, zero, and negative; a small configured value still honoured; empty, whitespace-only, reasoning-block-only, and nil responses all yielding an error; non-empty responses passing through unchanged; and the `max_tokens` value actually observed on the wire, decoded from a stub server's request body.

Per-function line coverage on every touched function (verified with `go tool cover -func`):

```
llmproxy: AnalysisMaxTokens 100.0%  BuildClientOptions 100.0%
overview: extractTextFromResponse 100.0%  generateSummaryFromPrompt 100.0%  createLLMClient 100.0%
api:      getAIAnalysis 100.0%  writeAIAnalysisResponse 100.0%  createLLMClient 100.0%
          parseDatabaseAnalysisResponse 94.1%  handleServerInfoAI 91.3%
alerter:  Classify 100.0%  newLibReasoning 100.0%  NewReasoningProvider 100.0%
          SetLLMDefaults 100.0%  NewConfig 100.0%  LoadFromFile 100.0%
```

The single uncovered statement in `parseDatabaseAnalysisResponse` is in the pre-existing numbered-list-prefix stripper, untouched here.

`gofmt -l` is clean. `cd server && make test` and `cd alerter && make test` both pass. `go test ./internal/api/ -run OpenAPI -v` passes.

`make test-all` could not complete locally: the collector's lint step fails because the installed `golangci-lint` is built with Go 1.25 while the config targets Go 1.26.2. This reproduces on a pristine tree with all changes stashed, so it is pre-existing and unrelated to this change. `go vet ./...` is clean on both modules as a substitute; CI is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Piu2z26Jjg1fuPrkSJ5aFq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Piu2z26Jjg1fuPrkSJ5aFq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable `llm.max_tokens` for AI analysis and alerter reasoning, defaulting to 4096 tokens.
  - Applied token limits across AI Overview, Ask Ellie, server analysis, and alert classification.
- **Bug Fixes**
  - Empty, whitespace-only, or reasoning-only model responses are now detected as unusable.
  - Server information analysis returns HTTP 502 with an actionable error when no usable analysis is produced; unavailable analysis remains `null`.
- **Documentation**
  - Updated configuration guides, API specifications, examples, and changelog with token-budget and error-handling details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->