### PR TITLE
fix(metrics): build the bucket series in FROM, not the select list

### DIFF
--- a/server/src/internal/metrics/query.go
+++ b/server/src/internal/metrics/query.go
@@ -427,7 +427,8 @@ func BuildMetricsQuery(
             GROUP BY date_bin($1::interval, collected_at, $3)
         ),
         all_buckets AS (
-            SELECT generate_series($3::timestamptz, $4::timestamptz, $1::interval) AS bucket_time
+            SELECT bucket_time
+            FROM generate_series($3::timestamptz, $4::timestamptz, $1::interval) AS g(bucket_time)
         )
         SELECT
             all_buckets.bucket_time,
@@ -682,7 +683,8 @@ func BuildDerivedMetricsQuery(
 
 	ctes = append(ctes, `
         all_buckets AS (
-            SELECT generate_series($3::timestamptz, $4::timestamptz, $1::interval) AS bucket_time
+            SELECT bucket_time
+            FROM generate_series($3::timestamptz, $4::timestamptz, $1::interval) AS g(bucket_time)
         )`)
 
 	query := fmt.Sprintf(`

--- a/server/src/internal/metrics/query_test.go
+++ b/server/src/internal/metrics/query_test.go
@@ -200,6 +200,10 @@ func TestBuildMetricsQuery(t *testing.T) {
 		if strings.Contains(query, `COALESCE(data_buckets."xact_commit"`) {
 			t.Error("query should not COALESCE metric columns; LOCF is applied in Go")
 		}
+		if !strings.Contains(query, `FROM generate_series($3::timestamptz, `+
+			`$4::timestamptz, $1::interval) AS g(bucket_time)`) {
+			t.Error("bucket series must be generated in the FROM clause")
+		}
 
 		// Check args
 		if len(args) != 4 {
@@ -1586,7 +1590,7 @@ func TestBuildDerivedMetricsQuery(t *testing.T) {
 			`CASE WHEN (total_0 - prev_0) >= 0 AND elapsed_sec > 0`,
 			`(total_0 - prev_0)::float / elapsed_sec`,
 			`avg(rate_0) AS "seq_scan_per_sec"`,
-			`generate_series($3::timestamptz, $4::timestamptz, $1::interval)`,
+			`FROM generate_series($3::timestamptz, $4::timestamptz, $1::interval) AS g(bucket_time)`,
 			`LEFT JOIN rate_buckets ON all_buckets.bucket_time = rate_buckets.bucket_time`,
 			`rate_buckets."seq_scan_per_sec"`,
 			`connection_id = $2`,


### PR DESCRIPTION
## Summary

The gap-filling bucket series in the metrics time-series queries is
built with `generate_series` in the select list. This moves it into the
`FROM` clause. The two forms return identical rows in PostgreSQL, so
this is a pure rewrite of the query text with no behaviour change.

The reason for the change is that a set-returning function in a select
list has no equivalent in DuckDB. When the `metrics.*` tables are read
through a view whose query is executed by DuckDB rather than
PostgreSQL, DuckDB's timestamp `generate_series` returns a LIST in that
position instead of a set, and the read fails with:

```
Conversion Error: Unimplemented type for cast
(TIMESTAMP WITH TIME ZONE -> TIMESTAMP WITH TIME ZONE[])
```

It is the placement that matters, not the arguments; the failure
reproduces with all-literal arguments. Moving the call into `FROM`
works on both backends, so the change is applied unconditionally
rather than behind a flag.

## Changes

Both sites are the `all_buckets` CTE, in `BuildMetricsQuery` and
`BuildDerivedMetricsQuery`.

Before:

```sql
all_buckets AS (
    SELECT generate_series($3::timestamptz, $4::timestamptz, $1::interval) AS bucket_time
)
```

After:

```sql
all_buckets AS (
    SELECT bucket_time
    FROM generate_series($3::timestamptz, $4::timestamptz, $1::interval) AS g(bucket_time)
)
```

- `server/src/internal/metrics/query.go`: both `all_buckets` CTEs.

- `server/src/internal/metrics/query_test.go`: the existing derived
  query assertion checked only the `generate_series(...)` substring,
  which both forms contain; it now asserts the full `FROM
  generate_series(...) AS g(bucket_time)` form. An equivalent
  assertion is added to `TestBuildMetricsQuery` so the placement is
  pinned at both sites.

## Testing

- `cd server && make test` passes; `gofmt`, `go vet`, and
  `golangci-lint run ./internal/metrics/...` are all clean.

- `BuildMetricsQuery` and `BuildDerivedMetricsQuery` are both at 100%
  statement coverage in `go tool cover -func`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics query compatibility while preserving gap-filled time buckets for standard and derived metrics.
* **Tests**
  * Updated coverage to verify the generated time-series buckets are constructed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->