### PR TITLE
Stop metric_staleness alerts firing and clearing in a loop

### DIFF
--- a/.claude/golang-expert/metrics-queries.md
+++ b/.claude/golang-expert/metrics-queries.md
@@ -196,8 +196,12 @@ distinguishes three failure modes, and callers must keep them apart:
 - `ErrNoMetricData` - the registry query ran and returned no rows.
 - Any other error - the query itself failed.
 
-`checkAlertResolved` (`alerter/src/internal/engine/cleanup.go`) clears an
-alert only for `ErrNoMetricData`. An unsupported metric or a failed query
+When `GetLatestMetricValues` returns an error, `checkAlertResolved`
+(`alerter/src/internal/engine/cleanup.go`) clears an alert only for
+`ErrNoMetricData`; it still clears on its other, non-error paths, when
+the metric reports no value for the alert's connection or database, or
+when the current value no longer violates the threshold. An
+unsupported metric or a failed query
 says nothing about whether the alerting condition still holds, so the
 alert is left active and logged. Treating those errors as a resolution
 was the root cause of issue #405, in which `metric_staleness` alerts were

--- a/.claude/golang-expert/metrics-queries.md
+++ b/.claude/golang-expert/metrics-queries.md
@@ -184,10 +184,44 @@ at execution; `scanSeriesRows`'s own `pool.Query` and `rows.Scan` error
 branches are driven by a cancelled context and a destination-count mismatch
 respectively.
 
+## Alerter Metric Lookup Errors
+
+`GetLatestMetricValues` (`alerter/src/internal/database/metric_queries.go`)
+distinguishes three failure modes, and callers must keep them apart:
+
+- `ErrMetricNotSupported` - the metric has no `metricRegistry` entry, or
+  its entry carries an unknown scan type. Metrics evaluated by bespoke
+  code paths, notably `probe_staleness_ratio`, are deliberately absent
+  from the registry and always fail this way.
+- `ErrNoMetricData` - the registry query ran and returned no rows.
+- Any other error - the query itself failed.
+
+`checkAlertResolved` (`alerter/src/internal/engine/cleanup.go`) clears an
+alert only for `ErrNoMetricData`. An unsupported metric or a failed query
+says nothing about whether the alerting condition still holds, so the
+alert is left active and logged. Treating those errors as a resolution
+was the root cause of issue #405, in which `metric_staleness` alerts were
+cleared by the cleaner and immediately re-raised by the evaluator, once
+per cycle, for as long as a probe stayed stale.
+
+Probe-scoped alerts (those with a non-NULL `probe_name`) never reach the
+registry path at all: `checkAlertResolved` routes them to
+`checkStalenessAlertResolved`, which re-reads
+`GetProbeStalenessByConnection` and clears the alert when the probe's
+staleness ratio no longer violates the stored threshold, or when the
+probe stops being reported. Their evaluator,
+`evaluateMetricStaleness` (`alerter/src/internal/engine/thresholds.go`),
+keys both the active-alert lookup and the cooldown check by probe via
+`GetActiveThresholdAlertForProbe` and `GetRecentlyClearedAlertForProbe`,
+so several stale probes on one connection raise one alert each.
+
 ## Related Issues
 
 - #56: Alerter FK violations when calculating baselines for deleted
   connections.
+- #405: `metric_staleness` alert fire/clear loop; introduced the
+  `ErrMetricNotSupported`/`ErrNoMetricData` sentinels and the
+  probe-scoped alert lookups.
 - #342: Derived metrics (`_per_sec` rates and `dead_tuple_ratio`) added to
   `QueryTimeSeries` to fix blank Activity Charts; retired #339's
   `resolveMetricValue` in favour of the `finiteFloat` guard in `toFloat64`.

--- a/alerter/src/internal/database/alert_queries.go
+++ b/alerter/src/internal/database/alert_queries.go
@@ -58,6 +58,61 @@ func (d *Datastore) GetActiveThresholdAlert(ctx context.Context, ruleID int64, c
 	return &alert, nil
 }
 
+// GetActiveThresholdAlertForProbe checks if there's an existing active alert
+// for a rule/connection/probe combination. Probe-scoped rules such as
+// metric_staleness raise one alert per probe, so keying the lookup on the
+// rule and connection alone would collapse every stale probe on a server
+// into a single row whose title and description are overwritten by whichever
+// probe was evaluated last.
+func (d *Datastore) GetActiveThresholdAlertForProbe(ctx context.Context, ruleID int64, connectionID int, probeName string) (*Alert, error) {
+	var alert Alert
+	err := d.pool.QueryRow(ctx, `
+        SELECT id, alert_type, rule_id, connection_id, database_name, object_name,
+               probe_name, metric_name, metric_value, threshold_value, operator,
+               severity, title, description, correlation_id, status, triggered_at,
+               cleared_at, last_updated, anomaly_score, anomaly_details
+        FROM alerts
+        WHERE rule_id = $1 AND connection_id = $2 AND probe_name = $3
+          AND status IN ('active', 'acknowledged')
+        LIMIT 1
+    `, ruleID, connectionID, probeName).Scan(
+		&alert.ID, &alert.AlertType, &alert.RuleID, &alert.ConnectionID,
+		&alert.DatabaseName, &alert.ObjectName, &alert.ProbeName, &alert.MetricName,
+		&alert.MetricValue, &alert.ThresholdValue, &alert.Operator, &alert.Severity,
+		&alert.Title, &alert.Description, &alert.CorrelationID, &alert.Status,
+		&alert.TriggeredAt, &alert.ClearedAt, &alert.LastUpdated, &alert.AnomalyScore,
+		&alert.AnomalyDetails)
+
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &alert, nil
+}
+
+// GetRecentlyClearedAlertForProbe reports whether an alert for the same rule,
+// connection, and probe was cleared within the cooldown period. It is the
+// probe-scoped counterpart of GetRecentlyClearedAlert.
+func (d *Datastore) GetRecentlyClearedAlertForProbe(ctx context.Context, ruleID int64, connectionID int, probeName string, cooldown time.Duration) (bool, error) {
+	var exists bool
+	err := d.pool.QueryRow(ctx, `
+        SELECT EXISTS(
+            SELECT 1 FROM alerts
+            WHERE rule_id = $1 AND connection_id = $2 AND probe_name = $3
+              AND status = 'cleared'
+              AND cleared_at > NOW() - $4::interval
+        )
+    `, ruleID, connectionID, probeName,
+		fmt.Sprintf("%d seconds", int(cooldown.Seconds()))).Scan(&exists)
+
+	if err != nil {
+		return false, fmt.Errorf("failed to check recently cleared probe alert: %w", err)
+	}
+	return exists, nil
+}
+
 // GetActiveAnomalyAlert checks for an existing active anomaly alert for the
 // given metric name, connection, and optional database name.
 func (d *Datastore) GetActiveAnomalyAlert(ctx context.Context, metricName string, connectionID int, dbName *string) (*Alert, error) {

--- a/alerter/src/internal/database/metric_queries.go
+++ b/alerter/src/internal/database/metric_queries.go
@@ -11,7 +11,26 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
+)
+
+// Sentinel errors returned by GetLatestMetricValues. Callers need to tell
+// the three failure modes apart, because they have opposite consequences
+// for an active alert: a metric that the registry cannot answer at all,
+// or a query that failed, says nothing about whether the alerting
+// condition still holds, whereas an empty result set means the condition
+// genuinely reports nothing for any connection.
+var (
+	// ErrMetricNotSupported reports that the metric has no entry in
+	// metricRegistry, or has an entry whose scan type is unknown. Metrics
+	// evaluated by bespoke code paths (probe_staleness_ratio, for example)
+	// are deliberately absent from the registry and always fail this way.
+	ErrMetricNotSupported = errors.New("metric not implemented")
+
+	// ErrNoMetricData reports that the registry query ran successfully but
+	// returned no rows.
+	ErrNoMetricData = errors.New("no data found for metric")
 )
 
 // queryMetricValues executes a SQL query that returns rows with three columns
@@ -94,7 +113,7 @@ func (d *Datastore) queryMetricValuesWithDBAndObject(ctx context.Context, sql st
 func (d *Datastore) GetLatestMetricValues(ctx context.Context, metricName string) ([]MetricValue, error) {
 	cfg, ok := metricRegistry[metricName]
 	if !ok {
-		return nil, fmt.Errorf("metric %s not implemented", metricName)
+		return nil, fmt.Errorf("metric %s: %w", metricName, ErrMetricNotSupported)
 	}
 
 	var results []MetricValue
@@ -108,7 +127,8 @@ func (d *Datastore) GetLatestMetricValues(ctx context.Context, metricName string
 	case scanWithDBObject:
 		results, err = d.queryMetricValuesWithDBAndObject(ctx, cfg.latestSQL)
 	default:
-		return nil, fmt.Errorf("unknown scan type for metric: %s", metricName)
+		return nil, fmt.Errorf("unknown scan type for metric %s: %w",
+			metricName, ErrMetricNotSupported)
 	}
 
 	if err != nil {
@@ -116,7 +136,7 @@ func (d *Datastore) GetLatestMetricValues(ctx context.Context, metricName string
 	}
 
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no data found for metric %s", metricName)
+		return nil, fmt.Errorf("%w: %s", ErrNoMetricData, metricName)
 	}
 
 	return results, nil

--- a/alerter/src/internal/database/probe_alert_queries_integration_test.go
+++ b/alerter/src/internal/database/probe_alert_queries_integration_test.go
@@ -1,0 +1,261 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// insertProbeScopedAlert inserts a probe-scoped threshold alert with the
+// supplied status and returns its id. cleared alerts are stamped with a
+// cleared_at of NOW() so the cooldown lookup can see them.
+func insertProbeScopedAlert(t *testing.T, pool *pgxpool.Pool, connID int, ruleID int64, probeName, status string) int64 {
+	t.Helper()
+	var id int64
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO alerts (
+			alert_type, rule_id, connection_id, probe_name, severity,
+			title, description, status, metric_name, metric_value,
+			threshold_value, operator, cleared_at
+		) VALUES ('threshold', $1, $2, $3, 'warning', 'stale-alert',
+		    'desc', $4, 'probe_staleness_ratio', 30, 3, '>',
+		    CASE WHEN $4 = 'cleared' THEN NOW() ELSE NULL END)
+		RETURNING id
+	`, ruleID, connID, probeName, status).Scan(&id)
+	if err != nil {
+		t.Fatalf("insertProbeScopedAlert: %v", err)
+	}
+	return id
+}
+
+// TestGetActiveThresholdAlertForProbe verifies that the probe-scoped lookup
+// distinguishes alerts raised for different probes on the same connection,
+// which the rule/connection-keyed lookup cannot do.
+func TestGetActiveThresholdAlertForProbe(t *testing.T) {
+	ds, pool, cleanup := newFullTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertTestConnection(t, pool, "probe-alert-conn")
+	ruleID := insertTestRule(t, pool, "metric_staleness", "probe_staleness_ratio",
+		">", 3, "warning", true)
+
+	// No alert yet.
+	got, err := ds.GetActiveThresholdAlertForProbe(ctx, ruleID, connID, "pg_stat_activity")
+	if err != nil {
+		t.Fatalf("GetActiveThresholdAlertForProbe (none): %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+
+	activityID := insertProbeScopedAlert(t, pool, connID, ruleID, "pg_stat_activity", "active")
+	databaseID := insertProbeScopedAlert(t, pool, connID, ruleID, "pg_stat_database", "active")
+
+	got, err = ds.GetActiveThresholdAlertForProbe(ctx, ruleID, connID, "pg_stat_activity")
+	if err != nil {
+		t.Fatalf("GetActiveThresholdAlertForProbe: %v", err)
+	}
+	if got == nil || got.ID != activityID {
+		t.Fatalf("got %+v, want id=%d", got, activityID)
+	}
+	if got.ProbeName == nil || *got.ProbeName != "pg_stat_activity" {
+		t.Errorf("probe name = %v, want pg_stat_activity", got.ProbeName)
+	}
+
+	got, err = ds.GetActiveThresholdAlertForProbe(ctx, ruleID, connID, "pg_stat_database")
+	if err != nil {
+		t.Fatalf("GetActiveThresholdAlertForProbe (second probe): %v", err)
+	}
+	if got == nil || got.ID != databaseID {
+		t.Fatalf("got %+v, want id=%d", got, databaseID)
+	}
+
+	// A cleared alert must not be returned.
+	if _, err := pool.Exec(ctx, `UPDATE alerts SET status = 'cleared' WHERE id = $1`,
+		activityID); err != nil {
+		t.Fatalf("failed to clear alert: %v", err)
+	}
+	got, err = ds.GetActiveThresholdAlertForProbe(ctx, ruleID, connID, "pg_stat_activity")
+	if err != nil {
+		t.Fatalf("GetActiveThresholdAlertForProbe (cleared): %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for a cleared alert, got %+v", got)
+	}
+
+	// Canceled context: error.
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := ds.GetActiveThresholdAlertForProbe(canceled, ruleID, connID,
+		"pg_stat_activity"); err == nil {
+		t.Errorf("expected cancellation error")
+	}
+}
+
+// TestGetRecentlyClearedAlertForProbe verifies the probe-scoped cooldown
+// lookup, including that a clear for one probe does not suppress another.
+func TestGetRecentlyClearedAlertForProbe(t *testing.T) {
+	ds, pool, cleanup := newFullTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	connID := insertTestConnection(t, pool, "probe-cooldown-conn")
+	ruleID := insertTestRule(t, pool, "metric_staleness", "probe_staleness_ratio",
+		">", 3, "warning", true)
+
+	insertProbeScopedAlert(t, pool, connID, ruleID, "pg_stat_activity", "cleared")
+
+	exists, err := ds.GetRecentlyClearedAlertForProbe(ctx, ruleID, connID,
+		"pg_stat_activity", 60*time.Second)
+	if err != nil {
+		t.Fatalf("GetRecentlyClearedAlertForProbe: %v", err)
+	}
+	if !exists {
+		t.Error("expected the recent clear to be inside the cooldown window")
+	}
+
+	// A different probe on the same connection is unaffected.
+	exists, err = ds.GetRecentlyClearedAlertForProbe(ctx, ruleID, connID,
+		"pg_stat_database", 60*time.Second)
+	if err != nil {
+		t.Fatalf("GetRecentlyClearedAlertForProbe (other probe): %v", err)
+	}
+	if exists {
+		t.Error("a clear for one probe must not suppress another probe")
+	}
+
+	// The clear falls outside a very short cooldown.
+	if _, err := pool.Exec(ctx, `
+		UPDATE alerts SET cleared_at = NOW() - INTERVAL '10 seconds'
+		WHERE rule_id = $1
+	`, ruleID); err != nil {
+		t.Fatalf("failed to age the clear: %v", err)
+	}
+	exists, err = ds.GetRecentlyClearedAlertForProbe(ctx, ruleID, connID,
+		"pg_stat_activity", 1*time.Second)
+	if err != nil {
+		t.Fatalf("GetRecentlyClearedAlertForProbe (short cooldown): %v", err)
+	}
+	if exists {
+		t.Error("expected exists=false with a 1s cooldown")
+	}
+
+	// Canceled context: error.
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := ds.GetRecentlyClearedAlertForProbe(canceled, ruleID, connID,
+		"pg_stat_activity", 60*time.Second); err == nil {
+		t.Errorf("expected cancellation error")
+	}
+}
+
+// TestGetLatestMetricValuesErrorKinds pins the sentinel errors that
+// checkAlertResolved relies on to tell an unusable metric apart from one
+// that genuinely reports nothing.
+func TestGetLatestMetricValuesErrorKinds(t *testing.T) {
+	ds, _, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// A metric with no registry entry, such as the bespoke staleness
+	// metric, is not supported rather than empty.
+	_, err := ds.GetLatestMetricValues(ctx, "probe_staleness_ratio")
+	if !errors.Is(err, ErrMetricNotSupported) {
+		t.Errorf("probe_staleness_ratio error = %v, want ErrMetricNotSupported", err)
+	}
+	if errors.Is(err, ErrNoMetricData) {
+		t.Error("probe_staleness_ratio must not report as an empty result")
+	}
+
+	// A registered metric whose tables are empty reports no data.
+	_, err = ds.GetLatestMetricValues(ctx, "pg_replication_slots.inactive_count")
+	if !errors.Is(err, ErrNoMetricData) {
+		t.Errorf("empty metric error = %v, want ErrNoMetricData", err)
+	}
+}
+
+// withTestMetric registers a temporary metric registry entry for the
+// duration of the test. Tests in this package run sequentially, so
+// mutating the package-level registry is safe as long as the entry is
+// removed again.
+func withTestMetric(t *testing.T, name string, cfg metricQueryConfig) {
+	t.Helper()
+
+	if _, exists := metricRegistry[name]; exists {
+		t.Fatalf("metric %s already exists in the registry", name)
+	}
+	metricRegistry[name] = cfg
+	t.Cleanup(func() { delete(metricRegistry, name) })
+}
+
+// TestGetLatestMetricValuesScanTypes exercises every scan branch of
+// GetLatestMetricValues, including the guard against a registry entry with
+// an unrecognized scan type and the wrapping of a failed query.
+func TestGetLatestMetricValuesScanTypes(t *testing.T) {
+	ds, _, cleanup := newMetricRegistryTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	withTestMetric(t, "test.with_db", metricQueryConfig{
+		latestSQL: `SELECT 1 AS connection_id, 'app_db'::text AS database_name,
+		                   2.5::float AS value, NOW() AS collected_at`,
+		scan: scanWithDB,
+	})
+	withTestMetric(t, "test.with_db_object", metricQueryConfig{
+		latestSQL: `SELECT 1 AS connection_id, 'app_db'::text AS database_name,
+		                   'tbl'::text AS object_name, 3.5::float AS value,
+		                   NOW() AS collected_at`,
+		scan: scanWithDBObject,
+	})
+	withTestMetric(t, "test.bad_scan", metricQueryConfig{
+		latestSQL: `SELECT 1`,
+		scan:      scanType(99),
+	})
+	withTestMetric(t, "test.broken_query", metricQueryConfig{
+		latestSQL: `SELECT connection_id, value, collected_at FROM metrics.no_such_table`,
+		scan:      scanBasic,
+	})
+
+	values, err := ds.GetLatestMetricValues(ctx, "test.with_db")
+	if err != nil {
+		t.Fatalf("scanWithDB: %v", err)
+	}
+	if len(values) != 1 || values[0].DatabaseName == nil || *values[0].DatabaseName != "app_db" {
+		t.Errorf("scanWithDB values = %+v", values)
+	}
+
+	values, err = ds.GetLatestMetricValues(ctx, "test.with_db_object")
+	if err != nil {
+		t.Fatalf("scanWithDBObject: %v", err)
+	}
+	if len(values) != 1 || values[0].ObjectName == nil || *values[0].ObjectName != "tbl" {
+		t.Errorf("scanWithDBObject values = %+v", values)
+	}
+
+	if _, err := ds.GetLatestMetricValues(ctx, "test.bad_scan"); !errors.Is(err, ErrMetricNotSupported) {
+		t.Errorf("unknown scan type error = %v, want ErrMetricNotSupported", err)
+	}
+
+	_, err = ds.GetLatestMetricValues(ctx, "test.broken_query")
+	if err == nil {
+		t.Error("expected an error from a query against a missing table")
+	}
+	if errors.Is(err, ErrNoMetricData) || errors.Is(err, ErrMetricNotSupported) {
+		t.Errorf("a failed query must not report as missing data: %v", err)
+	}
+}

--- a/alerter/src/internal/engine/cleanup.go
+++ b/alerter/src/internal/engine/cleanup.go
@@ -11,6 +11,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/pgedge/ai-workbench/alerter/internal/database"
@@ -44,12 +45,31 @@ func (e *Engine) checkAlertResolved(ctx context.Context, alert *database.Alert) 
 		return
 	}
 
+	// Probe-scoped alerts (metric_staleness) are raised by a bespoke
+	// evaluator and their metric has no registry entry, so they need a
+	// bespoke resolution check too.
+	if alert.ProbeName != nil {
+		e.checkStalenessAlertResolved(ctx, alert)
+		return
+	}
+
 	// Get current metric values for all connections/databases
 	values, err := e.datastore.GetLatestMetricValues(ctx, *alert.MetricName)
 	if err != nil {
-		// No data returned for this metric at all — the condition
-		// no longer exists (e.g. all values filtered out), so clear
-		e.clearResolvedAlert(ctx, alert, 0)
+		if errors.Is(err, database.ErrNoMetricData) {
+			// The query ran and reported nothing for any connection —
+			// the condition no longer exists (e.g. all values filtered
+			// out), so clear
+			e.clearResolvedAlert(ctx, alert, 0)
+			return
+		}
+		// The metric could not be evaluated at all: either it has no
+		// registry entry or the query failed. Neither says anything
+		// about whether the condition still holds, so leave the alert
+		// alone rather than clearing it and letting the evaluator
+		// re-raise it on its next pass.
+		e.log("ERROR: Cannot evaluate metric %s for alert %d, leaving it active: %v",
+			*alert.MetricName, alert.ID, err)
 		return
 	}
 
@@ -82,6 +102,37 @@ func (e *Engine) checkAlertResolved(ctx context.Context, alert *database.Alert) 
 	if !stillViolated {
 		e.clearResolvedAlert(ctx, alert, value)
 	}
+}
+
+// checkStalenessAlertResolved checks whether a probe-scoped staleness alert
+// has resolved. The metric_staleness rule is evaluated by
+// evaluateMetricStaleness rather than through metricRegistry, so the
+// resolution check reads the same probe_availability source the evaluator
+// does. The alert clears when the probe's staleness ratio no longer violates
+// the threshold stored on the alert, or when the probe stops being reported
+// at all because it was disabled or its connection is no longer monitored.
+func (e *Engine) checkStalenessAlertResolved(ctx context.Context, alert *database.Alert) {
+	entries, err := e.datastore.GetProbeStalenessByConnection(ctx)
+	if err != nil {
+		e.log("ERROR: Failed to get probe staleness for alert %d: %v", alert.ID, err)
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.ConnectionID != alert.ConnectionID || entry.ProbeName != *alert.ProbeName {
+			continue
+		}
+		if !e.checkThreshold(entry.StalenessRatio, *alert.Operator, *alert.ThresholdValue) {
+			e.clearResolvedAlert(ctx, alert, entry.StalenessRatio)
+		}
+		return
+	}
+
+	// The probe no longer appears in the staleness view, so there is
+	// nothing left to be stale about.
+	e.debugLog("Probe %s on connection %d is no longer reported; clearing alert %d",
+		*alert.ProbeName, alert.ConnectionID, alert.ID)
+	e.clearResolvedAlert(ctx, alert, 0)
 }
 
 // clearResolvedAlert clears an alert and queues a notification

--- a/alerter/src/internal/engine/staleness_alerts_errors_integration_test.go
+++ b/alerter/src/internal/engine/staleness_alerts_errors_integration_test.go
@@ -1,0 +1,389 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgedge/ai-workbench/alerter/internal/database"
+)
+
+// The statements below break the schema in a controlled way so the error
+// branches of the staleness evaluator and the alert cleaner can be driven
+// from an integration test. Each one disables exactly one database
+// operation, leaving the rest of the path working.
+const (
+	dropProbeAvailabilityTableSQL = `DROP TABLE probe_availability CASCADE`
+
+	dropAlertsTableSQL = `DROP TABLE alerts CASCADE`
+
+	rejectProbeAlertInsertsSQL = `
+        ALTER TABLE alerts
+            ADD CONSTRAINT reject_probe_alerts CHECK (probe_name IS NULL)
+    `
+
+	createRejectAlertUpdatesFuncSQL = `
+        CREATE OR REPLACE FUNCTION reject_alert_updates() RETURNS trigger AS $$
+        BEGIN
+            RAISE EXCEPTION 'alert updates are rejected by this test';
+        END;
+        $$ LANGUAGE plpgsql
+    `
+
+	createRejectAlertUpdatesTriggerSQL = `
+        CREATE TRIGGER reject_alert_updates
+            BEFORE UPDATE ON alerts
+            FOR EACH ROW EXECUTE FUNCTION reject_alert_updates()
+    `
+
+	dropRejectAlertUpdatesSQL = `
+        DROP FUNCTION IF EXISTS reject_alert_updates() CASCADE
+    `
+
+	disableStalenessRuleSQL = `
+        UPDATE alert_rules SET default_enabled = FALSE WHERE id = $1
+    `
+
+	insertConnectionThresholdOverrideSQL = `
+        INSERT INTO alert_thresholds
+            (rule_id, scope, connection_id, operator, threshold, severity, enabled)
+        VALUES ($1, 'server', $2, '>', 3, 'warning', FALSE)
+    `
+
+	insertActiveBlackoutSQL = `
+        INSERT INTO blackouts
+            (scope, connection_id, reason, start_time, end_time, created_by)
+        VALUES ('server', $1, 'test blackout',
+                NOW() - INTERVAL '1 hour', NOW() + INTERVAL '1 hour', 'test')
+    `
+
+	dropBlackoutsTableSQL = `DROP TABLE blackouts CASCADE`
+
+	insertSlotSampleSQL = `
+        INSERT INTO metrics.pg_replication_slots
+            (connection_id, slot_name, active, retained_bytes, collected_at)
+        VALUES ($1, $2, FALSE, 5000000000, NOW())
+    `
+
+	insertRegistryMetricAlertSQL = `
+        INSERT INTO alerts
+            (alert_type, rule_id, connection_id, database_name, metric_name,
+             metric_value, threshold_value, operator, severity, title,
+             description, status, triggered_at)
+        VALUES ('threshold', $1, $2, $3, 'pg_replication_slots.max_retained_bytes',
+                5000000000, 1000000000, '>', 'warning', 'slot retention',
+                'desc', 'active', NOW())
+        RETURNING id
+    `
+)
+
+// TestStalenessEvaluatorSurvivesStalenessQueryFailure covers the two paths
+// that read probe_availability when the table cannot be queried at all: the
+// evaluator gives up for this pass, and the cleaner leaves the alert alone
+// rather than guessing that the condition resolved.
+func TestStalenessEvaluatorSurvivesStalenessQueryFailure(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-query-failure")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	engine.evaluateThresholds(ctx)
+	if alerts := readAlertsForRule(t, pool, ruleID); len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+
+	if _, err := pool.Exec(ctx, dropProbeAvailabilityTableSQL); err != nil {
+		t.Fatalf("failed to drop probe_availability: %v", err)
+	}
+
+	// Neither pass may change anything: the evaluator cannot see the
+	// probes, and the cleaner cannot tell whether the alert resolved.
+	engine.evaluateMetricStaleness(ctx)
+	engine.cleanResolvedAlerts(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+	if alerts[0].status != "active" {
+		t.Errorf("alert status = %q, want \"active\"; the staleness query failed "+
+			"and says nothing about the condition", alerts[0].status)
+	}
+}
+
+// TestStalenessEvaluatorSurvivesAlertLookupFailure covers the branch where
+// the existing-alert lookup fails. The evaluator must not create a fresh
+// alert on a failed lookup, because that would duplicate an alert that may
+// already exist.
+func TestStalenessEvaluatorSurvivesAlertLookupFailure(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	capture := installStalenessNotificationCapture(t, engine)
+	seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-lookup-failure")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	if _, err := pool.Exec(ctx, dropAlertsTableSQL); err != nil {
+		t.Fatalf("failed to drop alerts: %v", err)
+	}
+
+	engine.evaluateMetricStaleness(ctx)
+
+	if counts := capture.drain(t); counts[database.NotificationTypeAlertFire] != 0 {
+		t.Errorf("fire notifications = %d, want 0 when the lookup failed",
+			counts[database.NotificationTypeAlertFire])
+	}
+}
+
+// TestStalenessEvaluatorSurvivesAlertCreateFailure covers the branch where
+// the INSERT itself fails; the evaluator logs and moves on to the next
+// probe rather than notifying about an alert that was never stored.
+func TestStalenessEvaluatorSurvivesAlertCreateFailure(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	capture := installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-create-failure")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	if _, err := pool.Exec(ctx, rejectProbeAlertInsertsSQL); err != nil {
+		t.Fatalf("failed to add the rejecting constraint: %v", err)
+	}
+
+	engine.evaluateMetricStaleness(ctx)
+
+	if alerts := readAlertsForRule(t, pool, ruleID); len(alerts) != 0 {
+		t.Errorf("alert rows = %d, want 0 when the insert is rejected", len(alerts))
+	}
+	if counts := capture.drain(t); counts[database.NotificationTypeAlertFire] != 0 {
+		t.Errorf("fire notifications = %d, want 0 when the insert failed",
+			counts[database.NotificationTypeAlertFire])
+	}
+}
+
+// TestStalenessEvaluatorSurvivesAlertUpdateFailure covers the branch where
+// refreshing an existing alert's values fails. The alert must survive
+// unchanged rather than being duplicated.
+func TestStalenessEvaluatorSurvivesAlertUpdateFailure(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-update-failure")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	engine.evaluateMetricStaleness(ctx)
+	if alerts := readAlertsForRule(t, pool, ruleID); len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+
+	if _, err := pool.Exec(ctx, createRejectAlertUpdatesFuncSQL); err != nil {
+		t.Fatalf("failed to create the rejecting trigger function: %v", err)
+	}
+	if _, err := pool.Exec(ctx, createRejectAlertUpdatesTriggerSQL); err != nil {
+		t.Fatalf("failed to install the rejecting trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(), dropRejectAlertUpdatesSQL); err != nil {
+			t.Logf("failed to drop the rejecting trigger: %v", err)
+		}
+	})
+
+	engine.evaluateMetricStaleness(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Errorf("alert rows = %d, want 1 after a failed update", len(alerts))
+	}
+}
+
+// TestStalenessEvaluatorSkipConditions covers the guards that stop the
+// staleness evaluator raising an alert: a disabled rule, an active
+// blackout, and a per-connection threshold override that disables the rule.
+// Each case runs against a probe that is comfortably stale, so an alert
+// would appear were the guard not honored.
+func TestStalenessEvaluatorSkipConditions(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(t *testing.T, pool *pgxpool.Pool, ruleID int64, connID int)
+	}{
+		{
+			name: "rule disabled",
+			prepare: func(t *testing.T, pool *pgxpool.Pool, ruleID int64, connID int) {
+				if _, err := pool.Exec(context.Background(),
+					disableStalenessRuleSQL, ruleID); err != nil {
+					t.Fatalf("failed to disable the rule: %v", err)
+				}
+			},
+		},
+		{
+			name: "blackout active",
+			prepare: func(t *testing.T, pool *pgxpool.Pool, ruleID int64, connID int) {
+				if _, err := pool.Exec(context.Background(),
+					insertActiveBlackoutSQL, connID); err != nil {
+					t.Fatalf("failed to insert blackout: %v", err)
+				}
+			},
+		},
+		{
+			name: "rule disabled for connection",
+			prepare: func(t *testing.T, pool *pgxpool.Pool, ruleID int64, connID int) {
+				if _, err := pool.Exec(context.Background(),
+					insertConnectionThresholdOverrideSQL, ruleID, connID); err != nil {
+					t.Fatalf("failed to insert threshold override: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			installStalenessNotificationCapture(t, engine)
+			ruleID := seedStalenessRule(t, pool)
+			connID := insertTestConnection(t, pool, "staleness-skip")
+			seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+			tt.prepare(t, pool, ruleID, connID)
+
+			engine.evaluateMetricStaleness(ctx)
+
+			if alerts := readAlertsForRule(t, pool, ruleID); len(alerts) != 0 {
+				t.Errorf("alert rows = %d, want 0", len(alerts))
+			}
+		})
+	}
+}
+
+// TestStalenessEvaluatorSurvivesBlackoutLookupFailure covers the branch
+// where the blackout check itself fails. A failed check must not stop the
+// evaluator raising the alert, because suppressing alerts on a database
+// error would hide real problems.
+func TestStalenessEvaluatorSurvivesBlackoutLookupFailure(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-blackout-failure")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	if _, err := pool.Exec(ctx, dropBlackoutsTableSQL); err != nil {
+		t.Fatalf("failed to drop blackouts: %v", err)
+	}
+
+	engine.evaluateMetricStaleness(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+	if alerts[0].status != "active" {
+		t.Errorf("alert status = %q, want \"active\"", alerts[0].status)
+	}
+}
+
+// TestStalenessAlertIgnoresOtherProbesInTheView covers the loop skip in the
+// staleness resolution check: entries for other connections and other
+// probes must not be mistaken for the alert's own probe.
+func TestStalenessAlertIgnoresOtherProbesInTheView(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-other-probes")
+	otherConnID := insertTestConnection(t, pool, "staleness-other-conn")
+
+	// A fresh probe on another connection, plus a fresh probe on this
+	// connection, both of which the resolution check must skip over
+	// before it finds the stale probe the alert belongs to.
+	seedStaleProbe(t, pool, otherConnID, "pg_stat_bgwriter", "1 second")
+	seedStaleProbe(t, pool, connID, "pg_stat_database", "1 second")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	engine.evaluateMetricStaleness(ctx)
+	engine.cleanResolvedAlerts(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+	if alerts[0].status != "active" {
+		t.Errorf("alert status = %q, want \"active\"; the probe is still stale",
+			alerts[0].status)
+	}
+}
+
+// TestCheckAlertResolvedClearsWhenConnectionOrDatabaseHasNoValue covers the
+// registry-backed matching loop: values reported for a different connection,
+// or for a row with no database name when the alert is database-scoped, do
+// not count as the alert's own value, so the alert resolves.
+func TestCheckAlertResolvedClearsWhenConnectionOrDatabaseHasNoValue(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	alertConnID := insertTestConnection(t, pool, "resolve-alert-conn")
+	dataConnID := insertTestConnection(t, pool, "resolve-data-conn")
+
+	// The only slot sample belongs to a different connection.
+	if _, err := pool.Exec(ctx, insertSlotSampleSQL, dataConnID, "slot_a"); err != nil {
+		t.Fatalf("failed to seed replication slot sample: %v", err)
+	}
+
+	var alertID int64
+	if err := pool.QueryRow(ctx, insertRegistryMetricAlertSQL, ruleID, alertConnID,
+		nil).Scan(&alertID); err != nil {
+		t.Fatalf("failed to insert alert: %v", err)
+	}
+
+	// A second alert on the connection that does have data, but scoped to
+	// a database the basic metric never reports.
+	dbName := "app_db"
+	var dbAlertID int64
+	if err := pool.QueryRow(ctx, insertRegistryMetricAlertSQL, ruleID, dataConnID,
+		&dbName).Scan(&dbAlertID); err != nil {
+		t.Fatalf("failed to insert database-scoped alert: %v", err)
+	}
+
+	engine.cleanResolvedAlerts(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 2 {
+		t.Fatalf("alert rows = %d, want 2", len(alerts))
+	}
+	for _, alert := range alerts {
+		if alert.status != "cleared" {
+			t.Errorf("alert %d status = %q, want \"cleared\"; the metric reports "+
+				"no value for it", alert.id, alert.status)
+		}
+	}
+}

--- a/alerter/src/internal/engine/staleness_alerts_errors_integration_test.go
+++ b/alerter/src/internal/engine/staleness_alerts_errors_integration_test.go
@@ -54,13 +54,13 @@ const (
         UPDATE alert_rules SET default_enabled = FALSE WHERE id = $1
     `
 
-	insertConnectionThresholdOverrideSQL = `
+	stalenessThresholdOverrideInsertSQL = `
         INSERT INTO alert_thresholds
             (rule_id, scope, connection_id, operator, threshold, severity, enabled)
         VALUES ($1, 'server', $2, '>', 3, 'warning', FALSE)
     `
 
-	insertActiveBlackoutSQL = `
+	stalenessActiveBlackoutInsertSQL = `
         INSERT INTO blackouts
             (scope, connection_id, reason, start_time, end_time, created_by)
         VALUES ('server', $1, 'test blackout',
@@ -69,13 +69,13 @@ const (
 
 	dropBlackoutsTableSQL = `DROP TABLE blackouts CASCADE`
 
-	insertSlotSampleSQL = `
+	stalenessSlotSampleInsertSQL = `
         INSERT INTO metrics.pg_replication_slots
             (connection_id, slot_name, active, retained_bytes, collected_at)
         VALUES ($1, $2, FALSE, 5000000000, NOW())
     `
 
-	insertRegistryMetricAlertSQL = `
+	stalenessRegistryMetricAlertInsertSQL = `
         INSERT INTO alerts
             (alert_type, rule_id, connection_id, database_name, metric_name,
              metric_value, threshold_value, operator, severity, title,
@@ -102,7 +102,7 @@ func TestStalenessEvaluatorSurvivesStalenessQueryFailure(t *testing.T) {
 	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
 
 	engine.evaluateThresholds(ctx)
-	if alerts := readAlertsForRule(t, pool, ruleID); len(alerts) != 1 {
+	if alerts := readStalenessAlertsForRule(t, pool, ruleID); len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}
 
@@ -115,7 +115,7 @@ func TestStalenessEvaluatorSurvivesStalenessQueryFailure(t *testing.T) {
 	engine.evaluateMetricStaleness(ctx)
 	engine.cleanResolvedAlerts(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}
@@ -170,7 +170,7 @@ func TestStalenessEvaluatorSurvivesAlertCreateFailure(t *testing.T) {
 
 	engine.evaluateMetricStaleness(ctx)
 
-	if alerts := readAlertsForRule(t, pool, ruleID); len(alerts) != 0 {
+	if alerts := readStalenessAlertsForRule(t, pool, ruleID); len(alerts) != 0 {
 		t.Errorf("alert rows = %d, want 0 when the insert is rejected", len(alerts))
 	}
 	if counts := capture.drain(t); counts[database.NotificationTypeAlertFire] != 0 {
@@ -193,7 +193,7 @@ func TestStalenessEvaluatorSurvivesAlertUpdateFailure(t *testing.T) {
 	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
 
 	engine.evaluateMetricStaleness(ctx)
-	if alerts := readAlertsForRule(t, pool, ruleID); len(alerts) != 1 {
+	if alerts := readStalenessAlertsForRule(t, pool, ruleID); len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}
 
@@ -211,7 +211,7 @@ func TestStalenessEvaluatorSurvivesAlertUpdateFailure(t *testing.T) {
 
 	engine.evaluateMetricStaleness(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Errorf("alert rows = %d, want 1 after a failed update", len(alerts))
 	}
@@ -240,7 +240,7 @@ func TestStalenessEvaluatorSkipConditions(t *testing.T) {
 			name: "blackout active",
 			prepare: func(t *testing.T, pool *pgxpool.Pool, ruleID int64, connID int) {
 				if _, err := pool.Exec(context.Background(),
-					insertActiveBlackoutSQL, connID); err != nil {
+					stalenessActiveBlackoutInsertSQL, connID); err != nil {
 					t.Fatalf("failed to insert blackout: %v", err)
 				}
 			},
@@ -249,7 +249,7 @@ func TestStalenessEvaluatorSkipConditions(t *testing.T) {
 			name: "rule disabled for connection",
 			prepare: func(t *testing.T, pool *pgxpool.Pool, ruleID int64, connID int) {
 				if _, err := pool.Exec(context.Background(),
-					insertConnectionThresholdOverrideSQL, ruleID, connID); err != nil {
+					stalenessThresholdOverrideInsertSQL, ruleID, connID); err != nil {
 					t.Fatalf("failed to insert threshold override: %v", err)
 				}
 			},
@@ -271,7 +271,7 @@ func TestStalenessEvaluatorSkipConditions(t *testing.T) {
 
 			engine.evaluateMetricStaleness(ctx)
 
-			if alerts := readAlertsForRule(t, pool, ruleID); len(alerts) != 0 {
+			if alerts := readStalenessAlertsForRule(t, pool, ruleID); len(alerts) != 0 {
 				t.Errorf("alert rows = %d, want 0", len(alerts))
 			}
 		})
@@ -298,7 +298,7 @@ func TestStalenessEvaluatorSurvivesBlackoutLookupFailure(t *testing.T) {
 
 	engine.evaluateMetricStaleness(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}
@@ -330,7 +330,7 @@ func TestStalenessAlertIgnoresOtherProbesInTheView(t *testing.T) {
 	engine.evaluateMetricStaleness(ctx)
 	engine.cleanResolvedAlerts(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}
@@ -355,12 +355,12 @@ func TestCheckAlertResolvedClearsWhenConnectionOrDatabaseHasNoValue(t *testing.T
 	dataConnID := insertTestConnection(t, pool, "resolve-data-conn")
 
 	// The only slot sample belongs to a different connection.
-	if _, err := pool.Exec(ctx, insertSlotSampleSQL, dataConnID, "slot_a"); err != nil {
+	if _, err := pool.Exec(ctx, stalenessSlotSampleInsertSQL, dataConnID, "slot_a"); err != nil {
 		t.Fatalf("failed to seed replication slot sample: %v", err)
 	}
 
 	var alertID int64
-	if err := pool.QueryRow(ctx, insertRegistryMetricAlertSQL, ruleID, alertConnID,
+	if err := pool.QueryRow(ctx, stalenessRegistryMetricAlertInsertSQL, ruleID, alertConnID,
 		nil).Scan(&alertID); err != nil {
 		t.Fatalf("failed to insert alert: %v", err)
 	}
@@ -369,14 +369,14 @@ func TestCheckAlertResolvedClearsWhenConnectionOrDatabaseHasNoValue(t *testing.T
 	// a database the basic metric never reports.
 	dbName := "app_db"
 	var dbAlertID int64
-	if err := pool.QueryRow(ctx, insertRegistryMetricAlertSQL, ruleID, dataConnID,
+	if err := pool.QueryRow(ctx, stalenessRegistryMetricAlertInsertSQL, ruleID, dataConnID,
 		&dbName).Scan(&dbAlertID); err != nil {
 		t.Fatalf("failed to insert database-scoped alert: %v", err)
 	}
 
 	engine.cleanResolvedAlerts(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 2 {
 		t.Fatalf("alert rows = %d, want 2", len(alerts))
 	}

--- a/alerter/src/internal/engine/staleness_alerts_integration_test.go
+++ b/alerter/src/internal/engine/staleness_alerts_integration_test.go
@@ -25,7 +25,7 @@ import (
 // multi-line SQL passed to Exec or QueryRow; every value is still bound
 // via $N.
 const (
-	insertStalenessRuleSQL = `
+	stalenessRuleInsertSQL = `
         INSERT INTO alert_rules
             (name, description, category, metric_name, default_operator,
              default_threshold, default_severity, default_enabled, is_built_in)
@@ -36,37 +36,37 @@ const (
         RETURNING id
     `
 
-	insertProbeConfigSQL = `
+	stalenessProbeConfigInsertSQL = `
         INSERT INTO probe_configs
             (name, connection_id, is_enabled, collection_interval_seconds)
         VALUES ($1, NULL, TRUE, $2)
     `
 
-	insertProbeAvailabilitySQL = `
+	stalenessProbeAvailabilityInsertSQL = `
         INSERT INTO probe_availability
             (connection_id, probe_name, is_available, last_collected)
         VALUES ($1, $2, TRUE, NOW() - $3::interval)
     `
 
-	refreshProbeAvailabilitySQL = `
+	stalenessProbeAvailabilityRefreshSQL = `
         UPDATE probe_availability
            SET last_collected = NOW()
          WHERE connection_id = $1 AND probe_name = $2
     `
 
-	deleteProbeAvailabilitySQL = `
+	stalenessProbeAvailabilityDeleteSQL = `
         DELETE FROM probe_availability
          WHERE connection_id = $1 AND probe_name = $2
     `
 
-	selectAlertsForRuleSQL = `
+	stalenessAlertsForRuleSelectSQL = `
         SELECT id, status, probe_name
         FROM alerts
         WHERE rule_id = $1
         ORDER BY id
     `
 
-	insertUnsupportedMetricAlertSQL = `
+	stalenessUnsupportedMetricAlertInsertSQL = `
         INSERT INTO alerts
             (alert_type, rule_id, connection_id, metric_name, metric_value,
              threshold_value, operator, severity, title, description, status,
@@ -135,7 +135,7 @@ func seedStalenessRule(t *testing.T, pool *pgxpool.Pool) int64 {
 	t.Helper()
 
 	var ruleID int64
-	if err := pool.QueryRow(context.Background(), insertStalenessRuleSQL).Scan(&ruleID); err != nil {
+	if err := pool.QueryRow(context.Background(), stalenessRuleInsertSQL).Scan(&ruleID); err != nil {
 		t.Fatalf("failed to insert metric_staleness rule: %v", err)
 	}
 	return ruleID
@@ -148,10 +148,10 @@ func seedStaleProbe(t *testing.T, pool *pgxpool.Pool, connID int, probeName, sta
 	t.Helper()
 
 	ctx := context.Background()
-	if _, err := pool.Exec(ctx, insertProbeConfigSQL, probeName, 60); err != nil {
+	if _, err := pool.Exec(ctx, stalenessProbeConfigInsertSQL, probeName, 60); err != nil {
 		t.Fatalf("failed to insert probe config for %s: %v", probeName, err)
 	}
-	if _, err := pool.Exec(ctx, insertProbeAvailabilitySQL, connID, probeName, staleFor); err != nil {
+	if _, err := pool.Exec(ctx, stalenessProbeAvailabilityInsertSQL, connID, probeName, staleFor); err != nil {
 		t.Fatalf("failed to insert probe availability for %s: %v", probeName, err)
 	}
 }
@@ -164,11 +164,11 @@ type stalenessAlertRow struct {
 	probe  *string
 }
 
-// readAlertsForRule returns every alert row belonging to a rule, oldest first.
-func readAlertsForRule(t *testing.T, pool *pgxpool.Pool, ruleID int64) []stalenessAlertRow {
+// readStalenessAlertsForRule returns every alert row belonging to a rule, oldest first.
+func readStalenessAlertsForRule(t *testing.T, pool *pgxpool.Pool, ruleID int64) []stalenessAlertRow {
 	t.Helper()
 
-	rows, err := pool.Query(context.Background(), selectAlertsForRuleSQL, ruleID)
+	rows, err := pool.Query(context.Background(), stalenessAlertsForRuleSelectSQL, ruleID)
 	if err != nil {
 		t.Fatalf("failed to read alerts: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestStalenessAlertDoesNotFireClearLoop(t *testing.T) {
 		engine.cleanResolvedAlerts(ctx)
 	}
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1 for a continuously stale probe", len(alerts))
 	}
@@ -246,21 +246,21 @@ func TestStalenessAlertClearsWhenProbeRecovers(t *testing.T) {
 	engine.evaluateThresholds(ctx)
 	engine.cleanResolvedAlerts(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 || alerts[0].status != "active" {
 		t.Fatalf("expected one active alert, got %+v", alerts)
 	}
 
 	// The probe collects again, so the staleness ratio drops below the
 	// threshold.
-	if _, err := pool.Exec(ctx, refreshProbeAvailabilitySQL, connID,
+	if _, err := pool.Exec(ctx, stalenessProbeAvailabilityRefreshSQL, connID,
 		"pg_stat_activity"); err != nil {
 		t.Fatalf("failed to refresh probe availability: %v", err)
 	}
 
 	engine.cleanResolvedAlerts(ctx)
 
-	alerts = readAlertsForRule(t, pool, ruleID)
+	alerts = readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}
@@ -291,14 +291,14 @@ func TestStalenessAlertClearsWhenProbeStopsReporting(t *testing.T) {
 
 	engine.evaluateThresholds(ctx)
 
-	if _, err := pool.Exec(ctx, deleteProbeAvailabilitySQL, connID,
+	if _, err := pool.Exec(ctx, stalenessProbeAvailabilityDeleteSQL, connID,
 		"pg_stat_activity"); err != nil {
 		t.Fatalf("failed to delete probe availability: %v", err)
 	}
 
 	engine.cleanResolvedAlerts(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}
@@ -324,7 +324,7 @@ func TestStalenessAlertPerProbe(t *testing.T) {
 
 	engine.evaluateThresholds(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 2 {
 		t.Fatalf("alert rows = %d, want 2 (one per stale probe)", len(alerts))
 	}
@@ -344,7 +344,7 @@ func TestStalenessAlertPerProbe(t *testing.T) {
 
 	// A second pass updates the existing alerts instead of adding more.
 	engine.evaluateThresholds(ctx)
-	if alerts = readAlertsForRule(t, pool, ruleID); len(alerts) != 2 {
+	if alerts = readStalenessAlertsForRule(t, pool, ruleID); len(alerts) != 2 {
 		t.Errorf("alert rows after a second pass = %d, want 2", len(alerts))
 	}
 }
@@ -402,14 +402,14 @@ func TestCheckAlertResolvedKeepsUnevaluableMetricAlerts(t *testing.T) {
 	connID := insertTestConnection(t, pool, "unevaluable-metric")
 
 	var alertID int64
-	if err := pool.QueryRow(ctx, insertUnsupportedMetricAlertSQL, ruleID, connID,
+	if err := pool.QueryRow(ctx, stalenessUnsupportedMetricAlertInsertSQL, ruleID, connID,
 		"metric_that_does_not_exist").Scan(&alertID); err != nil {
 		t.Fatalf("failed to insert alert: %v", err)
 	}
 
 	engine.cleanResolvedAlerts(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}
@@ -435,14 +435,14 @@ func TestCheckAlertResolvedClearsWhenMetricReportsNoData(t *testing.T) {
 	connID := insertTestConnection(t, pool, "empty-metric")
 
 	var alertID int64
-	if err := pool.QueryRow(ctx, insertUnsupportedMetricAlertSQL, ruleID, connID,
+	if err := pool.QueryRow(ctx, stalenessUnsupportedMetricAlertInsertSQL, ruleID, connID,
 		"pg_replication_slots.inactive_count").Scan(&alertID); err != nil {
 		t.Fatalf("failed to insert alert: %v", err)
 	}
 
 	engine.cleanResolvedAlerts(ctx)
 
-	alerts := readAlertsForRule(t, pool, ruleID)
+	alerts := readStalenessAlertsForRule(t, pool, ruleID)
 	if len(alerts) != 1 {
 		t.Fatalf("alert rows = %d, want 1", len(alerts))
 	}

--- a/alerter/src/internal/engine/staleness_alerts_integration_test.go
+++ b/alerter/src/internal/engine/staleness_alerts_integration_test.go
@@ -1,0 +1,453 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pgedge/ai-workbench/alerter/internal/database"
+	"github.com/pgedge/ai-workbench/pkg/worker"
+)
+
+// Seed statements used by the staleness tests. They are named constants
+// so the Codacy/Semgrep go_sql_rule-concat-sqli rule does not flag inline
+// multi-line SQL passed to Exec or QueryRow; every value is still bound
+// via $N.
+const (
+	insertStalenessRuleSQL = `
+        INSERT INTO alert_rules
+            (name, description, category, metric_name, default_operator,
+             default_threshold, default_severity, default_enabled, is_built_in)
+        VALUES ('metric_staleness',
+                'Metrics collection is stale; dashboards may show outdated data',
+                'availability', 'probe_staleness_ratio', '>', 3, 'warning',
+                TRUE, TRUE)
+        RETURNING id
+    `
+
+	insertProbeConfigSQL = `
+        INSERT INTO probe_configs
+            (name, connection_id, is_enabled, collection_interval_seconds)
+        VALUES ($1, NULL, TRUE, $2)
+    `
+
+	insertProbeAvailabilitySQL = `
+        INSERT INTO probe_availability
+            (connection_id, probe_name, is_available, last_collected)
+        VALUES ($1, $2, TRUE, NOW() - $3::interval)
+    `
+
+	refreshProbeAvailabilitySQL = `
+        UPDATE probe_availability
+           SET last_collected = NOW()
+         WHERE connection_id = $1 AND probe_name = $2
+    `
+
+	deleteProbeAvailabilitySQL = `
+        DELETE FROM probe_availability
+         WHERE connection_id = $1 AND probe_name = $2
+    `
+
+	selectAlertsForRuleSQL = `
+        SELECT id, status, probe_name
+        FROM alerts
+        WHERE rule_id = $1
+        ORDER BY id
+    `
+
+	insertUnsupportedMetricAlertSQL = `
+        INSERT INTO alerts
+            (alert_type, rule_id, connection_id, metric_name, metric_value,
+             threshold_value, operator, severity, title, description, status,
+             triggered_at)
+        VALUES ('threshold', $1, $2, $3, 42, 10, '>', 'warning',
+                'unsupported metric alert', 'desc', 'active', NOW())
+        RETURNING id
+    `
+)
+
+// stalenessNotificationCapture records the notification jobs the engine
+// submits to its worker pool. The pool handler forwards each job onto a
+// buffered channel so tests can await an exact number of jobs without
+// polling.
+type stalenessNotificationCapture struct {
+	jobs chan notificationJob
+}
+
+// installStalenessNotificationCapture replaces the engine's notification
+// worker pool with one whose handler records every submitted job. The pool
+// is stopped via t.Cleanup so no goroutine outlives the test.
+//
+// The engine's own pool is only created when a notification manager is
+// configured; the integration environments in this package build the
+// engine without one, so this helper is the only way to observe
+// queueNotification.
+func installStalenessNotificationCapture(t *testing.T, e *Engine) *stalenessNotificationCapture {
+	t.Helper()
+
+	capture := &stalenessNotificationCapture{jobs: make(chan notificationJob, 256)}
+	pool := worker.NewWorkerPool(1, 256, func(job notificationJob) {
+		capture.jobs <- job
+	})
+	pool.Start()
+
+	previous := e.notificationPool
+	e.notificationPool = pool
+	t.Cleanup(func() {
+		e.notificationPool = previous
+		pool.Stop()
+	})
+	return capture
+}
+
+// drain reads every job that has arrived, waiting a short grace period for
+// stragglers, and summarizes the result by notification type.
+func (c *stalenessNotificationCapture) drain(t *testing.T) map[database.NotificationType]int {
+	t.Helper()
+
+	counts := make(map[database.NotificationType]int)
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case job := <-c.jobs:
+			counts[job.notifTyp]++
+		case <-time.After(300 * time.Millisecond):
+			return counts
+		case <-deadline:
+			return counts
+		}
+	}
+}
+
+// seedStalenessRule inserts the metric_staleness rule and returns its id.
+func seedStalenessRule(t *testing.T, pool *pgxpool.Pool) int64 {
+	t.Helper()
+
+	var ruleID int64
+	if err := pool.QueryRow(context.Background(), insertStalenessRuleSQL).Scan(&ruleID); err != nil {
+		t.Fatalf("failed to insert metric_staleness rule: %v", err)
+	}
+	return ruleID
+}
+
+// seedStaleProbe registers a probe with the given collection interval and
+// records a last collection far enough in the past to breach the default
+// staleness ratio of 3.
+func seedStaleProbe(t *testing.T, pool *pgxpool.Pool, connID int, probeName, staleFor string) {
+	t.Helper()
+
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, insertProbeConfigSQL, probeName, 60); err != nil {
+		t.Fatalf("failed to insert probe config for %s: %v", probeName, err)
+	}
+	if _, err := pool.Exec(ctx, insertProbeAvailabilitySQL, connID, probeName, staleFor); err != nil {
+		t.Fatalf("failed to insert probe availability for %s: %v", probeName, err)
+	}
+}
+
+// stalenessAlertRow is a minimal projection of the alerts table used by the
+// assertions below.
+type stalenessAlertRow struct {
+	id     int64
+	status string
+	probe  *string
+}
+
+// readAlertsForRule returns every alert row belonging to a rule, oldest first.
+func readAlertsForRule(t *testing.T, pool *pgxpool.Pool, ruleID int64) []stalenessAlertRow {
+	t.Helper()
+
+	rows, err := pool.Query(context.Background(), selectAlertsForRuleSQL, ruleID)
+	if err != nil {
+		t.Fatalf("failed to read alerts: %v", err)
+	}
+	defer rows.Close()
+
+	var out []stalenessAlertRow
+	for rows.Next() {
+		var row stalenessAlertRow
+		if err := rows.Scan(&row.id, &row.status, &row.probe); err != nil {
+			t.Fatalf("failed to scan alert: %v", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration error: %v", err)
+	}
+	return out
+}
+
+// TestStalenessAlertDoesNotFireClearLoop is the regression test for issue
+// #405. A continuously stale probe must produce exactly one alert that
+// stays active, rather than one created-and-cleared alert per evaluate and
+// clean cycle.
+func TestStalenessAlertDoesNotFireClearLoop(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	capture := installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-loop")
+	// 30 minutes stale against a 60 second interval is a ratio of 30,
+	// well above the seeded threshold of 3.
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	const cycles = 3
+	for i := 0; i < cycles; i++ {
+		engine.evaluateThresholds(ctx)
+		engine.cleanResolvedAlerts(ctx)
+	}
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1 for a continuously stale probe", len(alerts))
+	}
+	if alerts[0].status != "active" {
+		t.Errorf("alert status = %q, want \"active\" while the probe is stale",
+			alerts[0].status)
+	}
+
+	counts := capture.drain(t)
+	if counts[database.NotificationTypeAlertFire] != 1 {
+		t.Errorf("fire notifications = %d, want 1",
+			counts[database.NotificationTypeAlertFire])
+	}
+	if counts[database.NotificationTypeAlertClear] != 0 {
+		t.Errorf("clear notifications = %d, want 0 while the probe is stale",
+			counts[database.NotificationTypeAlertClear])
+	}
+}
+
+// TestStalenessAlertClearsWhenProbeRecovers verifies that the bespoke
+// resolution path still clears the alert once the probe collects again, so
+// suppressing the spurious clears does not leave the alert latched.
+func TestStalenessAlertClearsWhenProbeRecovers(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	capture := installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-recovery")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	engine.evaluateThresholds(ctx)
+	engine.cleanResolvedAlerts(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 || alerts[0].status != "active" {
+		t.Fatalf("expected one active alert, got %+v", alerts)
+	}
+
+	// The probe collects again, so the staleness ratio drops below the
+	// threshold.
+	if _, err := pool.Exec(ctx, refreshProbeAvailabilitySQL, connID,
+		"pg_stat_activity"); err != nil {
+		t.Fatalf("failed to refresh probe availability: %v", err)
+	}
+
+	engine.cleanResolvedAlerts(ctx)
+
+	alerts = readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+	if alerts[0].status != "cleared" {
+		t.Errorf("alert status = %q, want \"cleared\" after the probe recovered",
+			alerts[0].status)
+	}
+
+	counts := capture.drain(t)
+	if counts[database.NotificationTypeAlertClear] != 1 {
+		t.Errorf("clear notifications = %d, want 1",
+			counts[database.NotificationTypeAlertClear])
+	}
+}
+
+// TestStalenessAlertClearsWhenProbeStopsReporting covers the case where the
+// probe disappears from the staleness view entirely, for example because it
+// was disabled or its connection is no longer monitored.
+func TestStalenessAlertClearsWhenProbeStopsReporting(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-vanished")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	engine.evaluateThresholds(ctx)
+
+	if _, err := pool.Exec(ctx, deleteProbeAvailabilitySQL, connID,
+		"pg_stat_activity"); err != nil {
+		t.Fatalf("failed to delete probe availability: %v", err)
+	}
+
+	engine.cleanResolvedAlerts(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+	if alerts[0].status != "cleared" {
+		t.Errorf("alert status = %q, want \"cleared\" once the probe stopped reporting",
+			alerts[0].status)
+	}
+}
+
+// TestStalenessAlertPerProbe verifies that two stale probes on one
+// connection raise one alert each, rather than collapsing into a single row
+// whose title is overwritten by whichever probe was evaluated last.
+func TestStalenessAlertPerProbe(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-multi-probe")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+	seedStaleProbe(t, pool, connID, "pg_stat_database", "45 minutes")
+
+	engine.evaluateThresholds(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 2 {
+		t.Fatalf("alert rows = %d, want 2 (one per stale probe)", len(alerts))
+	}
+
+	seen := make(map[string]bool)
+	for _, alert := range alerts {
+		if alert.probe == nil {
+			t.Fatalf("alert %d has no probe name", alert.id)
+		}
+		seen[*alert.probe] = true
+	}
+	for _, probe := range []string{"pg_stat_activity", "pg_stat_database"} {
+		if !seen[probe] {
+			t.Errorf("no alert raised for stale probe %s", probe)
+		}
+	}
+
+	// A second pass updates the existing alerts instead of adding more.
+	engine.evaluateThresholds(ctx)
+	if alerts = readAlertsForRule(t, pool, ruleID); len(alerts) != 2 {
+		t.Errorf("alert rows after a second pass = %d, want 2", len(alerts))
+	}
+}
+
+// TestStalenessAlertRespectsCooldown verifies that the staleness path now
+// applies the same recently-cleared guard as triggerThresholdAlert, so an
+// alert cleared by an operator does not immediately re-fire.
+func TestStalenessAlertRespectsCooldown(t *testing.T) {
+	engine, ds, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "staleness-cooldown")
+	seedStaleProbe(t, pool, connID, "pg_stat_activity", "30 minutes")
+
+	engine.evaluateThresholds(ctx)
+
+	alert, err := ds.GetActiveThresholdAlertForProbe(ctx, ruleID, connID,
+		"pg_stat_activity")
+	if err != nil || alert == nil {
+		t.Fatalf("expected a staleness alert after the first pass (alert=%v err=%v)",
+			alert, err)
+	}
+	if err := ds.ClearAlert(ctx, alert.ID); err != nil {
+		t.Fatalf("failed to clear staleness alert: %v", err)
+	}
+
+	// Second pass on unchanged data, well inside AlertCooldownPeriod.
+	engine.evaluateThresholds(ctx)
+
+	refired, err := ds.GetActiveThresholdAlertForProbe(ctx, ruleID, connID,
+		"pg_stat_activity")
+	if err != nil {
+		t.Fatalf("GetActiveThresholdAlertForProbe: %v", err)
+	}
+	if refired != nil {
+		t.Errorf("staleness alert re-fired inside the cooldown window (alert %d)",
+			refired.ID)
+	}
+}
+
+// TestCheckAlertResolvedKeepsUnevaluableMetricAlerts verifies that an alert
+// whose metric cannot be evaluated at all is left alone rather than being
+// cleared. Treating an unusable metric as a resolution is what drove the
+// notification loop in issue #405.
+func TestCheckAlertResolvedKeepsUnevaluableMetricAlerts(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	capture := installStalenessNotificationCapture(t, engine)
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "unevaluable-metric")
+
+	var alertID int64
+	if err := pool.QueryRow(ctx, insertUnsupportedMetricAlertSQL, ruleID, connID,
+		"metric_that_does_not_exist").Scan(&alertID); err != nil {
+		t.Fatalf("failed to insert alert: %v", err)
+	}
+
+	engine.cleanResolvedAlerts(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+	if alerts[0].status != "active" {
+		t.Errorf("alert status = %q, want \"active\"; an unusable metric says "+
+			"nothing about the condition", alerts[0].status)
+	}
+	if counts := capture.drain(t); counts[database.NotificationTypeAlertClear] != 0 {
+		t.Errorf("clear notifications = %d, want 0",
+			counts[database.NotificationTypeAlertClear])
+	}
+}
+
+// TestCheckAlertResolvedClearsWhenMetricReportsNoData pins the behavior
+// that is deliberately unchanged: a registry metric that runs successfully
+// and returns no rows still resolves the alert.
+func TestCheckAlertResolvedClearsWhenMetricReportsNoData(t *testing.T) {
+	engine, _, pool, cleanup := newEngineSpockTestEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	ruleID := seedStalenessRule(t, pool)
+	connID := insertTestConnection(t, pool, "empty-metric")
+
+	var alertID int64
+	if err := pool.QueryRow(ctx, insertUnsupportedMetricAlertSQL, ruleID, connID,
+		"pg_replication_slots.inactive_count").Scan(&alertID); err != nil {
+		t.Fatalf("failed to insert alert: %v", err)
+	}
+
+	engine.cleanResolvedAlerts(ctx)
+
+	alerts := readAlertsForRule(t, pool, ruleID)
+	if len(alerts) != 1 {
+		t.Fatalf("alert rows = %d, want 1", len(alerts))
+	}
+	if alerts[0].status != "cleared" {
+		t.Errorf("alert status = %q, want \"cleared\" when the metric reports nothing",
+			alerts[0].status)
+	}
+}

--- a/alerter/src/internal/engine/thresholds.go
+++ b/alerter/src/internal/engine/thresholds.go
@@ -288,14 +288,38 @@ func (e *Engine) evaluateMetricStaleness(ctx context.Context) {
 				TriggeredAt:    time.Now(),
 			}
 
-			// Check if there's already an active alert for this rule/connection
-			existing, err := e.datastore.GetActiveThresholdAlert(ctx, rule.ID, entry.ConnectionID, nil)
-			if err == nil && existing != nil {
+			// Check if there's already an active alert for this
+			// rule/connection/probe. The lookup is keyed by probe so that
+			// several stale probes on one connection raise one alert each
+			// rather than fighting over a single row.
+			existing, err := e.datastore.GetActiveThresholdAlertForProbe(ctx, rule.ID, entry.ConnectionID, entry.ProbeName)
+			if err != nil {
+				// Creating an alert now could duplicate one that already
+				// exists, so wait for the next pass instead.
+				e.log("ERROR: Failed to look up staleness alert for %s on connection %d: %v",
+					entry.ProbeName, entry.ConnectionID, err)
+				continue
+			}
+			if existing != nil {
 				if err := e.datastore.UpdateAlertValues(ctx, existing.ID, entry.StalenessRatio, threshold, operator, severity); err != nil {
 					e.log("ERROR: Failed to update staleness alert values: %v", err)
 				} else {
 					e.debugLog("Updated staleness alert for %s on connection %d", entry.ProbeName, entry.ConnectionID)
 				}
+				continue
+			}
+
+			// Check cooldown - don't re-fire if recently cleared. The
+			// registry-backed path applies the same guard in
+			// triggerThresholdAlert.
+			recentlyCleared, err := e.datastore.GetRecentlyClearedAlertForProbe(
+				ctx, rule.ID, entry.ConnectionID, entry.ProbeName, AlertCooldownPeriod)
+			if err != nil {
+				e.debugLog("Error checking staleness cooldown for %s on connection %d: %v",
+					entry.ProbeName, entry.ConnectionID, err)
+			} else if recentlyCleared {
+				e.debugLog("Skipping staleness alert for %s on connection %d: cooldown active (cleared within %v)",
+					entry.ProbeName, entry.ConnectionID, AlertCooldownPeriod)
 				continue
 			}
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,20 @@ project adheres to
 
 ### Fixed
 
+- Fix the `metric_staleness` alert rule firing and clearing in a
+  loop, which sent a notification pair every cycle for as long as a
+  probe remained stale. The alert cleaner resolved the rule's metric
+  through the metric registry, where the bespoke staleness metric
+  has no entry, and treated the resulting lookup error as proof that
+  the condition had gone away. The cleaner now distinguishes a
+  metric it cannot evaluate, or a query that failed, from a metric
+  that ran and reported nothing; only the latter clears an alert.
+  Staleness alerts resolve through their own check against probe
+  availability, the staleness evaluator applies the same cooldown
+  guard as every other rule, and each stale probe on a connection
+  now raises its own alert rather than overwriting a shared one.
+  (#405)
+
 - Fix every chat request that included a tool list failing with
   `anthropic (400): tools.0.custom.input_schema: Input does not
   match the expected shape`, which broke Ask Ellie and the Server,


### PR DESCRIPTION
## Summary

While any probe was stale, the alerter raised and cleared the same
`metric_staleness` alert on every cycle, sending a fire and a clear
notification each time. The cleaner resolved the alert's metric,
`probe_staleness_ratio`, through `metricRegistry`, where the bespoke
staleness metric deliberately has no entry, and read the resulting
lookup error as proof that the condition had gone away; the evaluator
then re-raised the alert on its next pass, because unlike
`triggerThresholdAlert` it applied no cooldown guard.

The change is in three parts:

- `GetLatestMetricValues` now returns distinguishable errors
  (`ErrMetricNotSupported` and `ErrNoMetricData`), so callers can tell a
  metric that cannot be evaluated at all, or a query that failed, apart
  from one that ran and reported nothing. `checkAlertResolved` clears an
  alert only in the last of those cases.

- Probe-scoped alerts skip the registry path entirely and resolve
  through `checkStalenessAlertResolved`, which re-reads probe
  availability, so they still clear promptly once the probe collects
  again or stops being reported; suppressing the spurious clears does
  not leave the alert latched.

- `evaluateMetricStaleness` applies the same recently-cleared cooldown
  guard as every other rule, and keys both its active-alert lookup and
  its cooldown check by probe, so several stale probes on one connection
  raise one alert each rather than fighting over a single row whose
  title and description were overwritten arbitrarily.

Issue #407 shares the root cause in `checkAlertResolved`, and the error
handling half of it is fixed here: a query error no longer clears an
alert. The rest of #407 is deliberately out of scope, because it needs
semantic rewrites of several `metric_registry.go` queries
(`cache_hit_ratio` latest-sample reduction, an interval mean for
`slow_query_count`, wider delta windows, and freshness cutoffs on the
replication slot metrics) that are independent of this fix.

## Test plan

- `alerter/src/internal/engine/staleness_alerts_integration_test.go`
  covers the loop itself, resolution when the probe recovers, resolution
  when the probe stops being reported, one alert per stale probe, the
  cooldown guard, and both sides of the new error handling in
  `checkAlertResolved`. Every one of those tests fails against the code
  as it stood before this change, verified by reverting `cleanup.go` and
  `thresholds.go` alone.

- `alerter/src/internal/engine/staleness_alerts_errors_integration_test.go`
  drives the evaluator's and cleaner's database error branches by
  breaking exactly one operation at a time.

- `alerter/src/internal/database/probe_alert_queries_integration_test.go`
  covers the two new probe-scoped queries and every branch of
  `GetLatestMetricValues`.

- `cd alerter && make coverage` passes with no failures. The new and
  modified units are at 100% (`checkAlertResolved`,
  `checkStalenessAlertResolved`, `GetLatestMetricValues`,
  `GetActiveThresholdAlertForProbe`, `GetRecentlyClearedAlertForProbe`)
  and 96.4% (`evaluateMetricStaleness`), against the project's 90%
  floor. `make lint` and `make fmt-check` are clean.

Closes #405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staleness alerts are now tracked separately for each probe.
  * Added cooldown protection to prevent repeated alerts.
  * Alerts resolve when probes recover or stop reporting.
  * Metric evaluation now distinguishes unsupported metrics, missing data, and query failures.

* **Bug Fixes**
  * Prevented metric staleness alert loops and duplicate alert creation.
  * Improved cleanup behavior when metrics cannot be evaluated.

* **Documentation**
  * Added changelog and troubleshooting guidance for staleness alerts and metric errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Interaction with PR #410

PR #410 (branch `claude/dashboard-chart-stats-review-0iq76e`) adds
`TestAudit*` regression tests that deliberately pin the *current,
defective* behaviour for issues #405 to #409. It is test-only and is not
yet merged, so nothing in it needed changing here, but two of its tests
document behaviour that this PR removes and will legitimately start
failing once both land. I verified that by copying #410's two test files
into this branch and running them; the results were:

- `TestAuditC1StalenessAlertFireClearLoop` fails. It asserts three alert
  rows, all cleared, and three fire plus three clear notifications after
  three cycles; it now sees one row, active, and one fire notification.
  It should be inverted to assert exactly that, which is what its `Demo`
  counterpart already asserts.

- `TestAuditC1StalenessAlertFireClearLoopDemo` now passes. Its
  `ALERTER_DEFECT_DEMO` skip guard should be removed. Once the test above
  is inverted the two are equivalent, so one of them can go; the
  `Demo` variant's assertions are the clearer of the pair.

- `TestAuditC1StalenessPathSkipsCooldownGuard` fails on its final
  assertion, "expected the staleness path to re-fire inside the
  cooldown". The staleness path now honours `AlertCooldownPeriod` exactly
  as the registry-backed control rule in the same test does, so the
  assertion should be flipped to require that neither path re-fires.

Everything else in #410 is unaffected: the whole `internal/database`
audit suite still passes, as do `TestAuditC2`, `C6`, `C7`, `C8` and `C10`
in `internal/engine`. In particular the `C8` and `C9` defects are
untouched here, because this PR changes only the error handling in
`checkAlertResolved`, not the row-matching path those tests exercise.

I also renamed this PR's test fixtures with a `staleness` prefix, because
#410 defines constants of the same names (`insertStalenessRuleSQL`,
`insertProbeConfigSQL`, and friends) in the same package; with the rename
both files compile together, which I confirmed with `go vet` over the
combined tree.
