### PR TITLE
Explain why utility statements have no query plan

### DIFF
--- a/client/src/components/Dashboard/ObjectDashboard/QueryPlanPanel.tsx
+++ b/client/src/components/Dashboard/ObjectDashboard/QueryPlanPanel.tsx
@@ -22,6 +22,7 @@ import { Refresh as RefreshIcon } from '@mui/icons-material';
 import CollapsibleSection from '../CollapsibleSection';
 import PlanTree from './PlanTree';
 import { useQueryPlan } from '../../../hooks/useQueryPlan';
+import { buildNotExplainableMessage } from '../../../utils/sqlHelpers';
 import { spinKeyframes } from '../styles';
 
 interface QueryPlanPanelProps {
@@ -93,6 +94,7 @@ const QueryPlanPanel: React.FC<QueryPlanPanelProps> = ({
         jsonPlan,
         loading,
         error,
+        notExplainable,
         fetch: fetchPlan,
     } = useQueryPlan(queryText, connectionId, databaseName);
 
@@ -149,7 +151,13 @@ const QueryPlanPanel: React.FC<QueryPlanPanelProps> = ({
                 </Box>
             )}
 
-            {error && !textPlan && !jsonPlan && (
+            {notExplainable !== null && (
+                <Alert severity="info" sx={{ mt: 1 }}>
+                    {buildNotExplainableMessage(notExplainable)}
+                </Alert>
+            )}
+
+            {notExplainable === null && error && !textPlan && !jsonPlan && (
                 <Alert severity="info" sx={{ mt: 1 }}>
                     {isParameterError(error)
                         ? PARAM_ERROR_MSG

--- a/client/src/components/Dashboard/ObjectDashboard/__tests__/QueryPlanPanel.test.tsx
+++ b/client/src/components/Dashboard/ObjectDashboard/__tests__/QueryPlanPanel.test.tsx
@@ -52,6 +52,7 @@ describe('QueryPlanPanel', () => {
             jsonPlan: null,
             loading: false,
             error: null,
+            notExplainable: null,
             fetch: mockFetch,
         });
     });
@@ -86,6 +87,7 @@ describe('QueryPlanPanel', () => {
             jsonPlan: null,
             loading: true,
             error: null,
+            notExplainable: null,
             fetch: mockFetch,
         });
 
@@ -108,6 +110,7 @@ describe('QueryPlanPanel', () => {
             jsonPlan: null,
             loading: false,
             error: 'Something went wrong',
+            notExplainable: null,
             fetch: mockFetch,
         });
 
@@ -130,6 +133,7 @@ describe('QueryPlanPanel', () => {
             jsonPlan: null,
             loading: false,
             error: 'could not determine data type of parameter $1',
+            notExplainable: null,
             fetch: mockFetch,
         });
 
@@ -146,6 +150,62 @@ describe('QueryPlanPanel', () => {
         ).toBeInTheDocument();
     });
 
+    it('shows a friendly message for non-explainable statements', () => {
+        mockUseQueryPlan.mockReturnValue({
+            textPlan: null,
+            jsonPlan: null,
+            loading: false,
+            error: null,
+            notExplainable: 'VACUUM',
+            fetch: mockFetch,
+        });
+
+        render(
+            <QueryPlanPanel
+                connectionId={1}
+                databaseName="testdb"
+                queryText="VACUUM"
+            />,
+        );
+
+        expect(
+            screen.getByText(
+                /cannot produce a query plan for VACUUM statements/,
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('tab', { name: 'Visual' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('prefers the non-explainable notice over a stale error', () => {
+        mockUseQueryPlan.mockReturnValue({
+            textPlan: null,
+            jsonPlan: null,
+            loading: false,
+            error: 'syntax error at or near "VACUUM"',
+            notExplainable: '',
+            fetch: mockFetch,
+        });
+
+        render(
+            <QueryPlanPanel
+                connectionId={1}
+                databaseName="testdb"
+                queryText="/* comment only */"
+            />,
+        );
+
+        expect(
+            screen.getByText(
+                /cannot produce a query plan for this statement/,
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText(/syntax error at or near/),
+        ).not.toBeInTheDocument();
+    });
+
     it('shows text plan in monospace when text tab is selected', () => {
         const planText = 'Seq Scan on users (cost=0.00..35.50)';
         mockUseQueryPlan.mockReturnValue({
@@ -153,6 +213,7 @@ describe('QueryPlanPanel', () => {
             jsonPlan: null,
             loading: false,
             error: null,
+            notExplainable: null,
             fetch: mockFetch,
         });
 
@@ -184,6 +245,7 @@ describe('QueryPlanPanel', () => {
             }],
             loading: false,
             error: null,
+            notExplainable: null,
             fetch: mockFetch,
         });
 
@@ -205,6 +267,7 @@ describe('QueryPlanPanel', () => {
             jsonPlan: null,
             loading: false,
             error: null,
+            notExplainable: null,
             fetch: mockFetch,
         });
 
@@ -228,6 +291,7 @@ describe('QueryPlanPanel', () => {
             jsonPlan: null,
             loading: false,
             error: null,
+            notExplainable: null,
             fetch: mockFetch,
         });
 
@@ -249,6 +313,7 @@ describe('QueryPlanPanel', () => {
             jsonPlan: null,
             loading: false,
             error: null,
+            notExplainable: null,
             fetch: mockFetch,
         });
 

--- a/client/src/hooks/__tests__/useQueryPlan.test.ts
+++ b/client/src/hooks/__tests__/useQueryPlan.test.ts
@@ -104,7 +104,81 @@ describe('useQueryPlan', () => {
         expect(result.current.jsonPlan).toBeNull();
         expect(result.current.loading).toBe(false);
         expect(result.current.error).toBeNull();
+        expect(result.current.notExplainable).toBeNull();
         expect(typeof result.current.fetch).toBe('function');
+    });
+
+    it.each([
+        ['VACUUM', 'VACUUM'],
+        ['VACUUM (ANALYZE, VERBOSE) public.users', 'VACUUM'],
+        ['ANALYZE', 'ANALYZE'],
+        ['REINDEX INDEX users_pkey', 'REINDEX'],
+        ['CLUSTER users USING users_pkey', 'CLUSTER'],
+        ['CREATE INDEX idx ON users (id)', 'CREATE'],
+        ['TRUNCATE users', 'TRUNCATE'],
+    ])(
+        'skips EXPLAIN for %s and reports the statement type',
+        async (query, keyword) => {
+            const { result } = renderHook(() =>
+                useQueryPlan(query, 1, 'testdb'),
+            );
+
+            await act(async () => {
+                result.current.fetch();
+            });
+
+            expect(mockApiFetch).not.toHaveBeenCalled();
+            expect(result.current.notExplainable).toBe(keyword);
+            expect(result.current.textPlan).toBeNull();
+            expect(result.current.jsonPlan).toBeNull();
+            expect(result.current.error).toBeNull();
+            expect(result.current.loading).toBe(false);
+        },
+    );
+
+    it('reports an empty keyword for unidentifiable text', async () => {
+        const { result } = renderHook(() =>
+            useQueryPlan('-- only a comment', 1, 'testdb'),
+        );
+
+        await act(async () => {
+            result.current.fetch();
+        });
+
+        expect(mockApiFetch).not.toHaveBeenCalled();
+        expect(result.current.notExplainable).toBe('');
+    });
+
+    it('clears notExplainable when a plannable query follows', async () => {
+        const textResponse = makeQueryResponse([['Seq Scan']]);
+        const jsonResponse = makeQueryResponse([[
+            JSON.stringify([{ Plan: { 'Node Type': 'Seq Scan' } }]),
+        ]]);
+        mockApiFetch
+            .mockResolvedValueOnce(textResponse)
+            .mockResolvedValueOnce(jsonResponse);
+
+        const { result, rerender } = renderHook(
+            ({ q }: { q: string }) =>
+                useQueryPlan(q, 1, 'testdb'),
+            { initialProps: { q: 'VACUUM' } },
+        );
+
+        await act(async () => {
+            result.current.fetch();
+        });
+        expect(result.current.notExplainable).toBe('VACUUM');
+
+        rerender({ q: `SELECT switch_${testCounter}` });
+
+        await act(async () => {
+            result.current.fetch();
+        });
+
+        await waitFor(() => {
+            expect(result.current.textPlan).toBe('Seq Scan');
+        });
+        expect(result.current.notExplainable).toBeNull();
     });
 
     it('fetch triggers two parallel API calls', async () => {
@@ -230,6 +304,31 @@ describe('useQueryPlan', () => {
         expect(
             result.current.jsonPlan?.[0]['Total Cost'],
         ).toBe(35.5);
+    });
+
+    it('keeps JSON plans that are not wrapped in Plan nodes', async () => {
+        const bareNodes = [{ 'Node Type': 'Seq Scan' }];
+        mockApiFetch
+            .mockResolvedValueOnce(
+                makeQueryResponse([['Seq Scan on users']]),
+            )
+            .mockResolvedValueOnce(
+                makeQueryResponse([[JSON.stringify(bareNodes)]]),
+            );
+
+        const { result } = renderHook(() =>
+            useQueryPlan(`SELECT bare_${testCounter}`, 1, 'testdb'),
+        );
+
+        await act(async () => {
+            result.current.fetch();
+        });
+
+        await waitFor(() => {
+            expect(result.current.jsonPlan).not.toBeNull();
+        });
+
+        expect(result.current.jsonPlan).toEqual(bareNodes);
     });
 
     it('sets error when both requests fail', async () => {

--- a/client/src/hooks/useQueryPlan.ts
+++ b/client/src/hooks/useQueryPlan.ts
@@ -11,6 +11,10 @@
 import { useState, useCallback, useRef } from 'react';
 import { apiFetch } from '../utils/apiClient';
 import { djb2Hash } from '../utils/textHelpers';
+import {
+    getStatementKeyword,
+    isExplainable,
+} from '../utils/sqlHelpers';
 
 export interface PlanNode {
     'Node Type': string;
@@ -58,6 +62,13 @@ export interface UseQueryPlanReturn {
     jsonPlan: PlanNode[] | null;
     loading: boolean;
     error: string | null;
+    /**
+     * Leading keyword of a statement that EXPLAIN cannot plan
+     * (for example VACUUM), or null when the statement is
+     * explainable. An empty string means the statement type
+     * could not be identified.
+     */
+    notExplainable: string | null;
     fetch: () => void;
 }
 
@@ -174,6 +185,8 @@ export function useQueryPlan(
         useState<PlanNode[] | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [notExplainable, setNotExplainable] =
+        useState<string | null>(null);
 
     const queryRef = useRef(query);
     const connRef = useRef(connectionId);
@@ -186,6 +199,20 @@ export function useQueryPlan(
         const q = queryRef.current;
         const conn = connRef.current;
         const db = dbRef.current;
+
+        // pg_stat_statements captures utility commands such as
+        // VACUUM or REINDEX, which EXPLAIN rejects outright.
+        // Detect those up front rather than issuing a request
+        // that can only fail with a raw syntax error.
+        if (!isExplainable(q)) {
+            setTextPlan(null);
+            setJsonPlan(null);
+            setError(null);
+            setLoading(false);
+            setNotExplainable(getStatementKeyword(q));
+            return;
+        }
+        setNotExplainable(null);
 
         const cacheKey = computeCacheKey(q, conn, db);
 
@@ -288,6 +315,7 @@ export function useQueryPlan(
         jsonPlan,
         loading,
         error,
+        notExplainable,
         fetch: fetchPlan,
     };
 }

--- a/client/src/utils/__tests__/sqlHelpers.test.ts
+++ b/client/src/utils/__tests__/sqlHelpers.test.ts
@@ -1,0 +1,152 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    buildNotExplainableMessage,
+    getStatementKeyword,
+    isExplainable,
+} from '../sqlHelpers';
+
+// ---------------------------------------------------------------------------
+// Statements PostgreSQL's EXPLAIN accepts (verified on PostgreSQL 18)
+// ---------------------------------------------------------------------------
+
+const EXPLAINABLE = [
+    'SELECT 1',
+    'select * from users where id = $1',
+    "INSERT INTO t (a) VALUES ('x')",
+    'UPDATE t SET a = 1 WHERE b = 2',
+    'DELETE FROM t WHERE a = 1',
+    'MERGE INTO t USING s ON true WHEN MATCHED THEN DO NOTHING',
+    'VALUES (1), (2)',
+    'EXECUTE my_plan(1)',
+    'DECLARE c CURSOR FOR SELECT 1',
+    'WITH cte AS (SELECT 1) SELECT * FROM cte',
+    'TABLE users',
+    '(SELECT 1) UNION (SELECT 2)',
+    'CREATE TABLE snapshot AS SELECT * FROM t',
+    'CREATE TEMP TABLE snapshot AS SELECT * FROM t',
+    'CREATE GLOBAL TEMPORARY TABLE s AS SELECT 1',
+    'CREATE UNLOGGED TABLE s AS SELECT 1',
+    'CREATE MATERIALIZED VIEW mv AS SELECT 1',
+    'REFRESH MATERIALIZED VIEW mv',
+];
+
+// ---------------------------------------------------------------------------
+// Statements EXPLAIN rejects (verified on PostgreSQL 18)
+// ---------------------------------------------------------------------------
+
+const NOT_EXPLAINABLE = [
+    'VACUUM',
+    'VACUUM (ANALYZE, VERBOSE)',
+    'ANALYZE',
+    'ANALYZE public.users',
+    'REINDEX INDEX users_pkey',
+    'CLUSTER users USING users_pkey',
+    'CREATE INDEX idx ON t (a)',
+    'CREATE TABLE t (a int)',
+    'CREATE VIEW v AS SELECT 1',
+    'ALTER TABLE t ADD COLUMN b int',
+    'DROP TABLE t',
+    'TRUNCATE t',
+    'COPY t TO STDOUT',
+    "SET work_mem = '4MB'",
+    'SHOW all',
+    'CALL my_proc()',
+    'DO $$ BEGIN END $$',
+    'CHECKPOINT',
+    'BEGIN',
+    'COMMIT',
+    'GRANT SELECT ON t TO app',
+    'REFRESH PUBLICATION pub',
+    'LISTEN chan',
+];
+
+describe('getStatementKeyword', () => {
+    it('returns the leading keyword in upper case', () => {
+        expect(getStatementKeyword('vacuum verbose')).toBe('VACUUM');
+        expect(getStatementKeyword('SELECT 1')).toBe('SELECT');
+    });
+
+    it('skips leading whitespace and line comments', () => {
+        expect(
+            getStatementKeyword('  -- daily job\n  VACUUM'),
+        ).toBe('VACUUM');
+    });
+
+    it('skips leading block comments', () => {
+        expect(
+            getStatementKeyword('/* app: cron */ ANALYZE users'),
+        ).toBe('ANALYZE');
+    });
+
+    it('skips leading parentheses', () => {
+        expect(getStatementKeyword('((SELECT 1))')).toBe('SELECT');
+    });
+
+    it('returns an empty string when no keyword is present', () => {
+        expect(getStatementKeyword('')).toBe('');
+        expect(getStatementKeyword('   ')).toBe('');
+        expect(getStatementKeyword('-- only a comment')).toBe('');
+        expect(getStatementKeyword('123')).toBe('');
+    });
+
+    it('tolerates a nullish query', () => {
+        expect(
+            getStatementKeyword(
+                undefined as unknown as string,
+            ),
+        ).toBe('');
+    });
+});
+
+describe('isExplainable', () => {
+    it.each(EXPLAINABLE)('accepts %s', (query) => {
+        expect(isExplainable(query)).toBe(true);
+    });
+
+    it.each(NOT_EXPLAINABLE)('rejects %s', (query) => {
+        expect(isExplainable(query)).toBe(false);
+    });
+
+    it('is case insensitive', () => {
+        expect(isExplainable('create materialized view mv as select 1'))
+            .toBe(true);
+        expect(isExplainable('vacuum full')).toBe(false);
+    });
+
+    it('ignores leading comments when classifying', () => {
+        expect(isExplainable('-- nightly\nVACUUM ANALYZE')).toBe(false);
+        expect(isExplainable('/* app */ SELECT 1')).toBe(true);
+    });
+
+    it('rejects empty or unrecognisable text', () => {
+        expect(isExplainable('')).toBe(false);
+        expect(isExplainable('   ')).toBe(false);
+        expect(
+            isExplainable(undefined as unknown as string),
+        ).toBe(false);
+    });
+});
+
+describe('buildNotExplainableMessage', () => {
+    it('names the statement type when known', () => {
+        const msg = buildNotExplainableMessage('VACUUM');
+        expect(msg).toContain('VACUUM statements');
+        expect(msg).toContain('EXPLAIN supports only');
+    });
+
+    it('falls back to a generic subject when unknown', () => {
+        expect(buildNotExplainableMessage('')).toContain(
+            'this statement',
+        );
+    });
+});

--- a/client/src/utils/sqlHelpers.ts
+++ b/client/src/utils/sqlHelpers.ts
@@ -1,0 +1,120 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Helpers for reasoning about captured SQL statement text.
+ *
+ * `pg_stat_statements` tracks utility and DDL commands alongside
+ * ordinary DML, so statement text taken from it cannot simply be
+ * wrapped in EXPLAIN. PostgreSQL's EXPLAIN accepts only SELECT,
+ * INSERT, UPDATE, DELETE, MERGE, VALUES, EXECUTE, DECLARE,
+ * CREATE TABLE AS and CREATE MATERIALIZED VIEW statements; the
+ * grammar additionally accepts REFRESH MATERIALIZED VIEW.
+ */
+
+/**
+ * Leading keywords that introduce a statement EXPLAIN accepts.
+ * SELECT covers WITH-prefixed, TABLE and parenthesised forms,
+ * which the grammar folds into a select statement.
+ */
+const EXPLAINABLE_KEYWORDS = new Set([
+    'SELECT',
+    'INSERT',
+    'UPDATE',
+    'DELETE',
+    'MERGE',
+    'VALUES',
+    'EXECUTE',
+    'DECLARE',
+    'WITH',
+    'TABLE',
+]);
+
+/** CREATE [GLOBAL|LOCAL] [TEMP|TEMPORARY|UNLOGGED] TABLE ... AS. */
+const CREATE_TABLE_AS_RE =
+    /^CREATE\s+(?:(?:GLOBAL|LOCAL)\s+)?(?:(?:TEMP|TEMPORARY|UNLOGGED)\s+)?TABLE\b[\s\S]*\bAS\b/i;
+
+/** CREATE [MATERIALIZED] VIEW, optionally recursive-free. */
+const CREATE_MATVIEW_RE = /^CREATE\s+MATERIALIZED\s+VIEW\b/i;
+
+/** REFRESH MATERIALIZED VIEW, accepted by the EXPLAIN grammar. */
+const REFRESH_MATVIEW_RE = /^REFRESH\s+MATERIALIZED\s+VIEW\b/i;
+
+/**
+ * Remove leading whitespace, SQL comments and opening parentheses
+ * so that the first significant keyword can be inspected.
+ */
+function stripLeadingNoise(query: string): string {
+    let text = query;
+    for (;;) {
+        const before = text;
+        text = text
+            .replace(/^\s+/, '')
+            .replace(/^--[^\n]*(?:\n|$)/, '')
+            .replace(/^\/\*[\s\S]*?\*\//, '')
+            .replace(/^\(+/, '');
+        if (text === before) {
+            return text;
+        }
+    }
+}
+
+/**
+ * Return the leading command keyword of a statement in upper
+ * case, or an empty string when no keyword can be identified.
+ */
+export function getStatementKeyword(query: string): string {
+    const match = /^[A-Za-z][A-Za-z_]*/.exec(
+        stripLeadingNoise(query ?? ''),
+    );
+    return match ? match[0].toUpperCase() : '';
+}
+
+/**
+ * Report whether PostgreSQL's EXPLAIN accepts the given
+ * statement. Empty or unrecognised text is treated as not
+ * explainable, so the caller avoids issuing a doomed request.
+ */
+export function isExplainable(query: string): boolean {
+    const text = stripLeadingNoise(query ?? '');
+    const keyword = getStatementKeyword(text);
+
+    if (keyword === '') {
+        return false;
+    }
+    if (EXPLAINABLE_KEYWORDS.has(keyword)) {
+        return true;
+    }
+    if (keyword === 'CREATE') {
+        return CREATE_TABLE_AS_RE.test(text)
+            || CREATE_MATVIEW_RE.test(text);
+    }
+    if (keyword === 'REFRESH') {
+        return REFRESH_MATVIEW_RE.test(text);
+    }
+    return false;
+}
+
+/**
+ * Build a friendly explanation of why a statement has no query
+ * plan. The keyword is included when one could be identified.
+ */
+export function buildNotExplainableMessage(keyword: string): string {
+    const subject = keyword
+        ? `${keyword} statements`
+        : 'this statement';
+    return (
+        `PostgreSQL cannot produce a query plan for ${subject}. `
+        + 'EXPLAIN supports only SELECT, INSERT, UPDATE, DELETE, '
+        + 'MERGE, VALUES, EXECUTE, DECLARE, CREATE TABLE AS and '
+        + 'CREATE MATERIALIZED VIEW statements; maintenance and '
+        + 'other utility commands are recorded without a plan.'
+    );
+}


### PR DESCRIPTION
## Summary

The Query Plan panel built its request by concatenating `EXPLAIN` with
the captured statement text, and because `pg_stat_statements` records
utility and DDL commands alongside DML, a Top Queries row can hold bare
`VACUUM`, `ANALYZE`, `REINDEX ...` or `CLUSTER ...` text; wrapping any
of those in `EXPLAIN` is invalid SQL, so the panel surfaced a raw
`syntax error at or near "VACUUM"` back at the user.

This change adds `client/src/utils/sqlHelpers.ts`, which classifies a
statement from its leading keyword after skipping leading whitespace,
line and block comments, and opening parentheses. `useQueryPlan` now
checks that classification before building the request and reports the
statement type through a new `notExplainable` field instead of firing a
request that can only fail, whilst `QueryPlanPanel` renders a friendly
informational alert naming the statement type in place of the Postgres
error.

The explainable set is SELECT, INSERT, UPDATE, DELETE, MERGE, VALUES,
EXECUTE, DECLARE, WITH, TABLE, CREATE TABLE AS and CREATE MATERIALIZED
VIEW, plus REFRESH MATERIALIZED VIEW, which the EXPLAIN grammar accepts
even though the documentation omits it. Every case in the test tables
was verified empirically against PostgreSQL 18.4 rather than assumed.

## Test plan

- New `sqlHelpers` unit tests cover keyword extraction, comment and
  parenthesis stripping, and eighteen explainable and twenty-three
  non-explainable statements; the file reports 100% line, branch and
  function coverage.
- New `useQueryPlan` tests assert that VACUUM, ANALYZE, REINDEX,
  CLUSTER, CREATE INDEX and TRUNCATE issue no API call at all, that the
  detected keyword is reported, and that the flag clears when a
  plannable query follows; the hook reports 98.68% line coverage.
- New `QueryPlanPanel` tests assert the friendly message renders, that
  the plan tabs stay hidden, and that the notice takes precedence over
  a stale error; the component reports 100% line coverage.
- `npm run lint` reports 0 errors, and `npm run build` succeeds.

Closes #368