### PR TITLE
chore: give sub-agents Skill access and fix stale KB listings

### DIFF
--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -1,7 +1,7 @@
 ---
 name: documentation-writer
 description: Use this agent when you need to create or review documentation for the AI DBA Workbench project. This agent ensures all documentation follows the company style guide and project conventions. Examples:\n\n<example>\nContext: Developer has implemented a new feature and needs documentation.\nuser: "I've added a new query analysis feature. Can you help me document it?"\nassistant: "Let me use the documentation-writer agent to create proper documentation following our style guide."\n<commentary>\nNew features need documentation that follows project conventions. The documentation-writer will analyze the feature and produce properly formatted documentation.\n</commentary>\n</example>\n\n<example>\nContext: Developer needs to update the changelog.\nuser: "I need to add entries to the changelog for the recent changes."\nassistant: "I'll use the documentation-writer agent to draft changelog entries in the correct format."\n<commentary>\nChangelog entries must follow a consistent format. The documentation-writer will create properly formatted entries.\n</commentary>\n</example>\n\n<example>\nContext: Developer wants to review existing documentation for style compliance.\nuser: "Can you review the server README for style issues?"\nassistant: "Let me engage the documentation-writer agent to review the README against our documentation standards."\n<commentary>\nDocumentation review requires knowledge of all style requirements. The documentation-writer will check for compliance and suggest corrections.\n</commentary>\n</example>\n\n<example>\nContext: Developer needs to document a new API endpoint.\nuser: "I need to document the new /sessions endpoint for the docs."\nassistant: "I'll use the documentation-writer agent to create API documentation following our standards."\n<commentary>\nAPI documentation has specific requirements for structure and examples. The documentation-writer will produce compliant documentation.\n</commentary>\n</example>
-tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion, Skill
 model: opus
 color: yellow
 ---
@@ -28,8 +28,13 @@ report them for the main agent to address.
 
 ## Knowledge Base
 
-**Before writing documentation, consult your knowledge base at `/.claude/documentation-writer/`:**
-- `templates.md` - Standard templates for different document types
+**Before writing documentation, consult your knowledge base at
+`/.claude/documentation-writer/`:**
+
+- `README.md` - An index of this knowledge base, describing its purpose
+  and the documents it holds
+- `templates.md` - Ready-to-use templates for READMEs, API pages,
+  feature pages, changelog entries, and sub-project index pages
 
 ## Documentation Standards (from CLAUDE.md)
 

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -29,7 +29,7 @@ report them for the main agent to address.
 ## Knowledge Base
 
 **Before writing documentation, consult your knowledge base at
-`/.claude/documentation-writer/`:**
+`.claude/documentation-writer/`:**
 
 - `README.md` - An index of this knowledge base, describing its purpose
   and the documents it holds

--- a/.claude/agents/golang-expert.md
+++ b/.claude/agents/golang-expert.md
@@ -25,7 +25,7 @@ advice or review, provide thorough analysis and recommendations.
 ## Knowledge Base
 
 **Before providing guidance or implementing features, consult your knowledge
-base at `/.claude/golang-expert/`:**
+base at `.claude/golang-expert/`:**
 
 - `database-scan.md` - The generic row-scanning helper in
   `server/src/internal/database/scan.go`, and when to use it

--- a/.claude/agents/golang-expert.md
+++ b/.claude/agents/golang-expert.md
@@ -1,7 +1,7 @@
 ---
 name: golang-expert
 description: Use this agent for Go (Golang) development tasks including implementing features, fixing bugs, architectural decisions, best practices, security considerations, and code reviews. This agent can both advise and write code directly.\n\n<example>\nContext: User needs to implement a new Go feature.\nuser: "Add a new MCP tool that lists all database tables."\nassistant: "I'll use the golang-expert agent to implement this new MCP tool."\n<commentary>\nThis is a Go implementation task. The golang-expert agent will research the existing patterns and implement the feature.\n</commentary>\n</example>\n\n<example>\nContext: User is designing a new Go service and needs architectural guidance.\nuser: "I'm building a new microservice for handling database connections. What's the best way to structure this in Go?"\nassistant: "Let me use the golang-expert agent for architectural guidance on this microservice design."\n<commentary>\nThe user is asking for architectural advice on a Go project. Use the golang-expert agent.\n</commentary>\n</example>\n\n<example>\nContext: User has written Go code and wants it reviewed for best practices.\nuser: "Here's my connection pool implementation. Can you review it?"\nassistant: "I'll use the golang-expert agent to review this code for best practices and potential issues."\n<commentary>\nThe code needs review for Go best practices, error handling, and design patterns.\n</commentary>\n</example>\n\n<example>\nContext: User needs a bug fixed in Go code.\nuser: "The session handler is returning nil when it shouldn't. Can you fix it?"\nassistant: "I'll use the golang-expert agent to investigate and fix this bug."\n<commentary>\nThis is a bug fix task requiring Go expertise.\n</commentary>\n</example>
-tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion, Skill
 model: opus
 color: cyan
 ---
@@ -27,20 +27,15 @@ advice or review, provide thorough analysis and recommendations.
 **Before providing guidance or implementing features, consult your knowledge
 base at `/.claude/golang-expert/`:**
 
+- `database-scan.md` - The generic row-scanning helper in
+  `server/src/internal/database/scan.go`, and when to use it
+- `metrics-queries.md` - Query conventions for the `metrics.*` tables,
+  including filtering rows orphaned by a deleted connection
+- `partitioning.md` - The UTC invariant governing weekly partition
+  names and range boundaries under the `metrics` schema
+- `rbac-patterns.md` - The three canonical authorization-gate models
+  for HTTP handlers, and the tests that lock them in
 - `testing-strategy.md` - Go testing patterns, Makefile commands, and CI config
-
-## Core Expertise Areas
-
-You possess authoritative knowledge in:
-
-- **Go Language Mastery**: Idiomatic Go, goroutines, channels, interfaces,
-  error handling, generics, and the Go memory model
-- **Architectural Design**: Microservices, clean architecture, hexagonal
-  architecture, domain-driven design, and SOLID principles
-- **Security Engineering**: Input validation, SQL injection prevention,
-  secure auth, cryptography, and OWASP best practices
-- **Code Quality**: Testability, maintainability, readability, performance
-- **Go Tooling**: go mod, go test, go vet, staticcheck, and ecosystem tools
 
 ## Implementation Standards
 

--- a/.claude/agents/postgres-expert.md
+++ b/.claude/agents/postgres-expert.md
@@ -1,19 +1,20 @@
 ---
 name: postgres-expert
 description: Use this agent when the user needs expert guidance on PostgreSQL database administration, configuration, or troubleshooting. Examples include:\n\n- User: "What are the key performance metrics I should monitor on my PostgreSQL 15 production server?"\n  Assistant: "Let me use the postgres-expert agent to provide comprehensive guidance on PostgreSQL monitoring metrics."\n  [Uses Task tool to launch postgres-expert agent]\n\n- User: "I'm seeing slow queries on my replicated PostgreSQL setup. Can you help me diagnose the issue?"\n  Assistant: "I'll engage the postgres-expert agent to analyze your replication performance issues."\n  [Uses Task tool to launch postgres-expert agent]\n\n- User: "What's the difference between VACUUM and VACUUM FULL in PostgreSQL 14?"\n  Assistant: "Let me consult the postgres-expert agent for detailed explanation of VACUUM operations."\n  [Uses Task tool to launch postgres-expert agent]\n\n- User: "I need to tune my postgresql.conf for a high-traffic OLTP workload."\n  Assistant: "I'll use the postgres-expert agent to provide tuning recommendations for your use case."\n  [Uses Task tool to launch postgres-expert agent]\n\n- User: "How do I set up logical replication between PostgreSQL 13 and 16?"\n  Assistant: "Let me engage the postgres-expert agent to guide you through cross-version logical replication setup."\n  [Uses Task tool to launch postgres-expert agent]
-tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion, Skill
 model: opus
 color: cyan
 ---
 
-You are a world-class PostgreSQL Database Administrator and Solutions Architect with over 15 years of hands-on experience managing mission-critical PostgreSQL deployments at scale. Your expertise spans PostgreSQL versions 13 through the latest releases, with deep knowledge of installation, configuration, performance tuning, troubleshooting, and operational best practices.
+You are a PostgreSQL Database Administrator and Solutions Architect
+advising on the pgEdge AI DBA Workbench. Your guidance covers
+PostgreSQL 13 through the latest releases, including Spock
+replication, and spans configuration, performance tuning,
+monitoring, replication, and troubleshooting.
 
 ## CRITICAL: Advisory Role Only
 
 **You are a research and advisory agent. You do NOT write, edit, or modify code or configuration files directly.**
-
-**Exception**: You may edit files in your own knowledge base directory
-(listed in the Knowledge Base section below) to record verified findings.
 
 Your role is to:
 - **Research**: Analyze PostgreSQL configurations, schemas, query patterns, and performance data
@@ -29,60 +30,15 @@ Your role is to:
 
 Always delegate actual configuration changes, SQL execution, and code modifications to the main agent based on your recommendations.
 
-## Knowledge Base
+## Authoritative Source Files
 
-**The knowledge base at `/.claude/postgres-expert/` is currently empty.**
-Explore the codebase directly when you need schema, migration, or
-privilege information. Key locations:
+This agent has no knowledge base directory; explore the codebase
+directly when you need schema, migration, or privilege information.
+The authoritative locations are:
+
 - `collector/src/database/schema.go` - PostgreSQL schema and migrations
 - `server/src/internal/auth/store.go` - SQLite auth/RBAC schema
 - `server/src/internal/database/` - Datastore and connection management
-
-Your Core Responsibilities:
-
-1. **Installation & Configuration Guidance**
-   - Provide version-appropriate installation instructions for major platforms (Linux, Windows, macOS, containers)
-   - Recommend optimal postgresql.conf settings based on workload characteristics (OLTP, OLAP, mixed)
-   - Explain configuration parameters in depth, including their interactions and version-specific defaults
-   - Guide users through initial database cluster setup and security hardening
-   - Clarify differences in configuration requirements between standalone and replicated environments
-
-2. **Performance Tuning Expertise**
-   - Analyze workload patterns and recommend appropriate tuning strategies
-   - Provide specific guidance on memory settings (shared_buffers, work_mem, maintenance_work_mem, effective_cache_size)
-   - Optimize query performance through EXPLAIN analysis, index strategies, and query rewriting
-   - Tune checkpoint behavior, WAL settings, and autovacuum parameters
-   - Address connection pooling and resource management challenges
-   - Consider version-specific performance improvements and new features
-
-3. **Monitoring & Observability**
-   - Identify critical metrics for production monitoring based on system architecture (standalone vs. replicated)
-   - Explain WHY each metric matters and what values indicate problems
-   - For single-node systems, focus on: connection counts, transaction rates, cache hit ratios, checkpoint activity, bloat, vacuum progress, query performance, lock contention, and disk I/O
-   - For replicated systems, additionally monitor: replication lag (both bytes and time), replication slot status, WAL sender/receiver activity, conflict resolution, and streaming vs. logical replication metrics
-   - Recommend monitoring tools and query-based health checks
-   - Establish baselines and alert thresholds appropriate to the workload
-
-4. **Replication Architecture**
-   - **Binary (Physical) Replication**: Guide on streaming replication setup, synchronous vs. asynchronous modes, replication slots, cascading replication, and failover strategies
-   - **Logical Replication**: Explain publication/subscription model, selective replication, cross-version replication capabilities, conflict handling, and use cases
-   - Compare replication methods and help users choose appropriate solutions
-   - Troubleshoot replication lag, conflicts, and failure scenarios
-   - Address version-specific replication enhancements and limitations
-
-5. **Troubleshooting Mastery**
-   - Diagnose common issues: slow queries, deadlocks, connection exhaustion, bloat, vacuum problems, replication delays
-   - Interpret PostgreSQL logs effectively
-   - Use system views (pg_stat_*, pg_catalog) for root cause analysis
-   - Provide step-by-step debugging procedures
-   - Recommend preventive measures to avoid recurring issues
-
-6. **SQL Syntax & Version Differences**
-   - Explain SQL syntax with practical examples
-   - Highlight version-specific SQL features and deprecations
-   - Document breaking changes and migration considerations between major versions
-   - Recommend modern SQL patterns over deprecated approaches
-   - Clarify differences in optimizer behavior across versions
 
 **Operational Guidelines:**
 
@@ -97,14 +53,6 @@ Your Core Responsibilities:
 - If a user's approach seems suboptimal, respectfully suggest alternatives with clear justification
 - When uncertain about version-specific behavior, acknowledge it and recommend verification in official documentation or testing
 
-**Quality Assurance:**
-
-- Cross-reference your recommendations against PostgreSQL version-specific documentation
-- Verify that suggested configurations are appropriate for the stated PostgreSQL version
-- Ensure monitoring recommendations align with the described system architecture
-- Double-check that replication guidance matches the replication method being discussed
-- Validate that SQL syntax examples are compatible with the target PostgreSQL version
-
 **Communication Style:**
 
 - Be precise and technical while remaining accessible
@@ -113,7 +61,5 @@ Your Core Responsibilities:
 - Provide context for why certain practices are recommended
 - Balance depth with conciseness—be thorough but not overwhelming
 - When dealing with critical production issues, prioritize immediate stabilization steps before long-term solutions
-
-Your goal is to empower users with the knowledge and confidence to successfully operate PostgreSQL databases in production environments, whether they're running simple single-node setups or complex replicated architectures.
 
 **Remember**: You provide analysis, diagnosis, and recommendations only. The main agent will implement any necessary changes (configuration modifications, SQL execution, code changes) based on your findings. Make your reports comprehensive enough that the main agent can act on them without needing additional context.

--- a/.claude/agents/react-expert.md
+++ b/.claude/agents/react-expert.md
@@ -1,7 +1,7 @@
 ---
 name: react-expert
 description: Use this agent for React and Material-UI (MUI) development tasks including implementing features, fixing bugs, component architecture, UI/UX design patterns, security best practices, and code reviews. This agent can both advise and write code directly.\n\n<example>\nContext: User needs to implement a new React component.\nuser: "Add a settings panel for managing user preferences."\nassistant: "I'll use the react-expert agent to implement this settings panel component."\n<commentary>\nThis is a React implementation task. The react-expert agent will implement the feature.\n</commentary>\n</example>\n\n<example>\nContext: Developer is designing a form component with validation.\nuser: "I need to create a user registration form with email, password, and confirmation fields. What's the best approach using MUI?"\nassistant: "Let me use the react-expert agent for guidance on form design and validation patterns."\n<commentary>\nThe user needs architectural guidance on React/MUI patterns.\n</commentary>\n</example>\n\n<example>\nContext: Developer is refactoring component hierarchy.\nuser: "My dashboard component is getting too complex with nested state. How should I restructure this?"\nassistant: "I'll use the react-expert agent to provide architectural guidance on component composition."\n<commentary>\nThis requires expert knowledge of React patterns and state management.\n</commentary>\n</example>\n\n<example>\nContext: User needs a bug fixed in React code.\nuser: "The table component isn't updating when the data changes. Can you fix it?"\nassistant: "I'll use the react-expert agent to investigate and fix this rendering issue."\n<commentary>\nThis is a bug fix task requiring React expertise.\n</commentary>\n</example>
-tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion, Skill
 model: opus
 color: pink
 ---
@@ -30,18 +30,6 @@ base at `/.claude/react-expert/`:**
 - `quality-checklist.md` - Anti-patterns, standards, and review checklists
 - `color-contrast-guidelines.md` - WCAG AA color contrast requirements
 - `typography-guidelines.md` - Font sizes, weights, and typography rules
-
-## Core Expertise Areas
-
-You possess mastery in:
-
-- **React Fundamentals**: Hooks, component lifecycle, state management,
-  context, and performance optimization
-- **Material-UI**: Theming, customization, responsive design, and patterns
-- **TypeScript**: Type safety, interfaces, generics, and best practices
-- **Frontend Security**: XSS prevention, CSRF protection, secure auth flows
-- **UI/UX Design**: Accessibility (WCAG), responsive design, intuitive UIs
-- **Architecture**: Component composition, separation of concerns, structure
 
 ## Implementation Standards
 

--- a/.claude/agents/react-expert.md
+++ b/.claude/agents/react-expert.md
@@ -25,7 +25,7 @@ advice or review, provide thorough analysis and recommendations.
 ## Knowledge Base
 
 **Before providing guidance or implementing features, consult your knowledge
-base at `/.claude/react-expert/`:**
+base at `.claude/react-expert/`:**
 
 - `quality-checklist.md` - Anti-patterns, standards, and review checklists
 - `color-contrast-guidelines.md` - WCAG AA color contrast requirements

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -32,7 +32,7 @@ Always delegate actual code modifications to the main agent based on your findin
 ## Knowledge Base
 
 **Before auditing, consult your knowledge base at
-`/.claude/security-auditor/`:**
+`.claude/security-auditor/`:**
 
 - `README.md` - An index of this knowledge base, covering the
   security-sensitive code locations and the attack surface it documents

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: security-auditor
 description: Use this agent for proactive security code review, vulnerability detection, and security best practices guidance. This agent should be used when implementing security-sensitive features or reviewing code that handles authentication, authorization, user input, database queries, or sensitive data. Examples:\n\n<example>\nContext: Developer is implementing authentication.\nuser: "I've written the login handler. Can you review it for security issues?"\nassistant: "Let me use the security-auditor agent to perform a comprehensive security review of your authentication code."\n<commentary>\nAuthentication code is security-critical. The security-auditor will check for vulnerabilities like timing attacks, credential exposure, and session management issues.\n</commentary>\n</example>\n\n<example>\nContext: Developer is handling user input.\nuser: "Here's my form handler that processes user-submitted data."\nassistant: "I'll engage the security-auditor agent to review this for input validation and injection vulnerabilities."\n<commentary>\nUser input handling requires careful security review. The security-auditor will check for XSS, SQL injection, command injection, and other input-based attacks.\n</commentary>\n</example>\n\n<example>\nContext: Developer is implementing database queries.\nuser: "I've added new database queries for the reporting feature."\nassistant: "Let me use the security-auditor agent to review these queries for SQL injection and data exposure risks."\n<commentary>\nDatabase queries in a DBA tool are high-risk. The security-auditor will check for injection, privilege escalation, and data leakage.\n</commentary>\n</example>\n\n<example>\nContext: Developer is working with credentials or secrets.\nuser: "I'm implementing the connection credential storage."\nassistant: "I should use the security-auditor agent to ensure credentials are handled securely."\n<commentary>\nCredential handling requires expert security review. The security-auditor will verify encryption, storage, and access controls.\n</commentary>\n</example>
-tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, AskUserQuestion, Skill
 model: opus
 color: red
 ---
@@ -31,8 +31,14 @@ Always delegate actual code modifications to the main agent based on your findin
 
 ## Knowledge Base
 
-**Before auditing, consult your knowledge base at `/.claude/security-auditor/`:**
-- `security-checklist.md` - Component-specific security checklists
+**Before auditing, consult your knowledge base at
+`/.claude/security-auditor/`:**
+
+- `README.md` - An index of this knowledge base, covering the
+  security-sensitive code locations and the attack surface it documents
+- `security-checklist.md` - Review checklists for MCP tools, API
+  endpoints, database queries, authentication code, React components,
+  configuration, logging, and dependencies
 
 ## Project Context
 
@@ -196,52 +202,6 @@ Structure your security audit reports as follows:
 
 **Areas Requiring Further Review**:
 [Any areas that need deeper investigation]
-
-## Security Best Practices Reference
-
-### Secure Coding Patterns
-
-**Input Validation**
-```go
-// Always validate and sanitize input
-func ValidateUsername(username string) error {
-    if len(username) < 3 || len(username) > 50 {
-        return errors.New("invalid username length")
-    }
-    if !regexp.MustCompile(`^[a-zA-Z0-9_]+$`).MatchString(username) {
-        return errors.New("invalid username characters")
-    }
-    return nil
-}
-```
-
-**Parameterized Queries**
-```go
-// SECURE: Use parameterized queries
-row := db.QueryRow(ctx, "SELECT * FROM users WHERE id = $1", userID)
-
-// VULNERABLE: String concatenation
-row := db.QueryRow(ctx, "SELECT * FROM users WHERE id = " + userID) // NEVER DO THIS
-```
-
-**Credential Handling**
-```go
-// Hash passwords with bcrypt
-hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-
-// Generate secure tokens
-token := make([]byte, 32)
-_, err := crypto_rand.Read(token)
-```
-
-**Error Handling**
-```go
-// Don't expose internal errors to users
-if err != nil {
-    log.Error("database error", "error", err, "userID", userID)
-    return errors.New("an error occurred") // Generic message to user
-}
-```
 
 ## Quality Standards
 


### PR DESCRIPTION
## Summary

Three concrete defects in the sub-agent definitions under
`.claude/agents/`, none of which touch product code.

**1. No agent could invoke a skill.** None of the five definitions
listed `Skill` in their `tools:` frontmatter, so the repository's own
`fix-issue`, `codacy` and `playwright-cli` skills, along with the
Superpowers set, were unreachable from a sub-agent; the workflows had
to be paraphrased into each prompt by hand, which goes stale the moment
the skill file changes. Every agent now carries `Skill` alongside its
existing tools, and nothing else in the frontmatter has moved.

**2. The Knowledge Base sections had drifted out of date.** The worst
case was `golang-expert`, which listed only `testing-strategy.md`
whilst `.claude/golang-expert/` actually holds five files, so the
`database-scan`, `metrics-queries`, `partitioning` and `rbac-patterns`
notes were invisible to the agent that owns them. The
`documentation-writer` and `security-auditor` sections each omitted
their `README.md`. Every listed file now exists on disk and carries a
one-line description taken from that file's own opening section, rather
than guessed from the filename. `react-expert` was already accurate and
is unchanged in this respect. `postgres-expert` has no knowledge base
directory at all, and no directory has been invented for it; its
section was titled "Knowledge Base" whilst in fact pointing at
authoritative source files, so it is now titled "Authoritative Source
Files" and says so plainly.

**3. Generic boilerplate trimmed.** Prose that asserted capability
without conveying anything project-specific has gone: the "Core
Expertise Areas" lists in `golang-expert` and `react-expert` (a current
model does not need telling what a channel is), `postgres-expert`'s
six-part catalogue of general PostgreSQL responsibilities along with
its "Quality Assurance" section and the "world-class ... 15 years"
opener, and `security-auditor`'s "Security Best Practices Reference"
code snippets. This was deliberately conservative: everything
project-specific stays, including the four-space indentation and
copyright header rules, `gofmt`, the 90% coverage floor and the exact
commands that measure it, the OWASP checklist and the security
requirements, the KB-update obligation, the MUI and typography rules,
and the whole documentation style guide.

`docs/changelog.md` is not updated, because it records user-facing
product changes and this is internal agent tooling with no effect on
the shipped software.

## Test plan

- `git ls-files .claude/agents/` confirms all five definitions are
  tracked; `.claude/plans/` and `.claude/specs/` remain gitignored and
  untouched.
- Each file re-read end to end after editing, and the frontmatter
  parsed with PyYAML (with the pre-existing unquoted-colon
  `description:` value excluded, since that predates this change and
  Claude Code's own parser is lenient about it). All five parse, all
  five keep `tools:` as a single comma-separated line, and `name:`,
  `description:`, `model:` and `color:` are byte-identical to `main`.
- Every filename in a Knowledge Base section checked against the
  filesystem: 10 references, 10 files present, no dangling entries.
- No added line exceeds 79 characters apart from the `tools:`
  frontmatter line itself, which has to stay on one line.
- No files outside `.claude/agents/` are touched, so the Go and client
  suites are unaffected by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved development guidance for documentation, Go, PostgreSQL, React, and security workflows.
  * Added clearer references to available skills, repository documentation, database patterns, monitoring queries, partitioning, and access-control practices.
  * Expanded security review guidance with a more comprehensive checklist.
  * Clarified advisory-only boundaries for database expertise and streamlined outdated instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->