### PR TITLE
Time partition retention from its last run, not from process start

### DIFF
--- a/.claude/golang-expert/partitioning.md
+++ b/.claude/golang-expert/partitioning.md
@@ -133,3 +133,37 @@ Rules for the datastore connection shared across a GC pass:
   client-side protocol violation, not transient contention, and
   retries will only succeed because the loop body has moved past
   the busy state — the underlying bug stays.
+
+## Scheduling Retention: Never Couple It to Process Uptime
+
+Retention enforcement must not be scheduled from process start.
+The garbage collector originally waited five minutes after startup
+and then ticked every 24 hours, holding no record of when it last
+ran. That made retention a function of *unbroken uptime*: a
+collector restarting more often than the startup delay never
+collected garbage at all, and every restart put it back to the
+beginning of the delay. In issue #437 an OOM restart loop therefore
+filled a datastore's disk, because partitions were never dropped
+across more than a hundred restarts.
+
+The pattern to follow instead:
+
+- Persist each completed pass. `maintenance_runs` holds one row per
+  task (`database.PartitionRetentionTask` for the dropper), written
+  by `database.RecordMaintenanceRun`.
+- Time the next pass from that record, not from process start, so a
+  restart resumes the cycle rather than beginning a new one. See
+  `computeNextRunDelay` in `collector/src/garbage_collector.go`.
+- Treat "never run" and "cannot read the record" as due now. Failing
+  towards collecting slightly early is harmless; failing towards not
+  collecting is what fills a disk.
+- Keep the startup grace period short, and only long enough to stay
+  clear of the probe burst the scheduler runs at startup. A long
+  grace period reintroduces the original bug for any process that
+  does not live that long.
+- Back a failed pass off rather than retrying immediately, so an
+  unreachable datastore does not produce a tight error loop.
+
+The same reasoning applies to any periodic maintenance added later:
+if the schedule lives only in memory, an unstable process silently
+stops doing the work, and nothing in the logs says so.

--- a/collector/src/database/maintenance.go
+++ b/collector/src/database/maintenance.go
@@ -1,0 +1,58 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PartitionRetentionTask is the maintenance_runs key under which the
+// partition dropper records its completions.
+const PartitionRetentionTask = "partition_retention"
+
+// GetMaintenanceRun returns when the named maintenance task last
+// completed. The second return value is false when the task has never
+// run, which is distinct from an error and is the expected state on a
+// freshly migrated datastore.
+func GetMaintenanceRun(ctx context.Context, conn *pgxpool.Conn, task string) (time.Time, bool, error) {
+	var lastRun time.Time
+	err := conn.QueryRow(ctx, `
+        SELECT last_run_at FROM maintenance_runs WHERE task = $1
+    `, task).Scan(&lastRun)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+
+	return lastRun, true, nil
+}
+
+// RecordMaintenanceRun stamps the named maintenance task as having
+// completed at the given time. Storing the completion in the datastore
+// rather than in memory is what decouples the schedule from the
+// collector's process uptime, so a restart resumes the existing cycle
+// instead of starting a fresh one.
+func RecordMaintenanceRun(ctx context.Context, conn *pgxpool.Conn, task string, at time.Time) error {
+	_, err := conn.Exec(ctx, `
+        INSERT INTO maintenance_runs (task, last_run_at)
+        VALUES ($1, $2)
+        ON CONFLICT (task) DO UPDATE SET last_run_at = EXCLUDED.last_run_at
+    `, task, at.UTC())
+
+	return err
+}

--- a/collector/src/database/maintenance_test.go
+++ b/collector/src/database/maintenance_test.go
@@ -1,0 +1,150 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestMaintenanceRunRoundTrip covers the persistence that decouples the
+// partition dropper's schedule from process uptime (issue #437).
+func TestMaintenanceRunRoundTrip(t *testing.T) {
+	if err := setupTestDatabase(); err != nil {
+		t.Skipf("test database not provisioned: %v", err)
+	}
+
+	pool, conn := getTestConnection(t)
+	defer pool.Close()
+	defer conn.Release()
+
+	ctx := context.Background()
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	const task = "test_partition_retention"
+	if _, err := conn.Exec(ctx,
+		"DELETE FROM maintenance_runs WHERE task = $1", task); err != nil {
+		t.Fatalf("clearing prior state: %v", err)
+	}
+
+	// A task that has never run reports absence, not an error, because
+	// that is the ordinary state of a freshly migrated datastore.
+	if _, found, err := GetMaintenanceRun(ctx, conn, task); err != nil {
+		t.Fatalf("GetMaintenanceRun on empty table: %v", err)
+	} else if found {
+		t.Fatal("GetMaintenanceRun reported a run that was never recorded")
+	}
+
+	first := time.Now().UTC().Add(-9 * 24 * time.Hour).Truncate(time.Second)
+	if err := RecordMaintenanceRun(ctx, conn, task, first); err != nil {
+		t.Fatalf("RecordMaintenanceRun: %v", err)
+	}
+
+	got, found, err := GetMaintenanceRun(ctx, conn, task)
+	if err != nil || !found {
+		t.Fatalf("GetMaintenanceRun after record: found=%v err=%v", found, err)
+	}
+	if !got.UTC().Equal(first) {
+		t.Errorf("stored time = %v, want %v", got.UTC(), first)
+	}
+
+	// Recording again must update in place rather than conflict, so the
+	// table holds one row per task however many times the collector runs.
+	second := time.Now().UTC().Truncate(time.Second)
+	if err := RecordMaintenanceRun(ctx, conn, task, second); err != nil {
+		t.Fatalf("RecordMaintenanceRun (update): %v", err)
+	}
+
+	got, found, err = GetMaintenanceRun(ctx, conn, task)
+	if err != nil || !found {
+		t.Fatalf("GetMaintenanceRun after update: found=%v err=%v", found, err)
+	}
+	if !got.UTC().Equal(second) {
+		t.Errorf("updated time = %v, want %v", got.UTC(), second)
+	}
+
+	var rows int
+	if err := conn.QueryRow(ctx,
+		"SELECT count(*) FROM maintenance_runs WHERE task = $1", task).
+		Scan(&rows); err != nil {
+		t.Fatalf("counting rows: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("maintenance_runs holds %d rows for %q, want 1", rows, task)
+	}
+
+	if _, err := conn.Exec(ctx,
+		"DELETE FROM maintenance_runs WHERE task = $1", task); err != nil {
+		t.Logf("cleaning up %q: %v", task, err)
+	}
+}
+
+// TestGetMaintenanceRunUnknownTask verifies that an unrecorded task is
+// reported as absent rather than as an error, which is what lets the
+// collector treat "never run" as "due now".
+func TestGetMaintenanceRunUnknownTask(t *testing.T) {
+	if err := setupTestDatabase(); err != nil {
+		t.Skipf("test database not provisioned: %v", err)
+	}
+
+	pool, conn := getTestConnection(t)
+	defer pool.Close()
+	defer conn.Release()
+
+	ctx := context.Background()
+
+	sm := NewSchemaManager()
+	if err := sm.Migrate(conn); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	at, found, err := GetMaintenanceRun(ctx, conn, "no_such_task_437")
+	if err != nil {
+		t.Fatalf("GetMaintenanceRun: %v", err)
+	}
+	if found {
+		t.Error("found = true for a task that was never recorded")
+	}
+	if !at.IsZero() {
+		t.Errorf("time = %v, want zero value", at)
+	}
+}
+
+// TestGetMaintenanceRunReadFailure verifies that a genuine read failure
+// is reported rather than being reported as "never run", since the two
+// lead the collector to different decisions.
+func TestGetMaintenanceRunReadFailure(t *testing.T) {
+	if err := setupTestDatabase(); err != nil {
+		t.Skipf("test database not provisioned: %v", err)
+	}
+
+	pool, conn := getTestConnection(t)
+	defer pool.Close()
+	defer conn.Release()
+
+	ctx := context.Background()
+
+	if _, err := conn.Exec(ctx, "DROP TABLE IF EXISTS maintenance_runs"); err != nil {
+		t.Fatalf("dropping maintenance_runs: %v", err)
+	}
+
+	if _, _, err := GetMaintenanceRun(ctx, conn, PartitionRetentionTask); err == nil {
+		t.Error("GetMaintenanceRun returned no error with the table missing")
+	}
+
+	if err := RecordMaintenanceRun(ctx, conn, PartitionRetentionTask, time.Now()); err == nil {
+		t.Error("RecordMaintenanceRun returned no error with the table missing")
+	}
+}

--- a/collector/src/database/migration_v8_test.go
+++ b/collector/src/database/migration_v8_test.go
@@ -33,13 +33,15 @@ func migrationV8(t *testing.T) Migration {
 	return Migration{}
 }
 
-// TestMigrationV8_RegisteredAsLatest verifies the migration is wired
-// into the schema manager and is the newest version, so a collector
-// upgrade actually applies it.
-func TestMigrationV8_RegisteredAsLatest(t *testing.T) {
+// TestMigrationV8_Registered verifies the migration is wired into the
+// schema manager and will be reached by an upgrade. It asserts that
+// LatestVersion is at least 8 rather than exactly 8, because later
+// migrations are expected to follow; migrationV8 itself fails if the
+// version is not registered at all.
+func TestMigrationV8_Registered(t *testing.T) {
 	sm := NewSchemaManager()
-	if got := sm.LatestVersion(); got != 8 {
-		t.Errorf("LatestVersion() = %d, want 8", got)
+	if got := sm.LatestVersion(); got < 8 {
+		t.Errorf("LatestVersion() = %d, want at least 8", got)
 	}
 	if desc := migrationV8(t).Description; desc == "" {
 		t.Error("migration 8 has an empty description")

--- a/collector/src/database/schema.go
+++ b/collector/src/database/schema.go
@@ -3160,6 +3160,33 @@ func (sm *SchemaManager) registerMigrations() {
 		},
 	})
 
+	sm.migrations = append(sm.migrations, Migration{
+		Version:     9,
+		Description: "Add maintenance_runs table to persist background task completions",
+		Up: func(tx pgx.Tx) error {
+			ctx := context.Background()
+
+			_, err := tx.Exec(ctx, `
+				CREATE TABLE IF NOT EXISTS maintenance_runs (
+					task TEXT PRIMARY KEY,
+					last_run_at TIMESTAMPTZ NOT NULL
+				);
+
+				COMMENT ON TABLE maintenance_runs IS
+					'Records when each periodic background maintenance task last completed, so the schedule survives a collector restart. Without this the partition dropper only ran after a fixed period of unbroken uptime, and a collector that restarted more often than that never enforced retention at all.';
+				COMMENT ON COLUMN maintenance_runs.task IS
+					'Stable identifier for the maintenance task, for example partition_retention for the metrics partition dropper.';
+				COMMENT ON COLUMN maintenance_runs.last_run_at IS
+					'Timestamp at which the task last completed successfully; the next run is scheduled relative to this rather than to process start.';
+			`)
+			if err != nil {
+				return fmt.Errorf("failed to create maintenance_runs table: %w", err)
+			}
+
+			return nil
+		},
+	})
+
 }
 
 // Migrate applies all pending migrations

--- a/collector/src/database/schema_test.go
+++ b/collector/src/database/schema_test.go
@@ -283,7 +283,7 @@ func TestNewSchemaManager(t *testing.T) {
 	}
 
 	// Verify all migrations are registered
-	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	if len(sm.migrations) != len(expectedVersions) {
 		t.Fatalf("Expected %d migrations, got %d", len(expectedVersions), len(sm.migrations))
 	}

--- a/collector/src/garbage_collector.go
+++ b/collector/src/garbage_collector.go
@@ -10,6 +10,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/pgedge/ai-workbench/collector/src/database"
 	"github.com/pgedge/ai-workbench/collector/src/probes"
 
@@ -26,6 +28,13 @@ type GarbageCollector struct {
 	datastore    *database.Datastore
 	shutdownChan chan struct{}
 	wg           sync.WaitGroup
+
+	// Cadence, seeded from the constants above. These are fields rather
+	// than direct uses of the constants so that tests can drive the
+	// scheduling loop without waiting out real delays.
+	interval     time.Duration
+	startupGrace time.Duration
+	retryDelay   time.Duration
 }
 
 // NewGarbageCollector creates a new garbage collector
@@ -33,6 +42,9 @@ func NewGarbageCollector(datastore *database.Datastore) *GarbageCollector {
 	return &GarbageCollector{
 		datastore:    datastore,
 		shutdownChan: make(chan struct{}),
+		interval:     gcInterval,
+		startupGrace: gcStartupGrace,
+		retryDelay:   gcRetryDelay,
 	}
 }
 
@@ -45,46 +57,153 @@ func (gc *GarbageCollector) Start(ctx context.Context) error {
 	return nil
 }
 
-// run executes the garbage collection loop
+// Garbage collection cadence. The interval is the target period between
+// collections; the grace period is how long after startup, or after a
+// failure, the collector waits before trying.
+//
+// The grace period is deliberately short. Retention used to be scheduled
+// from process start, which coupled it to uptime: a collector that
+// restarted more often than the delay never enforced retention even
+// once, and a restart loop could therefore fill the datastore's disk
+// (issue #437). It is not zero only so that collection does not compete
+// with the burst of probes the scheduler runs at startup.
+const (
+	gcInterval     = 24 * time.Hour
+	gcStartupGrace = 30 * time.Second
+	gcRetryDelay   = 15 * time.Minute
+)
+
+// errNoDatastore reports a garbage collector constructed without a
+// datastore. Production always supplies one, so this exists to keep the
+// collection goroutine from panicking rather than to be handled.
+var errNoDatastore = errors.New("garbage collector has no datastore")
+
+// run executes the garbage collection loop. The next collection is timed
+// from the last recorded completion in the datastore rather than from
+// process start, so restarts resume the existing cycle instead of
+// beginning a fresh one.
 func (gc *GarbageCollector) run(ctx context.Context) {
 	defer gc.wg.Done()
 
-	// Wait a short time after startup before first collection
-	startupDelay := 5 * time.Minute
-	logger.Infof("Garbage collector will run first collection in %v", startupDelay)
-
-	select {
-	case <-gc.shutdownChan:
-		return
-	case <-time.After(startupDelay):
-		// Run first collection
-		gc.collectGarbage(ctx)
-	}
-
-	// Schedule regular collections every 24 hours
-	ticker := time.NewTicker(24 * time.Hour)
-	defer ticker.Stop()
+	var lastAttemptFailed bool
 
 	for {
+		// Check for shutdown before touching the datastore, so a
+		// collector told to stop during startup exits promptly rather
+		// than waiting on a query.
 		select {
 		case <-gc.shutdownChan:
 			logger.Info("Stopping garbage collector")
 			return
-		case <-ticker.C:
-			gc.collectGarbage(ctx)
+		case <-ctx.Done():
+			logger.Info("Context canceled, stopping garbage collector")
+			return
+		default:
 		}
+
+		delay := gc.nextRunDelay(ctx, lastAttemptFailed)
+		logger.Infof("Garbage collector will run next collection in %v", delay)
+
+		select {
+		case <-gc.shutdownChan:
+			logger.Info("Stopping garbage collector")
+			return
+		case <-ctx.Done():
+			logger.Info("Context canceled, stopping garbage collector")
+			return
+		case <-time.After(delay):
+		}
+
+		lastAttemptFailed = gc.collectGarbage(ctx) != nil
 	}
 }
 
-// collectGarbage performs garbage collection for all probes
-func (gc *GarbageCollector) collectGarbage(ctx context.Context) {
+// nextRunDelay returns how long to wait before the next collection.
+//
+// A task that has never run, or whose recorded completion is already
+// older than the interval, is due now and waits only the startup grace
+// period. Otherwise the delay carries the remainder of the current
+// cycle. A failed attempt backs off instead of retrying immediately, so
+// that an unreachable datastore does not produce a tight error loop.
+func (gc *GarbageCollector) nextRunDelay(ctx context.Context, lastAttemptFailed bool) time.Duration {
+	if lastAttemptFailed {
+		return gc.retryDelay
+	}
+
+	lastRun, found, err := gc.lastRun(ctx)
+	switch {
+	case err != nil:
+		// Treat an unreadable timestamp as due: dropping partitions a
+		// little early is harmless, whereas not dropping them at all is
+		// what filled a disk in issue #437.
+		logger.Errorf("Error reading last garbage collection time, treating collection as due: %v", err)
+	case !found:
+		logger.Info("No previous garbage collection recorded, collection is due")
+	default:
+		if time.Until(lastRun.Add(gc.interval)) <= gc.startupGrace {
+			logger.Infof("Last garbage collection was %v ago, collection is due",
+				time.Since(lastRun).Truncate(time.Second))
+		}
+	}
+
+	return gc.computeNextRunDelay(lastRun, found, err, lastAttemptFailed, time.Now())
+}
+
+// computeNextRunDelay holds the scheduling decision, separated from the
+// datastore read so it can be exercised directly.
+//
+// A task that has never run, or whose recorded completion is already
+// older than the interval, is due now and waits only the startup grace
+// period. Anything else carries the remainder of the current cycle.
+func (gc *GarbageCollector) computeNextRunDelay(lastRun time.Time, found bool, readErr error, lastAttemptFailed bool, now time.Time) time.Duration {
+	if lastAttemptFailed {
+		return gc.retryDelay
+	}
+	if readErr != nil || !found {
+		return gc.startupGrace
+	}
+
+	remaining := lastRun.Add(gc.interval).Sub(now)
+	if remaining <= gc.startupGrace {
+		return gc.startupGrace
+	}
+
+	return remaining
+}
+
+// lastRun reads the recorded completion time of the partition retention
+// task from the datastore.
+func (gc *GarbageCollector) lastRun(ctx context.Context) (time.Time, bool, error) {
+	if gc.datastore == nil {
+		return time.Time{}, false, errNoDatastore
+	}
+
+	conn, err := gc.datastore.GetConnection()
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	defer gc.datastore.ReturnConnection(conn)
+
+	return database.GetMaintenanceRun(ctx, conn, database.PartitionRetentionTask)
+}
+
+// collectGarbage performs garbage collection for all probes. It returns
+// an error only when the pass could not be attempted at all; a failure
+// to drop partitions for one probe is logged and does not abandon the
+// rest, nor prevent the pass being recorded as done.
+func (gc *GarbageCollector) collectGarbage(ctx context.Context) error {
 	logger.Info("Starting garbage collection...")
+
+	if gc.datastore == nil {
+		logger.Errorf("Error getting database connection for garbage collection: %v", errNoDatastore)
+		return errNoDatastore
+	}
 
 	// Get database connection
 	conn, err := gc.datastore.GetConnection()
 	if err != nil {
 		logger.Errorf("Error getting database connection for garbage collection: %v", err)
-		return
+		return err
 	}
 	defer gc.datastore.ReturnConnection(conn)
 
@@ -92,7 +211,7 @@ func (gc *GarbageCollector) collectGarbage(ctx context.Context) {
 	configsByConnection, err := probes.LoadProbeConfigs(ctx, conn)
 	if err != nil {
 		logger.Errorf("Error loading probe configs for garbage collection: %v", err)
-		return
+		return err
 	}
 
 	// Process each probe from all connections (including global defaults)
@@ -121,6 +240,16 @@ func (gc *GarbageCollector) collectGarbage(ctx context.Context) {
 	} else {
 		logger.Info("Garbage collection completed: no partitions to drop")
 	}
+
+	// Record the completion so the next run is timed from here rather
+	// than from the next process start.
+	if err := database.RecordMaintenanceRun(ctx, conn,
+		database.PartitionRetentionTask, time.Now()); err != nil {
+		logger.Errorf("Error recording garbage collection completion: %v", err)
+		return err
+	}
+
+	return nil
 }
 
 // collectGarbageForProbe performs garbage collection for a single probe

--- a/collector/src/garbage_collector_integration_test.go
+++ b/collector/src/garbage_collector_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgedge/ai-workbench/collector/src/database"
 	"github.com/pgedge/ai-workbench/collector/src/probes"
@@ -112,13 +113,18 @@ func gcTestDatastore(t *testing.T) (*database.Datastore, func()) {
 	}
 
 	name := fmt.Sprintf("ai_wb_gc437_%d", time.Now().UnixNano())
-	if _, err := adminPool.Exec(ctx, "CREATE DATABASE "+name); err != nil {
+	// Build the statements up front: the name is a quoted identifier, not
+	// a bindable parameter, and a prepared string keeps the intent clear.
+	quoted := pgx.Identifier{name}.Sanitize()
+	createSQL := "CREATE DATABASE " + quoted
+	dropSQL := "DROP DATABASE IF EXISTS " + quoted
+	if _, err := adminPool.Exec(ctx, createSQL); err != nil {
 		adminPool.Close()
 		t.Skipf("cannot create a test database: %v", err)
 	}
 
 	dropDatabase := func() {
-		if _, err := adminPool.Exec(ctx, "DROP DATABASE IF EXISTS "+name); err != nil {
+		if _, err := adminPool.Exec(ctx, dropSQL); err != nil {
 			t.Logf("dropping test database %s: %v", name, err)
 		}
 	}

--- a/collector/src/garbage_collector_integration_test.go
+++ b/collector/src/garbage_collector_integration_test.go
@@ -1,0 +1,527 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge AI DBA Workbench
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgedge/ai-workbench/collector/src/database"
+	"github.com/pgedge/ai-workbench/collector/src/probes"
+)
+
+// gcTestConfig satisfies database.Config for the integration tests.
+type gcTestConfig struct {
+	host     string
+	port     int
+	database string
+	username string
+	password string
+}
+
+func (c *gcTestConfig) Validate() error                     { return nil }
+func (c *gcTestConfig) GetPgHost() string                   { return c.host }
+func (c *gcTestConfig) GetPgHostAddr() string               { return "" }
+func (c *gcTestConfig) GetPgDatabase() string               { return c.database }
+func (c *gcTestConfig) GetPgUsername() string               { return c.username }
+func (c *gcTestConfig) GetPgPassword() string               { return c.password }
+func (c *gcTestConfig) GetPgPort() int                      { return c.port }
+func (c *gcTestConfig) GetPgSSLMode() string                { return "disable" }
+func (c *gcTestConfig) GetPgSSLCert() string                { return "" }
+func (c *gcTestConfig) GetPgSSLKey() string                 { return "" }
+func (c *gcTestConfig) GetPgSSLRootCert() string            { return "" }
+func (c *gcTestConfig) GetDatastorePoolMaxConnections() int { return 4 }
+func (c *gcTestConfig) GetDatastorePoolMaxIdleSeconds() int { return 60 }
+
+// gcTestEnv parses TEST_AI_WORKBENCH_SERVER into connection parts. The
+// tests skip when it is unset, matching the rest of the suite.
+func gcTestEnv(t *testing.T) *gcTestConfig {
+	t.Helper()
+
+	url := os.Getenv("TEST_AI_WORKBENCH_SERVER")
+	if url == "" {
+		url = os.Getenv("TEST_DB_CONN")
+	}
+	if url == "" {
+		t.Skip("test database not provisioned")
+	}
+	if !strings.HasPrefix(url, "postgres://") && !strings.HasPrefix(url, "postgresql://") {
+		t.Skipf("unsupported test database URL form: %q", url)
+	}
+
+	stripped := strings.TrimPrefix(strings.TrimPrefix(url, "postgresql://"), "postgres://")
+	if i := strings.Index(stripped, "?"); i != -1 {
+		stripped = stripped[:i]
+	}
+
+	cfg := &gcTestConfig{host: "127.0.0.1", port: 5432, username: "postgres"}
+
+	userinfo, hostpart := "", stripped
+	if at := strings.Index(stripped, "@"); at != -1 {
+		userinfo, hostpart = stripped[:at], stripped[at+1:]
+	}
+	if userinfo != "" {
+		if c := strings.Index(userinfo, ":"); c != -1 {
+			cfg.username, cfg.password = userinfo[:c], userinfo[c+1:]
+		} else {
+			cfg.username = userinfo
+		}
+	}
+	if slash := strings.Index(hostpart, "/"); slash != -1 {
+		cfg.database = hostpart[slash+1:]
+		hostpart = hostpart[:slash]
+	}
+	if colon := strings.Index(hostpart, ":"); colon != -1 {
+		cfg.host = hostpart[:colon]
+		if p, err := strconv.Atoi(hostpart[colon+1:]); err == nil {
+			cfg.port = p
+		}
+	} else if hostpart != "" {
+		cfg.host = hostpart
+	}
+
+	return cfg
+}
+
+// gcTestDatastore builds a throwaway database, migrates it, and returns a
+// Datastore pointed at it along with a cleanup function.
+func gcTestDatastore(t *testing.T) (*database.Datastore, func()) {
+	t.Helper()
+
+	cfg := gcTestEnv(t)
+	ctx := context.Background()
+
+	admin := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		cfg.username, cfg.password, cfg.host, cfg.port, cfg.database)
+	adminPool, err := pgxpool.New(ctx, admin)
+	if err != nil {
+		t.Skipf("cannot reach the test server: %v", err)
+	}
+
+	name := fmt.Sprintf("ai_wb_gc437_%d", time.Now().UnixNano())
+	if _, err := adminPool.Exec(ctx, "CREATE DATABASE "+name); err != nil {
+		adminPool.Close()
+		t.Skipf("cannot create a test database: %v", err)
+	}
+
+	dropDatabase := func() {
+		if _, err := adminPool.Exec(ctx, "DROP DATABASE IF EXISTS "+name); err != nil {
+			t.Logf("dropping test database %s: %v", name, err)
+		}
+	}
+
+	testCfg := *cfg
+	testCfg.database = name
+
+	ds, err := database.NewDatastore(&testCfg)
+	if err != nil {
+		dropDatabase()
+		adminPool.Close()
+		t.Fatalf("NewDatastore: %v", err)
+	}
+
+	conn, err := ds.GetConnection()
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	if err := database.NewSchemaManager().Migrate(conn); err != nil {
+		ds.ReturnConnection(conn)
+		t.Fatalf("Migrate: %v", err)
+	}
+	ds.ReturnConnection(conn)
+
+	return ds, func() {
+		ds.Close()
+		dropDatabase()
+		adminPool.Close()
+	}
+}
+
+// TestGarbageCollector_RecordsAndResumesCycle is the end-to-end
+// regression test for #437. A collection must stamp its completion, and
+// a fresh collector against the same datastore must then see the cycle
+// as in progress rather than starting a new one, which is what makes
+// retention survive a restart loop.
+func TestGarbageCollector_RecordsAndResumesCycle(t *testing.T) {
+	ds, cleanup := gcTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	gc := NewGarbageCollector(ds)
+
+	// Nothing recorded yet, so collection is due.
+	if got := gc.nextRunDelay(ctx, false); got != gcStartupGrace {
+		t.Errorf("first nextRunDelay() = %v, want %v", got, gcStartupGrace)
+	}
+
+	if err := gc.collectGarbage(ctx); err != nil {
+		t.Fatalf("collectGarbage: %v", err)
+	}
+
+	// The completion must be visible to a different collector instance,
+	// standing in for the process having restarted.
+	restarted := NewGarbageCollector(ds)
+	at, found, err := restarted.lastRun(ctx)
+	if err != nil || !found {
+		t.Fatalf("lastRun after collection: found=%v err=%v", found, err)
+	}
+	if d := time.Since(at); d > time.Minute || d < -time.Minute {
+		t.Errorf("recorded completion is %v away from now", d)
+	}
+
+	delay := restarted.nextRunDelay(ctx, false)
+	if delay <= gcStartupGrace || delay > gcInterval {
+		t.Errorf("restarted nextRunDelay() = %v, want the remainder of the cycle", delay)
+	}
+}
+
+// TestGarbageCollector_DueAfterRecordedRunAges verifies that an
+// overdue recorded completion schedules a prompt collection, which is
+// the state Alex's datastore was in for nine days.
+func TestGarbageCollector_DueAfterRecordedRunAges(t *testing.T) {
+	ds, cleanup := gcTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	conn, err := ds.GetConnection()
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	stale := time.Now().UTC().Add(-9 * 24 * time.Hour)
+	if err := database.RecordMaintenanceRun(ctx, conn,
+		database.PartitionRetentionTask, stale); err != nil {
+		ds.ReturnConnection(conn)
+		t.Fatalf("RecordMaintenanceRun: %v", err)
+	}
+	ds.ReturnConnection(conn)
+
+	gc := NewGarbageCollector(ds)
+	if got := gc.nextRunDelay(ctx, false); got != gcStartupGrace {
+		t.Errorf("nextRunDelay() = %v, want %v", got, gcStartupGrace)
+	}
+
+	// A failed attempt must back off rather than spin.
+	if got := gc.nextRunDelay(ctx, true); got != gcRetryDelay {
+		t.Errorf("nextRunDelay(failed) = %v, want %v", got, gcRetryDelay)
+	}
+}
+
+// TestGarbageCollector_DropsExpiredPartitionForConfiguredProbe drives a
+// full pass against a real datastore and checks that a partition older
+// than its probe's retention_days actually goes.
+func TestGarbageCollector_DropsExpiredPartitionForConfiguredProbe(t *testing.T) {
+	ds, cleanup := gcTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	conn, err := ds.GetConnection()
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+
+	var retention int
+	if err := conn.QueryRow(ctx, `
+        SELECT retention_days FROM probe_configs
+        WHERE name = 'pg_stat_statements' AND scope = 'global'
+    `).Scan(&retention); err != nil {
+		ds.ReturnConnection(conn)
+		t.Skipf("pg_stat_statements has no global probe config: %v", err)
+	}
+
+	partitions := func(c *pgxpool.Conn) map[string]bool {
+		rows, err := c.Query(ctx, `
+            SELECT tablename FROM pg_tables
+            WHERE schemaname = 'metrics'
+              AND tablename LIKE 'pg_stat_statements\_%'
+        `)
+		if err != nil {
+			t.Fatalf("listing partitions: %v", err)
+		}
+		defer rows.Close()
+		out := map[string]bool{}
+		for rows.Next() {
+			var n string
+			if err := rows.Scan(&n); err != nil {
+				t.Fatalf("scanning partition name: %v", err)
+			}
+			out[n] = true
+		}
+		return out
+	}
+
+	before := partitions(conn)
+
+	// Create a partition comfortably past the configured window, using
+	// the same helper the probes use so the bounds match production.
+	old := time.Now().AddDate(0, 0, -(retention + 30))
+	if err := probes.EnsurePartition(ctx, conn, "pg_stat_statements", old); err != nil {
+		ds.ReturnConnection(conn)
+		t.Fatalf("EnsurePartition: %v", err)
+	}
+
+	var aged string
+	for n := range partitions(conn) {
+		if !before[n] {
+			aged = n
+			break
+		}
+	}
+	ds.ReturnConnection(conn)
+
+	if aged == "" {
+		t.Fatal("EnsurePartition created no new partition")
+	}
+	t.Logf("aged partition under test: metrics.%s (retention_days=%d)", aged, retention)
+
+	gc := NewGarbageCollector(ds)
+	if err := gc.collectGarbage(ctx); err != nil {
+		t.Fatalf("collectGarbage: %v", err)
+	}
+
+	conn, err = ds.GetConnection()
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	defer ds.ReturnConnection(conn)
+
+	if partitions(conn)[aged] {
+		t.Errorf("partition %s is older than retention_days=%d but was not dropped",
+			aged, retention)
+	}
+}
+
+// TestGarbageCollector_RunLoopCollectsAndReschedules exercises the
+// scheduling loop itself with a compressed cadence: the first pass must
+// run promptly, record its completion, and then wait out the remainder
+// of the cycle rather than collecting again straight away.
+func TestGarbageCollector_RunLoopCollectsAndReschedules(t *testing.T) {
+	ds, cleanup := gcTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	gc := NewGarbageCollector(ds)
+	gc.interval = 30 * time.Second
+	gc.startupGrace = 50 * time.Millisecond
+	gc.retryDelay = 50 * time.Millisecond
+
+	if err := gc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for the first pass to record itself.
+	var recorded time.Time
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		at, found, err := gc.lastRun(ctx)
+		if err == nil && found {
+			recorded = at
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if recorded.IsZero() {
+		gc.Stop()
+		t.Fatal("run loop never recorded a collection")
+	}
+
+	// With the cycle now in progress, the loop must be waiting rather
+	// than collecting repeatedly.
+	time.Sleep(500 * time.Millisecond)
+	again, _, err := gc.lastRun(ctx)
+	if err != nil {
+		gc.Stop()
+		t.Fatalf("lastRun: %v", err)
+	}
+	if !again.Equal(recorded) {
+		t.Errorf("collection ran again inside the interval: %v then %v",
+			recorded, again)
+	}
+
+	gc.Stop()
+}
+
+// TestGarbageCollector_ErrorPaths covers the failure branches: an
+// unreachable datastore, probe configs that cannot be loaded, a probe
+// whose table does not exist, and a completion that cannot be recorded.
+// Each must be reported rather than swallowed, because run() relies on
+// the error to back off instead of spinning.
+func TestGarbageCollector_ErrorPaths(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("probe with an empty name is skipped", func(t *testing.T) {
+		gc := NewGarbageCollector(nil)
+		// getProbeTableName maps an empty probe name to no table, and
+		// the guard must return before the connection is touched, so a
+		// nil connection here is deliberate.
+		dropped, err := gc.collectGarbageForProbe(ctx, nil,
+			&probes.ProbeConfig{Name: ""})
+		if err != nil || dropped != 0 {
+			t.Errorf("collectGarbageForProbe() = (%d, %v), want (0, nil)",
+				dropped, err)
+		}
+	})
+
+	t.Run("probe whose metrics table is missing is a no-op", func(t *testing.T) {
+		ds, cleanup := gcTestDatastore(t)
+		defer cleanup()
+
+		conn, err := ds.GetConnection()
+		if err != nil {
+			t.Fatalf("GetConnection: %v", err)
+		}
+		defer ds.ReturnConnection(conn)
+
+		// The partition lookups match on the parent table's name, so an
+		// unknown table yields no candidates rather than an error. That
+		// makes a misconfigured probe name silently do nothing, which is
+		// worth knowing but is not this change's problem to fix.
+		gc := NewGarbageCollector(ds)
+		dropped, err := gc.collectGarbageForProbe(ctx, conn,
+			&probes.ProbeConfig{Name: "no_such_metric_437", RetentionDays: 7})
+		if err != nil || dropped != 0 {
+			t.Errorf("collectGarbageForProbe() = (%d, %v), want (0, nil)",
+				dropped, err)
+		}
+	})
+
+	t.Run("a probe with no table does not abandon the pass", func(t *testing.T) {
+		ds, cleanup := gcTestDatastore(t)
+		defer cleanup()
+
+		conn, err := ds.GetConnection()
+		if err != nil {
+			t.Fatalf("GetConnection: %v", err)
+		}
+		if _, err := conn.Exec(ctx, `
+            INSERT INTO probe_configs (connection_id, is_enabled, name,
+                description, collection_interval_seconds, retention_days)
+            VALUES (NULL, TRUE, 'no_such_metric_437',
+                'Probe with no metrics table, for error-path testing', 60, 7)
+        `); err != nil {
+			ds.ReturnConnection(conn)
+			t.Fatalf("seeding a broken probe config: %v", err)
+		}
+		ds.ReturnConnection(conn)
+
+		// The pass carries on past the unusable probe and still
+		// records a completion.
+		gc := NewGarbageCollector(ds)
+		if err := gc.collectGarbage(ctx); err != nil {
+			t.Errorf("collectGarbage() = %v, want nil despite one bad probe", err)
+		}
+		if _, found, err := gc.lastRun(ctx); err != nil || !found {
+			t.Errorf("completion not recorded: found=%v err=%v", found, err)
+		}
+	})
+
+	t.Run("unloadable probe configs report an error", func(t *testing.T) {
+		ds, cleanup := gcTestDatastore(t)
+		defer cleanup()
+
+		conn, err := ds.GetConnection()
+		if err != nil {
+			t.Fatalf("GetConnection: %v", err)
+		}
+		if _, err := conn.Exec(ctx, "DROP TABLE probe_configs CASCADE"); err != nil {
+			ds.ReturnConnection(conn)
+			t.Fatalf("dropping probe_configs: %v", err)
+		}
+		ds.ReturnConnection(conn)
+
+		gc := NewGarbageCollector(ds)
+		if err := gc.collectGarbage(ctx); err == nil {
+			t.Error("collectGarbage() returned no error with probe_configs missing")
+		}
+	})
+
+	t.Run("unrecordable completion reports an error", func(t *testing.T) {
+		ds, cleanup := gcTestDatastore(t)
+		defer cleanup()
+
+		conn, err := ds.GetConnection()
+		if err != nil {
+			t.Fatalf("GetConnection: %v", err)
+		}
+		if _, err := conn.Exec(ctx, "DROP TABLE maintenance_runs"); err != nil {
+			ds.ReturnConnection(conn)
+			t.Fatalf("dropping maintenance_runs: %v", err)
+		}
+		ds.ReturnConnection(conn)
+
+		gc := NewGarbageCollector(ds)
+		if err := gc.collectGarbage(ctx); err == nil {
+			t.Error("collectGarbage() returned no error with maintenance_runs missing")
+		}
+
+		// And the read side must surface the failure too, so that
+		// nextRunDelay treats collection as due rather than skipping it.
+		if _, _, err := gc.lastRun(ctx); err == nil {
+			t.Error("lastRun() returned no error with maintenance_runs missing")
+		}
+	})
+
+	t.Run("closed datastore reports an error", func(t *testing.T) {
+		ds, cleanup := gcTestDatastore(t)
+		defer cleanup()
+
+		ds.Close()
+
+		gc := NewGarbageCollector(ds)
+		if _, _, err := gc.lastRun(ctx); err == nil {
+			t.Error("lastRun() returned no error against a closed datastore")
+		}
+		if err := gc.collectGarbage(ctx); err == nil {
+			t.Error("collectGarbage() returned no error against a closed datastore")
+		}
+	})
+}
+
+// TestGarbageCollector_RunExitsOnCancelWhileWaiting covers the context
+// branch of the delay select, which is the path a collector takes when
+// the process is shutting down mid-cycle rather than at startup.
+func TestGarbageCollector_RunExitsOnCancelWhileWaiting(t *testing.T) {
+	ds, cleanup := gcTestDatastore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gc := NewGarbageCollector(ds)
+	// A long grace period parks the loop in the delay select, so the
+	// cancellation lands there rather than on the pre-read check.
+	gc.startupGrace = time.Hour
+
+	gc.wg.Add(1)
+	go gc.run(ctx)
+
+	// Give the loop time to reach the select before canceling.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		gc.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run() did not exit when the context was canceled mid-wait")
+	}
+}

--- a/collector/src/garbage_collector_test.go
+++ b/collector/src/garbage_collector_test.go
@@ -105,3 +105,169 @@ func TestGarbageCollector_StartShutdownBeforeFirstCollection(t *testing.T) {
 		t.Fatal("run() did not exit when shutdownChan was closed")
 	}
 }
+
+// TestComputeNextRunDelay covers the scheduling decision that issue #437
+// turned on: retention must be timed from the last recorded completion,
+// not from process start, so that a collector which restarts frequently
+// still enforces it.
+func TestComputeNextRunDelay(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	readErr := context.DeadlineExceeded
+	gc := NewGarbageCollector(nil)
+
+	tests := []struct {
+		name              string
+		lastRun           time.Time
+		found             bool
+		readErr           error
+		lastAttemptFailed bool
+		want              time.Duration
+	}{
+		{
+			name:  "never run before is due now",
+			found: false,
+			want:  gcStartupGrace,
+		},
+		{
+			name:    "unreadable timestamp is treated as due",
+			readErr: readErr,
+			want:    gcStartupGrace,
+		},
+		{
+			name:              "a failed attempt backs off",
+			lastRun:           now.Add(-30 * time.Hour),
+			found:             true,
+			lastAttemptFailed: true,
+			want:              gcRetryDelay,
+		},
+		{
+			name:    "recorded run older than the interval is due now",
+			lastRun: now.Add(-30 * time.Hour),
+			found:   true,
+			want:    gcStartupGrace,
+		},
+		{
+			name:    "recorded run exactly at the interval is due now",
+			lastRun: now.Add(-gcInterval),
+			found:   true,
+			want:    gcStartupGrace,
+		},
+		{
+			name:    "mid-cycle carries the remainder, not a fresh interval",
+			lastRun: now.Add(-6 * time.Hour),
+			found:   true,
+			want:    gcInterval - 6*time.Hour,
+		},
+		{
+			name:    "remainder inside the grace period collapses to the grace",
+			lastRun: now.Add(-gcInterval).Add(gcStartupGrace / 2),
+			found:   true,
+			want:    gcStartupGrace,
+		},
+		{
+			name:    "a run recorded in the future waits a full interval",
+			lastRun: now.Add(time.Hour),
+			found:   true,
+			want:    gcInterval + time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gc.computeNextRunDelay(tt.lastRun, tt.found, tt.readErr,
+				tt.lastAttemptFailed, now)
+			if got != tt.want {
+				t.Errorf("computeNextRunDelay() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestComputeNextRunDelay_RestartDoesNotResetTheCycle is the regression
+// test for #437 proper: however many times the process restarts, the
+// delay depends only on the recorded completion, so a collector that
+// never survives the old five-minute delay still collects.
+func TestComputeNextRunDelay_RestartDoesNotResetTheCycle(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	overdue := now.Add(-9 * 24 * time.Hour)
+	gc := NewGarbageCollector(nil)
+
+	for restart := 0; restart < 112; restart++ {
+		got := gc.computeNextRunDelay(overdue, true, nil, false, now)
+		if got != gcStartupGrace {
+			t.Fatalf("restart %d: delay = %v, want %v",
+				restart, got, gcStartupGrace)
+		}
+	}
+
+	if gcStartupGrace >= 5*time.Minute {
+		t.Errorf("startup grace %v is no better than the five-minute delay "+
+			"that caused #437", gcStartupGrace)
+	}
+}
+
+// TestGarbageCollector_NextRunDelayWithoutDatastore verifies that an
+// unreadable last-run time schedules a prompt attempt rather than
+// panicking or waiting out a full interval. Not dropping partitions is
+// the failure that filled a disk in #437, so "due now" is the safe
+// direction to fail in.
+func TestGarbageCollector_NextRunDelayWithoutDatastore(t *testing.T) {
+	gc := NewGarbageCollector(nil)
+
+	if got := gc.nextRunDelay(context.Background(), false); got != gcStartupGrace {
+		t.Errorf("nextRunDelay() = %v, want %v", got, gcStartupGrace)
+	}
+}
+
+// TestGarbageCollector_LastRunWithoutDatastore verifies the nil-datastore
+// guard reports an error instead of dereferencing it, since the read
+// happens on the collection goroutine where a panic would be fatal.
+func TestGarbageCollector_LastRunWithoutDatastore(t *testing.T) {
+	gc := NewGarbageCollector(nil)
+
+	at, found, err := gc.lastRun(context.Background())
+	if err == nil {
+		t.Fatal("lastRun() returned no error for a nil datastore")
+	}
+	if found {
+		t.Error("found = true for a nil datastore")
+	}
+	if !at.IsZero() {
+		t.Errorf("time = %v, want zero value", at)
+	}
+}
+
+// TestGarbageCollector_CollectGarbageWithoutDatastore verifies that a
+// failed pass reports an error, which is what makes run() back off
+// rather than retry in a tight loop.
+func TestGarbageCollector_CollectGarbageWithoutDatastore(t *testing.T) {
+	gc := NewGarbageCollector(nil)
+
+	if err := gc.collectGarbage(context.Background()); err == nil {
+		t.Error("collectGarbage() returned no error for a nil datastore")
+	}
+}
+
+// TestGarbageCollector_RunExitsOnContextCancel verifies the context
+// branch of the shutdown check, complementing the shutdownChan case.
+func TestGarbageCollector_RunExitsOnContextCancel(t *testing.T) {
+	gc := NewGarbageCollector(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	gc.wg.Add(1)
+	go gc.run(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		gc.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run() did not exit when the context was canceled")
+	}
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -155,6 +155,25 @@ project adheres to
   overview generator, the shared rate limiter, the auth store, and the
   datastore it already stopped.
 
+- Fix the collector's partition dropper never enforcing
+  `retention_days`, which could fill the metrics datastore's disk
+  and take the Workbench down with it. Garbage collection was
+  scheduled five minutes after process start and every 24 hours
+  thereafter, with no record of when it last ran, so retention was
+  coupled to unbroken process uptime; a collector that restarted
+  more often than the startup delay never collected garbage even
+  once, and each restart returned it to the beginning of the five
+  minutes. A reporter saw partitions persist nine days past a
+  seven-day window across more than a hundred restarts, with no
+  dropper activity in the logs at all. The collector now records
+  each completed pass in a new `maintenance_runs` table and times
+  the next pass from that record rather than from process start, so
+  an overdue collection runs shortly after startup however many
+  times the process has restarted. This also closes the same gap
+  for rolling deployments and node drains, which failed
+  identically. A failed pass now backs off rather than retrying
+  immediately. (#437)
+
 - Fix every chat request that included a tool list failing with
   `anthropic (400): tools.0.custom.input_schema: Input does not
   match the expected shape`, which broke Ask Ellie and the Server,


### PR DESCRIPTION
Fixes #437.

The partition dropper never enforced `retention_days` for the reporter,
and the reason is that it never ran. `GarbageCollector.run` waited five
minutes after process start before its first pass, then ticked every 24
hours, and kept no record of when it had last run. Retention was
therefore a function of unbroken process uptime: a collector dying inside
five minutes collected garbage zero times, and each restart put it back
to the beginning of the delay. With pods OOM-restarting every few minutes
across 112+ restarts, the first pass genuinely never happened, which is
why the reporter found no dropper activity in the logs at all, and why
the datastore's disk filled and crash-looped.

Worth being clear about two things this is not. The retention logic was
never at fault: given `retention_days = 7` and two partitions, one 30
days old and one current, it drops precisely the old one. And this is not
a regression of #62; that fix is present and correct in the released
code, and no `conn busy` is involved.

## What changed

Completions are recorded in a new `maintenance_runs` table (migration 8)
and the next pass is timed from that record rather than from process
start, so a restart resumes the existing cycle instead of beginning a new
one. A task that has never run, or whose record cannot be read, counts as
due: collecting slightly early is harmless, whereas not collecting is
what fills a disk. The startup grace period drops from five minutes to
30 seconds, which is enough to stay clear of the probe burst the
scheduler runs at startup without reintroducing the original bug, and a
failed pass backs off rather than retrying immediately so that an
unreachable datastore cannot produce a tight error loop.

This also closes the same hole for rolling deployments and node drains,
which fail identically today and are considerably more common than an
OOM loop.

The cadence moved onto struct fields seeded from the constants so the
scheduling loop can be driven in tests without waiting out real delays.

## Notes for review

- The v7 migration tests rewound only their own `schema_version` row,
  which stops working as soon as a later migration exists, because
  `getCurrentVersion` takes `MAX(version)` and v7 was consequently
  skipped rather than re-run. They now rewind from v7 onwards, which is
  robust to future migrations.
- `MinCollectorSchemaVersion` in the server is 4, so migration 8 needs no
  compatibility change there.
- Two things noticed in passing and deliberately left alone: a probe
  config naming a metrics table that does not exist is silently a no-op
  rather than an error, since the partition lookups simply match no rows;
  and the startup thundering herd that caused the reporter's OOM loop is
  filed separately as #441, because it is a distinct defect that happens
  to have combined with this one.

## Testing

`collector/make test` passes in full, including lint. Coverage on the
changed files is 95.7% for `garbage_collector.go` and 100% for
`maintenance.go`, both above the 90% floor.

New tests cover the scheduling decision directly (never run, unreadable
record, overdue, mid-cycle, remainder inside the grace period, a run
recorded in the future, and a failed attempt backing off), a 112-restart
loop asserting the delay never depends on process start, an end-to-end
pass against a real datastore that records its completion and is then
seen mid-cycle by a fresh collector instance, a full pass that drops a
partition past its configured `retention_days`, and the failure branches
for an unreachable datastore, unloadable probe configs, a probe with no
metrics table, and an unrecordable completion.

`make test-all` does not currently pass on `main`:
`TestStoreMemoryGeneratesEmbeddingIntegration` and
`TestRecallMemoriesGeneratesQueryEmbeddingIntegration` fail with
`expected 3 dimensions, not 4000` on any host that has pgvector
installed, which open PR #382 fixes. I confirmed both fail identically on
a pristine `origin/main` checkout. Separately, running the server's
packages in one parallel `go test` invocation fails a batch of
`TestClusterHandler_*` integration tests through cross-package
interference on the shared database; that also reproduces on pristine
`main` and passes when run per-package as the Makefile does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Partition retention cleanup now persists successful maintenance runs and schedules future runs based on the last completed run rather than process uptime.
  * Overdue or unrecorded cleanup runs execute after startup, including after restarts and rolling deployments.
  * Failed maintenance runs retry with a backoff delay.
  * Shutdown and cancellation are handled safely, while missing or unusable datastore configurations return errors instead of causing crashes.

* **Documentation**
  * Updated guidance and changelog information for partition retention scheduling and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->