### PR TITLE
Split the connections chart into a gauge and a counter

### DIFF
--- a/.claude/react-expert/quality-checklist.md
+++ b/.claude/react-expert/quality-checklist.md
@@ -101,6 +101,50 @@ dialog.
 
 ## TextField Native Input Attributes
 
+## Dashboard Chart Semantics
+
+Metric series carry units and semantics, and a chart must not mix
+kinds of quantity on one shared axis. The two kinds seen most often
+in this project are gauges, such as `numbackends`, which are
+point-in-time values bounded by a configured limit, and cumulative
+counters, such as `sessions` or `xact_commit`, which only ever
+climb until `stats_reset`. Plotting one of each on a single axis
+lets the counter set the scale, flattens the gauge into a
+featureless line, and invites the reader to compare two numbers
+that are not comparable.
+
+The rules for new or modified charts are as follows:
+
+- Give a gauge and a counter their own charts, even when the
+  underlying metric query fetches both in one request; splitting
+  the presentation does not require splitting the query.
+
+- Draw a reference line for a gauge whose limit is known. The
+  `Chart` component does not register the ECharts `MarkLine`
+  component, so add the limit as an extra constant series with the
+  same units instead of reaching for `markLine`; passing `series`
+  through `echartsOptions` would replace the real data, because
+  `deepMerge` assigns arrays rather than merging them.
+
+- Say what the numbers cover in the chart title and legend. The
+  `pg_stat_database` probe filters on `current_database()`, so
+  anything derived from it describes the monitored database rather
+  than the whole server, and the title should say so.
+
+- Label a cumulative series as cumulative in the legend, so that a
+  reader does not mistake it for a rate.
+
+The reference implementation is
+`client/src/components/Dashboard/ServerDashboard/PostgresOverviewSection.tsx`,
+which draws backends with a `max_connections` reference series and
+keeps cumulative sessions on a separate chart. It reads the limit
+from the latest `pg_server_info` row through the latest-row mode of
+`/api/v1/metrics/query` (`limit` and `order_by` parameters), since
+that probe only stores a row when the server configuration changes
+and a bucketed query would usually come back empty.
+
+## TypeScript Standards
+
 `client/package.json` depends on `@mui/material` at `^5.14.20`. The
 committed lockfile resolves that to `5.18.0`, where `slotProps` works
 and a handful of components already use it (`ConnectionLostOverlay.tsx`,

--- a/client/src/components/Dashboard/ServerDashboard/PostgresOverviewSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/PostgresOverviewSection.tsx
@@ -82,17 +82,33 @@ interface ServerInfoRow {
     max_connections?: number | null;
 }
 
+/** A max_connections lookup result tied to the connection it came from. */
+interface MaxConnectionsResult {
+    connectionId: number;
+    value: number | null;
+}
+
 /**
  * Fetch the configured max_connections for a connection from the most
  * recent pg_server_info row. The probe only stores a row when the
  * server configuration changes, so the latest-row query is used rather
  * than a time-bucketed series that would usually be empty.
+ *
+ * The result carries the connection it belongs to, so that switching
+ * connections never draws the previous server's limit over the new
+ * server's backend count whilst the fresh lookup is still in flight.
  */
 const useMaxConnections = (connectionId: number): number | null => {
-    const [maxConnections, setMaxConnections] = useState<number | null>(null);
+    const [result, setResult] = useState<MaxConnectionsResult>({
+        connectionId,
+        value: null,
+    });
 
     useEffect(() => {
         const controller = new AbortController();
+        const setValue = (value: number | null) => {
+            setResult({ connectionId, value });
+        };
         const params = new URLSearchParams({
             probe_name: 'pg_server_info',
             connection_id: connectionId.toString(),
@@ -108,20 +124,18 @@ const useMaxConnections = (connectionId: number): number | null => {
             .then((rows) => {
                 if (controller.signal.aborted) { return; }
                 const value = Array.isArray(rows) ? rows[0]?.max_connections : null;
-                setMaxConnections(
-                    typeof value === 'number' && value > 0 ? value : null
-                );
+                setValue(typeof value === 'number' && value > 0 ? value : null);
             })
             .catch((err: unknown) => {
                 if (controller.signal.aborted) { return; }
                 logger.error('Error fetching max_connections:', err);
-                setMaxConnections(null);
+                setValue(null);
             });
 
         return () => { controller.abort(); };
     }, [connectionId]);
 
-    return maxConnections;
+    return result.connectionId === connectionId ? result.value : null;
 };
 
 /**

--- a/client/src/components/Dashboard/ServerDashboard/PostgresOverviewSection.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/PostgresOverviewSection.tsx
@@ -9,7 +9,7 @@
  */
 
 import type React from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import { Storage as StorageIcon } from '@mui/icons-material';
@@ -21,6 +21,8 @@ import KpiTile from '../KpiTile';
 import CollapsibleSection from '../CollapsibleSection';
 import { Chart } from '../../Chart';
 import ChartPanel from '../ChartPanel';
+import { apiGet } from '../../../utils/apiClient';
+import { logger } from '../../../utils/logger';
 import { formatBytes, formatValue, formatNumber, formatCompactNumber } from '../../../utils/formatters';
 import { type ServerSectionProps, extractSparklineData, extractLatestValue } from './types';
 
@@ -32,6 +34,14 @@ const CHART_BUCKETS = 150;
 
 /** Chart height in pixels */
 const CHART_HEIGHT = 250;
+
+/**
+ * Titles for the connection charts. The pg_stat_database probe filters
+ * on current_database(), so both charts cover the monitored database
+ * rather than the whole server; the titles say so explicitly.
+ */
+const CONNECTIONS_CHART_TITLE = 'Connections (Monitored Database)';
+const SESSIONS_CHART_TITLE = 'Sessions Established (Monitored Database)';
 
 /**
  * Build chart data from metric series for the Chart component.
@@ -65,6 +75,53 @@ const buildChartData = (
             data: s.data,
         })),
     };
+};
+
+/** Shape of the latest pg_server_info row used for max_connections. */
+interface ServerInfoRow {
+    max_connections?: number | null;
+}
+
+/**
+ * Fetch the configured max_connections for a connection from the most
+ * recent pg_server_info row. The probe only stores a row when the
+ * server configuration changes, so the latest-row query is used rather
+ * than a time-bucketed series that would usually be empty.
+ */
+const useMaxConnections = (connectionId: number): number | null => {
+    const [maxConnections, setMaxConnections] = useState<number | null>(null);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        const params = new URLSearchParams({
+            probe_name: 'pg_server_info',
+            connection_id: connectionId.toString(),
+            limit: '1',
+            order_by: 'collected_at',
+            order: 'desc',
+        });
+
+        apiGet<ServerInfoRow[]>(
+            `/api/v1/metrics/query?${params.toString()}`,
+            { signal: controller.signal },
+        )
+            .then((rows) => {
+                if (controller.signal.aborted) { return; }
+                const value = Array.isArray(rows) ? rows[0]?.max_connections : null;
+                setMaxConnections(
+                    typeof value === 'number' && value > 0 ? value : null
+                );
+            })
+            .catch((err: unknown) => {
+                if (controller.signal.aborted) { return; }
+                logger.error('Error fetching max_connections:', err);
+                setMaxConnections(null);
+            });
+
+        return () => { controller.abort(); };
+    }, [connectionId]);
+
+    return maxConnections;
 };
 
 /**
@@ -165,6 +222,7 @@ const PostgresOverviewSection: React.FC<ServerSectionProps> = ({
 
     // Fetch chart data
     const connectionChart = useMetrics(connectionChartParams);
+    const maxConnections = useMaxConnections(connectionId);
     const txnChart = useMetrics(txnChartParams);
     const blockIoChart = useMetrics(blockIoChartParams);
     const tupleChart = useMetrics(tupleChartParams);
@@ -211,12 +269,34 @@ const PostgresOverviewSection: React.FC<ServerSectionProps> = ({
         tempKpi.data, 'temp_bytes'
     );
 
-    // Build chart datasets
-    const connectionChartData = useMemo(
+    // Build chart datasets. Backends and sessions are deliberately kept
+    // apart: numbackends is a gauge bounded by max_connections, whilst
+    // sessions is a counter that only ever climbs, so plotting them on
+    // one axis flattens the gauge and invites a false comparison.
+    const connectionChartData = useMemo(() => {
+        const base = buildChartData(
+            connectionChart.data,
+            ['numbackends'],
+            ['Backends'],
+        );
+        if (!base || maxConnections === null) { return base; }
+        return {
+            ...base,
+            series: [
+                ...base.series,
+                {
+                    name: 'Max Connections',
+                    data: base.categories.map(() => maxConnections),
+                },
+            ],
+        };
+    }, [connectionChart.data, maxConnections]);
+
+    const sessionChartData = useMemo(
         () => buildChartData(
             connectionChart.data,
-            ['numbackends', 'sessions'],
-            ['Backends', 'Sessions'],
+            ['sessions'],
+            ['Cumulative Sessions'],
         ),
         [connectionChart.data]
     );
@@ -326,7 +406,7 @@ const PostgresOverviewSection: React.FC<ServerSectionProps> = ({
             <Box sx={CHART_SECTION_SX}>
                 <Box>
                     <ChartPanel
-                        title="Connections Over Time"
+                        title={CONNECTIONS_CHART_TITLE}
                         loading={connectionChart.loading && !connectionChartData}
                         hasData={!!connectionChartData}
                         emptyMessage="No connection data available"
@@ -336,14 +416,43 @@ const PostgresOverviewSection: React.FC<ServerSectionProps> = ({
                             <Chart
                                 type="line"
                                 data={connectionChartData}
-                                title="Connections Over Time"
+                                title={CONNECTIONS_CHART_TITLE}
                                 height={CHART_HEIGHT}
                                 smooth
                                 showLegend
                                 showTooltip
                                 enableExport={false}
                                 analysisContext={{
-                                    metricDescription: 'PostgreSQL backend connections and sessions over time',
+                                    metricDescription: 'PostgreSQL backends connected to the monitored database over time, against the max_connections limit',
+                                    connectionId,
+                                    connectionName,
+                                    timeRange: timeRange.range,
+                                }}
+                            />
+                        )}
+                    </ChartPanel>
+                </Box>
+
+                <Box>
+                    <ChartPanel
+                        title={SESSIONS_CHART_TITLE}
+                        loading={connectionChart.loading && !sessionChartData}
+                        hasData={!!sessionChartData}
+                        emptyMessage="No session data available"
+                        height={CHART_HEIGHT}
+                    >
+                        {sessionChartData && (
+                            <Chart
+                                type="line"
+                                data={sessionChartData}
+                                title={SESSIONS_CHART_TITLE}
+                                height={CHART_HEIGHT}
+                                smooth
+                                showLegend
+                                showTooltip
+                                enableExport={false}
+                                analysisContext={{
+                                    metricDescription: 'Cumulative sessions established against the monitored database since the last statistics reset',
                                     connectionId,
                                     connectionName,
                                     timeRange: timeRange.range,

--- a/client/src/components/Dashboard/ServerDashboard/__tests__/PostgresOverviewSection.test.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/__tests__/PostgresOverviewSection.test.tsx
@@ -172,9 +172,47 @@ const seriesValuesFor = (title: string, name: string): string =>
             && el.getAttribute('data-series') === name)
         .map(el => el.getAttribute('data-values') ?? '')[0];
 
-const renderSection = () => render(
-    <PostgresOverviewSection connectionId={7} connectionName="Test Server" />,
+const renderSection = (connectionId = 7) => render(
+    <PostgresOverviewSection
+        connectionId={connectionId}
+        connectionName="Test Server"
+    />,
 );
+
+/** Deferred settlement handles for each queued apiGet call. */
+interface Deferred {
+    resolve: (value: unknown) => void;
+    reject: (reason: unknown) => void;
+}
+
+/**
+ * Make apiGet return promises that the test settles by hand, so that
+ * every assertion about the reference series follows an observed state
+ * transition rather than the initial pre-fetch render.
+ */
+const deferApiGet = (): Deferred[] => {
+    const deferrals: Deferred[] = [];
+    mockApiGet.mockImplementation(() => new Promise((resolve, reject) => {
+        deferrals.push({ resolve, reject });
+    }));
+    return deferrals;
+};
+
+/**
+ * Render, settle the first lookup with a usable limit, and wait for the
+ * reference series to appear. Returns the rerender helper and the
+ * deferred queue so the caller can drive a connection change.
+ */
+const renderWithLimit = async (deferrals: Deferred[]) => {
+    const view = renderSection(7);
+    await waitFor(() => { expect(deferrals).toHaveLength(1); });
+    deferrals[0].resolve([{ max_connections: 100 }]);
+    await waitFor(() => {
+        expect(seriesNamesFor(CONNECTIONS_TITLE))
+            .toEqual(['Backends', 'Max Connections']);
+    });
+    return view;
+};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -232,36 +270,79 @@ describe('PostgresOverviewSection', () => {
             expect(url).toContain('order_by=collected_at');
         });
 
-        it('omits the reference series when max_connections is unavailable', async () => {
-            mockApiGet.mockResolvedValue([]);
-            renderSection();
+        it('drops the previous limit as soon as the connection changes', async () => {
+            const deferrals = deferApiGet();
+            const { rerender } = await renderWithLimit(deferrals);
+
+            // Switching connection must not leave the old server's limit
+            // drawn over the new server's backend count whilst the
+            // second lookup is still in flight.
+            rerender(
+                <PostgresOverviewSection
+                    connectionId={8}
+                    connectionName="Other Server"
+                />,
+            );
+            expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
+
+            await waitFor(() => { expect(deferrals).toHaveLength(2); });
+            deferrals[1].resolve([{ max_connections: 250 }]);
+            await waitFor(() => {
+                expect(seriesValuesFor(CONNECTIONS_TITLE, 'Max Connections'))
+                    .toBe('250,250');
+            });
+        });
+
+        /**
+         * Drive a connection change whose lookup settles with an
+         * unusable response, and assert the reference series is dropped
+         * rather than merely absent from the outset.
+         */
+        const expectOmittedAfter = async (
+            settle: (deferred: Deferred) => void,
+        ) => {
+            const deferrals = deferApiGet();
+            const { rerender } = await renderWithLimit(deferrals);
+
+            rerender(
+                <PostgresOverviewSection
+                    connectionId={8}
+                    connectionName="Other Server"
+                />,
+            );
+            await waitFor(() => { expect(deferrals).toHaveLength(2); });
+            settle(deferrals[1]);
 
             await waitFor(() => {
-                expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
+                expect(mockApiGet).toHaveBeenCalledTimes(2);
             });
+            expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
+        };
+
+        it('omits the reference series when max_connections is unavailable', async () => {
+            await expectOmittedAfter(d => { d.resolve([]); });
         });
 
         it('omits the reference series when max_connections is not positive', async () => {
-            mockApiGet.mockResolvedValue([{ max_connections: 0 }]);
-            renderSection();
-
-            await waitFor(() => {
-                expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
-            });
+            await expectOmittedAfter(d => { d.resolve([{ max_connections: 0 }]); });
         });
 
         it('omits the reference series when the response is not an array', async () => {
-            mockApiGet.mockResolvedValue(null);
-            renderSection();
-
-            await waitFor(() => {
-                expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
-            });
+            await expectOmittedAfter(d => { d.resolve(null); });
         });
 
         it('logs and degrades gracefully when the lookup fails', async () => {
-            mockApiGet.mockRejectedValue(new Error('boom'));
-            renderSection();
+            const deferrals = deferApiGet();
+            const { rerender } = await renderWithLimit(deferrals);
+
+            rerender(
+                <PostgresOverviewSection
+                    connectionId={8}
+                    connectionName="Other Server"
+                />,
+            );
+            await waitFor(() => { expect(deferrals).toHaveLength(2); });
+            deferrals[1].reject(new Error('boom'));
 
             await waitFor(() => {
                 expect(mockLoggerError).toHaveBeenCalledWith(
@@ -272,35 +353,43 @@ describe('PostgresOverviewSection', () => {
             expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
         });
 
-        it('ignores a resolved lookup once the request is aborted', async () => {
-            let resolveLookup: ((value: unknown) => void) | undefined;
-            mockApiGet.mockImplementation(() => new Promise((resolve) => {
-                resolveLookup = resolve;
-            }));
-
+        it('aborts the in-flight lookup and ignores a late resolution', async () => {
+            const deferrals = deferApiGet();
             const { unmount } = renderSection();
-            await waitFor(() => { expect(mockApiGet).toHaveBeenCalled(); });
-            unmount();
-            resolveLookup?.([{ max_connections: 100 }]);
+            await waitFor(() => { expect(deferrals).toHaveLength(1); });
 
-            // No state update occurs after unmount, so React logs no
-            // warning and the test simply completes cleanly.
+            const signal = (mockApiGet.mock.calls[0][1] as {
+                signal: AbortSignal;
+            }).signal;
+            expect(signal.aborted).toBe(false);
+
+            unmount();
+            expect(signal.aborted).toBe(true);
+
+            // A late success is discarded by the aborted guard, so no
+            // state update is attempted after teardown.
+            deferrals[0].resolve([{ max_connections: 100 }]);
             await waitFor(() => {
                 expect(screen.queryByTestId('chart')).not.toBeInTheDocument();
             });
+            expect(mockLoggerError).not.toHaveBeenCalled();
         });
 
-        it('ignores a rejected lookup once the request is aborted', async () => {
-            let rejectLookup: ((reason: unknown) => void) | undefined;
-            mockApiGet.mockImplementation(() => new Promise((_resolve, reject) => {
-                rejectLookup = reject;
-            }));
-
+        it('aborts the in-flight lookup and ignores a late rejection', async () => {
+            const deferrals = deferApiGet();
             const { unmount } = renderSection();
-            await waitFor(() => { expect(mockApiGet).toHaveBeenCalled(); });
-            unmount();
-            rejectLookup?.(new Error('aborted'));
+            await waitFor(() => { expect(deferrals).toHaveLength(1); });
 
+            const signal = (mockApiGet.mock.calls[0][1] as {
+                signal: AbortSignal;
+            }).signal;
+
+            unmount();
+            expect(signal.aborted).toBe(true);
+
+            // A late failure is swallowed rather than logged, because
+            // the abort is the cause rather than a real lookup error.
+            deferrals[0].reject(new Error('aborted'));
             await waitFor(() => {
                 expect(mockLoggerError).not.toHaveBeenCalled();
             });

--- a/client/src/components/Dashboard/ServerDashboard/__tests__/PostgresOverviewSection.test.tsx
+++ b/client/src/components/Dashboard/ServerDashboard/__tests__/PostgresOverviewSection.test.tsx
@@ -1,0 +1,433 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import PostgresOverviewSection from '../PostgresOverviewSection';
+import type { UseMetricsReturn } from '../../../../hooks/useMetrics';
+import type { MetricQueryParams, MetricSeries } from '../../types';
+import type { ChartData } from '../../../Chart/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+type UseMetricsFn = (params: MetricQueryParams | null) => UseMetricsReturn;
+
+const mockUseMetrics = vi.fn<UseMetricsFn>();
+vi.mock('../../../../hooks/useMetrics', () => ({
+    useMetrics: (params: MetricQueryParams | null) => mockUseMetrics(params),
+}));
+
+vi.mock('../../../../contexts/useDashboard', () => ({
+    useDashboard: () => ({
+        timeRange: { range: '1h' },
+        refreshTrigger: 0,
+    }),
+}));
+
+vi.mock('../../../../contexts/useAICapabilities', () => ({
+    useAICapabilities: () => ({
+        capabilities: null,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+        isAIEnabled: false,
+    }),
+}));
+
+const mockApiGet = vi.fn();
+vi.mock('../../../../utils/apiClient', () => ({
+    apiGet: (url: string, options?: { signal?: AbortSignal }) =>
+        mockApiGet(url, options) as unknown,
+}));
+
+const mockLoggerError = vi.fn();
+vi.mock('../../../../utils/logger', () => ({
+    logger: {
+        error: (...args: unknown[]) => mockLoggerError(...args),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+    },
+}));
+
+/*
+ * The Chart mock renders the title plus a serialised description of
+ * every series so the tests can assert exactly which metric ends up on
+ * which chart, which is the whole point of the split.
+ */
+vi.mock('../../../Chart', () => ({
+    Chart: ({ title, data }: { title: string; data: ChartData }) => (
+        <div data-testid="chart" data-title={title}>
+            <span>{title}</span>
+            {data.series.map((s) => (
+                <span
+                    key={s.name}
+                    data-testid="chart-series"
+                    data-chart={title}
+                    data-series={s.name}
+                    data-values={s.data.join(',')}
+                >
+                    {s.name}
+                </span>
+            ))}
+        </div>
+    ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CONNECTIONS_TITLE = 'Connections (Monitored Database)';
+const SESSIONS_TITLE = 'Sessions Established (Monitored Database)';
+
+/** Build a MetricSeries for the given metric and values. */
+const series = (metric: string, values: number[]): MetricSeries => ({
+    name: metric,
+    metric,
+    data: values.map((value, idx) => ({
+        time: `2024-01-01T00:0${idx}:00Z`,
+        value,
+    })),
+}) as MetricSeries;
+
+/** Wrap metric series in a resolved UseMetricsReturn. */
+const ready = (data: MetricSeries[] | null): UseMetricsReturn => ({
+    data,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+});
+
+/** A UseMetricsReturn that is still loading with no data yet. */
+const loading = (): UseMetricsReturn => ({
+    data: null,
+    loading: true,
+    error: null,
+    refetch: vi.fn(),
+});
+
+/**
+ * Route each useMetrics call to a response based on the metrics it
+ * requests, mirroring how the component issues one query per concern.
+ */
+const routeMetrics = (
+    overrides: Partial<Record<string, UseMetricsReturn>> = {},
+): void => {
+    mockUseMetrics.mockImplementation((params) => {
+        const key = (params?.metrics ?? []).join(',');
+        const override = overrides[key];
+        if (override) { return override; }
+
+        switch (key) {
+            case 'numbackends':
+                return ready([series('numbackends', [10, 12])]);
+            case 'numbackends,sessions':
+                return ready([
+                    series('numbackends', [10, 12]),
+                    series('sessions', [8000, 8100]),
+                ]);
+            case 'xact_commit,xact_rollback':
+                return ready([
+                    series('xact_commit', [100, 200]),
+                    series('xact_rollback', [1, 2]),
+                ]);
+            case 'blks_hit,blks_read':
+                return ready([
+                    series('blks_hit', [90, 95]),
+                    series('blks_read', [10, 5]),
+                ]);
+            case 'temp_bytes':
+                return ready([series('temp_bytes', [1024, 2048])]);
+            default:
+                return ready([
+                    series('tup_fetched', [1, 2]),
+                    series('tup_inserted', [3, 4]),
+                    series('tup_updated', [5, 6]),
+                    series('tup_deleted', [7, 8]),
+                ]);
+        }
+    });
+};
+
+/** Find the rendered series names for a given chart title. */
+const seriesNamesFor = (title: string): string[] =>
+    screen.getAllByTestId('chart-series')
+        .filter(el => el.getAttribute('data-chart') === title)
+        .map(el => el.getAttribute('data-series') ?? '');
+
+/** Find the rendered series values for a chart/series pair. */
+const seriesValuesFor = (title: string, name: string): string =>
+    screen.getAllByTestId('chart-series')
+        .filter(el => el.getAttribute('data-chart') === title
+            && el.getAttribute('data-series') === name)
+        .map(el => el.getAttribute('data-values') ?? '')[0];
+
+const renderSection = () => render(
+    <PostgresOverviewSection connectionId={7} connectionName="Test Server" />,
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PostgresOverviewSection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(localStorage.getItem).mockReturnValue(null);
+        routeMetrics();
+        mockApiGet.mockResolvedValue([{ max_connections: 100 }]);
+    });
+
+    describe('connection charts', () => {
+        it('renders backends and sessions as two separate charts', async () => {
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getByText(CONNECTIONS_TITLE)).toBeInTheDocument();
+            });
+            expect(screen.getByText(SESSIONS_TITLE)).toBeInTheDocument();
+
+            // The gauge and the counter must never share a chart.
+            expect(seriesNamesFor(CONNECTIONS_TITLE))
+                .not.toContain('Cumulative Sessions');
+            expect(seriesNamesFor(SESSIONS_TITLE))
+                .toEqual(['Cumulative Sessions']);
+        });
+
+        it('plots numbackends with a max_connections reference series', async () => {
+            renderSection();
+
+            await waitFor(() => {
+                expect(seriesNamesFor(CONNECTIONS_TITLE))
+                    .toEqual(['Backends', 'Max Connections']);
+            });
+
+            expect(seriesValuesFor(CONNECTIONS_TITLE, 'Backends'))
+                .toBe('10,12');
+            // One reference point per category, at the configured limit.
+            expect(seriesValuesFor(CONNECTIONS_TITLE, 'Max Connections'))
+                .toBe('100,100');
+        });
+
+        it('queries the latest pg_server_info row for max_connections', async () => {
+            renderSection();
+
+            await waitFor(() => {
+                expect(mockApiGet).toHaveBeenCalled();
+            });
+            const url = mockApiGet.mock.calls[0][0] as string;
+            expect(url).toContain('probe_name=pg_server_info');
+            expect(url).toContain('connection_id=7');
+            expect(url).toContain('limit=1');
+            expect(url).toContain('order_by=collected_at');
+        });
+
+        it('omits the reference series when max_connections is unavailable', async () => {
+            mockApiGet.mockResolvedValue([]);
+            renderSection();
+
+            await waitFor(() => {
+                expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
+            });
+        });
+
+        it('omits the reference series when max_connections is not positive', async () => {
+            mockApiGet.mockResolvedValue([{ max_connections: 0 }]);
+            renderSection();
+
+            await waitFor(() => {
+                expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
+            });
+        });
+
+        it('omits the reference series when the response is not an array', async () => {
+            mockApiGet.mockResolvedValue(null);
+            renderSection();
+
+            await waitFor(() => {
+                expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
+            });
+        });
+
+        it('logs and degrades gracefully when the lookup fails', async () => {
+            mockApiGet.mockRejectedValue(new Error('boom'));
+            renderSection();
+
+            await waitFor(() => {
+                expect(mockLoggerError).toHaveBeenCalledWith(
+                    'Error fetching max_connections:',
+                    expect.any(Error),
+                );
+            });
+            expect(seriesNamesFor(CONNECTIONS_TITLE)).toEqual(['Backends']);
+        });
+
+        it('ignores a resolved lookup once the request is aborted', async () => {
+            let resolveLookup: ((value: unknown) => void) | undefined;
+            mockApiGet.mockImplementation(() => new Promise((resolve) => {
+                resolveLookup = resolve;
+            }));
+
+            const { unmount } = renderSection();
+            await waitFor(() => { expect(mockApiGet).toHaveBeenCalled(); });
+            unmount();
+            resolveLookup?.([{ max_connections: 100 }]);
+
+            // No state update occurs after unmount, so React logs no
+            // warning and the test simply completes cleanly.
+            await waitFor(() => {
+                expect(screen.queryByTestId('chart')).not.toBeInTheDocument();
+            });
+        });
+
+        it('ignores a rejected lookup once the request is aborted', async () => {
+            let rejectLookup: ((reason: unknown) => void) | undefined;
+            mockApiGet.mockImplementation(() => new Promise((_resolve, reject) => {
+                rejectLookup = reject;
+            }));
+
+            const { unmount } = renderSection();
+            await waitFor(() => { expect(mockApiGet).toHaveBeenCalled(); });
+            unmount();
+            rejectLookup?.(new Error('aborted'));
+
+            await waitFor(() => {
+                expect(mockLoggerError).not.toHaveBeenCalled();
+            });
+        });
+
+        it('shows empty messages when no connection data is returned', async () => {
+            routeMetrics({ 'numbackends,sessions': ready([]) });
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getByText('No connection data available'))
+                    .toBeInTheDocument();
+            });
+            expect(screen.getByText('No session data available'))
+                .toBeInTheDocument();
+        });
+
+        it('shows chart loading indicators while the query is in flight', async () => {
+            routeMetrics({ 'numbackends,sessions': loading() });
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getAllByLabelText('Loading chart').length)
+                    .toBeGreaterThanOrEqual(2);
+            });
+        });
+    });
+
+    describe('other charts', () => {
+        it('renders the transaction, block I/O and tuple charts', async () => {
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getByText('Transactions')).toBeInTheDocument();
+            });
+            expect(seriesNamesFor('Transactions'))
+                .toEqual(['Commits', 'Rollbacks']);
+            expect(seriesNamesFor('Block I/O'))
+                .toEqual(['Blocks Hit', 'Blocks Read']);
+            expect(seriesNamesFor('Tuple Operations'))
+                .toEqual(['Fetched', 'Inserted', 'Updated', 'Deleted']);
+        });
+    });
+
+    describe('KPI tiles', () => {
+        it('renders the KPI values derived from the metric series', async () => {
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getByText('Cache Hit Ratio')).toBeInTheDocument();
+            });
+            // 'Backends' and 'Commits' are both KPI labels and chart
+            // series names, so each appears more than once.
+            expect(screen.getAllByText('Backends').length)
+                .toBeGreaterThanOrEqual(2);
+            expect(screen.getAllByText('Commits').length)
+                .toBeGreaterThanOrEqual(2);
+            expect(screen.getByText('12')).toBeInTheDocument();
+            // 95 hits against 5 reads gives a 95.0% ratio.
+            expect(screen.getByText('95.0')).toBeInTheDocument();
+            expect(screen.getByText('Temp Bytes')).toBeInTheDocument();
+        });
+
+        it('renders placeholders when the KPI queries return nothing', async () => {
+            mockUseMetrics.mockImplementation(() => ready([]));
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getByText('Backends')).toBeInTheDocument();
+            });
+            expect(screen.getByText('Temp Bytes')).toBeInTheDocument();
+            expect(screen.getAllByText('--').length).toBeGreaterThanOrEqual(3);
+        });
+
+        it('shows the section spinner during the initial KPI load', () => {
+            mockUseMetrics.mockImplementation(() => loading());
+            renderSection();
+
+            expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+        });
+
+        it('handles a cache hit ratio with no blocks accounted for', async () => {
+            routeMetrics({
+                'blks_hit,blks_read': ready([
+                    series('blks_hit', [0, 0]),
+                    series('blks_read', [0, 0]),
+                ]),
+            });
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getByText('Cache Hit Ratio')).toBeInTheDocument();
+            });
+            expect(screen.getAllByText('--').length).toBeGreaterThanOrEqual(1);
+        });
+
+        it('pads the cache ratio sparkline when the series lengths differ', async () => {
+            routeMetrics({
+                'blks_hit,blks_read': ready([
+                    series('blks_hit', [90, 95, 99]),
+                    series('blks_read', [10]),
+                ]),
+            });
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getByText('Cache Hit Ratio')).toBeInTheDocument();
+            });
+            // The sparkline pads the shorter read series with zeros; the
+            // tile itself still reports 99 hits against 10 reads.
+            expect(screen.getByText('90.8')).toBeInTheDocument();
+        });
+
+        it('pads the cache ratio sparkline when hits are missing entirely', async () => {
+            routeMetrics({
+                'blks_hit,blks_read': ready([
+                    series('blks_read', [10, 20]),
+                ]),
+            });
+            renderSection();
+
+            await waitFor(() => {
+                expect(screen.getByText('Cache Hit Ratio')).toBeInTheDocument();
+            });
+            // With no hit series at all the ratio is unknown, so the
+            // tile falls back to the placeholder.
+            expect(screen.getAllByText('--').length).toBeGreaterThanOrEqual(1);
+        });
+    });
+});

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -131,6 +131,17 @@ project adheres to
   honoured again by `autovacuum_not_running`, which previously
   always assumed the shipped defaults. (#406)
 
+- Split the server dashboard "Connections Over Time" chart into a
+  Connections chart and a Sessions Established chart. The old chart
+  plotted `numbackends`, a gauge bounded by `max_connections`,
+  alongside `sessions`, a counter that climbs until the statistics
+  are reset, so the counter set the scale and flattened the backend
+  count into a featureless line. The Connections chart now shows
+  backends against a `max_connections` reference line, and both
+  titles state that the figures cover the monitored database, since
+  the `pg_stat_database` probe reports on `current_database()` only.
+  (#403)
+
 - Fix every chat request that included a tool list failing with
   `anthropic (400): tools.0.custom.input_schema: Input does not
   match the expected shape`, which broke Ask Ellie and the Server,


### PR DESCRIPTION
## Summary

`PostgresOverviewSection` plotted `numbackends` and `sessions` as two
series on one shared axis, which mixes two different kinds of
quantity. `numbackends` is a gauge, bounded by `max_connections` and
typically in the tens; `sessions` is a cumulative counter that only
climbs until `stats_reset` and readily reaches the thousands. The
counter set the scale, the gauge flattened into a line along the
bottom, and the legend invited the reader to compare "40 backends"
with "85,000 sessions" as though both were concurrent.

The section now renders two charts from the same metrics query, so no
extra time-series request is made:

- **Connections (Monitored Database)** shows backends together with a
  `Max Connections` reference series, since a backend count trending
  towards the limit is the signal worth seeing. The reference value
  comes from the latest `pg_server_info` row through the latest-row
  mode of `/api/v1/metrics/query`; that probe only stores a row when
  the server configuration changes, so a bucketed query would usually
  come back empty. When the limit is unknown the reference series is
  simply omitted.

- **Sessions Established (Monitored Database)** keeps the counter on
  its own axis, with the legend naming it `Cumulative Sessions` so it
  is not mistaken for a rate.

Both titles state the per-database scope, because the
`pg_stat_database` probe filters on `current_database()` and so
undercounts the server total; it also misses walsenders and autovacuum
workers, which still consume connection slots.

The reference line is drawn as a constant series rather than an
ECharts `markLine`, because `Chart` does not register the `MarkLine`
component and `deepMerge` assigns arrays wholesale, so passing
`series` through `echartsOptions` would replace the real data.

### Deliberately out of scope

The cleanest long-term treatment of the session counter is a
per-second rate, which would show connection churn directly. That
belongs with #400, which covers raw counters that should be rates
across the dashboard, and is left to it rather than expanded into
this PR. The stacked `pg_stat_activity` breakdown of active, idle and
idle-in-transaction suggested in #403 is likewise a larger piece of
work needing a new probe series, and is not attempted here. The
change is confined to `PostgresOverviewSection.tsx` and its tests, so
it does not overlap #404's branch.

## Test plan

- New `client/src/components/Dashboard/ServerDashboard/__tests__/PostgresOverviewSection.test.tsx`
  with 18 tests covering the split (asserting that no chart carries
  both series), the reference series values, the latest-row query
  parameters, the missing/zero/non-array/failed/aborted `max_connections`
  paths, the empty and loading panel states, the remaining charts, and
  the KPI tiles.

- `cd client && make coverage`: 172 test files, 3506 tests passing.
  `PostgresOverviewSection.tsx` reports 100% statements, 100% lines,
  100% functions and 97.46% branches, comfortably above the 90% floor.

- `npm run lint` is clean for both changed files (0 errors, and the
  40 warnings in the repository are pre-existing and elsewhere), and
  `npm run typecheck` reports no errors for either file.

- Visual validation was not possible: neither the dev server nor the
  Vite client was running on the dev host, and they are started
  manually by the developer, so no browser check was made.

- `.claude/react-expert/quality-checklist.md` gains a "Dashboard Chart
  Semantics" section recording the gauge-versus-counter rule and the
  `markLine` caveat.

Closes #403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split the server dashboard’s combined connections chart into separate Connections and Sessions Established charts.
  * Added database-specific chart titles and descriptions for clearer monitoring context.
  * Added a `max_connections` reference line to connection charts when available.

* **Bug Fixes**
  * Improved handling of loading, invalid, failed, and interrupted metric requests.
  * Added clearer placeholders and edge-case handling for dashboard KPIs and cache ratios.

* **Documentation**
  * Documented the updated server dashboard chart behavior and metric distinctions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->